### PR TITLE
Send wide event steps as metadata

### DIFF
--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/WideEventSender.kt
@@ -51,6 +51,10 @@ class PixelWideEventSender @Inject constructor(
                 if (event.flowEntryPoint != null) {
                     put(PARAM_CONTEXT_NAME, event.flowEntryPoint)
                 }
+
+                event.steps.forEach { (name, success) ->
+                    put(PARAM_METADATA_STEP_PREFIX + name, success.toString())
+                }
             }
 
         val encodedParameters =
@@ -111,6 +115,7 @@ class PixelWideEventSender @Inject constructor(
         const val PARAM_DEV_MODE = "app.dev_mode"
 
         const val PARAM_METADATA_PREFIX = "feature.data.ext."
+        const val PARAM_METADATA_STEP_PREFIX = PARAM_METADATA_PREFIX + "step."
     }
 }
 

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -77,6 +77,10 @@ class PixelWideEventSenderTest {
                     status = WideEventRepository.WideEventStatus.SUCCESS,
                     flowEntryPoint = "app_settings",
                     metadata = mapOf("plan_type" to "premium"),
+                    steps = listOf(
+                        WideEventRepository.WideEventStep(name = "init", success = true),
+                        WideEventRepository.WideEventStep(name = "refresh_data", success = false),
+                    ),
                 )
 
             pixelWideEventSender.sendWideEvent(event)
@@ -93,6 +97,8 @@ class PixelWideEventSenderTest {
                     "context.name" to "app_settings",
                     "feature.status" to "SUCCESS",
                     "app.dev_mode" to "false",
+                    "feature.data.ext.step.init" to "true",
+                    "feature.data.ext.step.refresh_data" to "false",
                 )
             val expectedEncodedParameters = mapOf("feature.data.ext.plan_type" to "premium")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211661694972813?focus=true

### Description

This PR adds missing wide event step info to pixel parameters.

### Steps to test this PR

QA-optional

### No UI changes
