### PR TITLE
Increase timeouts for ADS maestro tests

### DIFF
--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -24,7 +24,7 @@ tags:
         - assertVisible: "COLOR PALETTE"
         - tapOn: "TYPOGRAPHY"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "Text Appearance Caption"
@@ -39,7 +39,7 @@ tags:
         - assertVisible: "Keep Using"
         - tapOn: "Keep Using"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "Stacked Text Alert Dialog With 4 buttons"
@@ -48,7 +48,7 @@ tags:
         - assertVisible: "Keep Using"
         - tapOn: "Keep Using"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "Promo Bottom Sheet with image"
@@ -66,7 +66,7 @@ tags:
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/bottomSheetPromoPrimaryButton"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "Cookie Consent dialog with animation"
@@ -108,14 +108,14 @@ tags:
             index: 0
         - tapOn: "LIST ITEMS"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "With Beta Pill and Switch"
             direction: DOWN
         - tapOn: "Others"
         - scrollUntilVisible:
-            timeout: 30000
+            timeout: 50000
             speed: 60
             element:
               text: "Enable Dark Theme"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211693554008282?focus=true

### Description

Increased timeout values from 30000 to 50000 milliseconds in the design system components Maestro test flow to address persistent test failures. This change gives the UI elements more time to appear during scrolling operations.

### Steps to test this PR

_Verify Maestro tests pass_

- [ ] Run the design system components Maestro test flow
- [ ] Verify that all scrolling operations complete successfully without timing out

### UI changes

No UI changes, this is a test configuration update only.