### PR TITLE
Update AndroidX Compose BOM version to 2025.10.00

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version.androidx.arch.core=2.2.0
 
 version.androidx.browser=1.8.0
 
-version.androidx.compose=2025.09.01
+version.androidx.compose=2025.10.00
 
 # Cannot update past 1.5.14 because we need Kotlin 2.x
 version.androidx.compose.compiler=1.5.14


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211599412417503?focus=true

Dependency update:

Increased the value of `version.androidx.compose` from `2025.09.01` to `2025.10.00` in `versions.properties` to use a newer Compose release.

### Description

### Steps to test this PR

- [x] Build and run

### UI changes
N/A
