### PR TITLE
Update content scope scripts to version 11.44.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -8980,8 +8980,8 @@
   var BACKGROUND_COLOR_START = "rgba(85, 127, 243, 0.10)";
   var BACKGROUND_COLOR_END = "rgba(85, 127, 243, 0.25)";
   var OVERLAY_ID = "ddg-password-import-overlay";
-  var TAKEOUT_DOWNLOAD_URL_BASE = "/takeout/download";
-  var _exportButtonSettings, _settingsButtonSettings, _signInButtonSettings, _exportConfirmButtonSettings, _elementToCenterOn, _currentOverlay, _currentElementConfig, _domLoaded, _exportId, _processingBookmark, _isBookmarkModalVisible, _tappedElements;
+  var MANAGE_ARCHIVE_DEFAULT_BASE = "/manage/archive";
+  var _exportButtonSettings, _settingsButtonSettings, _signInButtonSettings, _exportConfirmButtonSettings, _elementToCenterOn, _currentOverlay, _currentElementConfig, _domLoaded, _processingBookmark, _isBookmarkModalVisible, _tappedElements;
   var AutofillImport = class extends ActionExecutorBase {
     constructor() {
       super(...arguments);
@@ -8996,7 +8996,6 @@
       /** @type {ElementConfig|null} */
       __privateAdd(this, _currentElementConfig);
       __privateAdd(this, _domLoaded);
-      __privateAdd(this, _exportId);
       __privateAdd(this, _processingBookmark);
       __privateAdd(this, _isBookmarkModalVisible, false);
       /** @type {WeakSet<Element>} */
@@ -9456,18 +9455,15 @@
       return `${__privateGet(this, _settingsButtonSettings)?.selectors?.join(",")}, ${this.settingsLabelTextSelector}`;
     }
     /** Bookmark import code */
+    get defaultRetrySettings() {
+      return {
+        maxAttempts: this.getFeatureSetting("downloadRetryLimit") ?? Infinity,
+        interval: this.getFeatureSetting("downloadRetryInterval") ?? 1e3
+      };
+    }
     async downloadData() {
-      const downloadRetryLimit = this.getFeatureSetting("downloadRetryLimit") ?? Infinity;
-      const downloadRetryInterval = this.getFeatureSetting("downloadRetryInterval") ?? 1e3;
-      const userIdElement = await this.runWithRetry(
-        () => document.querySelector(this.bookmarkImportSelectorSettings.userIdLink),
-        downloadRetryLimit,
-        downloadRetryInterval,
-        "linear"
-      );
-      const userIdLink = userIdElement?.getAttribute("href");
-      const userId = userIdLink ? new URL(userIdLink, window.location.origin).searchParams.get("user") : null;
-      if (!userId || !__privateGet(this, _exportId)) {
+      const exportId = window.location.pathname.split("/").filter((segment) => segment).pop();
+      if (!exportId) {
         this.postBookmarkImportMessage("actionCompleted", {
           result: new ErrorResponse({
             actionID: "download-data",
@@ -9476,25 +9472,25 @@
         });
         return;
       }
-      await this.runWithRetry(
-        () => document.querySelector(`a[href="./manage/archive/${__privateGet(this, _exportId)}"]`),
-        downloadRetryLimit,
-        downloadRetryInterval,
-        "linear"
+      const downloadLinkSelector = this.bookmarkImportSelectorSettings.downloadLink ?? `a[href*="&i=0&user="]`;
+      const downloadButton = (
+        /** @type {HTMLAnchorElement|null} */
+        await this.runWithRetry(() => document.querySelector(downloadLinkSelector), 5, 1e3, "linear")
       );
-      const downloadURL = `${TAKEOUT_DOWNLOAD_URL_BASE}?j=${__privateGet(this, _exportId)}&i=0&user=${userId}`;
-      const downloadNavigationDelayMs = this.getFeatureSetting("downloadNavigationDelayMs") ?? 2e3;
-      await new Promise((resolve) => setTimeout(resolve, downloadNavigationDelayMs));
-      window.location.href = downloadURL;
+      if (downloadButton == null) {
+        window.location.reload();
+      }
+      downloadButton?.click();
     }
     /**
      * Here we ignore the action and return a default retry config
      * as for now the retry doesn't need to be per action.
      */
     retryConfigFor(_2) {
+      const { interval, maxAttempts } = this.defaultRetrySettings;
       return {
-        interval: { ms: 1e3 },
-        maxAttempts: 30
+        interval: { ms: interval },
+        maxAttempts
       };
     }
     postBookmarkImportMessage(name, data2) {
@@ -9512,12 +9508,13 @@
     async handleBookmarkImportPath(pathname) {
       if (pathname === "/" && !__privateGet(this, _isBookmarkModalVisible)) {
         for (const action of this.bookmarkImportActionSettings) {
-          if (action.id === "manage-button-click") {
-            await this.storeExportId();
-          }
           await this.patchMessagingAndProcessAction(action);
         }
+        const exportId = await this.getExportId();
+        window.location.href = `${MANAGE_ARCHIVE_DEFAULT_BASE}/${exportId}`;
+      } else if (pathname.startsWith(MANAGE_ARCHIVE_DEFAULT_BASE)) {
         await this.downloadData();
+      } else {
       }
     }
     setPasswordImportSettings() {
@@ -9529,10 +9526,12 @@
     findExportId() {
       const panels = document.querySelectorAll(this.bookmarkImportSelectorSettings.tabPanel);
       const exportPanel = panels[panels.length - 1];
-      return exportPanel.querySelector("div[data-archive-id]")?.getAttribute("data-archive-id");
+      const dataArchiveIdSelector = this.bookmarkImportSelectorSettings.dataArchiveId ?? `div[data-archive-id]`;
+      return exportPanel.querySelector(dataArchiveIdSelector)?.getAttribute("data-archive-id");
     }
-    async storeExportId() {
-      __privateSet(this, _exportId, await this.runWithRetry(() => this.findExportId(), 30, 1e3, "linear"));
+    async getExportId() {
+      const { maxAttempts, interval } = this.defaultRetrySettings;
+      return await this.runWithRetry(() => this.findExportId(), maxAttempts, interval, "linear");
     }
     urlChanged() {
       this.handleLocation(window.location);
@@ -9569,7 +9568,6 @@
   _currentOverlay = new WeakMap();
   _currentElementConfig = new WeakMap();
   _domLoaded = new WeakMap();
-  _exportId = new WeakMap();
   _processingBookmark = new WeakMap();
   _isBookmarkModalVisible = new WeakMap();
   _tappedElements = new WeakMap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.33.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.41.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.44.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
       },
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.33.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.33.0.tgz",
-      "integrity": "sha512-A83hwYOI1P1hUy8R/xGsHupIEOCyW1Ud8gnkTIHAlUzTnfhi6UgtkIkot5370T6JdRAQIj3TG9Xhbnuuv7gMRg==",
+      "version": "14.33.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.33.1.tgz",
+      "integrity": "sha512-YRcSMcHyroA3vSPDeaXTWLMvizff1udDL9Czf1mEtLKzUy1nemdlymYpVG+SJ5aubqzOb0i4B/Sno2Vm3Hqn3w==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#78e092d182bf1ad15bb14ee8e0b0c4cc959415bb",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4b7100465e1d738d472eac0a866cfd2c8c02ea35",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -542,7 +542,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.33.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.41.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.44.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211740937478157/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run