### PR TITLE
Add WebView specs to native crash pixel

### DIFF
--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation AndroidX.room.rxJava2
     implementation AndroidX.room.ktx
     implementation AndroidX.room.rxJava2
+    implementation AndroidX.webkit
 
     testImplementation project(':common-test')
     implementation project(':data-store-test')

--- a/anrs/anrs-impl/src/main/cpp/android.h
+++ b/anrs/anrs-impl/src/main/cpp/android.h
@@ -11,6 +11,8 @@ extern int loglevel;
 extern char pname[256];
 extern char appVersion[256];
 extern bool isCustomTab;
+extern char wvPackage[256];
+extern char wvVersion[256];
 
 // Use this method to print log messages into the console
 #define log_print(prio, format, ...) do { if (prio >= loglevel) __platform_log_print(prio, "ndk-crash", format, ##__VA_ARGS__); } while (0)

--- a/anrs/anrs-impl/src/main/cpp/jni.cpp
+++ b/anrs/anrs-impl/src/main/cpp/jni.cpp
@@ -13,6 +13,8 @@ int loglevel = 0;
 char appVersion[256];
 char pname[256];
 bool isCustomTab = false;
+char wvPackage[256];
+char wvVersion[256];
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -37,7 +39,9 @@ Java_com_duckduckgo_app_anr_ndk_NativeCrashInit_jni_1register_1sighandler(
         jint loglevel_,
         jstring version_,
         jstring pname_,
-        jboolean customtab_
+        jboolean customtab_,
+        jstring wvpackage_,
+        jstring wvversion_
 ) {
 
     if (!native_crash_handler_init()) {
@@ -59,6 +63,18 @@ Java_com_duckduckgo_app_anr_ndk_NativeCrashInit_jni_1register_1sighandler(
     strncpy(pname, pnameChars, sizeof(pname) - 1);
     pname[sizeof(pname) - 1] = '\0'; // Ensure null-termination
     env->ReleaseStringUTFChars(pname_, pnameChars);
+
+    // get and set webview package name
+    const char *wvpackageChars = env->GetStringUTFChars(wvpackage_, nullptr);
+    strncpy(wvPackage, wvpackageChars, sizeof(wvPackage) - 1);
+    wvPackage[sizeof(wvPackage) - 1] = '\0'; // Ensure null-termination
+    env->ReleaseStringUTFChars(wvpackage_, wvpackageChars);
+
+    // get and set webview version
+    const char *wvversionChars = env->GetStringUTFChars(wvversion_, nullptr);
+    strncpy(wvVersion, wvversionChars, sizeof(wvVersion) - 1);
+    wvVersion[sizeof(wvVersion) - 1] = '\0'; // Ensure null-termination
+    env->ReleaseStringUTFChars(wvversion_, wvversionChars);
 
     // get and set isCustomTabs
     isCustomTab = customtab_;

--- a/anrs/anrs-impl/src/main/cpp/pixel.cpp
+++ b/anrs/anrs-impl/src/main/cpp/pixel.cpp
@@ -56,7 +56,7 @@ static void send_request(const char* host, const char* path) {
 void send_crash_pixel() {
     const char* host = "improving.duckduckgo.com";
     char path[2048];
-    sprintf(path, "/t/m_app_native_crash_android?appVersion=%s&pn=%s&customTab=%s", appVersion, pname, isCustomTab ? "true" : "false");
+    sprintf(path, "/t/m_app_native_crash_android?appVersion=%s&pn=%s&customTab=%s&webViewPackage=%s&webViewVersion=%s", appVersion, pname, isCustomTab ? "true" : "false", wvPackage, wvVersion);
     send_request(host, path);
     log_print(ANDROID_LOG_ERROR, "Native crash pixel sent on %s", pname);
 }
@@ -64,7 +64,7 @@ void send_crash_pixel() {
 void send_crash_handle_init_pixel() {
     const char* host = "improving.duckduckgo.com";
     char path[2048];
-    sprintf(path, "/t/m_app_register_native_crash_handler_android?appVersion=%s&pn=%s&customTab=%s", appVersion, pname, isCustomTab ? "true" : "false");
+    sprintf(path, "/t/m_app_register_native_crash_handler_android?appVersion=%s&pn=%s&customTab=%s&webViewPackage=%s&webViewVersion=%s", appVersion, pname, isCustomTab ? "true" : "false", wvPackage, wvVersion);
     send_request(host, path);
     log_print(ANDROID_LOG_ERROR, "Native crash handler init pixel sent on %s", pname);
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewPackageSource.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewPackageSource.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.content.Context
+import androidx.webkit.WebViewCompat
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface WebViewPackageSource {
+    fun get(): String
+}
+
+@ContributesBinding(AppScope::class)
+class WebViewCompatWebViewPackageSource @Inject constructor(
+    private val context: Context,
+) : WebViewPackageSource {
+    override fun get(): String =
+        WebViewCompat.getCurrentWebViewPackage(context)?.packageName ?: ""
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewVersionProvider.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class DefaultWebViewVersionProvider @Inject constructor(
     private val webViewVersionSource: WebViewVersionSource,
+    private val webViewPackageSource: WebViewPackageSource,
 ) : WebViewVersionProvider {
     companion object {
         const val WEBVIEW_VERSION_DELIMITER = "."
@@ -34,6 +35,8 @@ class DefaultWebViewVersionProvider @Inject constructor(
 
     override fun getMajorVersion(): String =
         webViewVersionSource.get().captureMajorVersion().mapNonIntegerToUnknown()
+
+    override fun getPackageName(): String = webViewPackageSource.get().mapEmptyToUnknown()
 
     private fun String.captureMajorVersion() = this.split(WEBVIEW_VERSION_DELIMITER)[0]
 

--- a/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/MajorWebViewVersionProviderTest.kt
@@ -26,8 +26,10 @@ import org.mockito.kotlin.whenever
 @RunWith(AndroidJUnit4::class)
 class MajorWebViewVersionProviderTest {
     private val webViewVersionSource: WebViewVersionSource = mock()
+    private val webViewPackageSource: WebViewPackageSource = mock()
     private val testee = DefaultWebViewVersionProvider(
         webViewVersionSource,
+        webViewPackageSource,
     )
 
     @Test
@@ -38,6 +40,13 @@ class MajorWebViewVersionProviderTest {
     }
 
     @Test
+    fun whenWebViewPackageIsEmptyThenReturnUnknown() {
+        whenever(webViewPackageSource.get()).thenReturn("")
+
+        assertEquals("unknown", testee.getPackageName())
+    }
+
+    @Test
     fun whenWebViewVersionIsAvailableThenReturnFullVersion() {
         whenever(webViewVersionSource.get()).thenReturn("91.1.12.1234.423")
 
@@ -45,10 +54,24 @@ class MajorWebViewVersionProviderTest {
     }
 
     @Test
+    fun whenWebViewVPackageIsAvailableThenReturnPackage() {
+        whenever(webViewPackageSource.get()).thenReturn("com.test.webview")
+
+        assertEquals("com.test.webview", testee.getPackageName())
+    }
+
+    @Test
     fun whenWebViewVersionIsBlankThenReturnFullVersion() {
         whenever(webViewVersionSource.get()).thenReturn("    ")
 
         assertEquals("unknown", testee.getFullVersion())
+    }
+
+    @Test
+    fun whenWebViewPackageIsBlankThenReturnUnknown() {
+        whenever(webViewPackageSource.get()).thenReturn("    ")
+
+        assertEquals("unknown", testee.getPackageName())
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/WebViewVersionProvider.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/WebViewVersionProvider.kt
@@ -32,4 +32,10 @@ interface WebViewVersionProvider {
      * @returns a string [String] with the major version of WebView
      */
     fun getMajorVersion(): String
+
+    /**
+     * Returns the package name of the WebView provider or unknown if unable to get it
+     * @returns a string [String] with the package name of the WebView provider
+     */
+    fun getPackageName(): String
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211647635125358?focus=true

### Description
Add WebView version and package to native crashes

### Steps to test this PR

_Feature 1_
- [x] Apply this [patch](https://duckduckgo-my.sharepoint.com/:u:/p/cbarreiro/EVksCeY_Q6ZBpu99HYWpli8Bl7DdTxVZQ9oy1Zi47mvKfg?e=PCbHha)
- [x] Wait for app to crash right after launch
- [x] Check logs for `Native crash pixel sent...` with query params `webViewPackage` and `webViewVersion`

### UI changes
n/a
