### PR TITLE
Call stop loading before start/remove on protections changed

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7080,6 +7080,28 @@ class BrowserTabViewModelTest {
         }
 
     @Test
+    fun whenPrivacyProtectionsUpdatedAndUpdateScriptOnProtectionsChangedEnabledAndStopLoadingBeforeUpdatingScriptEnabledThenStopLoading() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.updateScriptOnProtectionsChanged().setRawStoredState(State(true))
+            fakeAndroidConfigBrowserFeature.stopLoadingBeforeUpdatingScript().setRawStoredState(State(true))
+
+            testee.privacyProtectionsUpdated(mockWebView)
+
+            verify(mockWebView).stopLoading()
+        }
+
+    @Test
+    fun whenPrivacyProtectionsUpdatedAndUpdateScriptOnProtectionsChangedEnabledAndStopLoadingBeforeUpdatingScriptDisabledThenDoNotStopLoading() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.updateScriptOnProtectionsChanged().setRawStoredState(State(true))
+            fakeAndroidConfigBrowserFeature.stopLoadingBeforeUpdatingScript().setRawStoredState(State(false))
+
+            testee.privacyProtectionsUpdated(mockWebView)
+
+            verify(mockWebView, never()).stopLoading()
+        }
+
+    @Test
     fun whenPrivacyProtectionsUpdatedAndUpdateScriptOnPageFinishedTrueAndUpdateScriptOnProtectionsChangedFalseThenNotAddDocumentStartJavaScript() =
         runTest {
             fakeAndroidConfigBrowserFeature.updateScriptOnPageFinished().setRawStoredState(State(true))

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -186,4 +186,7 @@ interface AndroidBrowserConfigFeature {
 
     @Toggle.DefaultValue(TRUE)
     fun updateScriptOnProtectionsChanged(): Toggle
+
+    @Toggle.DefaultValue(FALSE)
+    fun stopLoadingBeforeUpdatingScript(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211636309916115?focus=true

### Description
Call stop loading before start/remove on protections changed

### Steps to test this PR

_Feature 1_
- [ ] Enable `stopLoadingBeforeUpdatingScript` and `useNewWebCompatApis`
- [ ] Load a site
- [ ] Toggle protections on/off
- [ ] Check `stopLoading` is called and then the site is reloaded as normal

### UI changes
n/a
