### PR TITLE
Update content scope scripts to version 11.34.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -8932,7 +8932,7 @@
           return this.messaging.notify("actionError", { error: "No response found, exceptions: " + exceptions.join(", ") });
         }
       } catch (e) {
-        console.log("unhandled exception: ", e);
+        this.log.error("unhandled exception: ", e);
         return this.messaging.notify("actionError", { error: e.toString() });
       }
     }
@@ -9353,7 +9353,7 @@
             }
           }
         } catch {
-          console.error("password-import: failed for path:", pathname);
+          this.log.error("password-import: failed for path:", pathname);
         }
       }
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8901,7 +8901,7 @@
           return this.messaging.notify("actionError", { error: "No response found, exceptions: " + exceptions.join(", ") });
         }
       } catch (e) {
-        console.log("unhandled exception: ", e);
+        this.log.error("unhandled exception: ", e);
         return this.messaging.notify("actionError", { error: e.toString() });
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.33.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.34.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#258da982bc2c2d714fa11a47b4c5e598b15a7c5f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ceae5e5694bfe0cb7f09ecd589f44b887e99841b",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.12.3.tgz",
-      "integrity": "sha512-n0xxiQ96tZYN9RmV3v1hDXI/qx90zjqRmJdynQDXy7ZCP5H8rXJyBFn8YSKOXEUT0ZTY5MKDcqYEHHkoGl4E8w==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.12.4.tgz",
+      "integrity": "sha512-lUrMCeReX72IQ+xK6tAcROAVDn+OknW/kTokMcII9TJf6axUzpjM+v0shBYbsMghliADFz8P/dgArC2oCix9Eg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.12.3",
-        "@ghostery/adblocker-extended-selectors": "^2.12.3",
+        "@ghostery/adblocker-content": "^2.12.4",
+        "@ghostery/adblocker-extended-selectors": "^2.12.4",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.12.3.tgz",
-      "integrity": "sha512-GfcPbmKvZpB7Vj/GHDYu21uoarKxUU/912iW8n4Glcbrv+zgXU3OGBT7WxIAUbjKBBGeAu/nE84gRfh9phsJ0A==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.12.4.tgz",
+      "integrity": "sha512-JACPKvhfioE0jhzvoViljWu3eiFZ0oP3F3IKDOqIRuHywTa63W3ZXEiX4crKKPiLNp1kPsuFV7YRv5l2GJxNDg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.12.3"
+        "@ghostery/adblocker-extended-selectors": "^2.12.4"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.12.3.tgz",
-      "integrity": "sha512-1FxAb9a5xFBPs1+u0y8vJexXzcs2ThtTEdlbZ8EQ/Do4HXB1JIBOPxYluLvgcxCdb6xfVM8H+x8P5NWJs3TnAA==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.12.4.tgz",
+      "integrity": "sha512-t6AQiLgXjZBeXRlMX59RataQWGeghaYB4u7EGIrFrhl6DkJjwneWLirXfeyQVVAai5R2TZ6Br0UCA4P/i3UNDA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
-      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
-      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
+      "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.16.tgz",
-      "integrity": "sha512-ZAAIaD4KpdU6l8A0Sf0FI9mD2RZSW41cEu4DQD/i9EMZTR3txaWyWecQpTSJF62tI9/rc9+vdtopWFmdC9XMjA==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.17.tgz",
+      "integrity": "sha512-NGYJUDuOyb5UzoOKLufzSY2hLSlu7uEdobD+VzkWexuYOr/dqHnGhLRUoVWv1aifLV9gwBTY3XObCAnCnEA81w==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.16"
+        "tldts-core": "^7.0.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.33.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.34.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211605368706687/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run