### PR TITLE
send a pixel when installed app suggestion clicked

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -326,7 +326,7 @@ class AutoCompleteApi constructor(
                 AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_PROMPT_LEGACY_SELECTION
             }
             is AutoCompleteDeviceAppSuggestion -> {
-                // todo add pixel for device app selection
+                pixel.fire(AutoCompletePixelNames.AUTOCOMPLETE_INSTALLED_APP_SELECTION)
                 return
             }
 

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
@@ -17,6 +17,11 @@
 package com.duckduckgo.app.autocomplete.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
 enum class AutoCompletePixelNames(override val pixelName: String) : Pixel.PixelName {
 
@@ -32,4 +37,14 @@ enum class AutoCompletePixelNames(override val pixelName: String) : Pixel.PixelN
 
     AUTOCOMPLETE_DUCKAI_PROMPT_EXPERIMENTAL_SELECTION("m_autocomplete_click_duckai_experimental"),
     AUTOCOMPLETE_DUCKAI_PROMPT_LEGACY_SELECTION("m_autocomplete_click_duckai_legacy"),
+    AUTOCOMPLETE_INSTALLED_APP_SELECTION("m_autocomplete_click_installed-app"),
+}
+
+@ContributesMultibinding(AppScope::class)
+class AutocompleteParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            AutoCompletePixelNames.AUTOCOMPLETE_INSTALLED_APP_SELECTION.pixelName to PixelParameter.removeAtb(),
+        )
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -2012,6 +2012,26 @@ class AutoCompleteApiTest {
         assertEquals(0, deviceAppSuggestions.size)
     }
 
+    @Test
+    fun whenDeviceAppSuggestionSubmittedThenAutoCompleteInstalledAppSelectionPixelSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
+        whenever(mockSavedSitesRepository.hasFavorites()).thenReturn(false)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
+
+        val suggestion = AutoCompleteDeviceAppSuggestion(
+            phrase = "test",
+            shortName = "Test App",
+            packageName = "com.test.app",
+            launchIntent = Intent(),
+        )
+        val suggestions = listOf(suggestion)
+
+        testee.fireAutocompletePixel(suggestions, suggestion)
+
+        verify(mockPixel).fire(AutoCompletePixelNames.AUTOCOMPLETE_INSTALLED_APP_SELECTION)
+    }
+
     private fun favorite(
         id: String = UUID.randomUUID().toString(),
         title: String = "title",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211719139917333?focus=true

### Description
Sends a pixel when installed app suggestion clicked.

### Steps to test this PR
- [x] Go to Settings -> AI Features and enable Search & Duck.ai.
- [x] Go to Feature Flag Inventory and enable `showInputScreenOnSystemSearchLaunch`.
- [x] Force close and reopen the app.
- [x] Add a widget to the home screen (**not** a search-only widget).
- [x] Click on the widget and verify that Input Screen with a Search/Duck.ai toggle opens.
- [x] Search for an app installed on your device.
- [x] Click on the app name.
- [x] Verify that `m_autocomplete_click_installed-app` fires with only `appVersion` as parameter.
