### PR TITLE
Update content scope scripts to version 11.38.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -9456,20 +9456,35 @@
     }
     /** Bookmark import code */
     async downloadData() {
-      await new Promise((resolve) => setTimeout(resolve, 1e3));
-      const userId = document.querySelector(this.bookmarkImportSelectorSettings.userIdLink)?.getAttribute("href")?.split("&user=")[1];
-      await this.runWithRetry(() => document.querySelector(`a[href="./manage/archive/${__privateGet(this, _exportId)}"]`), 15, 2e3, "linear");
-      if (userId != null && __privateGet(this, _exportId) != null) {
-        const downloadURL = `${TAKEOUT_DOWNLOAD_URL_BASE}?j=${__privateGet(this, _exportId)}&i=0&user=${userId}`;
-        window.location.href = downloadURL;
-      } else {
+      const downloadRetryLimit = this.getFeatureSetting("downloadRetryLimit") ?? Infinity;
+      const downloadRetryInterval = this.getFeatureSetting("downloadRetryInterval") ?? 1e3;
+      const userIdElement = await this.runWithRetry(
+        () => document.querySelector(this.bookmarkImportSelectorSettings.userIdLink),
+        downloadRetryLimit,
+        downloadRetryInterval,
+        "linear"
+      );
+      const userIdLink = userIdElement?.getAttribute("href");
+      const userId = userIdLink ? new URL(userIdLink, window.location.origin).searchParams.get("user") : null;
+      if (!userId || !__privateGet(this, _exportId)) {
         this.postBookmarkImportMessage("actionCompleted", {
           result: new ErrorResponse({
             actionID: "download-data",
-            message: "No user id or export id found"
+            message: "User id or export id not found"
           })
         });
+        return;
       }
+      await this.runWithRetry(
+        () => document.querySelector(`a[href="./manage/archive/${__privateGet(this, _exportId)}"]`),
+        downloadRetryLimit,
+        downloadRetryInterval,
+        "linear"
+      );
+      const downloadURL = `${TAKEOUT_DOWNLOAD_URL_BASE}?j=${__privateGet(this, _exportId)}&i=0&user=${userId}`;
+      const downloadNavigationDelayMs = this.getFeatureSetting("downloadNavigationDelayMs") ?? 2e3;
+      await new Promise((resolve) => setTimeout(resolve, downloadNavigationDelayMs));
+      window.location.href = downloadURL;
     }
     /**
      * Here we ignore the action and return a default retry config

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.30.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.37.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.38.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e44e1539e8cc1863dfbca06bcfb63545ccf64350",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d069faac2111521ea1d9530b60fd7fefccc828a",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.0.tgz",
-      "integrity": "sha512-5x08bUtU8hfboMTrJ7mEO4CpepS9yBwAqcL52y86SWNmbPX8LVbNs3EP4cNrIZgdjk2NAlP2ahNihozpoZIxSg==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.30.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.37.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.38.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run