### PR TITLE
add `search_suggestion_index` pixel param to search suggestion click pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -22,6 +22,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
 import com.duckduckgo.app.autocomplete.impl.AutoCompletePixelNames
 import com.duckduckgo.app.autocomplete.impl.AutoCompleteRepository
+import com.duckduckgo.app.autocomplete.impl.AutocompletePixelParams
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.onboarding.store.AppStage
@@ -292,7 +293,7 @@ class AutoCompleteApi constructor(
         val hasFavoriteResults = suggestions.any { it is AutoCompleteBookmarkSuggestion && it.isFavorite }
         val hasHistoryResults = suggestions.any { it is AutoCompleteHistorySuggestion || it is AutoCompleteHistorySearchSuggestion }
         val hasSwitchToTabResults = suggestions.any { it is AutoCompleteSwitchToTabSuggestion }
-        val params = mapOf(
+        val params = mutableMapOf(
             PixelParameter.SHOWED_BOOKMARKS to hasBookmarkResults.toString(),
             PixelParameter.SHOWED_FAVORITES to hasFavoriteResults.toString(),
             PixelParameter.BOOKMARK_CAPABLE to hasBookmarks.toString(),
@@ -331,6 +332,11 @@ class AutoCompleteApi constructor(
             }
 
             else -> return
+        }
+
+        if (suggestion is AutoCompleteSearchSuggestion) {
+            val clickedSearchSuggestionIndex = suggestions.filter { it is AutoCompleteSearchSuggestion }.indexOf(suggestion)
+            params[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX] = clickedSearchSuggestionIndex.toString()
         }
 
         pixel.fire(pixelName, params)

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
@@ -33,3 +33,11 @@ enum class AutoCompletePixelNames(override val pixelName: String) : Pixel.PixelN
     AUTOCOMPLETE_DUCKAI_PROMPT_EXPERIMENTAL_SELECTION("m_autocomplete_click_duckai_experimental"),
     AUTOCOMPLETE_DUCKAI_PROMPT_LEGACY_SELECTION("m_autocomplete_click_duckai_legacy"),
 }
+
+object AutocompletePixelParams {
+    /**
+     * Parameter to capture the index of the selected suggestion within the list of search suggestions
+     * (either [AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION] or [AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION]).
+     */
+    const val PARAM_SEARCH_SUGGESTION_INDEX = "search_suggestion_index"
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211716661936840?focus=true

### Description
Adds a parameters to search suggestion click pixels with the index of the clicked suggestion. The index ignores history, favorites, bookmarks, and other suggestion types which are not strictly a query suggestion or a website suggestion.

For example, if the suggestions list includes:
- (history) hey
- (favorite) heeey.com/wave
- hey.com
- hey
- hello
- hello there

and users clicks on 'hello', the `search_suggestion_index=2` param will be appended.

### Steps to test this PR

- [x] Open the app, focus on the omnibar and type in a query.
- [x] Verify that clicking on a search suggestion sends an `m_autocomplete_click_phrase` pixel with `search_suggestion_index` matching the position of the suggestion in the list.
- [x] Verify that clicking on a website search suggestion sends an `m_autocomplete_click_website` pixel with `search_suggestion_index` matching the position of the suggestion in the list.