### PR TITLE
enabled Search/Duck.ai toggle in widgets

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -72,7 +72,7 @@ interface DuckChatFeature {
      * @return `true` when the Input Screen should be shown when user open the app from system widgets
      * If the remote feature is not present defaults to `disabled`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun showInputScreenOnSystemSearchLaunch(): Toggle
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211721545614750?focus=true

### Description
Enables Search/Duck.ai toggle in widgets.

### Steps to test this PR
- [x] Clean install the app.
- [x] Go to Settings -> AI Features and enable Search & Duck.ai.
- [x] Add a widget to the home screen (**not** a search-only widget).
- [x] Verify that clicking on the widget opens the Input Screen.

