### PR TITLE
Fix BadTokenException when showing NewAddressBarOptionBottomSheetDialog

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
@@ -175,7 +175,7 @@ class NewAddressBarOptionBottomSheetDialog(
 
             if (pendingShow) {
                 pendingShow = false
-                show()
+                if (isWindowValid()) { super.show() }
             }
         }
     }
@@ -246,7 +246,7 @@ class NewAddressBarOptionBottomSheetDialog(
                     playIntroThenLoop(lottieView, it.durationFrames.toInt())
                 }
             }
-            super.show()
+            if (isWindowValid()) { super.show() }
         } else {
             pendingShow = true
         }
@@ -256,6 +256,10 @@ class NewAddressBarOptionBottomSheetDialog(
         super.onDetachedFromWindow()
         restoreOrientation()
     }
+
+    private fun isWindowValid(): Boolean = (context as? Activity)?.let { activity ->
+        !activity.isFinishing && !activity.isDestroyed && activity.window?.decorView?.isAttachedToWindow == true
+    } ?: false
 
     companion object {
         const val MAX_HEIGHT_DP = 900


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211555187913871?focus=true

### Description

- Adds a `isWindowValid` check before displaying the dialog.

### Steps to test this PR

- [x] Fresh install the app
- [x] Complete onboarding (Use "I’ve been here before", **not** “Skip Onboarding”) and kill the app
- [x] Verify that the New Address Bar Option Dialog is displayed