### PR TITLE
Add AppInstall interface to expose installationTimestamp

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallRepository.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.install
+
+import com.duckduckgo.browser.api.install.AppInstall
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+class AppInstallRepository @Inject constructor(
+    private val appInstallStore: AppInstallStore,
+) : AppInstall {
+    override fun getInstallationTimestamp(): Long {
+        return appInstallStore.installTimestamp
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/install/AppInstall.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/install/AppInstall.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.api.install
+
+interface AppInstall {
+    fun getInstallationTimestamp(): Long
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211648823726464?focus=true 

### Description
Adds new interface as proposed in api discussion to expose installation timestamp to other modules

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
