### PR TITLE
Move DataClearerForegroundAppRestartPixel.firePendingPixels to coroutine

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/AutomaticDataClearerTest.kt
@@ -54,7 +54,12 @@ class AutomaticDataClearerTest {
     private val mockWorkManager: WorkManager = mock()
     private val pixel: Pixel = mock()
     private val dataClearerForegroundAppRestartPixel =
-        DataClearerForegroundAppRestartPixel(InstrumentationRegistry.getInstrumentation().targetContext, pixel)
+        DataClearerForegroundAppRestartPixel(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            pixel,
+            coroutineTestRule.testScope,
+            coroutineTestRule.testDispatcherProvider,
+        )
 
     @UiThreadTest
     @Before

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixelTest.kt
@@ -25,16 +25,21 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
+import com.duckduckgo.common.test.CoroutineTestRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 class DataClearerForegroundAppRestartPixelTest {
 
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val pixel = mock<Pixel>()
-    private val testee = DataClearerForegroundAppRestartPixel(context, pixel)
+    private val testee = DataClearerForegroundAppRestartPixel(context, pixel, coroutineTestRule.testScope, coroutineTestRule.testDispatcherProvider)
 
     @Before
     fun setUp() {

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearerForegroundAppRestartPixel.kt
@@ -23,13 +23,17 @@ import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchActivity
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import logcat.LogPriority.INFO
 import logcat.logcat
 import javax.inject.Inject
@@ -44,6 +48,8 @@ import javax.inject.Inject
 class DataClearerForegroundAppRestartPixel @Inject constructor(
     private val context: Context,
     private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
 ) : MainProcessLifecycleObserver {
     private var detectedUserIntent: Boolean = false
 
@@ -56,7 +62,9 @@ class DataClearerForegroundAppRestartPixel @Inject constructor(
     @UiThread
     override fun onCreate(owner: LifecycleOwner) {
         logcat(INFO) { "onAppCreated firePendingPixels" }
-        firePendingPixels()
+        appCoroutineScope.launch(dispatchers.io()) {
+            firePendingPixels()
+        }
     }
 
     @UiThread


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211694321477724/task/1211693809292322?focus=true

### Description

- Moves `firePendingPixels` to a coroutine

### Steps to test this PR

- [ ] Code review
