### PR TITLE
add device apps search to autocomplete suggestions and enable when launched from widgets

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -193,6 +193,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_INITIAL_CTA
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_SERP_CTA
 import com.duckduckgo.app.surrogates.SurrogateResponse
+import com.duckduckgo.app.systemsearch.DeviceAppLookup
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabStatsBucketing
@@ -616,6 +617,8 @@ class BrowserTabViewModelTest {
     private val fakeMessagingPlugins = FakeWebMessagingPluginPoint()
     private val fakePostMessageWrapperPlugins = FakePostMessageWrapperPluginPoint()
 
+    private val mockDeviceAppLookup: DeviceAppLookup = mock()
+
     @Before
     fun before() =
         runTest {
@@ -646,6 +649,9 @@ class BrowserTabViewModelTest {
                     mockHistory,
                     DefaultDispatcherProvider(),
                     mockPixel,
+                    mockDeviceAppLookup,
+                    coroutineRule.testScope,
+                    AutoComplete.Config(),
                 )
             val fireproofWebsiteRepositoryImpl =
                 FireproofWebsiteRepositoryImpl(

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.autocomplete.api
+
+import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
+import com.duckduckgo.app.autocomplete.impl.AutoCompleteRepository
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.systemsearch.DeviceAppLookup
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browser.api.autocomplete.AutoComplete
+import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.history.api.NavigationHistory
+import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class AutoCompleteFactoryImpl @Inject constructor(
+    private val autoCompleteService: AutoCompleteService,
+    private val savedSitesRepository: SavedSitesRepository,
+    private val navigationHistory: NavigationHistory,
+    private val autoCompleteScorer: AutoCompleteScorer,
+    private val autoCompleteRepository: AutoCompleteRepository,
+    private val tabRepository: TabRepository,
+    private val userStageStore: UserStageStore,
+    private val autocompleteTabsFeature: AutocompleteTabsFeature,
+    private val duckChat: DuckChat,
+    private val history: NavigationHistory,
+    private val dispatchers: DispatcherProvider,
+    private val pixel: Pixel,
+    private val deviceAppLookup: DeviceAppLookup,
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+) : AutoCompleteFactory {
+
+    override fun create(config: AutoComplete.Config): AutoComplete {
+        return AutoCompleteApi(
+            autoCompleteService = autoCompleteService,
+            savedSitesRepository = savedSitesRepository,
+            navigationHistory = navigationHistory,
+            autoCompleteScorer = autoCompleteScorer,
+            autoCompleteRepository = autoCompleteRepository,
+            tabRepository = tabRepository,
+            userStageStore = userStageStore,
+            autocompleteTabsFeature = autocompleteTabsFeature,
+            duckChat = duckChat,
+            history = history,
+            dispatchers = dispatchers,
+            pixel = pixel,
+            deviceAppLookup = deviceAppLookup,
+            coroutineScope = coroutineScope,
+            config = config,
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1006,6 +1006,9 @@ class BrowserTabViewModel @Inject constructor(
                     is AutoCompleteSwitchToTabSuggestion -> onUserSwitchedToTab(suggestion.tabId)
                     is AutoCompleteInAppMessageSuggestion -> return@withContext
                     is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> onUserTappedDuckAiPromptAutocomplete(suggestion.phrase)
+                    is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion -> {
+                        // no-op, installed apps search is disabled in tabs
+                    }
                 }
             }
             autoComplete.fireAutocompletePixel(autoCompleteViewState.searchResults.suggestions, suggestion)

--- a/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/SystemComponentsModule.kt
@@ -56,11 +56,13 @@ object SystemComponentsModule {
 
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun deviceAppsListProvider(packageManager: PackageManager): DeviceAppListProvider = InstalledDeviceAppListProvider(packageManager)
+    fun deviceAppsListProvider(packageManager: PackageManager, dispatcherProvider: DispatcherProvider): DeviceAppListProvider =
+        InstalledDeviceAppListProvider(packageManager, dispatcherProvider)
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun deviceAppLookup(deviceAppListProvider: DeviceAppListProvider): DeviceAppLookup = InstalledDeviceAppLookup(deviceAppListProvider)
+    fun deviceAppLookup(deviceAppListProvider: DeviceAppListProvider, dispatcherProvider: DispatcherProvider): DeviceAppLookup =
+        InstalledDeviceAppLookup(deviceAppListProvider, dispatcherProvider)
 
     @Provides
     fun appIconModifier(

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -160,25 +160,21 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
     private val inputScreenLauncher =
         registerForActivityResult(StartActivityForResult()) { result ->
-            val data = result.data ?: return@registerForActivityResult
-
             when (result.resultCode) {
                 InputScreenActivityResultCodes.NEW_SEARCH_REQUESTED -> {
-                    data.getStringExtra(InputScreenActivityResultParams.SEARCH_QUERY_PARAM)?.let { query ->
+                    result.data?.getStringExtra(InputScreenActivityResultParams.SEARCH_QUERY_PARAM)?.let { query ->
                         launchBrowser(query)
-                    }
+                    } ?: finish()
                 }
 
                 InputScreenActivityResultCodes.SWITCH_TO_TAB_REQUESTED -> {
-                    data.getStringExtra(InputScreenActivityResultParams.TAB_ID_PARAM)?.let { tabId ->
+                    result.data?.getStringExtra(InputScreenActivityResultParams.TAB_ID_PARAM)?.let { tabId ->
                         launchBrowser(query = "", openExistingTabId = tabId)
-                    }
+                    } ?: finish()
                 }
 
                 RESULT_CANCELED -> {
-                    data.getStringExtra(InputScreenActivityResultParams.CANCELED_DRAFT_PARAM)?.let { query ->
-                        finish()
-                    }
+                    finish()
                 }
             }
         }
@@ -274,6 +270,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                 query = "",
                 isTopOmnibar = isTopOmnibar,
                 browserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+                showInstalledApps = true,
             ),
         )?.let {
             inputScreenLauncher.launch(it)

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/DeviceAppLookupTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/DeviceAppLookupTest.kt
@@ -22,20 +22,26 @@ import com.duckduckgo.app.systemsearch.DeviceAppLookupTest.AppName.DDG_MOVIES
 import com.duckduckgo.app.systemsearch.DeviceAppLookupTest.AppName.DDG_MUSIC
 import com.duckduckgo.app.systemsearch.DeviceAppLookupTest.AppName.FILES
 import com.duckduckgo.app.systemsearch.DeviceAppLookupTest.AppName.LIVE_DDG
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class DeviceAppLookupTest {
 
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
     private val mockAppProvider: DeviceAppListProvider = mock()
 
-    private val testee = InstalledDeviceAppLookup(mockAppProvider)
+    private val testee = InstalledDeviceAppLookup(mockAppProvider, coroutineTestRule.testDispatcherProvider)
 
     @Test
-    fun whenQueryMatchesWordInShortNameThenMatchesAreReturned() {
+    fun whenQueryMatchesWordInShortNameThenMatchesAreReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("DDG")
         assertEquals(3, result.size)
@@ -45,7 +51,7 @@ class DeviceAppLookupTest {
     }
 
     @Test
-    fun whenQueryMatchesWordPrefixInShortNameThenMatchesAreReturned() {
+    fun whenQueryMatchesWordPrefixInShortNameThenMatchesAreReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("DDG")
         assertEquals(3, result.size)
@@ -55,7 +61,7 @@ class DeviceAppLookupTest {
     }
 
     @Test
-    fun whenQueryMatchesPastShortNameWordBoundaryToNextPrefixThenMatchesAreReturned() {
+    fun whenQueryMatchesPastShortNameWordBoundaryToNextPrefixThenMatchesAreReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("DDG M")
         assertEquals(2, result.size)
@@ -64,7 +70,7 @@ class DeviceAppLookupTest {
     }
 
     @Test
-    fun whenQueryMatchesWordPrefixInShortNameWithDifferentCaseThenMatchesAreReturned() {
+    fun whenQueryMatchesWordPrefixInShortNameWithDifferentCaseThenMatchesAreReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("ddg")
         assertEquals(3, result.size)
@@ -74,35 +80,35 @@ class DeviceAppLookupTest {
     }
 
     @Test
-    fun whenQueryMatchesMiddleOrSuffixOfAppNameWordThenNoAppsReturned() {
+    fun whenQueryMatchesMiddleOrSuffixOfAppNameWordThenNoAppsReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("DG")
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun whenQueryDoesNotMatchAnyPartOfAppNameThenNoAppsReturned() {
+    fun whenQueryDoesNotMatchAnyPartOfAppNameThenNoAppsReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("nonmatching")
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun whenQueryIsEmptyThenNoAppsReturned() {
+    fun whenQueryIsEmptyThenNoAppsReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query("")
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun whenAppsListIsEmptyThenNoAppsReturned() {
+    fun whenAppsListIsEmptyThenNoAppsReturned() = runTest {
         whenever(mockAppProvider.get()).thenReturn(noApps)
         val result = testee.query("DDG")
         assertTrue(result.isEmpty())
     }
 
     @Test
-    fun whenQueryMatchesAppNameWithSpecialRegexCharactersThenAppReturnedWithoutCrashing() {
+    fun whenQueryMatchesAppNameWithSpecialRegexCharactersThenAppReturnedWithoutCrashing() = runTest {
         whenever(mockAppProvider.get()).thenReturn(apps)
         val result = testee.query(APP_WITH_RESERVED_CHARS)
         assertEquals(1, result.size)

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.*
+import kotlinx.coroutines.test.runTest
 import org.junit.*
 import org.junit.Assert.*
 import org.mockito.Mockito.verify
@@ -87,7 +88,7 @@ class SystemSearchViewModelTest {
     private lateinit var testee: SystemSearchViewModel
 
     @Before
-    fun setup() {
+    fun setup() = runTest {
         whenever(mockAutoComplete.autoComplete(QUERY)).thenReturn(flowOf(autocompleteQueryResult))
         whenever(mockAutoComplete.autoComplete(BLANK_QUERY)).thenReturn(flowOf(autocompleteBlankResult))
         whenever(mockDeviceAppLookup.query(QUERY)).thenReturn(appQueryResult)

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoComplete.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoComplete.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.browser.api.autocomplete
 
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
 import kotlinx.coroutines.flow.Flow
 
 interface AutoComplete {
@@ -26,6 +29,10 @@ interface AutoComplete {
         suggestions: List<AutoCompleteSuggestion>,
         suggestion: AutoCompleteSuggestion,
         experimentalInputScreen: Boolean = false,
+    )
+
+    data class Config(
+        val showInstalledApps: Boolean = false,
     )
 
     data class AutoCompleteResult(
@@ -84,5 +91,19 @@ interface AutoComplete {
         data class AutoCompleteDuckAIPrompt(
             override val phrase: String,
         ) : AutoCompleteSuggestion(phrase)
+
+        data class AutoCompleteDeviceAppSuggestion(
+            override val phrase: String,
+            val shortName: String,
+            val packageName: String,
+            val launchIntent: Intent,
+            private var icon: Drawable? = null,
+        ) : AutoCompleteSuggestion(phrase) {
+            fun retrieveIcon(packageManager: PackageManager): Drawable {
+                return icon ?: packageManager.getApplicationIcon(packageName).also {
+                    icon = it
+                }
+            }
+        }
     }
 }

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoCompleteFactory.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoCompleteFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.api.autocomplete
+
+interface AutoCompleteFactory {
+    fun create(config: AutoComplete.Config = AutoComplete.Config()): AutoComplete
+}

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
@@ -102,6 +102,7 @@ class BrowserAutoCompleteSuggestionsAdapter(
             Type.SWITCH_TO_TAB_TYPE to SwitchToTabSuggestionViewHolderFactory(),
             Type.DIVIDER_TYPE to DividerViewHolderFactory(),
             Type.DUCK_AI_PROMPT_TYPE to DuckAIPromptSuggestionViewHolderFactory(),
+            Type.DEVICE_APP to DeviceAppSuggestionViewHolderFactory(),
         )
 
     private var phrase = ""
@@ -129,6 +130,7 @@ class BrowserAutoCompleteSuggestionsAdapter(
                     is AutoCompleteSwitchToTabSuggestion -> Type.SWITCH_TO_TAB_TYPE
                     is AutoCompleteUrlSuggestion -> Type.SWITCH_TO_TAB_TYPE
                     is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> Type.DUCK_AI_PROMPT_TYPE
+                    is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion -> Type.DEVICE_APP
                     else -> Type.SUGGESTION_TYPE
                 }
         }
@@ -193,7 +195,8 @@ class BrowserAutoCompleteSuggestionsAdapter(
     private fun needsDivider(
         current: AutoCompleteSuggestion,
         next: AutoCompleteSuggestion,
-    ): Boolean = current.isSearchItem != next.isSearchItem
+    ): Boolean = (current.isSearchItem != next.isSearchItem) ||
+        (current is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion) != (next is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion)
 
     object Type {
         const val EMPTY_TYPE = 1
@@ -206,5 +209,6 @@ class BrowserAutoCompleteSuggestionsAdapter(
         const val SWITCH_TO_TAB_TYPE = 8
         const val DIVIDER_TYPE = 9
         const val DUCK_AI_PROMPT_TYPE = 10
+        const val DEVICE_APP = 11
     }
 }

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/SuggestionViewHolderFactory.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/SuggestionViewHolderFactory.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.browser.ui.autocomplete
 
+import android.content.pm.PackageManager.NameNotFoundException
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -31,6 +32,7 @@ import com.duckduckgo.browser.ui.R
 import com.duckduckgo.browser.ui.autocomplete.AutoCompleteViewHolder.InAppMessageViewHolder
 import com.duckduckgo.browser.ui.databinding.ItemAutocompleteBookmarkSuggestionBinding
 import com.duckduckgo.browser.ui.databinding.ItemAutocompleteDefaultBinding
+import com.duckduckgo.browser.ui.databinding.ItemAutocompleteDeviceAppSuggestionBinding
 import com.duckduckgo.browser.ui.databinding.ItemAutocompleteDividerBinding
 import com.duckduckgo.browser.ui.databinding.ItemAutocompleteDuckaiSuggestionBinding
 import com.duckduckgo.browser.ui.databinding.ItemAutocompleteHistorySearchSuggestionBinding
@@ -290,9 +292,33 @@ class DuckAIPromptSuggestionViewHolderFactory : SuggestionViewHolderFactory {
         openSettingsClickListener: () -> Unit,
         longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
-        val bookmarkSuggestionViewHolder = holder as AutoCompleteViewHolder.DuckAIPromptViewHolder
-        bookmarkSuggestionViewHolder.bind(
+        val viewHolder = holder as AutoCompleteViewHolder.DuckAIPromptViewHolder
+        viewHolder.bind(
             suggestion as AutoCompleteSuggestion.AutoCompleteDuckAIPrompt,
+            immediateSearchClickListener,
+        )
+    }
+}
+
+class DeviceAppSuggestionViewHolderFactory : SuggestionViewHolderFactory {
+    override fun onCreateViewHolder(parent: ViewGroup): AutoCompleteViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemAutocompleteDeviceAppSuggestionBinding.inflate(inflater, parent, false)
+        return AutoCompleteViewHolder.DeviceAppViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: AutoCompleteViewHolder,
+        suggestion: AutoCompleteSuggestion,
+        immediateSearchClickListener: (AutoCompleteSuggestion) -> Unit,
+        editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
+        deleteClickListener: (AutoCompleteSuggestion) -> Unit,
+        openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
+    ) {
+        val viewHolder = holder as AutoCompleteViewHolder.DeviceAppViewHolder
+        viewHolder.bind(
+            suggestion as AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion,
             immediateSearchClickListener,
         )
     }
@@ -445,6 +471,24 @@ sealed class AutoCompleteViewHolder(
         ) = with(binding) {
             title.text = item.phrase
 
+            root.setOnClickListener { itemClickListener(item) }
+        }
+    }
+
+    class DeviceAppViewHolder(
+        val binding: ItemAutocompleteDeviceAppSuggestionBinding,
+    ) : AutoCompleteViewHolder(binding.root) {
+        fun bind(
+            item: AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion,
+            itemClickListener: (AutoCompleteSuggestion) -> Unit,
+        ) = with(binding) {
+            binding.title.text = item.shortName
+            try {
+                val drawable = item.retrieveIcon(binding.icon.context.packageManager)
+                binding.icon.setImageDrawable(drawable)
+            } catch (e: NameNotFoundException) {
+                binding.icon.setImageDrawable(null)
+            }
             root.setOnClickListener { itemClickListener(item) }
         }
     }

--- a/browser/browser-ui/src/main/res/layout/item_autocomplete_device_app_suggestion.xml
+++ b/browser/browser-ui/src/main/res/layout/item_autocomplete_device_app_suggestion.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingVertical="?attr/autocompleteListItemVerticalPadding"
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemEndPadding">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/logo_medium"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/autocompleteListItemIconMargin"
+        android:ellipsize="end"
+        android:gravity="center_vertical|start"
+        android:includeFontPadding="false"
+        android:maxLines="1"
+        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="@id/icon"
+        tools:text="DuckDuckGo" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -27,11 +27,13 @@ import java.io.Serializable
  * @param query The initial query text to pre-populate in the input field
  * @param isTopOmnibar whether the omnibar is positioned at the top of the screen
  * @param browserButtonsConfig configuration for displaying browser buttons (Fire Button, Tab Switcher, Menu)
+ * @param showInstalledApps whether apps installed on the device should appear in autocomplete results
  */
 data class InputScreenActivityParams(
     val query: String,
     val isTopOmnibar: Boolean,
     val browserButtonsConfig: InputScreenBrowserButtonsConfig,
+    val showInstalledApps: Boolean = false,
 ) : GlobalActivityStarter.ActivityParams
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolver.kt
@@ -30,6 +30,8 @@ import javax.inject.Inject
 interface InputScreenConfigResolver {
     val isTopOmnibar: Boolean
 
+    fun shouldShowInstalledApps(): Boolean
+
     fun useTopBar(): Boolean
 
     fun mainButtonsEnabled(): Boolean
@@ -50,6 +52,11 @@ class InputScreenConfigResolverImpl @Inject constructor(
 
     override val isTopOmnibar: Boolean by lazy {
         appCompatActivity.intent.getActivityParams(InputScreenActivityParams::class.java)?.isTopOmnibar ?: true
+    }
+
+    override fun shouldShowInstalledApps(): Boolean {
+        val params = appCompatActivity.intent?.getActivityParams(InputScreenActivityParams::class.java)
+        return params?.showInstalledApps ?: false
     }
 
     override fun useTopBar(): Boolean =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -27,6 +27,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.FrameLayout
+import android.widget.Toast
+import android.widget.Toast.LENGTH_SHORT
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
@@ -346,6 +348,22 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             is Command.TabSwitcherRequested -> {
                 requireActivity().setResult(InputScreenActivityResultCodes.TAB_SWITCHER_REQUESTED)
                 exitInputScreen()
+            }
+
+            is Command.LaunchDeviceApplication -> {
+                try {
+                    startActivity(command.deviceAppSuggestion.launchIntent)
+                    // This command is only available when launched from widgets or system search,
+                    // and since we're moving to a new task (in another app),
+                    // ensure that our task is finished so that it gets removed from recents.
+                    requireActivity().finishAffinity()
+                } catch (e: Exception) {
+                    viewModel.appNotFound(command.deviceAppSuggestion)
+                }
+            }
+
+            is Command.ShowAppNotFoundMessage -> {
+                Toast.makeText(requireContext(), R.string.autocompleteDeviceAppNotFound, LENGTH_SHORT).show()
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/Command.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/Command.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.duckchat.impl.inputscreen.ui.command
 
+import com.duckduckgo.browser.api.autocomplete.AutoComplete
+
 sealed class Command {
     data class SwitchToTab(
         val tabId: String,
@@ -59,4 +61,8 @@ sealed class Command {
     data object TabSwitcherRequested : Command()
 
     data object MenuRequested : Command()
+
+    data class LaunchDeviceApplication(val deviceAppSuggestion: AutoComplete.AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion) : Command()
+
+    data class ShowAppNotFoundMessage(val shortName: String) : Command()
 }

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Попитай Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Приложението не може да бъде намерено</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Търсене или въвеждане на адрес</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Zeptej se Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Aplikace nebyla nalezena</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Vyhledejte nebo zadejte adresu</string>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Spørg Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Appen kunne ikke findes</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Søg eller indtast adresse</string>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Frag Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Die Anwendung konnte nicht gefunden werden.</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Adresse suchen oder eingeben</string>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Ρωτήστε το Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Η εφαρμογή δεν βρέθηκε</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Αναζήτηση ή εισαγωγή διεύθυνσης</string>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Pregúntale a Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">No se pudo encontrar la aplicación</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Buscar o introducir dirección</string>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Küsi Duck.ai käest</string>
+    <string name="autocompleteDeviceAppNotFound">Rakendust ei leitud</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Otsi või sisesta aadress</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Kysy Duck.ai:lta</string>
+    <string name="autocompleteDeviceAppNotFound">Sovellusta ei löytynyt</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Hae tai anna osoite</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Demandez à Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Impossible de trouver l\'application</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Rechercher ou saisir une adresse</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Pitaj Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Aplikaciju nije bilo moguće pronaći</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Pretraži ili unesi adresu</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Duck.ai kérdezése</string>
+    <string name="autocompleteDeviceAppNotFound">Az alkalmazás nem található</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Keresés vagy cím megadása</string>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Chiedi a Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Impossibile trovare l\'applicazione</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Cerca o digita l\'indirizzo</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -65,7 +65,8 @@
     <string name="duck_ai_paid_settings_learn_more_title">Sužinoti daugiau</string>
 
     <!-- AutoComplete -->
-    <string name="autocompleteDuckAiPrompt">Paklausk „Duck.ai“</string>
+    <string name="autocompleteDuckAiPrompt">Paklausk „Duck.ai"</string>
+    <string name="autocompleteDeviceAppNotFound">Nepavyko rasti programos</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Ieškoti arba įvesti adresą</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Pajautā Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Lietojumprogrammu nevarēja atrast</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Meklē vai ievadi adresi</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Spør Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Programmet ble ikke funnet</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Søk eller skriv inn adresse</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Vraag stellen aan Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Toepassing kon niet worden gevonden</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Zoek of voer een adres in</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Zapytaj Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Nie można znaleźć aplikacji</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Wyszukaj lub wprowadź adres</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Pergunta ao Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Não foi possível encontrar a aplicação</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Pesquisar ou inserir endereço</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Întreabă Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Aplicația nu a fost găsită</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Caută sau introdu adresa</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Спросить у Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Приложение не найдено</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Введите поисковый запрос или адрес сайта</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Spýtaj sa Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Aplikáciu sa nepodarilo nájsť</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Vyhľadajte alebo zadajte adresu</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Vprašajte Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Prošnje ni bilo mogoče najti</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Poišči ali vnesi naslov</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Fråga Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Appen kunde inte hittas</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Sök eller ange adress</string>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -66,6 +66,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Duck.ai\'a sor</string>
+    <string name="autocompleteDeviceAppNotFound">Uygulama bulunamadı</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Adres ara veya gir</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -65,6 +65,7 @@
 
     <!-- AutoComplete -->
     <string name="autocompleteDuckAiPrompt">Ask Duck.ai</string>
+    <string name="autocompleteDeviceAppNotFound">Application could not be found</string>
 
     <!-- New Address Bar Option Bottom Sheet Dialog -->
     <string name="newAddressBarOptionBottomSheetDialogSearchText">Search or enter address</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenConfigResolverTest.kt
@@ -231,10 +231,29 @@ class InputScreenConfigResolverTest {
         assertFalse(inputScreenConfigResolver.mainButtonsEnabled())
     }
 
+    @Test
+    fun `when shouldShowInstalledApps called with showInstalledApps true then returns true`() {
+        val intent = createIntent(showInstalledApps = true)
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertTrue(inputScreenConfigResolver.shouldShowInstalledApps())
+    }
+
+    @Test
+    fun `when shouldShowInstalledApps called with showInstalledApps false then returns false`() {
+        val intent = createIntent(showInstalledApps = false)
+        whenever(mockAppCompatActivity.intent).thenReturn(intent)
+        inputScreenConfigResolver = InputScreenConfigResolverImpl(duckChatInternal, mockAppCompatActivity)
+
+        assertFalse(inputScreenConfigResolver.shouldShowInstalledApps())
+    }
+
     private fun createIntent(
         query: String = "",
         isTopOmnibar: Boolean = true,
         browserButtonsConfig: InputScreenBrowserButtonsConfig = InputScreenBrowserButtonsConfig.Disabled(),
+        showInstalledApps: Boolean = false,
     ) = Intent().apply {
         putExtra(
             "ACTIVITY_SERIALIZABLE_PARAMETERS_ARG",
@@ -242,6 +261,7 @@ class InputScreenConfigResolverTest {
                 query = query,
                 isTopOmnibar = isTopOmnibar,
                 browserButtonsConfig = browserButtonsConfig,
+                showInstalledApps = showInstalledApps,
             ),
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211589372131522?focus=true

### Description
Introduces a new autocomplete suggestion type that returns apps installed on the device, when enabled through a new configuration class. When enabled, the returned autocomplete results are limited to a max of 4 items per category (search + apps). This matches existing behavior for the `SystemSearchActivity`.

The configuration is enabled for autocomplete inside of the Input Screen when launched from widgets or system search.

### Steps to test this PR

- [x] Install the app and ensure that Input Screen is disabled.
- [x] Add a widget.
- [x] Click on the widget
- [x] Verify that autocomplete works and you see installed apps suggestions.
- [x] Open the browser.
- [x] Click on the omnibar.
- [x] Verify that autocomplete works and you **don't see** installed apps suggestions.
- [x] Go to settings and enable the Input Screen.
- [x] Go to Feature Flag Inventory and enable `showInputScreenOnSystemSearchLaunch`.
- [x] Force close and reopen the app.
- [x] Go back to the browser.
- [x] Click on the omnibar to open the Input Screen.
- [x] Verify that autocomplete works and you **don't see** installed apps suggestions.
- [x] Go to the home screen.
- [x] Click on the widget
- [x] Verify that autocomplete works and you see installed apps suggestions.

### Notes
- This PR is already relatively big, so I skipped the changes to `SystemSearchActivity`. I will look into rewiring it to use the installed app results from autocomplete suggestions in a follow up PR.