### PR TITLE
do not show search/Duck.ai toggle when launched from search-only widget

### DIFF
--- a/app/src/main/java/com/duckduckgo/widget/SearchOnlyWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchOnlyWidget.kt
@@ -113,7 +113,7 @@ class SearchOnlyWidget : AppWidgetProvider() {
     }
 
     private fun buildPendingIntent(context: Context): PendingIntent {
-        val intent = SystemSearchActivity.fromWidget(context)
+        val intent = SystemSearchActivity.fromSearchOnlyWidget(context)
         return PendingIntent.getActivity(
             context,
             SEARCH_ONLY_WIDGET_REQUEST_CODE,

--- a/app/src/main/java/com/duckduckgo/widget/SearchWidgetConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchWidgetConfigurator.kt
@@ -57,7 +57,7 @@ class SearchWidgetConfigurator @Inject constructor(
             remoteViews.setViewVisibility(R.id.search, if (!voiceSearchEnabled && !showDuckAi) View.VISIBLE else View.GONE)
 
             if (voiceSearchEnabled) {
-                val pendingIntent = buildVoiceSearchPendingIntent(context, fromFavWidget)
+                val pendingIntent = buildVoiceSearchPendingIntent(context, fromFavWidget, fromSearchOnlyWidget)
                 remoteViews.setOnClickPendingIntent(R.id.voiceSearch, pendingIntent)
             }
 
@@ -71,15 +71,34 @@ class SearchWidgetConfigurator @Inject constructor(
     private fun buildVoiceSearchPendingIntent(
         context: Context,
         fromFavWidget: Boolean,
+        fromSearchOnlyWidget: Boolean,
     ): PendingIntent {
-        val intent = if (fromFavWidget) SystemSearchActivity.fromFavWidget(context, true) else SystemSearchActivity.fromWidget(context, true)
-        return PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val (intent, requestCode) = when {
+            fromFavWidget -> {
+                SystemSearchActivity.fromFavWidget(context, launchVoice = true) to REQUEST_CODE_SEARCH_WITH_FAV_WIDGET_VOICE_INTENT
+            }
+            fromSearchOnlyWidget -> {
+                SystemSearchActivity.fromSearchOnlyWidget(context, launchVoice = true) to REQUEST_CODE_SEARCH_ONLY_WIDGET_VOICE_INTENT
+            }
+            else -> {
+                SystemSearchActivity.fromWidget(context, launchVoice = true) to REQUEST_CODE_SEARCH_WIDGET_VOICE_INTENT
+            }
+        }
+        return PendingIntent.getActivity(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
     }
 
     private fun buildDuckAiPendingIntent(
         context: Context,
     ): PendingIntent {
         val intent = BrowserActivity.intent(context, openDuckChat = true, duckChatSessionActive = true).also { it.action = Intent.ACTION_VIEW }
-        return PendingIntent.getActivity(context, 2, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val requestCode = REQUEST_CODE_WIDGET_DUCK_AI_INTENT
+        return PendingIntent.getActivity(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private companion object {
+        private const val REQUEST_CODE_SEARCH_WIDGET_VOICE_INTENT = 1531
+        private const val REQUEST_CODE_SEARCH_WITH_FAV_WIDGET_VOICE_INTENT = 1541
+        private const val REQUEST_CODE_SEARCH_ONLY_WIDGET_VOICE_INTENT = 1551
+        private const val REQUEST_CODE_WIDGET_DUCK_AI_INTENT = 1561
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211693781927849?focus=true

### Description
When search-only widget is used, interactions now open the `SystemSearchActivity` instead of the Input Screen, even if the latter is enabled.

### Steps to test this PR

- [x] Go to Settings -> AI Features and enable Search & Duck.ai.
- [x] Go to Settings -> Accessibility and enabled Private Voice Search.
- [x] Go to Feature Flag Inventory and enable `showInputScreenOnSystemSearchLaunch`.
- [x] Force close and reopen the app.
- [x] Add a search-only widget to the home screen.
  - [x] Click on the widget (text box).
  - [x] Verify that `SystemSearchActivity` (without the toggle) opens.
  - [x] Verify that `m_w_l` pixel was sent.
  - [x] Go back to the home screen.
  - [x] Click on the widget (voice icon) and do not say anything or click the back arrow after voice capture starts.
  - [x] Verify that `SystemSearchActivity` (without the toggle) is open.
- [x] Add a search widget to the home screen.
  - [x] Click on the widget (text box).
  - [x] Verify that `InputScreenActivity` (with the toggle) opens.
  - [x] Verify that `m_w_l` pixel was sent.
  - [x] Go back to the home screen.
  - [x] Click on the widget (voice icon) and do not say anything or click the back arrow after voice capture starts.
  - [x] Verify that `InputScreenActivity` (with the toggle) is open.
