### PR TITLE
Fix ANR when checking if vpnItem isEnabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.menu
 
 import com.duckduckgo.app.browser.viewstate.VpnMenuState
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.subscriptions.api.Product.NetP
@@ -26,6 +27,7 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 interface VpnMenuStateProvider {
@@ -38,6 +40,7 @@ class VpnMenuStateProviderImpl @Inject constructor(
     private val networkProtectionState: NetworkProtectionState,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val vpnMenuStore: VpnMenuStore,
+    private val dispatcherProvider: DispatcherProvider,
 ) : VpnMenuStateProvider {
     override fun getVpnMenuState(): Flow<VpnMenuState> {
         return combine(
@@ -63,7 +66,7 @@ class VpnMenuStateProviderImpl @Inject constructor(
                     }
                 }
             }
-        }
+        }.flowOn(dispatcherProvider.io())
     }
 }
 
@@ -73,5 +76,6 @@ private fun SubscriptionStatus.isActive(): Boolean =
         SubscriptionStatus.NOT_AUTO_RENEWABLE,
         SubscriptionStatus.GRACE_PERIOD,
         -> true
+
         else -> false
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
@@ -65,7 +65,13 @@ class VpnMenuStateProviderTest {
         whenever(androidBrowserConfigFeature.vpnMenuItem()).thenReturn(featureToggle)
         whenever(featureToggle.isEnabled()).thenReturn(true)
         whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(true)
-        testee = VpnMenuStateProviderImpl(subscriptions, networkProtectionState, androidBrowserConfigFeature, vpnMenuStore)
+        testee = VpnMenuStateProviderImpl(
+            subscriptions,
+            networkProtectionState,
+            androidBrowserConfigFeature,
+            vpnMenuStore,
+            coroutineTestRule.testDispatcherProvider,
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211741824546708?focus=true 

### Description
Ensure flow runs in io dispatcher

### Steps to test this PR

_Pre-steps_
- [x] Apply PPro patch -> https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Set device language to English (United Kingdom or United States)

_Not Subscribed_
- [x] Fresh install
- [x] Open a new tab page
- [x] Check you see the new VPN menu item with pill "TRY FOR FREE"

_Subscribed & Active_
- [ ] Tap on VPN menu item
- [ ] Purchase a subscription
- [ ] Once the purchase is finished, go back to new tab page
- [ ] Open overflow menu
- [ ] Check VPN menu item is there with off indicator

_Subscribed & Not Active_
- [ ] Tap on VPN menu item
- [ ] Check it navigates to VPN management screen
- [ ] Enable VPN
- [ ] Go back to new tab page
- [ ] Open overflow menu
- [ ] Check VPN menu item is there with on indicator

_Not en-GB or en-US_
- [x] Switch your device language to something other than English (UK) or English (US)
- [x] Go back to the browser
- [x] Open a new tab
- [x] Open overflow menu
- [x] Check VPN is not there, as user it is not eligible

_FF disabled_
- [x] Go to Feature Flag inventory and disable `vpnMenuItem`
- [x] Set device language back to English (UK or US)
- [x] Go to a new tab page
- [x] Check VPN menu item is not shown

### No UI changes
