### PR TITLE
Internal Tooling: Fix ModuleCreator to be compatible with configuration cache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.duckduckgo.gradle.ModuleCreator
+
 plugins {
     id 'com.android.application'
 
@@ -608,6 +610,8 @@ tasks.register('assemblePlayReleaseDefaultVariant', Exec) {
     commandLine "$rootDir/gradlew", ':app:assemblePlayRelease', "-Pforce-default-variant"
 }
 
-task newModule(type: com.duckduckgo.gradle.ModuleCreator) {
-    feature = project.hasProperty('feature') ? project.getProperty('feature') : null
+tasks.register('newModule', ModuleCreator) {
+    feature.set(providers.gradleProperty('feature'))
+    repoRootDirectory.set(rootProject.layout.projectDirectory)
+    appBuildGradleFile.set(layout.projectDirectory.file('build.gradle'))
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211755482019375?focus=true

### Description
Fixes the `ModuleCreator` task to be compatible with gradle configuration cache which is enabled for the project

### Steps to test this PR

_Create new impl module_
- [x] Run `./gradlew newModule -Pfeature=test-module/impl` 
- [x] Verify new module `test-module-impl` is created under `test-module` folder
- [x] Verify the task is successful and there is no exception

_Create new api module_
- [x] Run `./gradlew newModule -Pfeature=test-module/api` 
- [x] Verify new module `test-module-api` is created under `test-module` folder
- [x] Verify the task is successful and there is no exception

### UI changes
No UI changes
