### PR TITLE
disable browser buttons when Input Screen opened from widgets

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -295,6 +295,7 @@ import com.duckduckgo.duckchat.api.inputscreen.BrowserAndInputScreenTransitionPr
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
@@ -1119,8 +1120,8 @@ class BrowserTabFragment :
                 requireContext(),
                 InputScreenActivityParams(
                     query = query,
-                    tabs = viewModel.tabs.value?.size ?: 0,
                     isTopOmnibar = omnibar.omnibarPosition == TOP,
+                    browserButtonsConfig = InputScreenBrowserButtonsConfig.Enabled(tabs = viewModel.tabs.value?.size ?: 0),
                 ),
             )
         val enterTransition = browserAndInputScreenTransitionProvider.getInputScreenEnterAnimation(omnibar.omnibarPosition == TOP)

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -91,6 +91,7 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.impl.dialogs.EditSavedSiteDialogFragment
@@ -269,7 +270,11 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     private fun launchInputScreen(isTopOmnibar: Boolean) {
         globalActivityStarter.startIntent(
             this,
-            InputScreenActivityParams(query = "", isTopOmnibar = isTopOmnibar),
+            InputScreenActivityParams(
+                query = "",
+                isTopOmnibar = isTopOmnibar,
+                browserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+            ),
         )?.let {
             inputScreenLauncher.launch(it)
         }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -19,18 +19,19 @@ package com.duckduckgo.duckchat.api.inputscreen
 import android.app.Activity
 import androidx.activity.result.ActivityResult
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import java.io.Serializable
 
 /**
  * Parameters for launching the Input Screen activity.
  *
  * @param query The initial query text to pre-populate in the input field
  * @param isTopOmnibar whether the omnibar is positioned at the top of the screen
- * @param tabs number of tabs to display
+ * @param browserButtonsConfig configuration for displaying browser buttons (Fire Button, Tab Switcher, Menu)
  */
 data class InputScreenActivityParams(
     val query: String,
-    val tabs: Int = 0,
-    val isTopOmnibar: Boolean = false,
+    val isTopOmnibar: Boolean,
+    val browserButtonsConfig: InputScreenBrowserButtonsConfig,
 ) : GlobalActivityStarter.ActivityParams
 
 /**
@@ -65,4 +66,21 @@ data object InputScreenActivityResultParams {
 
     /** Key for any canceled draft content when result is [Activity.RESULT_CANCELED] */
     const val CANCELED_DRAFT_PARAM = "draft"
+}
+
+/**
+ * Configuration for displaying browser buttons (Fire Button, Tab Switcher, Menu) on the Input Screen.
+ */
+sealed class InputScreenBrowserButtonsConfig : Serializable {
+    /**
+     * Don't show any browser buttons.
+     */
+    class Disabled : InputScreenBrowserButtonsConfig(), Serializable
+
+    /**
+     * Show buttons when context allows for it.
+     *
+     * @param tabs number of tabs to display in the tab switcher button
+     */
+    data class Enabled(val tabs: Int) : InputScreenBrowserButtonsConfig(), Serializable
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenActivity.kt
@@ -48,7 +48,6 @@ class InputScreenActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        inputScreenConfigResolver.onInputScreenCreated(intent)
         setContentView(R.layout.activity_input_screen)
         inputScreenDiscoveryFunnel.onInputScreenOpened()
         val params =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentInputScreenBinding
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
@@ -215,7 +216,10 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
         configureViewPager()
 
-        val tabs = params?.tabs ?: 0
+        val tabs = when (val browserButtonsConfig = params?.browserButtonsConfig) {
+            is InputScreenBrowserButtonsConfig.Enabled -> browserButtonsConfig.tabs
+            else -> 0
+        }
         configureOmnibar(tabs)
 
         configureVoice(useTopBar)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -24,7 +24,6 @@ data class InputScreenVisibilityState(
     val showChatLogo: Boolean,
     val showSearchLogo: Boolean,
     val newLineButtonVisible: Boolean,
-    val mainButtonsEnabled: Boolean,
     val mainButtonsVisible: Boolean,
     val searchMode: Boolean,
 ) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
@@ -16,12 +16,13 @@
 
 package com.duckduckgo.duckchat.impl.inputscreen.ui
 
-import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Resources
+import androidx.appcompat.app.AppCompatActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertFalse
@@ -36,7 +37,8 @@ import org.mockito.kotlin.whenever
 class InputScreenConfigResolverTest {
     private val duckChatInternal: DuckChatInternal = mock()
     private val inputScreenBottomBarEnabled = MutableStateFlow(false)
-    private val mockActivityContext: Context = mock()
+    private val showMainButtonsInInputScreen = MutableStateFlow(true)
+    private val mockAppCompatActivity: AppCompatActivity = mock()
     private val mockResources: Resources = mock()
     private val configuration = Configuration()
 
@@ -45,57 +47,50 @@ class InputScreenConfigResolverTest {
     @Before
     fun setup() {
         whenever(duckChatInternal.inputScreenBottomBarEnabled).thenReturn(inputScreenBottomBarEnabled)
-        whenever(mockActivityContext.resources).thenReturn(mockResources)
+        whenever(duckChatInternal.showMainButtonsInInputScreen).thenReturn(showMainButtonsInInputScreen)
+        whenever(mockAppCompatActivity.resources).thenReturn(mockResources)
         whenever(mockResources.configuration).thenReturn(configuration)
         configuration.orientation = Configuration.ORIENTATION_PORTRAIT
-        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockActivityContext)
     }
 
     @Test
-    fun `when initialized then isTopOmnibar should default to true`() {
-        assertTrue(inputScreenConfigResolver.isTopOmnibar)
-    }
-
-    @Test
-    fun `when onInputScreenCreated called with null params then isTopOmnibar should remain true`() {
+    fun `when intent has null params then isTopOmnibar should default to true`() {
         val intent = Intent()
-
-        inputScreenConfigResolver.onInputScreenCreated(intent)
-
-        assertTrue(inputScreenConfigResolver.isTopOmnibar)
-    }
-
-    @Test
-    fun `when onInputScreenCreated called with isTopOmnibar true then isTopOmnibar should be true`() {
-        val intent =
-            Intent().apply {
-                putExtra("ACTIVITY_SERIALIZABLE_PARAMETERS_ARG", InputScreenActivityParams(query = "", isTopOmnibar = true, tabs = 1))
-            }
-
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
 
         assertTrue(inputScreenConfigResolver.isTopOmnibar)
     }
 
     @Test
-    fun `when onInputScreenCreated called with isTopOmnibar false then isTopOmnibar should be false`() {
-        val intent =
-            Intent().apply {
-                putExtra("ACTIVITY_SERIALIZABLE_PARAMETERS_ARG", InputScreenActivityParams(query = "", isTopOmnibar = false, tabs = 1))
-            }
+    fun `when intent has isTopOmnibar true then isTopOmnibar should be true`() {
+        val intent = createIntent(
+            isTopOmnibar = true,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
 
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        assertTrue(inputScreenConfigResolver.isTopOmnibar)
+    }
+
+    @Test
+    fun `when intent has isTopOmnibar false then isTopOmnibar should be false`() {
+        val intent = createIntent(
+            isTopOmnibar = false,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
 
         assertFalse(inputScreenConfigResolver.isTopOmnibar)
     }
 
     @Test
     fun `when isTopOmnibar is true then useTopBar should return true regardless of bottom bar feature`() {
-        val intent =
-            Intent().apply {
-                putExtra("ACTIVITY_SERIALIZABLE_PARAMETERS_ARG", InputScreenActivityParams(query = "", isTopOmnibar = true, tabs = 1))
-            }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = true,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
 
         inputScreenBottomBarEnabled.value = false
         assertTrue(inputScreenConfigResolver.useTopBar())
@@ -106,11 +101,11 @@ class InputScreenConfigResolverTest {
 
     @Test
     fun `when isTopOmnibar is false and bottom bar feature disabled then useTopBar should return true`() {
-        val intent =
-            Intent().apply {
-                putExtra("ACTIVITY_SERIALIZABLE_PARAMETERS_ARG", InputScreenActivityParams(query = "", isTopOmnibar = false, tabs = 1))
-            }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = false,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = false
 
         assertTrue(inputScreenConfigResolver.useTopBar())
@@ -118,11 +113,11 @@ class InputScreenConfigResolverTest {
 
     @Test
     fun `when isTopOmnibar is false and bottom bar feature enabled then useTopBar should return false`() {
-        val intent =
-            Intent().apply {
-                putExtra("ACTIVITY_SERIALIZABLE_PARAMETERS_ARG", InputScreenActivityParams(query = "", isTopOmnibar = false, tabs = 1))
-            }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = false,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = true
 
         assertFalse(inputScreenConfigResolver.useTopBar())
@@ -132,13 +127,11 @@ class InputScreenConfigResolverTest {
     fun `when landscape and isTopOmnibar true and bottom bar enabled then useTopBar returns true`() {
         configuration.orientation = Configuration.ORIENTATION_LANDSCAPE
 
-        val intent = Intent().apply {
-            putExtra(
-                "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
-                InputScreenActivityParams(query = "", isTopOmnibar = true, tabs = 1),
-            )
-        }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = true,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = true
 
         assertTrue(inputScreenConfigResolver.useTopBar())
@@ -148,13 +141,11 @@ class InputScreenConfigResolverTest {
     fun `when landscape and isTopOmnibar true and bottom bar disabled then useTopBar returns true`() {
         configuration.orientation = Configuration.ORIENTATION_LANDSCAPE
 
-        val intent = Intent().apply {
-            putExtra(
-                "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
-                InputScreenActivityParams(query = "", isTopOmnibar = true, tabs = 1),
-            )
-        }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = true,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = false
 
         assertTrue(inputScreenConfigResolver.useTopBar())
@@ -164,13 +155,11 @@ class InputScreenConfigResolverTest {
     fun `when landscape and isTopOmnibar false and bottom bar enabled then useTopBar returns true`() {
         configuration.orientation = Configuration.ORIENTATION_LANDSCAPE
 
-        val intent = Intent().apply {
-            putExtra(
-                "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
-                InputScreenActivityParams(query = "", isTopOmnibar = false, tabs = 1),
-            )
-        }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = false,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = true
 
         assertTrue(inputScreenConfigResolver.useTopBar())
@@ -180,15 +169,80 @@ class InputScreenConfigResolverTest {
     fun `when landscape and isTopOmnibar false and bottom bar disabled then useTopBar returns true`() {
         configuration.orientation = Configuration.ORIENTATION_LANDSCAPE
 
-        val intent = Intent().apply {
-            putExtra(
-                "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
-                InputScreenActivityParams(query = "", isTopOmnibar = false, tabs = 1),
-            )
-        }
-        inputScreenConfigResolver.onInputScreenCreated(intent)
+        val intent = createIntent(
+            isTopOmnibar = false,
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
         inputScreenBottomBarEnabled.value = false
 
         assertTrue(inputScreenConfigResolver.useTopBar())
+    }
+
+    @Test
+    fun `when showMainButtonsInInputScreen enabled and browserButtonsConfig is Enabled then mainButtonsEnabled returns true`() {
+        val intent = createIntent(
+            isTopOmnibar = true,
+            browserButtonsConfig = InputScreenBrowserButtonsConfig.Enabled(tabs = 1),
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        showMainButtonsInInputScreen.value = true
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertTrue(inputScreenConfigResolver.mainButtonsEnabled())
+    }
+
+    @Test
+    fun `when showMainButtonsInInputScreen enabled and browserButtonsConfig is Disabled then mainButtonsEnabled returns false`() {
+        val intent = createIntent(
+            isTopOmnibar = true,
+            browserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        showMainButtonsInInputScreen.value = true
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertFalse(inputScreenConfigResolver.mainButtonsEnabled())
+    }
+
+    @Test
+    fun `when showMainButtonsInInputScreen disabled and browserButtonsConfig is Enabled then mainButtonsEnabled returns false`() {
+        val intent = createIntent(
+            isTopOmnibar = true,
+            browserButtonsConfig = InputScreenBrowserButtonsConfig.Enabled(tabs = 1),
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        showMainButtonsInInputScreen.value = false
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertFalse(inputScreenConfigResolver.mainButtonsEnabled())
+    }
+
+    @Test
+    fun `when showMainButtonsInInputScreen disabled and browserButtonsConfig is Disabled then mainButtonsEnabled returns false`() {
+        val intent = createIntent(
+            isTopOmnibar = true,
+            browserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+        )
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        showMainButtonsInInputScreen.value = false
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertFalse(inputScreenConfigResolver.mainButtonsEnabled())
+    }
+
+    private fun createIntent(
+        query: String = "",
+        isTopOmnibar: Boolean = true,
+        browserButtonsConfig: InputScreenBrowserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+    ) = Intent().apply {
+        putExtra(
+            "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
+            InputScreenActivityParams(
+                query = query,
+                isTopOmnibar = isTopOmnibar,
+                browserButtonsConfig = browserButtonsConfig,
+            ),
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211664432268885?focus=true

### Description
Disables the browser buttons on the Input Screen when launched from widgets or system search.

### Steps to test this PR
- [x] Go to Settings -> AI Features and enable Search & Duck.ai.
- [x] Go to Feature Flag Inventory and enable `showInputScreenOnSystemSearchLaunch`.
- [x] Force close and reopen the app.
- [x] Go to the browser and verify that contextual browser buttons **are available** on the focused Input Screen when text box is empty.
- [x] Add a widget to the home screen.
- [x] Click on the widget and verify that contextual browser buttons **are not available** on the focused Input Screen when text box is empty.