### PR TITLE
Fix: Uninitialized omnibar error

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -767,7 +767,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             val anchorView =
                 when (settingsDataStore.omnibarPosition) {
                     TOP -> null
-                    BOTTOM -> currentTab?.omnibar?.newOmnibar?.toolbar ?: binding.fragmentContainer
+                    BOTTOM -> currentTab?.getOmnibar()?.newOmnibar?.toolbar ?: binding.fragmentContainer
                 }
             DefaultSnackbar(
                 parentView = binding.fragmentContainer,
@@ -868,7 +868,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             launchNewDuckChat(url, withTransition)
         }
 
-        currentTab?.omnibar?.newOmnibar?.omnibarTextInput?.let {
+        currentTab?.getOmnibar()?.newOmnibar?.omnibarTextInput?.let {
             hideKeyboard(it)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -637,7 +637,7 @@ class BrowserTabFragment :
 
     private val binding: FragmentBrowserTabBinding by viewBinding()
 
-    lateinit var omnibar: Omnibar
+    private lateinit var omnibar: Omnibar
 
     private lateinit var webViewContainer: FrameLayout
 
@@ -1936,6 +1936,14 @@ class BrowserTabFragment :
         webView?.reload()
         viewModel.onWebViewRefreshed()
         viewModel.resetErrors()
+    }
+
+    fun getOmnibar(): Omnibar? {
+        return if (this::omnibar.isInitialized) {
+            omnibar
+        } else {
+            null
+        }
     }
 
     private fun processCommand(it: Command?) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210171843711132?focus=true

### Description

This PR makes the return value of `BrowserTabFragment.getOmnibar()` nullable when accessed from the outside of the fragment. All access to it already was guarded with null checks for the fragment. This should solve the issue.

### Steps to test this PR

QA-optional
