### PR TITLE
launch and submit voice search automatically from widgets

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -223,7 +223,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             intent?.let {
                 sendLaunchPixels(it)
                 if (duckAiFeatureState.showInputScreenOnSystemSearchLaunch.value) {
-                    launchInputScreen(isTopOmnibar = isOmnibarAtTop)
+                    launchInputScreen(isTopOmnibar = isOmnibarAtTop, intent = it)
                 } else {
                     handleVoiceSearchLaunch(it)
                 }
@@ -257,13 +257,13 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         sendLaunchPixels(intent)
         if (duckAiFeatureState.showInputScreenOnSystemSearchLaunch.value) {
             val isOmnibarAtTop = settingsDataStore.omnibarPosition == OmnibarPosition.TOP
-            launchInputScreen(isTopOmnibar = isOmnibarAtTop)
+            launchInputScreen(isTopOmnibar = isOmnibarAtTop, intent = intent)
         } else {
             handleVoiceSearchLaunch(intent)
         }
     }
 
-    private fun launchInputScreen(isTopOmnibar: Boolean) {
+    private fun launchInputScreen(isTopOmnibar: Boolean, intent: Intent) {
         globalActivityStarter.startIntent(
             this,
             InputScreenActivityParams(
@@ -271,6 +271,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                 isTopOmnibar = isTopOmnibar,
                 browserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
                 showInstalledApps = true,
+                launchWithVoice = launchVoice(intent),
             ),
         )?.let {
             inputScreenLauncher.launch(it)
@@ -425,7 +426,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     private fun configureVoiceSearch() {
         voiceSearchLauncher.registerResultsCallback(this, this, WIDGET) {
             if (it is VoiceSearchLauncher.Event.VoiceRecognitionSuccess) {
-                viewModel.onUserSelectedToEditQuery(it.result)
+                viewModel.onVoiceSearchResult(it.result)
             } else if (it is VoiceSearchLauncher.Event.VoiceSearchDisabled) {
                 viewModel.onVoiceSearchStateChanged()
             }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -296,6 +296,10 @@ class SystemSearchViewModel @Inject constructor(
         command.value = Command.EditQuery(query)
     }
 
+    fun onVoiceSearchResult(capturedText: String) {
+        command.value = Command.LaunchBrowser(query = capturedText)
+    }
+
     fun onVoiceSearchStateChanged() {
         voiceSearchState.tryEmit(Unit)
     }

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -350,6 +350,14 @@ class SystemSearchViewModelTest {
     }
 
     @Test
+    fun `when voice search result then launch browser`() {
+        val query = "test"
+        testee.onVoiceSearchResult(capturedText = query)
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(Command.LaunchBrowser(query), commandCaptor.lastValue)
+    }
+
+    @Test
     fun whenQuickAccessItemClickedThenLaunchBrowser() {
         val quickAccessItem = QuickAccessFavorite(Favorite("favorite1", "title", "http://example.com", "timestamp", 0))
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -28,12 +28,14 @@ import java.io.Serializable
  * @param isTopOmnibar whether the omnibar is positioned at the top of the screen
  * @param browserButtonsConfig configuration for displaying browser buttons (Fire Button, Tab Switcher, Menu)
  * @param showInstalledApps whether apps installed on the device should appear in autocomplete results
+ * @param launchWithVoice whether to immediately launch voice input on activity start, if supported and enabled
  */
 data class InputScreenActivityParams(
     val query: String,
     val isTopOmnibar: Boolean,
     val browserButtonsConfig: InputScreenBrowserButtonsConfig,
     val showInstalledApps: Boolean = false,
+    val launchWithVoice: Boolean = false,
 ) : GlobalActivityStarter.ActivityParams
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolver.kt
@@ -32,6 +32,8 @@ interface InputScreenConfigResolver {
 
     fun shouldShowInstalledApps(): Boolean
 
+    fun shouldLaunchVoiceSearch(): Boolean
+
     fun useTopBar(): Boolean
 
     fun mainButtonsEnabled(): Boolean
@@ -57,6 +59,11 @@ class InputScreenConfigResolverImpl @Inject constructor(
     override fun shouldShowInstalledApps(): Boolean {
         val params = appCompatActivity.intent?.getActivityParams(InputScreenActivityParams::class.java)
         return params?.showInstalledApps ?: false
+    }
+
+    override fun shouldLaunchVoiceSearch(): Boolean {
+        val params = appCompatActivity.intent.getActivityParams(InputScreenActivityParams::class.java)
+        return params?.launchWithVoice ?: false
     }
 
     override fun useTopBar(): Boolean =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -481,6 +481,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                     }
                 }
             }.launchIn(lifecycleScope)
+        if (inputScreenConfigResolver.shouldLaunchVoiceSearch()) {
+            voiceSearchLauncher.launch(requireActivity())
+        }
     }
 
     private fun configureInputScreenButtons() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
@@ -249,11 +249,30 @@ class InputScreenConfigResolverTest {
         assertFalse(inputScreenConfigResolver.shouldShowInstalledApps())
     }
 
+    @Test
+    fun `when launchWithVoice is false then shouldLaunchVoiceSearch should return false`() {
+        val intent = createIntent(launchWithVoice = false)
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertFalse(inputScreenConfigResolver.shouldLaunchVoiceSearch())
+    }
+
+    @Test
+    fun `when launchWithVoice is true then shouldLaunchVoiceSearch should return true`() {
+        val intent = createIntent(launchWithVoice = true)
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertTrue(inputScreenConfigResolver.shouldLaunchVoiceSearch())
+    }
+
     private fun createIntent(
         query: String = "",
         isTopOmnibar: Boolean = true,
         browserButtonsConfig: InputScreenBrowserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
         showInstalledApps: Boolean = false,
+        launchWithVoice: Boolean = false,
     ) = Intent().apply {
         putExtra(
             "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
@@ -262,6 +281,7 @@ class InputScreenConfigResolverTest {
                 isTopOmnibar = isTopOmnibar,
                 browserButtonsConfig = browserButtonsConfig,
                 showInstalledApps = showInstalledApps,
+                launchWithVoice = launchWithVoice,
             ),
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211589372131525?focus=true

### Description
Ensure that if a voice input request is launched from a widget, it auto-submits the captured text to search.

### Steps to test this PR

- [x] Install the app and enable voice search.
- [x] Add a widget to the main screen.
- [x] Click the voice icon on the widget and verify that input is auto-submitted to search.
- [x] Go to Settings -> AI Features and enable the Search & Duck.ai address bar.
- [x] Go to Feature Flag Inventory and enable `showInputScreenOnSystemSearchLaunch`.
- [x] Force close and reopen the app. (this applies the flag change)
- [x] Click the voice icon on the widget and verify that input is auto-submitted to search.

