### PR TITLE
Add prefix to custom wide event parameters when sending them via pixel

### DIFF
--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventSender.kt
@@ -108,7 +108,7 @@ class PixelWideEventSender @Inject constructor(
         const val PARAM_APP_VERSION = "app.version"
         const val PARAM_FORM_FACTOR = "app.form_factor"
         const val PARAM_NA_EXPERIMENTS = "app.native_apps_experiments"
-        const val PARAM_DEV_MODE = "dev_mode"
+        const val PARAM_DEV_MODE = "app.dev_mode"
 
         const val PARAM_METADATA_PREFIX = "feature.data.ext."
     }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -90,7 +90,7 @@ class PixelWideEventSenderTest {
                     "app.native_apps_experiments" to "",
                     "context.name" to "app_settings",
                     "feature.status" to "SUCCESS",
-                    "dev_mode" to "false",
+                    "app.dev_mode" to "false",
                 )
             val expectedEncodedParameters = mapOf("feature.data.ext.plan_type" to "premium")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211661694972809?focus=true

### Description

Adds prefix when mapping wide event metadata to pixel params. This fixes an inconsistency between the implementation and the wide event format spec.

### Steps to test this PR

QA-optional

### No UI changes
