### PR TITLE
Remove fireproofedWebLocalStorage subfeature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
@@ -61,12 +61,8 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
             val settings = androidBrowserConfigFeature.webLocalStorage().getSettings()
             val webLocalStorageSettings = webLocalStorageSettingsJsonParser.parseJson(settings)
 
-            val fireproofedDomains = if (androidBrowserConfigFeature.fireproofedWebLocalStorage().isEnabled()) {
-                withContext(dispatcherProvider.io()) {
-                    fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
-                }
-            } else {
-                emptyList()
+            val fireproofedDomains = withContext(dispatcherProvider.io()) {
+                fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
             }
 
             domains = webLocalStorageSettings.domains.list + fireproofedDomains

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -103,14 +103,6 @@ interface AndroidBrowserConfigFeature {
     fun enableMaliciousSiteProtection(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "fireproofedWebLocalStorage" androidBrowserConfig
-     * sub-feature flag enabled
-     * If the remote feature is not present defaults to `false`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun fireproofedWebLocalStorage(): Toggle
-
-    /**
      * @return `true` when the remote config has the global "fireproofedIndexedDB" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211602646006974?focus=true

### Description

- Removes the `fireproofedWebLocalStorage` toggle which is no longer needed.

### Steps to test this PR

- [ ] Go to example.com
- [ ] Fireproof site
- [ ] Use the fire button
- [ ] In logcat, verify that you see `WebLocalStorageManager: Allowed domains: [duckduckgo.com, example.com]`
