### PR TITLE
Tweak icon size of the import bookmark result screen

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/fragment_import_bookmarks_result.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_import_bookmarks_result.xml
@@ -43,8 +43,8 @@
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/bookmarkIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="128dp"
+            android:layout_height="96dp"
             android:layout_marginTop="62dp"
             android:importantForAccessibility="no"
             android:scaleType="fitCenter"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211719217225178?focus=true 

### Description
Tweaks to icon size on the import bookmarks results screen

### Steps to test this PR
- QA optional
- If you want to test, go through the import bookmarks flow and make sure the icon on the results screen looks ok