### PR TITLE
Fix ADS tests after removing DaxExpandableMenu component

### DIFF
--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -80,7 +80,7 @@ tags:
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/primaryCta"
         - tapOn: "LAYOUTS"
-        - assertVisible: "Expandable Layout"
+        - assertVisible: "Dax Dialog Card"
         - tapOn: "INTERACTIVE"
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/dax_switch_one"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205617573940217/task/1211712231166079?focus=true

### Description

This PR fixes ADS test that is checking visibility of a recently removed component.

### Steps to test this PR

- [ ] Android Design System end-to-end tests should pass

### No UI changes
