### PR TITLE
Update reference tests to version 1760787856

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.37.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -85,7 +85,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c2c6de816e3b7053a38b9c3081a0bf6a453b9d93",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#ba9468089d7c153a48a41dfd110971daf6c7b5e0",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.0.tgz",
-      "integrity": "sha512-5x08bUtU8hfboMTrJ7mEO4CpepS9yBwAqcL52y86SWNmbPX8LVbNs3EP4cNrIZgdjk2NAlP2ahNihozpoZIxSg==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.37.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass