### PR TITLE
Fix tab switcher menu button visibility on real devices

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
@@ -141,7 +141,10 @@ fun Menu.createDynamicInterface(
         }
     }
 
-    findItem(R.id.popupMenuToolbarButton).isEnabled = dynamicMenu.isMenuButtonEnabled
+    findItem(R.id.popupMenuToolbarButton).apply {
+        isEnabled = dynamicMenu.isMenuButtonEnabled
+        isVisible = true // Always show the menu button regardless of enabled state
+    }
     findItem(R.id.fireToolbarButton).isVisible = dynamicMenu.isFireButtonVisible
     findItem(R.id.duckAIToolbarButton).isVisible = dynamicMenu.isDuckAIButtonVisible
     findItem(R.id.newTabToolbarButton).isVisible = dynamicMenu.isNewTabButtonVisible


### PR DESCRIPTION
## Description

Fixes #6702 - Tab switcher '...' menu is invisible

The issue was that the popup menu button was only having its `isEnabled` property set, but not its `isVisible` property. On some Android devices and different Android versions/themes, disabled menu items can become invisible or very faint, which caused the menu to not appear on real devices while still being visible on virtual devices.

## Changes Made

- Explicitly set `isVisible = true` for the popup menu toolbar button in `TabSwitcherMenuExt.kt`
- Added comment explaining the fix for future reference
- Ensured the menu button is always visible regardless of enabled state

## Testing

The fix addresses the root cause by ensuring the menu button visibility is explicitly controlled, which should resolve the difference in behavior between virtual and real devices.

## Root Cause Analysis

The issue occurred because:
1. The menu button was only having `isEnabled` set based on `dynamicMenu.isMenuButtonEnabled`
2. Different Android devices/versions handle disabled menu items differently - some make them invisible or very faint
3. Virtual devices may use a different theme or rendering that keeps disabled items visible
4. Real devices were applying system-level theming that hid disabled menu items

This fix ensures consistent behavior across all devices by explicitly controlling visibility.