### PR TITLE
do not show Duck.ai button in the address bar when launched from search-only widget

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -74,7 +74,6 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.ui.BrowserScreens.PrivateSearchScreenNoParams
 import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.browser.ui.omnibar.OmnibarPosition
-import com.duckduckgo.browser.ui.omnibar.OmnibarPosition.TOP
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.KeyboardAwareEditText
 import com.duckduckgo.common.ui.view.addBottomShadow
@@ -238,6 +237,8 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             )
         }
 
+        viewModel.setLaunchedFromSearchOnlyWidget(launchedFromSearchOnlyWidget(intent))
+
         showKeyboard(omnibarTextInput)
     }
 
@@ -253,6 +254,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         super.onNewIntent(intent)
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
         viewModel.resetViewState()
+        viewModel.setLaunchedFromSearchOnlyWidget(launchedFromSearchOnlyWidget(intent))
         sendLaunchPixels(intent)
         val isOmnibarAtTop = settingsDataStore.omnibarPosition == OmnibarPosition.TOP
         val inputScreenLaunched = launchInputScreen(isTopOmnibar = isOmnibarAtTop, intent = intent)

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -98,6 +98,7 @@ class SystemSearchViewModel @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel(),
     EditSavedSiteDialogFragment.EditSavedSiteListener {
+
     data class OnboardingViewState(
         val visible: Boolean,
         val expanded: Boolean = false,
@@ -176,6 +177,8 @@ class SystemSearchViewModel @Inject constructor(
         data object ExitSearch : Command()
     }
 
+    private val isSearchOnly = MutableStateFlow(false)
+
     val onboardingViewState: MutableLiveData<OnboardingViewState> = MutableLiveData()
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
@@ -221,10 +224,11 @@ class SystemSearchViewModel @Inject constructor(
             flow = voiceSearchState.map { voiceSearchAvailability.isVoiceSearchAvailable },
             flow2 = queryFlow,
             flow3 = duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus,
-        ) { isVoiceSearchEnabled, query, isDuckAiEnabled ->
+            flow4 = isSearchOnly,
+        ) { isVoiceSearchEnabled, query, isDuckAiEnabled, isSearchOnly ->
             OmnibarViewState(
                 isVoiceSearchButtonVisible = isVoiceSearchEnabled,
-                isDuckAiButtonVisible = isDuckAiEnabled,
+                isDuckAiButtonVisible = !isSearchOnly && isDuckAiEnabled,
                 isClearButtonVisible = query.isNotEmpty(),
             )
         }.stateIn(viewModelScope, SharingStarted.Lazily, OmnibarViewState())
@@ -232,6 +236,10 @@ class SystemSearchViewModel @Inject constructor(
     init {
         resetViewState()
         refreshAppList()
+    }
+
+    fun setLaunchedFromSearchOnlyWidget(launchedFromSearchOnlyWidget: Boolean) {
+        isSearchOnly.value = launchedFromSearchOnlyWidget
     }
 
     private fun currentOnboardingState(): OnboardingViewState = onboardingViewState.value!!

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -695,6 +695,95 @@ class SystemSearchViewModelTest {
         }
     }
 
+    @Test
+    fun `when launched from search only widget and duck ai enabled then duck ai button not visible`() = runTest {
+        whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+        (mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus as MutableStateFlow).value = true
+        testee.queryFlow.value = "query"
+
+        testee.setLaunchedFromSearchOnlyWidget(true)
+
+        testee.omnibarViewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.isVoiceSearchButtonVisible)
+            assertFalse(viewState.isDuckAiButtonVisible)
+            assertTrue(viewState.isClearButtonVisible)
+            assertFalse(viewState.isButtonDividerVisible)
+        }
+    }
+
+    @Test
+    fun `when not launched from search only widget and duck ai enabled then duck ai button visible`() = runTest {
+        whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+        (mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus as MutableStateFlow).value = true
+        testee.queryFlow.value = "query"
+
+        testee.setLaunchedFromSearchOnlyWidget(false)
+
+        testee.omnibarViewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.isVoiceSearchButtonVisible)
+            assertTrue(viewState.isDuckAiButtonVisible)
+            assertTrue(viewState.isClearButtonVisible)
+            assertTrue(viewState.isButtonDividerVisible)
+        }
+    }
+
+    @Test
+    fun `when launched from search only widget and duck ai disabled then duck ai button not visible`() = runTest {
+        whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+        (mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus as MutableStateFlow).value = false
+        testee.queryFlow.value = "query"
+
+        testee.setLaunchedFromSearchOnlyWidget(true)
+
+        testee.omnibarViewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.isVoiceSearchButtonVisible)
+            assertFalse(viewState.isDuckAiButtonVisible)
+            assertTrue(viewState.isClearButtonVisible)
+            assertFalse(viewState.isButtonDividerVisible)
+        }
+    }
+
+    @Test
+    fun `when launched from search only widget and query empty then duck ai button not visible`() = runTest {
+        whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+        (mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus as MutableStateFlow).value = true
+        testee.queryFlow.value = ""
+
+        testee.setLaunchedFromSearchOnlyWidget(true)
+
+        testee.omnibarViewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.isVoiceSearchButtonVisible)
+            assertFalse(viewState.isDuckAiButtonVisible)
+            assertFalse(viewState.isClearButtonVisible)
+            assertFalse(viewState.isButtonDividerVisible)
+        }
+    }
+
+    @Test
+    fun `when reset view state then search only widget state preserved`() = runTest {
+        whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
+        (mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus as MutableStateFlow).value = true
+
+        // Set search-only widget state
+        testee.setLaunchedFromSearchOnlyWidget(true)
+        testee.queryFlow.value = "query"
+
+        // Reset view state
+        testee.resetViewState()
+
+        testee.omnibarViewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.isVoiceSearchButtonVisible)
+            assertFalse(viewState.isDuckAiButtonVisible) // Should still be false due to search-only widget
+            assertFalse(viewState.isClearButtonVisible) // Should be false due to reset
+            assertFalse(viewState.isButtonDividerVisible)
+        }
+    }
+
     private suspend fun whenOnboardingShowing() {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.resetViewState()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211693781927851?focus=true

### Description
Hides the Duck.ai button in the address bar if the `SystemSearchActivity` is launched from the search-only widget.

### Steps to test this PR

- [x] Open the app.
- [x] Ensure that Search & Duck.ai is disabled (Settings -> AI Features and enable).
- [x] Send a prompt to Duck.ai (at least one, to go through onboarding).
- [x] Add a search-only widget to the home screen.
  - [x] Verify that Duck.ai button is not visible in the widget.
  - [x] Click on the widget (text box).
  - [x] Verify that `SystemSearchActivity` opens and there's no Duck.ai button in the address bar.
- [x] Add a search or search-with-favorites widget to the home screen.
  - [x] Verify that Duck.ai button is visible in the widget.
  - [x] Click on the widget (text box).
  - [x] Verify that `SystemSearchActivity` opens and there is Duck.ai button in the address bar.