### PR TITLE
PIR: Add support for storing edited profiles

### DIFF
--- a/pir/pir-impl/schemas/com.duckduckgo.pir.impl.store.PirDatabase/11.json
+++ b/pir/pir-impl/schemas/com.duckduckgo.pir.impl.store.PirDatabase/11.json
@@ -1,0 +1,890 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "cebb81345ad0a5c2cbd7f7bcfe02e909",
+    "entities": [
+      {
+        "tableName": "pir_broker_json_etag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fileName` TEXT NOT NULL, `etag` TEXT NOT NULL, PRIMARY KEY(`fileName`))",
+        "fields": [
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fileName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_broker_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `fileName` TEXT NOT NULL, `url` TEXT NOT NULL, `version` TEXT NOT NULL, `parent` TEXT, `addedDatetime` INTEGER NOT NULL, `removedAt` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parent",
+            "columnName": "parent",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "addedDatetime",
+            "columnName": "addedDatetime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_broker_opt_out",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `stepsJson` TEXT NOT NULL, `optOutUrl` TEXT, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutUrl",
+            "columnName": "optOutUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_broker_scan",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `stepsJson` TEXT, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_broker_scheduling_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `retryError` INTEGER NOT NULL, `confirmOptOutScan` INTEGER NOT NULL, `maintenanceScan` INTEGER NOT NULL, `maxAttempts` INTEGER, PRIMARY KEY(`brokerName`), FOREIGN KEY(`brokerName`) REFERENCES `pir_broker_details`(`name`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retryError",
+            "columnName": "retryError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmOptOutScan",
+            "columnName": "confirmOptOutScan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maintenanceScan",
+            "columnName": "maintenanceScan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxAttempts",
+            "columnName": "maxAttempts",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "pir_broker_details",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brokerName"
+            ],
+            "referencedColumns": [
+              "name"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pir_user_profile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `birthYear` INTEGER NOT NULL, `phone` TEXT, `deprecated` INTEGER NOT NULL, `user_firstName` TEXT NOT NULL, `user_lastName` TEXT NOT NULL, `user_middleName` TEXT, `user_suffix` TEXT, `address_city` TEXT NOT NULL, `address_state` TEXT NOT NULL, `address_street` TEXT, `address_zip` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthYear",
+            "columnName": "birthYear",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.firstName",
+            "columnName": "user_firstName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.lastName",
+            "columnName": "user_lastName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName.middleName",
+            "columnName": "user_middleName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userName.suffix",
+            "columnName": "user_suffix",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "addresses.city",
+            "columnName": "address_city",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses.state",
+            "columnName": "address_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses.street",
+            "columnName": "address_street",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "addresses.zip",
+            "columnName": "address_zip",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_events_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventTimeInMillis` INTEGER NOT NULL, `eventType` TEXT NOT NULL, PRIMARY KEY(`eventTimeInMillis`))",
+        "fields": [
+          {
+            "fieldPath": "eventTimeInMillis",
+            "columnName": "eventTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventTimeInMillis"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_broker_scan_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventTimeInMillis` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `eventType` TEXT NOT NULL, PRIMARY KEY(`eventTimeInMillis`))",
+        "fields": [
+          {
+            "fieldPath": "eventTimeInMillis",
+            "columnName": "eventTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventTimeInMillis"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_scan_complete_brokers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `profileQueryId` INTEGER NOT NULL, `startTimeInMillis` INTEGER NOT NULL, `endTimeInMillis` INTEGER NOT NULL, `isSuccess` INTEGER NOT NULL, PRIMARY KEY(`brokerName`, `profileQueryId`))",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileQueryId",
+            "columnName": "profileQueryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeInMillis",
+            "columnName": "startTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeInMillis",
+            "columnName": "endTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuccess",
+            "columnName": "isSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName",
+            "profileQueryId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_opt_out_complete_brokers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `brokerName` TEXT NOT NULL, `extractedProfile` TEXT NOT NULL, `startTimeInMillis` INTEGER NOT NULL, `endTimeInMillis` INTEGER NOT NULL, `isSubmitSuccess` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedProfile",
+            "columnName": "extractedProfile",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeInMillis",
+            "columnName": "startTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeInMillis",
+            "columnName": "endTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubmitSuccess",
+            "columnName": "isSubmitSuccess",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_opt_out_action_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `brokerName` TEXT NOT NULL, `extractedProfile` TEXT NOT NULL, `completionTimeInMillis` INTEGER NOT NULL, `actionType` TEXT NOT NULL, `isError` INTEGER NOT NULL, `result` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "extractedProfile",
+            "columnName": "extractedProfile",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completionTimeInMillis",
+            "columnName": "completionTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "isError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_extracted_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileQueryId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `name` TEXT NOT NULL, `alternativeNames` TEXT NOT NULL, `age` TEXT NOT NULL, `addresses` TEXT NOT NULL, `phoneNumbers` TEXT NOT NULL, `relatives` TEXT NOT NULL, `profileUrl` TEXT NOT NULL, `identifier` TEXT NOT NULL, `reportId` TEXT NOT NULL, `email` TEXT NOT NULL, `fullName` TEXT NOT NULL, `dateAddedInMillis` INTEGER NOT NULL, `deprecated` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileQueryId",
+            "columnName": "profileQueryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternativeNames",
+            "columnName": "alternativeNames",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "age",
+            "columnName": "age",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addresses",
+            "columnName": "addresses",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumbers",
+            "columnName": "phoneNumbers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatives",
+            "columnName": "relatives",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUrl",
+            "columnName": "profileUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "reportId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAddedInMillis",
+            "columnName": "dateAddedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pir_extracted_profiles_profileQueryId_brokerName_name_profileUrl_identifier",
+            "unique": true,
+            "columnNames": [
+              "profileQueryId",
+              "brokerName",
+              "name",
+              "profileUrl",
+              "identifier"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pir_extracted_profiles_profileQueryId_brokerName_name_profileUrl_identifier` ON `${TABLE_NAME}` (`profileQueryId`, `brokerName`, `name`, `profileUrl`, `identifier`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_scan_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `status` TEXT NOT NULL, `lastScanDateInMillis` INTEGER, PRIMARY KEY(`brokerName`, `userProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanDateInMillis",
+            "columnName": "lastScanDateInMillis",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "brokerName",
+            "userProfileId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_optout_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extractedProfileId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `status` TEXT NOT NULL, `attemptCount` INTEGER NOT NULL, `lastOptOutAttemptDate` INTEGER, `optOutRequestedDate` INTEGER NOT NULL, `optOutRemovedDate` INTEGER NOT NULL, PRIMARY KEY(`extractedProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "extractedProfileId",
+            "columnName": "extractedProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOptOutAttemptDate",
+            "columnName": "lastOptOutAttemptDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "optOutRequestedDate",
+            "columnName": "optOutRequestedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutRemovedDate",
+            "columnName": "optOutRemovedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extractedProfileId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_broker_mirror_sites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `url` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, `removedAt` INTEGER NOT NULL, `optOutUrl` TEXT NOT NULL, `parentSite` TEXT NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "removedAt",
+            "columnName": "removedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optOutUrl",
+            "columnName": "optOutUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentSite",
+            "columnName": "parentSite",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pir_email_confirmation_job_record",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extractedProfileId` INTEGER NOT NULL, `brokerName` TEXT NOT NULL, `userProfileId` INTEGER NOT NULL, `email` TEXT NOT NULL, `attemptId` TEXT NOT NULL, `dateCreatedInMillis` INTEGER NOT NULL, `emailConfirmationLink` TEXT NOT NULL, `linkFetchAttemptCount` INTEGER NOT NULL, `lastLinkFetchDateInMillis` INTEGER NOT NULL, `jobAttemptCount` INTEGER NOT NULL, `lastJobAttemptDateInMillis` INTEGER NOT NULL, `deprecated` INTEGER NOT NULL, PRIMARY KEY(`extractedProfileId`))",
+        "fields": [
+          {
+            "fieldPath": "extractedProfileId",
+            "columnName": "extractedProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brokerName",
+            "columnName": "brokerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userProfileId",
+            "columnName": "userProfileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptId",
+            "columnName": "attemptId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateCreatedInMillis",
+            "columnName": "dateCreatedInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emailConfirmationLink",
+            "columnName": "emailConfirmationLink",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkFetchAttemptCount",
+            "columnName": "linkFetchAttemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastLinkFetchDateInMillis",
+            "columnName": "lastLinkFetchDateInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobAttemptCount",
+            "columnName": "jobAttemptCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastJobAttemptDateInMillis",
+            "columnName": "lastJobAttemptDateInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deprecated",
+            "columnName": "deprecated",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extractedProfileId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cebb81345ad0a5c2cbd7f7bcfe02e909')"
+    ]
+  }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -36,7 +36,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebAddAddressToCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE
@@ -65,7 +65,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandler @Inject constructor(
         }
 
         // attempting to add a duplicate address should return success=false
-        if (!pirWebOnboardingStateHolder.addAddress(city, state)) {
+        if (!pirWebProfileStateHolder.addAddress(city, state)) {
             logcat { "PIR-WEB: PirWebAddAddressToCurrentUserProfileMessageHandler: address already exists" }
             jsMessaging.sendResponse(
                 jsMessage = jsMessage,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -36,7 +36,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebAddNameToCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE
@@ -66,7 +66,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandler @Inject constructor(
         }
 
         // attempting to add a duplicate name should return success=false
-        if (!pirWebOnboardingStateHolder.addName(
+        if (!pirWebProfileStateHolder.addName(
                 firstName = firstName,
                 middleName = middleName,
                 lastName = lastName,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -33,7 +33,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message: PirDashboardWebMessages = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE
@@ -46,7 +46,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler @Inject con
         logcat { "PIR-WEB: PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler: process $message" }
 
         val request = jsMessage.toRequestMessage(PirWebMessageRequest.RemoveAddressAtIndexFromCurrentUserProfileRequest::class)
-        if (request == null || !pirWebOnboardingStateHolder.removeAddressAtIndex(request.index)) {
+        if (request == null || !pirWebProfileStateHolder.removeAddressAtIndex(request.index)) {
             logcat { "PIR-WEB: PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler: failed to remove address at index ${request?.index}" }
             jsMessaging.sendResponse(
                 jsMessage = jsMessage,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -33,7 +33,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message: PirDashboardWebMessages = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE
@@ -46,7 +46,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler @Inject constr
         logcat { "PIR-WEB: PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler: process $message" }
 
         val request = jsMessage.toRequestMessage(PirWebMessageRequest.RemoveNameAtIndexFromCurrentUserProfileRequest::class)
-        if (request == null || !pirWebOnboardingStateHolder.removeNameAtIndex(request.index)) {
+        if (request == null || !pirWebProfileStateHolder.removeNameAtIndex(request.index)) {
             logcat { "PIR-WEB: PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler: failed to remove name at index ${request?.index}" }
             jsMessaging.sendResponse(
                 jsMessage = jsMessage,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
@@ -45,7 +45,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebSaveProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
     private val repository: PirRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val context: Context,
@@ -64,7 +64,7 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
         logcat { "PIR-WEB: PirWebSaveProfileMessageHandler: process $jsMessage" }
 
         // validate that we have the complete profile information
-        if (!pirWebOnboardingStateHolder.isProfileComplete) {
+        if (!pirWebProfileStateHolder.isProfileComplete) {
             logcat { "PIR-WEB: PirWebSaveProfileMessageHandler: incomplete profile information" }
             jsMessaging.sendResponse(
                 jsMessage = jsMessage,
@@ -74,7 +74,7 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
         }
 
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            val profileQueries = pirWebOnboardingStateHolder.toProfileQueries(currentTimeProvider.localDateTimeNow().year)
+            val profileQueries = pirWebProfileStateHolder.toProfileQueries(currentTimeProvider.localDateTimeNow().year)
             if (!repository.saveProfileQueries(profileQueries)) {
                 logcat { "PIR-WEB: PirWebSaveProfileMessageHandler: failed to save all user profiles" }
                 jsMessaging.sendResponse(
@@ -92,7 +92,7 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
             // start the initial scan at this point as startScanAndOptOut message is not reliable
             startAndScheduleInitialScan()
 
-            pirWebOnboardingStateHolder.clear()
+            pirWebProfileStateHolder.clear()
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
 import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
+import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
@@ -74,8 +75,9 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
         }
 
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            val profileQueries = pirWebProfileStateHolder.toProfileQueries(currentTimeProvider.localDateTimeNow().year)
-            if (!repository.saveProfileQueries(profileQueries)) {
+            val isProfileUpdateSuccess = handleProfileQueryUpdates()
+
+            if (!isProfileUpdateSuccess) {
                 logcat { "PIR-WEB: PirWebSaveProfileMessageHandler: failed to save all user profiles" }
                 jsMessaging.sendResponse(
                     jsMessage = jsMessage,
@@ -94,6 +96,64 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
 
             pirWebProfileStateHolder.clear()
         }
+    }
+
+    /**
+     * Storing the profile queries is a bit more complex than just replacing them as we need to consider
+     * that some profile queries might have already extracted profiles associated to them. In that case,
+     * we cannot delete those profile queries but we need to mark them as deprecated instead.
+     *
+     * This is so that the opt-outs for those deprecated profiles can be completed.
+     *
+     * https://app.asana.com/1/137249556945/project/481882893211075/task/1211369193255074?focus=true
+     */
+    private suspend fun handleProfileQueryUpdates(): Boolean {
+        // profiles queries that already exist in the database
+        // TODO consider moving the deprecated filtering to the DB layer when updating job handling for new profiles
+        val existingProfileQueries = repository.getUserProfileQueries().filterNot { it.deprecated }
+
+        // new profile queries that are the result of user changes (editing names or addresses)
+        val newProfileQueries = pirWebProfileStateHolder.toProfileQueries(currentTimeProvider.localDateTimeNow().year)
+
+        // the profile queries we need to create are the one that exist in the new ones but not in the database
+        val profileQueriesToCreate = newProfileQueries.filter { newProfileQuery ->
+            existingProfileQueries.none { existingProfileQuery ->
+                // ignore ID when comparing as database profile queries will have an actual id
+                newProfileQuery == existingProfileQuery.copy(id = 0)
+            }
+        }
+
+        // the ones that we need to remove are the ones that exist in the database but not in the new ones
+        val profileQueriesToRemove = existingProfileQueries.filter { existingProfileQuery ->
+            newProfileQueries.none { newProfileQuery ->
+                // ignore ID when comparing as database profile queries will have an actual id
+                newProfileQuery == existingProfileQuery.copy(id = 0)
+            }
+        }.toMutableList()
+
+        // if profile query has extracted profiles associated to it, do not delete it but mark it as deprecated
+        val profileQueriesToUpdate = mutableListOf<ProfileQuery>()
+        val extractedProfileQueryIds = repository.getAllExtractedProfiles().map { it.profileQueryId }.toSet()
+        profileQueriesToRemove.removeAll { profileQueryToRemove ->
+            if (profileQueryToRemove.id in extractedProfileQueryIds) {
+                profileQueriesToUpdate.add(profileQueryToRemove.copy(deprecated = true))
+                true
+            } else {
+                false
+            }
+        }
+
+        if (profileQueriesToCreate.isEmpty() && profileQueriesToUpdate.isEmpty() && profileQueriesToRemove.isEmpty()) {
+            // nothing to do
+            return true
+        }
+
+        // store the changes in a single transaction to ensure data consistency
+        return repository.updateProfileQueries(
+            profileQueriesToAdd = profileQueriesToCreate,
+            profileQueriesToUpdate = profileQueriesToUpdate,
+            profileQueryIdsToDelete = profileQueriesToRemove.map { it.id },
+        )
     }
 
     private fun startAndScheduleInitialScan() {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -33,7 +33,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message: PirDashboardWebMessages = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE
@@ -62,7 +62,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler @Inject construc
         }
 
         // attempting to add a duplicate address should return success=false
-        if (!pirWebOnboardingStateHolder.setAddressAtIndex(
+        if (!pirWebProfileStateHolder.setAddressAtIndex(
                 index = index,
                 city = city,
                 state = state,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfile.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfile.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -36,7 +36,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebSetBirthYearForCurrentUserProfile @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE
@@ -53,7 +53,7 @@ class PirWebSetBirthYearForCurrentUserProfile @Inject constructor(
         )?.year ?: 0
 
         // store the new birth year in the current user profile
-        pirWebOnboardingStateHolder.setBirthYear(birthYear)
+        pirWebProfileStateHolder.setBirthYear(birthYear)
 
         jsMessaging.sendResponse(
             jsMessage = jsMessage,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandler.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageRequest
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.squareup.anvil.annotations.ContributesMultibinding
 import logcat.logcat
 import javax.inject.Inject
@@ -33,7 +33,7 @@ import javax.inject.Inject
     boundType = PirWebJsMessageHandler::class,
 )
 class PirWebSetNameAtIndexInCurrentUserProfileMessageHandler @Inject constructor(
-    private val pirWebOnboardingStateHolder: PirWebOnboardingStateHolder,
+    private val pirWebProfileStateHolder: PirWebProfileStateHolder,
 ) : PirWebJsMessageHandler() {
 
     override val message: PirDashboardWebMessages =
@@ -64,7 +64,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandler @Inject constructor
         }
 
         // attempting to add a duplicate address should return success=false
-        if (!pirWebOnboardingStateHolder.setNameAtIndex(
+        if (!pirWebProfileStateHolder.setNameAtIndex(
                 index = index,
                 firstName = firstName,
                 middleName = middleName,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirWebProfileStateHolder.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirWebProfileStateHolder.kt
@@ -75,7 +75,7 @@ class RealPirWebProfileStateHolder @Inject constructor() : PirWebProfileStateHol
         profileQueries.forEach { profileQuery ->
             addName(
                 firstName = profileQuery.firstName,
-                middleName = profileQuery.middleName,
+                middleName = profileQuery.middleName?.takeIf { it.isNotBlank() },
                 lastName = profileQuery.lastName,
             )
             addAddress(
@@ -111,7 +111,7 @@ class RealPirWebProfileStateHolder @Inject constructor() : PirWebProfileStateHol
             Name(
                 firstName = firstName,
                 lastName = lastName,
-                middleName = middleName,
+                middleName = middleName?.takeIf { it.isNotBlank() },
             ),
         )
         return true
@@ -140,7 +140,7 @@ class RealPirWebProfileStateHolder @Inject constructor() : PirWebProfileStateHol
         names[index] = Name(
             firstName = firstName,
             lastName = lastName,
-            middleName = middleName,
+            middleName = middleName?.takeIf { it.isNotBlank() },
         )
         return true
     }
@@ -188,12 +188,12 @@ class RealPirWebProfileStateHolder @Inject constructor() : PirWebProfileStateHol
                         id = 0, // ID is auto-generated in the database
                         firstName = name.firstName,
                         lastName = name.lastName,
-                        middleName = name.middleName,
+                        middleName = name.middleName?.takeIf { it.isNotBlank() },
                         city = address.city,
                         state = address.state,
                         addresses = listOf(address),
                         birthYear = birthYear,
-                        fullName = name.middleName?.let { middleName ->
+                        fullName = name.middleName?.takeIf { it.isNotBlank() }?.let { middleName ->
                             "${name.firstName} $middleName ${name.lastName}"
                         } ?: "${name.firstName} ${name.lastName}",
                         age = currentYear - birthYear,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirWebProfileStateHolder.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirWebProfileStateHolder.kt
@@ -23,8 +23,10 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 
-interface PirWebOnboardingStateHolder {
+interface PirWebProfileStateHolder {
     val isProfileComplete: Boolean
+
+    fun setLoadedProfileQueries(profileQueries: List<ProfileQuery>)
 
     fun addAddress(
         city: String,
@@ -59,7 +61,7 @@ interface PirWebOnboardingStateHolder {
 
 @ContributesBinding(ActivityScope::class)
 @SingleInstanceIn(ActivityScope::class)
-class RealPirWebOnboardingStateHolder @Inject constructor() : PirWebOnboardingStateHolder {
+class RealPirWebProfileStateHolder @Inject constructor() : PirWebProfileStateHolder {
 
     private val names: MutableList<Name> = mutableListOf()
     private val addresses: MutableList<Address> = mutableListOf()
@@ -67,6 +69,24 @@ class RealPirWebOnboardingStateHolder @Inject constructor() : PirWebOnboardingSt
 
     override val isProfileComplete: Boolean
         get() = names.isNotEmpty() && addresses.isNotEmpty() && birthYear > 0
+
+    override fun setLoadedProfileQueries(profileQueries: List<ProfileQuery>) {
+        clear()
+        profileQueries.forEach { profileQuery ->
+            addName(
+                firstName = profileQuery.firstName,
+                middleName = profileQuery.middleName,
+                lastName = profileQuery.lastName,
+            )
+            addAddress(
+                city = profileQuery.city,
+                state = profileQuery.state,
+            )
+            if (birthYear == 0 && profileQuery.birthYear > 0) {
+                setBirthYear(profileQuery.birthYear)
+            }
+        }
+    }
 
     override fun addAddress(
         city: String,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDatabase.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDatabase.kt
@@ -51,7 +51,7 @@ import com.squareup.moshi.Types
 
 @Database(
     exportSchema = true,
-    version = 10,
+    version = 11,
     entities = [
         BrokerJsonEtag::class,
         BrokerEntity::class,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/UserProfileDao.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/UserProfileDao.kt
@@ -20,6 +20,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 
 @Dao
 interface UserProfileDao {
@@ -35,6 +36,24 @@ interface UserProfileDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertUserProfiles(userProfiles: List<UserProfile>): List<Long>
 
+    @Query("DELETE from pir_user_profile WHERE id IN (:ids)")
+    fun deleteUserProfiles(ids: List<Long>)
+
     @Query("DELETE from pir_user_profile")
     fun deleteAllProfiles()
+
+    @Transaction
+    fun updateUserProfiles(
+        profilesToAdd: List<UserProfile>,
+        profilesToUpdate: List<UserProfile>,
+        profileIdsToDelete: List<Long>,
+    ) {
+        if (profileIdsToDelete.isNotEmpty()) {
+            deleteUserProfiles(profileIdsToDelete)
+        }
+
+        if (profilesToAdd.isNotEmpty() || profilesToUpdate.isNotEmpty()) {
+            insertUserProfiles(profilesToAdd + profilesToUpdate)
+        }
+    }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/UserProfileEntities.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/db/UserProfileEntities.kt
@@ -29,6 +29,7 @@ data class UserProfile(
     val addresses: Address,
     val birthYear: Int,
     val phone: String? = null,
+    val deprecated: Boolean = false, // This should tell us if the profile is irrelevant for PIR (this is not me, profile edits)
 )
 
 data class UserName(

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandlerTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,14 +37,14 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebAddAddressToCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebAddAddressToCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -60,13 +60,13 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"city": "New York", "state": "NY"}""",
             method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addAddress("New York", "NY")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.addAddress("New York", "NY")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addAddress("New York", "NY")
+        verify(mockPirWebProfileStateHolder).addAddress("New York", "NY")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -77,13 +77,13 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"city": "  Los Angeles  ", "state": "  CA  "}""",
             method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addAddress("Los Angeles", "CA")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.addAddress("Los Angeles", "CA")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addAddress("Los Angeles", "CA")
+        verify(mockPirWebProfileStateHolder).addAddress("Los Angeles", "CA")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -99,7 +99,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -115,7 +115,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -131,7 +131,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -147,7 +147,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -163,7 +163,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -179,7 +179,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -195,7 +195,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -206,13 +206,13 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"city": "New York", "state": "NY"}""",
             method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addAddress("New York", "NY")).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.addAddress("New York", "NY")).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addAddress("New York", "NY")
+        verify(mockPirWebProfileStateHolder).addAddress("New York", "NY")
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -228,7 +228,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -244,7 +244,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -260,7 +260,7 @@ class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandlerTest.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -36,14 +36,14 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebAddNameToCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebAddNameToCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -59,13 +59,13 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"first": "John", "middle": "Michael", "last": "Doe"}""",
             method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addName("John", "Michael", "Doe")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.addName("John", "Michael", "Doe")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addName("John", "Michael", "Doe")
+        verify(mockPirWebProfileStateHolder).addName("John", "Michael", "Doe")
         PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -76,13 +76,13 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"first": "Jane", "last": "Smith"}""",
             method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addName("Jane", "", "Smith")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.addName("Jane", "", "Smith")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addName("Jane", "", "Smith")
+        verify(mockPirWebProfileStateHolder).addName("Jane", "", "Smith")
         PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -93,13 +93,13 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"first": "Bob", "middle": "", "last": "Johnson"}""",
             method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.addName("Bob", "", "Johnson")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.addName("Bob", "", "Johnson")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addName("Bob", "", "Johnson")
+        verify(mockPirWebProfileStateHolder).addName("Bob", "", "Johnson")
         PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -112,7 +112,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
                 method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
             )
         whenever(
-            mockPirWebOnboardingStateHolder.addName(
+            mockPirWebProfileStateHolder.addName(
                 "Alice",
                 "Marie",
                 "Brown",
@@ -123,7 +123,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addName("Alice", "Marie", "Brown")
+        verify(mockPirWebProfileStateHolder).addName("Alice", "Marie", "Brown")
         PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -139,7 +139,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -159,7 +159,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -179,7 +179,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -199,7 +199,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -219,7 +219,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -239,7 +239,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -259,7 +259,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -275,7 +275,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
             method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.addName(
+            mockPirWebProfileStateHolder.addName(
                 "John",
                 "Michael",
                 "Doe",
@@ -286,7 +286,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).addName("John", "Michael", "Doe")
+        verify(mockPirWebProfileStateHolder).addName("John", "Michael", "Doe")
         PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -302,7 +302,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -322,7 +322,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),
@@ -342,7 +342,7 @@ class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).addName(
             any(),
             any(),
             any(),

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,14 +37,14 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -63,13 +63,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(0)).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(0)).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(0)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -80,13 +80,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 2}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(2)).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(2)).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(2)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(2)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -97,13 +97,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 5}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(5)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(5)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(5)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(5)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -114,13 +114,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": -1}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(-1)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(-1)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(-1)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(-1)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -131,13 +131,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(0)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(0)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(0)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(0)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -154,7 +154,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -173,7 +173,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -192,7 +192,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -211,7 +211,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -230,7 +230,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -249,7 +249,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -268,7 +268,7 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
 
         // Then
         verify(
-            mockPirWebOnboardingStateHolder,
+            mockPirWebProfileStateHolder,
             org.mockito.kotlin.never(),
         ).removeAddressAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
@@ -281,13 +281,13 @@ class PirWebRemoveAddressAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 999}""",
             method = PirDashboardWebMessages.REMOVE_ADDRESS_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeAddressAtIndex(999)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeAddressAtIndex(999)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeAddressAtIndex(999)
+        verify(mockPirWebProfileStateHolder).removeAddressAtIndex(999)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,14 +37,14 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -60,13 +60,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(0)).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(0)).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(0)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -77,13 +77,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 2}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(2)).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(2)).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(2)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(2)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -94,13 +94,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 5}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(5)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(5)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(5)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(5)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -111,13 +111,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": -1}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(-1)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(-1)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(-1)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(-1)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -128,13 +128,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(0)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(0)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(0)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(0)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -150,7 +150,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -166,7 +166,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -182,7 +182,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -198,7 +198,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -214,7 +214,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -230,7 +230,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -246,7 +246,7 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).removeNameAtIndex(any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -257,13 +257,13 @@ class PirWebRemoveNameAtIndexFromCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 999}""",
             method = PirDashboardWebMessages.REMOVE_NAME_AT_INDEX_FROM_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.removeNameAtIndex(999)).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.removeNameAtIndex(999)).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).removeNameAtIndex(999)
+        verify(mockPirWebProfileStateHolder).removeNameAtIndex(999)
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages.SAVE_PROFILE
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.duckduckgo.pir.impl.models.Address
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
@@ -55,7 +55,7 @@ class PirWebSaveProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebSaveProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockRepository: PirRepository = mock()
     private val mockContext: Context = mock()
     private val mockScanScheduler: PirScanScheduler = mock()
@@ -67,7 +67,7 @@ class PirWebSaveProfileMessageHandlerTest {
     @Before
     fun setUp() {
         testee = PirWebSaveProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
             repository = mockRepository,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             context = mockContext,
@@ -86,17 +86,17 @@ class PirWebSaveProfileMessageHandlerTest {
     fun whenProcessWithIncompleteProfileThenSendsErrorResponse() = runTest {
         // Given
         val jsMessage = createJsMessage("""""", SAVE_PROFILE)
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).isProfileComplete
+        verify(mockPirWebProfileStateHolder).isProfileComplete
         verify(mockRepository, never()).saveProfileQueries(any())
         verify(mockContext, never()).startForegroundService(any())
         verify(mockScanScheduler, never()).scheduleScans()
-        verify(mockPirWebOnboardingStateHolder, never()).clear()
+        verify(mockPirWebProfileStateHolder, never()).clear()
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -108,9 +108,9 @@ class PirWebSaveProfileMessageHandlerTest {
         val currentDateTime = LocalDateTime.of(currentYear, 1, 1, 0, 0)
         val profileQueries = listOf(createProfileQuery())
 
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-        whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             profileQueries,
         )
         whenever(mockRepository.saveProfileQueries(profileQueries)).thenReturn(false)
@@ -119,11 +119,11 @@ class PirWebSaveProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).isProfileComplete
+        verify(mockPirWebProfileStateHolder).isProfileComplete
         verify(mockRepository).saveProfileQueries(profileQueries)
         verify(mockContext, never()).startForegroundService(any())
         verify(mockScanScheduler, never()).scheduleScans()
-        verify(mockPirWebOnboardingStateHolder, never()).clear()
+        verify(mockPirWebProfileStateHolder, never()).clear()
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -136,9 +136,9 @@ class PirWebSaveProfileMessageHandlerTest {
             val currentDateTime = LocalDateTime.of(currentYear, 6, 15, 10, 30)
             val profileQueries = listOf(createProfileQuery())
 
-            whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+            whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
             whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-            whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+            whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
                 profileQueries,
             )
             whenever(mockRepository.saveProfileQueries(profileQueries)).thenReturn(true)
@@ -147,11 +147,11 @@ class PirWebSaveProfileMessageHandlerTest {
             testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
             // Then
-            verify(mockPirWebOnboardingStateHolder).isProfileComplete
+            verify(mockPirWebProfileStateHolder).isProfileComplete
             verify(mockRepository).saveProfileQueries(profileQueries)
             verifyResponse(jsMessage, true, mockJsMessaging)
             verifyStartAndScheduleInitialScan()
-            verify(mockPirWebOnboardingStateHolder).clear()
+            verify(mockPirWebProfileStateHolder).clear()
         }
 
     @Test
@@ -164,9 +164,9 @@ class PirWebSaveProfileMessageHandlerTest {
         val profileQuery2 = createProfileQuery(firstName = "Jane", lastName = "Smith")
         val profileQueries = listOf(profileQuery1, profileQuery2)
 
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-        whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             profileQueries,
         )
         whenever(mockRepository.saveProfileQueries(profileQueries)).thenReturn(true)
@@ -175,11 +175,11 @@ class PirWebSaveProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).isProfileComplete
+        verify(mockPirWebProfileStateHolder).isProfileComplete
         verify(mockRepository).saveProfileQueries(profileQueries)
         verifyResponse(jsMessage, true, mockJsMessaging)
         verifyStartAndScheduleInitialScan()
-        verify(mockPirWebOnboardingStateHolder).clear()
+        verify(mockPirWebProfileStateHolder).clear()
     }
 
     @Test
@@ -190,9 +190,9 @@ class PirWebSaveProfileMessageHandlerTest {
         val currentDateTime = LocalDateTime.of(currentYear, 7, 4, 12, 0)
         val emptyProfileQueries = emptyList<ProfileQuery>()
 
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-        whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             emptyProfileQueries,
         )
         whenever(mockRepository.saveProfileQueries(emptyProfileQueries)).thenReturn(true)
@@ -201,11 +201,11 @@ class PirWebSaveProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).isProfileComplete
+        verify(mockPirWebProfileStateHolder).isProfileComplete
         verify(mockRepository).saveProfileQueries(emptyProfileQueries)
         verifyResponse(jsMessage, true, mockJsMessaging)
         verifyStartAndScheduleInitialScan()
-        verify(mockPirWebOnboardingStateHolder).clear()
+        verify(mockPirWebProfileStateHolder).clear()
     }
 
     @Test
@@ -216,9 +216,9 @@ class PirWebSaveProfileMessageHandlerTest {
         val currentDateTime = LocalDateTime.of(currentYear, 3, 15, 8, 45)
         val profileQueries = listOf(createProfileQuery())
 
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-        whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             profileQueries,
         )
         whenever(mockRepository.saveProfileQueries(profileQueries)).thenReturn(true)
@@ -230,7 +230,7 @@ class PirWebSaveProfileMessageHandlerTest {
         verify(mockRepository).saveProfileQueries(profileQueries)
         verifyResponse(jsMessage, true, mockJsMessaging)
         verifyStartAndScheduleInitialScan()
-        verify(mockPirWebOnboardingStateHolder).clear()
+        verify(mockPirWebProfileStateHolder).clear()
     }
 
     @Test
@@ -241,9 +241,9 @@ class PirWebSaveProfileMessageHandlerTest {
         val currentDateTime = LocalDateTime.of(currentYear, 1, 1, 0, 0)
         val profileQueries = listOf(createProfileQuery())
 
-        whenever(mockPirWebOnboardingStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
-        whenever(mockPirWebOnboardingStateHolder.toProfileQueries(currentYear)).thenReturn(
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             profileQueries,
         )
         whenever(mockRepository.saveProfileQueries(profileQueries)).thenReturn(true)
@@ -252,11 +252,11 @@ class PirWebSaveProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, null)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).isProfileComplete
+        verify(mockPirWebProfileStateHolder).isProfileComplete
         verify(mockRepository).saveProfileQueries(profileQueries)
         verifyResponse(jsMessage, true, mockJsMessaging)
         verifyStartAndScheduleInitialScan()
-        verify(mockPirWebOnboardingStateHolder).clear()
+        verify(mockPirWebProfileStateHolder).clear()
     }
 
     private fun createProfileQuery(

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,14 +37,14 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -60,13 +60,13 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0, "address": {"city": "New York", "state": "NY"}}""",
             method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(0, "New York", "NY")
+        verify(mockPirWebProfileStateHolder).setAddressAtIndex(0, "New York", "NY")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -77,13 +77,13 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 1, "address": {"city": "  Los Angeles  ", "state": "  CA  "}}""",
             method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(1, "Los Angeles", "CA")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.setAddressAtIndex(1, "Los Angeles", "CA")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(1, "Los Angeles", "CA")
+        verify(mockPirWebProfileStateHolder).setAddressAtIndex(1, "Los Angeles", "CA")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -94,13 +94,13 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"address": {"city": "Chicago", "state": "IL"}}""",
             method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "Chicago", "IL")).thenReturn(true)
+        whenever(mockPirWebProfileStateHolder.setAddressAtIndex(0, "Chicago", "IL")).thenReturn(true)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -116,7 +116,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -132,7 +132,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -148,7 +148,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -164,7 +164,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -180,7 +180,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -196,7 +196,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -212,7 +212,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -228,7 +228,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -239,13 +239,13 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 0, "address": {"city": "New York", "state": "NY"}}""",
             method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(0, "New York", "NY")
+        verify(mockPirWebProfileStateHolder).setAddressAtIndex(0, "New York", "NY")
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -256,13 +256,13 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 5, "address": {"city": "New York", "state": "NY"}}""",
             method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(5, "New York", "NY")).thenReturn(false)
+        whenever(mockPirWebProfileStateHolder.setAddressAtIndex(5, "New York", "NY")).thenReturn(false)
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(5, "New York", "NY")
+        verify(mockPirWebProfileStateHolder).setAddressAtIndex(5, "New York", "NY")
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -278,7 +278,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -294,7 +294,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -310,7 +310,7 @@ class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfileTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfileTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -35,14 +35,14 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
 
     private lateinit var testee: PirWebSetBirthYearForCurrentUserProfile
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebSetBirthYearForCurrentUserProfile(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -66,7 +66,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(1990)
+        verify(mockPirWebProfileStateHolder).setBirthYear(1990)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -82,7 +82,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(1985)
+        verify(mockPirWebProfileStateHolder).setBirthYear(1985)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -98,7 +98,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -114,7 +114,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(-1)
+        verify(mockPirWebProfileStateHolder).setBirthYear(-1)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -130,7 +130,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(2030)
+        verify(mockPirWebProfileStateHolder).setBirthYear(2030)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -146,7 +146,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -162,7 +162,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -178,7 +178,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then - The exact behavior depends on JSON parsing, but it should set some value
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(org.mockito.kotlin.any())
+        verify(mockPirWebProfileStateHolder).setBirthYear(org.mockito.kotlin.any())
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -194,7 +194,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -210,7 +210,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -226,7 +226,7 @@ class PirWebSetBirthYearForCurrentUserProfileTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verify(mockPirWebProfileStateHolder).setBirthYear(0)
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages.SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
-import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,14 +37,14 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
 
     private lateinit var testee: PirWebSetNameAtIndexInCurrentUserProfileMessageHandler
 
-    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockPirWebProfileStateHolder: PirWebProfileStateHolder = mock()
     private val mockJsMessaging: JsMessaging = mock()
     private val mockJsMessageCallback: JsMessageCallback = mock()
 
     @Before
     fun setUp() {
         testee = PirWebSetNameAtIndexInCurrentUserProfileMessageHandler(
-            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+            pirWebProfileStateHolder = mockPirWebProfileStateHolder,
         )
     }
 
@@ -61,7 +61,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.setNameAtIndex(
+            mockPirWebProfileStateHolder.setNameAtIndex(
                 0,
                 "John",
                 "Michael",
@@ -73,7 +73,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -84,7 +84,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 1, "name": {"first": "Jane", "last": "Smith"}}""",
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setNameAtIndex(1, "Jane", "", "Smith")).thenReturn(
+        whenever(mockPirWebProfileStateHolder.setNameAtIndex(1, "Jane", "", "Smith")).thenReturn(
             true,
         )
 
@@ -92,7 +92,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(1, "Jane", "", "Smith")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(1, "Jane", "", "Smith")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -104,7 +104,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.setNameAtIndex(
+            mockPirWebProfileStateHolder.setNameAtIndex(
                 0,
                 "Bob",
                 "",
@@ -116,7 +116,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "Bob", "", "Johnson")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(0, "Bob", "", "Johnson")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -128,7 +128,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.setNameAtIndex(
+            mockPirWebProfileStateHolder.setNameAtIndex(
                 2,
                 "Alice",
                 "Marie",
@@ -140,7 +140,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(2, "Alice", "Marie", "Brown")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(2, "Alice", "Marie", "Brown")
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
@@ -152,7 +152,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.setNameAtIndex(
+            mockPirWebProfileStateHolder.setNameAtIndex(
                 0,
                 "Charlie",
                 "",
@@ -164,7 +164,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -185,7 +185,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -206,7 +206,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -227,7 +227,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -248,7 +248,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -269,7 +269,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -290,7 +290,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -311,7 +311,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -332,7 +332,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -349,7 +349,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
         whenever(
-            mockPirWebOnboardingStateHolder.setNameAtIndex(
+            mockPirWebProfileStateHolder.setNameAtIndex(
                 0,
                 "John",
                 "Michael",
@@ -361,7 +361,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -372,7 +372,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
             paramsJson = """{"index": 5, "name": {"first": "John", "last": "Doe"}}""",
             method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
         )
-        whenever(mockPirWebOnboardingStateHolder.setNameAtIndex(5, "John", "", "Doe")).thenReturn(
+        whenever(mockPirWebProfileStateHolder.setNameAtIndex(5, "John", "", "Doe")).thenReturn(
             false,
         )
 
@@ -380,7 +380,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(5, "John", "", "Doe")
+        verify(mockPirWebProfileStateHolder).setNameAtIndex(5, "John", "", "Doe")
         verifyResponse(jsMessage, false, mockJsMessaging)
     }
 
@@ -396,7 +396,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -417,7 +417,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),
@@ -438,7 +438,7 @@ class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
 
         // Then
-        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+        verify(mockPirWebProfileStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
             any(),
             any(),
             any(),

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirWebProfileStateHolderTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirWebProfileStateHolderTest.kt
@@ -22,13 +22,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-class RealPirWebOnboardingStateHolderTest {
+class RealPirWebProfileStateHolderTest {
 
-    private lateinit var testee: RealPirWebOnboardingStateHolder
+    private lateinit var testee: RealPirWebProfileStateHolder
 
     @Before
     fun setUp() {
-        testee = RealPirWebOnboardingStateHolder()
+        testee = RealPirWebProfileStateHolder()
     }
 
     @Test

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirWebProfileStateHolderTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirWebProfileStateHolderTest.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.pir.impl.dashboard.state
 
+import com.duckduckgo.pir.impl.models.Address
+import com.duckduckgo.pir.impl.models.ProfileQuery
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -29,6 +31,220 @@ class RealPirWebProfileStateHolderTest {
     @Before
     fun setUp() {
         testee = RealPirWebProfileStateHolder()
+    }
+
+    // Tests for setLoadedProfileQueries method
+    @Test
+    fun whenSetLoadedProfileQueriesWithSingleProfileThenLoadsCorrectly() {
+        // Given
+        val profileQuery = createProfileQuery(
+            firstName = "John",
+            middleName = "Michael",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            birthYear = 1990,
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(profileQuery))
+
+        // Then
+        assertTrue(testee.isProfileComplete)
+        val resultProfiles = testee.toProfileQueries(2025)
+        assertEquals(1, resultProfiles.size)
+        with(resultProfiles[0]) {
+            assertEquals("John", firstName)
+            assertEquals("Michael", middleName)
+            assertEquals("Doe", lastName)
+            assertEquals("New York", city)
+            assertEquals("NY", state)
+            assertEquals(1990, birthYear)
+        }
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesWithMultipleProfilesThenDeduplicatesNamesAndAddresses() {
+        // Given
+        val profile1 = createProfileQuery(
+            firstName = "John",
+            middleName = "Michael",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            birthYear = 1990,
+        )
+        val profile2 = createProfileQuery(
+            firstName = "John", // Same name
+            middleName = "Michael",
+            lastName = "Doe",
+            city = "Los Angeles", // Different address
+            state = "CA",
+            birthYear = 1990,
+        )
+        val profile3 = createProfileQuery(
+            firstName = "Jane", // Different name
+            middleName = null,
+            lastName = "Smith",
+            city = "New York", // Same address as profile1
+            state = "NY",
+            birthYear = 1985,
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(profile1, profile2, profile3))
+
+        // Then
+        assertTrue(testee.isProfileComplete)
+        val resultProfiles = testee.toProfileQueries(2025)
+        assertEquals(4, resultProfiles.size) // 2 names × 2 addresses
+
+        // Verify combinations
+        val combinations = resultProfiles.map { "${it.firstName} ${it.lastName} - ${it.city}, ${it.state}" }
+        assertTrue(combinations.contains("John Doe - New York, NY"))
+        assertTrue(combinations.contains("John Doe - Los Angeles, CA"))
+        assertTrue(combinations.contains("Jane Smith - New York, NY"))
+        assertTrue(combinations.contains("Jane Smith - Los Angeles, CA"))
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesWithBlankMiddleNameThenIgnoresMiddleName() {
+        // Given
+        val profileWithBlankMiddle = createProfileQuery(
+            firstName = "John",
+            middleName = "   ", // Blank middle name
+            lastName = "Doe",
+            city = "Boston",
+            state = "MA",
+            birthYear = 1990,
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(profileWithBlankMiddle))
+
+        // Then
+        val resultProfiles = testee.toProfileQueries(2025)
+        assertEquals(1, resultProfiles.size)
+        assertEquals(null, resultProfiles[0].middleName) // Should be null, not blank
+        assertEquals("John Doe", resultProfiles[0].fullName) // Should not include middle name
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesWithMultipleBirthYearsThenUsesFirstNonZero() {
+        // Given
+        val profile1 = createProfileQuery(
+            firstName = "John",
+            lastName = "Doe",
+            city = "City1",
+            state = "ST",
+            birthYear = 0, // Zero birth year
+        )
+        val profile2 = createProfileQuery(
+            firstName = "Jane",
+            lastName = "Smith",
+            city = "City2",
+            state = "ST",
+            birthYear = 1990, // First non-zero
+        )
+        val profile3 = createProfileQuery(
+            firstName = "Bob",
+            lastName = "Johnson",
+            city = "City3",
+            state = "ST",
+            birthYear = 1985, // Second non-zero, should be ignored
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(profile1, profile2, profile3))
+
+        // Then
+        val resultProfiles = testee.toProfileQueries(2025)
+        resultProfiles.forEach { profile ->
+            assertEquals(1990, profile.birthYear) // All should have the first non-zero birth year
+            assertEquals(35, profile.age) // Age calculated from 1990
+        }
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesCalledThenClearsExistingData() {
+        // Given - Add some initial data
+        testee.addName("Initial", null, "Name")
+        testee.addAddress("Initial City", "IC")
+        testee.setBirthYear(2000)
+        assertTrue(testee.isProfileComplete)
+
+        val newProfile = createProfileQuery(
+            firstName = "New",
+            lastName = "Profile",
+            city = "New City",
+            state = "NC",
+            birthYear = 1995,
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(newProfile))
+
+        // Then - Only new data should exist
+        val resultProfiles = testee.toProfileQueries(2025)
+        assertEquals(1, resultProfiles.size)
+        with(resultProfiles[0]) {
+            assertEquals("New", firstName)
+            assertEquals("Profile", lastName)
+            assertEquals("New City", city)
+            assertEquals("NC", state)
+            assertEquals(1995, birthYear)
+        }
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesWithEmptyListThenClearsAll() {
+        // Given - Add some initial data
+        testee.addName("Test", null, "User")
+        testee.addAddress("Test City", "TC")
+        testee.setBirthYear(1990)
+        assertTrue(testee.isProfileComplete)
+
+        // When
+        testee.setLoadedProfileQueries(emptyList())
+
+        // Then
+        assertFalse(testee.isProfileComplete)
+        assertEquals(0, testee.toProfileQueries(2025).size)
+    }
+
+    @Test
+    fun whenSetLoadedProfileQueriesWithDuplicateProfilesThenDeduplicates() {
+        // Given - Identical profiles
+        val profile1 = createProfileQuery(
+            firstName = "John",
+            middleName = "Michael",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            birthYear = 1990,
+        )
+        val profile2 = createProfileQuery(
+            firstName = "John",
+            middleName = "Michael",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            birthYear = 1990,
+        )
+
+        // When
+        testee.setLoadedProfileQueries(listOf(profile1, profile2))
+
+        // Then - Should only have one combination since name and address are identical
+        val resultProfiles = testee.toProfileQueries(2025)
+        assertEquals(1, resultProfiles.size)
+        with(resultProfiles[0]) {
+            assertEquals("John", firstName)
+            assertEquals("Michael", middleName)
+            assertEquals("Doe", lastName)
+            assertEquals("New York", city)
+            assertEquals("NY", state)
+        }
     }
 
     @Test
@@ -453,5 +669,28 @@ class RealPirWebProfileStateHolderTest {
         assertTrue(addressResult)
         assertTrue(birthYearResult)
         assertTrue(testee.isProfileComplete)
+    }
+
+    private fun createProfileQuery(
+        firstName: String,
+        middleName: String? = null,
+        lastName: String,
+        city: String,
+        state: String,
+        birthYear: Int,
+    ): ProfileQuery {
+        return ProfileQuery(
+            id = 1L,
+            firstName = firstName,
+            middleName = middleName,
+            lastName = lastName,
+            city = city,
+            state = state,
+            addresses = listOf(Address(city, state)),
+            birthYear = birthYear,
+            fullName = if (middleName != null) "$firstName $middleName $lastName" else "$firstName $lastName",
+            age = 2025 - birthYear,
+            deprecated = false,
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210822763676213?focus=true

### Description
Adds support for storing, deleting and updating profiles as a result of profile edit.

Note: handling scan/opt-out jobs will be done in next PRs, this only contains the profile storing logic

There are three commits:
- First one is renaming only - no actual code changes
- Second one has the changes needed to support the storing logic
- Third one updates tests

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1211524792263651?focus=true

### UI changes
No UI changes