### PR TITLE
Fix: Fix widget crash on older devices

### DIFF
--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
@@ -67,11 +66,7 @@ class FavoritesWidgetItemFactory(
         AppWidgetManager.INVALID_APPWIDGET_ID,
     )
 
-    private val faviconItemSize = if (Build.VERSION.SDK_INT >= 32) {
-        context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt()
-    } else {
-        context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt() / 2
-    }
+    private val faviconItemSize = context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt()
     private val faviconItemCornerRadius = CommonR.dimen.searchWidgetFavoritesCornerRadius
 
     private val maxItems: Int

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
@@ -20,6 +20,7 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
@@ -64,7 +65,11 @@ class FavoritesWidgetItemFactory(
         AppWidgetManager.INVALID_APPWIDGET_ID,
     )
 
-    private val faviconItemSize = context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt()
+    private val faviconItemSize = if (Build.VERSION.SDK_INT >= 32) {
+        context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt()
+    } else {
+        context.resources.getDimension(CommonR.dimen.savedSiteGridItemFavicon).toInt() / 2
+    }
     private val faviconItemCornerRadius = CommonR.dimen.searchWidgetFavoritesCornerRadius
 
     private val maxItems: Int

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -20,4 +20,5 @@
         name="external_files"
         path="." />
     <cache-path name="sync" path="sync" />
+    <cache-path name="favicons" path="favicons/" />
 </paths>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1211540781460014?focus=true

### Description

### Steps to test this PR

Run the app on device API < 32 and add a search widget with favorites.
