### PR TITLE
Bookmark import flow observability

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImpl.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImpl.kt
@@ -42,7 +42,8 @@ class ImportFromGoogleImpl @Inject constructor(
     override suspend fun getBookmarksImportLaunchIntent(): Intent? {
         return withContext(dispatchers.io()) {
             if (autofillFeature.canImportBookmarksFromGoogleTakeout().isEnabled()) {
-                globalActivityStarter.startIntent(context, ImportBookmarksViaGoogleTakeoutScreen)
+                val launchSource = getLaunchSource()
+                globalActivityStarter.startIntent(context, ImportBookmarksViaGoogleTakeoutScreen(launchSource))
             } else {
                 null
             }
@@ -68,5 +69,10 @@ class ImportFromGoogleImpl @Inject constructor(
                 is ImportGoogleBookmarkResult.Error -> PublicResult.Error
             }
         }
+    }
+
+    private fun getLaunchSource(): String {
+        // launchSource can only be bookmarks screen or dev settings currently, so hardcoding to bookmarks screen for now
+        return "bookmarks_screen"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarkResult.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarkResult.kt
@@ -49,5 +49,5 @@ sealed interface UserCannotImportReason : Parcelable {
     data object Unknown : UserCannotImportReason
 
     @Parcelize
-    data object WebViewError : UserCannotImportReason
+    data class WebViewError(val step: String) : UserCannotImportReason
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt
@@ -63,11 +63,6 @@ import com.duckduckgo.autofill.impl.importing.takeout.webflow.ImportGoogleBookma
 import com.duckduckgo.autofill.impl.importing.takeout.webflow.ImportGoogleBookmarksWebFlowViewModel.ViewState.ShowWebPage
 import com.duckduckgo.autofill.impl.importing.takeout.webflow.ImportGoogleBookmarksWebFlowViewModel.ViewState.UserCancelledImportFlow
 import com.duckduckgo.autofill.impl.importing.takeout.webflow.ImportGoogleBookmarksWebFlowViewModel.ViewState.UserFinishedCannotImport
-import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.DownloadError
-import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.ErrorParsingBookmarks
-import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.Unknown
-import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebAutomationError
-import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebViewError
 import com.duckduckgo.autofill.impl.jsbridge.request.SupportedAutofillInputSubType
 import com.duckduckgo.autofill.impl.jsbridge.request.SupportedAutofillInputSubType.PASSWORD
 import com.duckduckgo.autofill.impl.store.ReAuthenticationDetails
@@ -388,7 +383,7 @@ class ImportGoogleBookmarksWebFlowFragment :
 
     override fun onFatalWebViewError() {
         logcat(WARN) { "Bookmark-import: Fatal WebView error received" }
-        exitFlowAsError(WebViewError)
+        viewModel.onFatalWebViewError()
     }
 
     private fun configureBackButtonHandler() {
@@ -435,7 +430,7 @@ class ImportGoogleBookmarksWebFlowFragment :
     }
 
     private fun exitFlowAsError(reason: UserCannotImportReason) {
-        logcat { "Bookmark-import: Flow error at stage: ${reason.mapToStage()}" }
+        logcat { "Bookmark-import: Flow error at stage: $reason" }
         onWebFlowEnding()
 
         lifecycleScope.launch {
@@ -576,12 +571,3 @@ class ImportGoogleBookmarksWebFlowFragment :
         private const val SELECT_CREDENTIALS_FRAGMENT_TAG = "autofillSelectCredentialsDialog"
     }
 }
-
-private fun UserCannotImportReason.mapToStage(): String =
-    when (this) {
-        is DownloadError -> "zip-download-error"
-        is ErrorParsingBookmarks -> "zip-parse-error"
-        is Unknown -> "import-error-unknown"
-        is WebViewError -> "webview-error"
-        is WebAutomationError -> "web-automation-step-failure-${this.step}"
-    }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowViewModel.kt
@@ -260,6 +260,13 @@ class ImportGoogleBookmarksWebFlowViewModel @Inject constructor(
         }
     }
 
+    fun onFatalWebViewError() {
+        viewModelScope.launch {
+            val stage = webFlowStepObserver.getCurrentStep()
+            _commands.emit(ExitFlowAsFailure(UserCannotImportReason.WebViewError(stage)))
+        }
+    }
+
     companion object {
         private const val TAKEOUT_ADDRESS = "takeout.google.com"
         private const val ACCOUNTS_ADDRESS = "accounts.google.com"

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/ImportGoogleBookmarksDurationBucketing.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/ImportGoogleBookmarksDurationBucketing.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.takeout.webflow.journey
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+interface ImportGoogleBookmarksDurationBucketing {
+    fun bucket(durationMillis: Long): String
+}
+
+@ContributesBinding(AppScope::class)
+class RealImportGoogleBookmarksDurationBucketing @Inject constructor() : ImportGoogleBookmarksDurationBucketing {
+
+    override fun bucket(durationMillis: Long): String {
+        if (durationMillis < 0) return "negative"
+        val seconds = TimeUnit.MILLISECONDS.toSeconds(durationMillis)
+
+        return when (seconds) {
+            in 0..19 -> "20"
+            in 20..39 -> "40"
+            in 40..59 -> "60"
+            in 60..89 -> "90"
+            in 90..119 -> "120"
+            in 120..149 -> "150"
+            in 150..179 -> "180"
+            in 180..239 -> "240"
+            in 240..299 -> "300"
+            else -> "longer"
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/ImportGoogleBookmarksJourney.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/ImportGoogleBookmarksJourney.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.takeout.webflow.journey
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.DownloadError
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.ErrorParsingBookmarks
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.Unknown
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebAutomationError
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebViewError
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS
+import com.duckduckgo.autofill.impl.time.TimeProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import logcat.logcat
+import javax.inject.Inject
+
+interface ImportGoogleBookmarksJourney {
+    fun started(launchSource: String)
+    fun startedWaitingForExport()
+    fun stoppedWaitingForExport()
+    fun finishedWithSuccess()
+    fun finishedWithError(error: UserCannotImportReason)
+    fun cancelled(stepReached: String)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealImportGoogleBookmarksJourney @Inject constructor(
+    private val timeProvider: TimeProvider,
+    private val pixel: Pixel,
+    private val flowDurationBucketing: ImportGoogleBookmarksDurationBucketing,
+) : ImportGoogleBookmarksJourney {
+
+    private var wholeFlowStartTime: Long = 0
+    private var totalWaitingDuration: Long = 0
+    private var currentWaitingStartTime: Long? = null
+    private var launchSource: String = "unknown"
+    private var userIsWaitingOnExport: Boolean = false
+
+    override fun started(launchSource: String) {
+        logcat { "Bookmark-import: journey started from source: $launchSource" }
+        this.launchSource = launchSource
+        reset()
+
+        val params = mapOf(LAUNCH_SOURCE_PARAM to launchSource)
+        pixel.fire(pixel = AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED, params, type = Count)
+    }
+
+    private fun reset() {
+        wholeFlowStartTime = timeProvider.currentTimeMillis()
+        totalWaitingDuration = 0
+        currentWaitingStartTime = null
+        userIsWaitingOnExport = false
+    }
+
+    override fun startedWaitingForExport() {
+        if (userIsWaitingOnExport) {
+            logcat { "Bookmark-import: already waiting for export, no further action required" }
+            return
+        }
+        userIsWaitingOnExport = true
+        currentWaitingStartTime = timeProvider.currentTimeMillis()
+        logcat { "Bookmark-import: user is now waiting for export" }
+    }
+
+    override fun stoppedWaitingForExport() {
+        userIsWaitingOnExport = false
+        currentWaitingStartTime?.let { startTime ->
+            totalWaitingDuration += (timeProvider.currentTimeMillis() - startTime)
+            currentWaitingStartTime = null
+            logcat { "Bookmark-import: no longer waiting for export. total wait time: ${totalWaitingDuration}ms" }
+        }
+    }
+
+    override fun finishedWithSuccess() {
+        stoppedWaitingForExport()
+
+        val durations = calculateDurations()
+        logcat {
+            "Bookmark-import: journey finished successfully, " +
+                "source: $launchSource, " +
+                "durationFullFlow: ${durations.fullFlow}, " +
+                "durationWaitingForExport: ${durations.waitingForExport}"
+        }
+
+        val params = mapOf(
+            LAUNCH_SOURCE_PARAM to launchSource,
+            DURATION_FULL_FLOW_PARAM to flowDurationBucketing.bucket(durations.fullFlow),
+            DURATION_WAITING_FOR_EXPORT_PARAM to flowDurationBucketing.bucket(durations.waitingForExport),
+        )
+
+        pixel.fire(pixel = BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS, params, type = Count)
+    }
+
+    override fun finishedWithError(error: UserCannotImportReason) {
+        stoppedWaitingForExport()
+
+        val durations = calculateDurations()
+        val errorParam = error.mapToJourneyParam()
+
+        logcat {
+            "Bookmark-import: journey finished with error, " +
+                "error: $errorParam, " +
+                "source: $launchSource, " +
+                "durationFullFlow: ${durations.fullFlow}, " +
+                "durationWaitingForExport: ${durations.waitingForExport}"
+        }
+
+        val params = mapOf(
+            LAUNCH_SOURCE_PARAM to launchSource,
+            DURATION_FULL_FLOW_PARAM to flowDurationBucketing.bucket(durations.fullFlow),
+            DURATION_WAITING_FOR_EXPORT_PARAM to flowDurationBucketing.bucket(durations.waitingForExport),
+            ERROR_REASON_PARAM to errorParam,
+        )
+
+        pixel.fire(pixel = BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR, params, type = Count)
+    }
+
+    override fun cancelled(stepReached: String) {
+        stoppedWaitingForExport()
+
+        val durations = calculateDurations()
+        logcat {
+            "Bookmark-import: journey finished because of cancellation, " +
+                "step: $stepReached, " +
+                "source: $launchSource, " +
+                "durationFullFlow: ${durations.fullFlow}, " +
+                "durationWaitingForExport: ${durations.waitingForExport}"
+        }
+
+        val params = mapOf(
+            LAUNCH_SOURCE_PARAM to launchSource,
+            DURATION_FULL_FLOW_PARAM to flowDurationBucketing.bucket(durations.fullFlow),
+            DURATION_WAITING_FOR_EXPORT_PARAM to flowDurationBucketing.bucket(durations.waitingForExport),
+            STEP_REACHED_PARAM to stepReached,
+        )
+
+        pixel.fire(pixel = BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED, params, type = Count)
+    }
+
+    private fun calculateDurations(): Durations {
+        val durationFullFlow = (timeProvider.currentTimeMillis() - wholeFlowStartTime)
+        val durationWaitingForExport = totalWaitingDuration
+        return Durations(fullFlow = durationFullFlow, waitingForExport = durationWaitingForExport)
+    }
+
+    private fun UserCannotImportReason.mapToJourneyParam(): String {
+        return when (this) {
+            is DownloadError -> "downloadingExport"
+            is ErrorParsingBookmarks -> "parsingBookmarks"
+            is WebViewError -> "webView-${this.step}"
+            is WebAutomationError -> "webAutomation-${this.step}"
+            is Unknown -> "unknown"
+        }
+    }
+
+    private data class Durations(
+        val fullFlow: Long,
+        val waitingForExport: Long,
+    )
+
+    companion object {
+        private const val LAUNCH_SOURCE_PARAM = "launchSource"
+        private const val DURATION_FULL_FLOW_PARAM = "durationFullFlow"
+        private const val DURATION_WAITING_FOR_EXPORT_PARAM = "durationWaitingForExport"
+        private const val STEP_REACHED_PARAM = "stepReached"
+        private const val ERROR_REASON_PARAM = "errorReason"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -64,6 +64,11 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAK
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_EXTRA_CHROME_EXPORT
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -211,6 +216,12 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_OVERFLOW_MENU("autofill_reset_excluded_overflow_menu_tapped"),
 
     AUTOFILL_SYSTEM_AUTOFILL_USED("autofill_systemautofill_used"),
+
+    BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED("bookmark_import_from_google_flow_started"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS("bookmark_import_from_google_flow_success"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR("bookmark_import_from_google_flow_error"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED("bookmark_import_from_google_flow_cancelled"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_EXTRA_CHROME_EXPORT("bookmark_import_from_google_flow_extra_chrome_export"),
 }
 
 object AutofillPixelParameters {
@@ -289,6 +300,12 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_SYSTEM_AUTOFILL_USED.pixelName to PixelParameter.removeAtb(),
 
             AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_WEBVIEW_CRASH.pixelName to PixelParameter.removeAtb(),
+
+            BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED.pixelName to PixelParameter.removeAtb(),
+            BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR.pixelName to PixelParameter.removeAtb(),
+            BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED.pixelName to PixelParameter.removeAtb(),
+            BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_EXTRA_CHROME_EXPORT.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImplTest.kt
@@ -37,8 +37,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import com.duckduckgo.autofill.api.ImportFromGoogle.ImportFromGoogleResult as PublicResult
 import com.duckduckgo.autofill.impl.importing.takeout.webflow.ImportGoogleBookmarkResult as InternalResult
@@ -67,8 +67,12 @@ class ImportFromGoogleImplTest {
             context = context,
         )
 
-        whenever(globalActivityStarter.startIntent(anyOrNull(), eq(ImportBookmarksViaGoogleTakeoutScreen)))
-            .thenReturn(Intent())
+        whenever(
+            globalActivityStarter.startIntent(
+                anyOrNull(),
+                any<ImportBookmarksViaGoogleTakeoutScreen>(),
+            ),
+        ).thenReturn(Intent())
     }
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowViewModelTest.kt
@@ -39,118 +39,114 @@ class ImportGoogleBookmarksWebFlowViewModelTest {
     )
 
     @Test
-    fun whenOnPageStartedWithTakeoutUrlThenHideWebPage() =
-        runTest {
-            testee.onPageStarted("https://takeout.google.com")
-            assertEquals(HideWebPage, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithTakeoutUrlThenHideWebPage() = runTest {
+        testee.onPageStarted("https://takeout.google.com")
+        assertEquals(HideWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithUppercaseTakeoutUrlThenHideWebPage() =
-        runTest {
-            testee.onPageStarted("https://TAKEOUT.GOOGLE.COM")
-            assertEquals(HideWebPage, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithUppercaseTakeoutUrlThenHideWebPage() = runTest {
+        testee.onPageStarted("https://TAKEOUT.GOOGLE.COM")
+        assertEquals(HideWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithAccountsGoogleUrlThenShowWebPage() =
-        runTest {
-            testee.onPageStarted("https://accounts.google.com/signin")
-            assertEquals(ShowWebPage, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithAccountsGoogleUrlThenShowWebPage() = runTest {
+        testee.onPageStarted("https://accounts.google.com/signin")
+        assertEquals(ShowWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithExampleUrlThenShowWebPage() =
-        runTest {
-            testee.onPageStarted("https://example.com/page")
-            assertEquals(ShowWebPage, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithExampleUrlThenShowWebPage() = runTest {
+        testee.onPageStarted("https://example.com/page")
+        assertEquals(ShowWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithAccountsGoogleUrlContainingTakeoutInPathThenShowWebPage() =
-        runTest {
-            testee.onPageStarted("https://accounts.google.com/signin?continue=https://takeout.google.com")
-            assertEquals(ShowWebPage, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithAccountsGoogleUrlContainingTakeoutInPathThenShowWebPage() = runTest {
+        testee.onPageStarted("https://accounts.google.com/signin?continue=https://takeout.google.com")
+        assertEquals(ShowWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithNullUrlThenViewStateRemainsUnchanged() =
-        runTest {
-            val initialState = testee.viewState.value
-            testee.onPageStarted(null)
-            assertEquals(initialState, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithNullUrlThenViewStateRemainsUnchanged() = runTest {
+        val initialState = testee.viewState.value
+        testee.onPageStarted(null)
+        assertEquals(initialState, testee.viewState.value)
+    }
 
     @Test
-    fun whenOnPageStartedWithMalformedUrlThenViewStateRemainsUnchanged() =
-        runTest {
-            val initialState = testee.viewState.value
-            testee.onPageStarted("not-a-valid-url")
-            assertEquals(initialState, testee.viewState.value)
-        }
+    fun whenOnPageStartedWithMalformedUrlThenViewStateRemainsUnchanged() = runTest {
+        val initialState = testee.viewState.value
+        testee.onPageStarted("not-a-valid-url")
+        assertEquals(initialState, testee.viewState.value)
+    }
 
     @Test
-    fun whenFirstPageLoadingThenShowWebPageState() =
-        runTest {
-            testee.firstPageLoading()
-            assertEquals(ShowWebPage, testee.viewState.value)
-        }
+    fun whenFirstPageLoadingThenShowWebPageState() = runTest {
+        testee.firstPageLoading()
+        assertEquals(ShowWebPage, testee.viewState.value)
+    }
 
     @Test
-    fun whenBackButtonPressedAndCannotGoBackThenPromptUserToConfirmFlowCancellation() =
-        runTest {
-            testee.commands.test {
-                testee.onBackButtonPressed(canGoBack = false)
-                val command = awaitItem()
-                assertTrue(command is PromptUserToConfirmFlowCancellation)
-            }
+    fun whenBackButtonPressedAndCannotGoBackThenPromptUserToConfirmFlowCancellation() = runTest {
+        testee.commands.test {
+            testee.onBackButtonPressed(canGoBack = false)
+            val command = awaitItem()
+            assertTrue(command is PromptUserToConfirmFlowCancellation)
         }
+    }
 
     @Test
-    fun whenBackButtonPressedAndCanGoBackThenNavigatingBackState() =
-        runTest {
-            testee.onBackButtonPressed(canGoBack = true)
-            assertEquals(NavigatingBack, testee.viewState.value)
-        }
+    fun whenBackButtonPressedAndCanGoBackThenNavigatingBackState() = runTest {
+        testee.onBackButtonPressed(canGoBack = true)
+        assertEquals(NavigatingBack, testee.viewState.value)
+    }
 
     @Test
-    fun whenDownloadDetectedWithValidZipThenProcessorCalled() =
-        runTest {
-            configureImportSuccessful()
+    fun whenDownloadDetectedWithValidZipThenProcessorCalled() = runTest {
+        configureImportSuccessful()
 
-            testee.commands.test {
-                triggerDownloadDetectedWithTakeoutZip()
-                awaitItem()
-                verify(mockBookmarkImportProcessor).downloadAndImportFromTakeoutZipUrl(any(), any(), any())
-            }
+        testee.commands.test {
+            triggerDownloadDetectedWithTakeoutZip()
+            awaitItem()
+            verify(mockBookmarkImportProcessor).downloadAndImportFromTakeoutZipUrl(any(), any(), any())
         }
+    }
 
     @Test
-    fun whenDownloadDetectedWithValidZipButFailsToDownloadThenExitFlowAsFailureCommandEmitted() =
-        runTest {
-            configureImportFailure()
+    fun whenDownloadDetectedWithValidZipButFailsToDownloadThenExitFlowAsFailureCommandEmitted() = runTest {
+        configureImportFailure()
 
-            testee.commands.test {
-                triggerDownloadDetectedWithTakeoutZip()
-                awaitItem() as Command.ExitFlowAsFailure
-            }
+        testee.commands.test {
+            triggerDownloadDetectedWithTakeoutZip()
+            awaitItem() as Command.ExitFlowAsFailure
         }
-
-    @Test
-    fun whenDownloadDetectedWithInvalidTypeThenExitFlowAsFailureCommandEmitted() =
-        runTest {
-            testee.commands.test {
-                triggerDownloadDetectedButNotATakeoutZip()
-                awaitItem() as Command.ExitFlowAsFailure
-            }
-        }
+    }
 
     @Test
-    fun whenUpdateLatestStepLoginPageFromUninitializedThenSetsToFirstVisit() =
-        runTest {
-            testee.onPageStarted("https://accounts.google.com")
-            assertEquals(ShowWebPage, testee.viewState.value)
+    fun whenDownloadDetectedWithInvalidTypeThenExitFlowAsFailureCommandEmitted() = runTest {
+        testee.commands.test {
+            triggerDownloadDetectedButNotATakeoutZip()
+            awaitItem() as Command.ExitFlowAsFailure
         }
+    }
+
+    @Test
+    fun whenUpdateLatestStepLoginPageFromUninitializedThenSetsToFirstVisit() = runTest {
+        testee.onPageStarted("https://accounts.google.com")
+        assertEquals(ShowWebPage, testee.viewState.value)
+    }
+
+    @Test
+    fun whenFatalWebViewErrorEncounteredThenExitFlowAsFailure() = runTest {
+        whenever(mockWebFlowStepObserver.getCurrentStep()).thenReturn("some-step")
+        testee.commands.test {
+            testee.onFatalWebViewError()
+            val command = awaitItem() as Command.ExitFlowAsFailure
+            assertTrue(command.reason is UserCannotImportReason.WebViewError)
+        }
+    }
 
     private fun triggerDownloadDetectedWithTakeoutZip() {
         testee.onDownloadDetected(

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/RealImportGoogleBookmarksDurationBucketingTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/RealImportGoogleBookmarksDurationBucketingTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.takeout.webflow.journey
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.concurrent.TimeUnit.MINUTES
+import java.util.concurrent.TimeUnit.SECONDS
+
+class RealImportGoogleBookmarksDurationBucketingTest {
+
+    private val testee = RealImportGoogleBookmarksDurationBucketing()
+
+    @Test
+    fun whenInputIsNegativeThenBucketIsNegative() {
+        assertEquals("negative", testee.bucket(-1))
+    }
+
+    @Test
+    fun whenInputIsZeroThenBucketIs20() {
+        assertEquals("20", testee.bucket(0))
+    }
+
+    @Test
+    fun whenInputIs19SecondsThenBucketIs20() {
+        assertEquals("20", testee.bucket(SECONDS.toMillis(19)))
+    }
+
+    @Test
+    fun whenInputIs20SecondsThenBucketIs40() {
+        assertEquals("40", testee.bucket(SECONDS.toMillis(20)))
+    }
+
+    @Test
+    fun whenInputIs39SecondsThenBucketIs40() {
+        assertEquals("40", testee.bucket(SECONDS.toMillis(39)))
+    }
+
+    @Test
+    fun whenInputIs40SecondsThenBucketIs60() {
+        assertEquals("60", testee.bucket(SECONDS.toMillis(40)))
+    }
+
+    @Test
+    fun whenInputIs59SecondsThenBucketIs60() {
+        assertEquals("60", testee.bucket(SECONDS.toMillis(59)))
+    }
+
+    @Test
+    fun whenInputIs60SecondsThenBucketIs90() {
+        assertEquals("90", testee.bucket(SECONDS.toMillis(60)))
+    }
+
+    @Test
+    fun whenInputIs89SecondsThenBucketIs90() {
+        assertEquals("90", testee.bucket(SECONDS.toMillis(89)))
+    }
+
+    @Test
+    fun whenInputIs90SecondsThenBucketIs120() {
+        assertEquals("120", testee.bucket(SECONDS.toMillis(90)))
+    }
+
+    @Test
+    fun whenInputIs119SecondsThenBucketIs120() {
+        assertEquals("120", testee.bucket(SECONDS.toMillis(119)))
+    }
+
+    @Test
+    fun whenInputIs120SecondsThenBucketIs150() {
+        assertEquals("150", testee.bucket(SECONDS.toMillis(120)))
+    }
+
+    @Test
+    fun whenInputIs149SecondsThenBucketIs150() {
+        assertEquals("150", testee.bucket(SECONDS.toMillis(149)))
+    }
+
+    @Test
+    fun whenInputIs150SecondsThenBucketIs180() {
+        assertEquals("180", testee.bucket(SECONDS.toMillis(150)))
+    }
+
+    @Test
+    fun whenInputIs179SecondsThenBucketIs180() {
+        assertEquals("180", testee.bucket(SECONDS.toMillis(179)))
+    }
+
+    @Test
+    fun whenInputIs180SecondsThenBucketIs240() {
+        assertEquals("240", testee.bucket(SECONDS.toMillis(180)))
+    }
+
+    @Test
+    fun whenInputIs239SecondsThenBucketIs240() {
+        assertEquals("240", testee.bucket(SECONDS.toMillis(239)))
+    }
+
+    @Test
+    fun whenInputIs240SecondsThenBucketIs300() {
+        assertEquals("300", testee.bucket(SECONDS.toMillis(240)))
+    }
+
+    @Test
+    fun whenInputIs299SecondsThenBucketIs300() {
+        assertEquals("300", testee.bucket(SECONDS.toMillis(299)))
+    }
+
+    @Test
+    fun whenInputIs300SecondsThenBucketIsLonger() {
+        assertEquals("longer", testee.bucket(SECONDS.toMillis(300)))
+    }
+
+    @Test
+    fun whenInputIsLargeThenBucketIsLonger() {
+        assertEquals("longer", testee.bucket(MINUTES.toMillis(10)))
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/RealImportGoogleBookmarksJourneyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/journey/RealImportGoogleBookmarksJourneyTest.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.takeout.webflow.journey
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebAutomationError
+import com.duckduckgo.autofill.impl.importing.takeout.webflow.UserCannotImportReason.WebViewError
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS
+import com.duckduckgo.autofill.impl.time.TimeProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealImportGoogleBookmarksJourneyTest {
+
+    private val mockTimeProvider: TimeProvider = mock()
+    private val pixel: Pixel = mock()
+
+    private val durationCaptor = argumentCaptor<Long>()
+    private val pixelParamsCaptor = argumentCaptor<Map<String, String>>()
+    private val flowDurationBucketing: ImportGoogleBookmarksDurationBucketing = mock()
+
+    private val testee = RealImportGoogleBookmarksJourney(
+        timeProvider = mockTimeProvider,
+        pixel = pixel,
+        flowDurationBucketing = flowDurationBucketing,
+    )
+
+    @Before
+    fun setup() {
+        whenever(flowDurationBucketing.bucket(anyOrNull())).thenReturn(FULL_FLOW_BUCKET, WAITING_FOR_EXPORT_BUCKET)
+        whenever(mockTimeProvider.currentTimeMillis()).thenReturn(0L)
+    }
+
+    @Test
+    fun whenStartedThenPixelIsCorrect() = runTest {
+        testee.started(LAUNCH_SOURCE)
+
+        verifyPixelFired(BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_STARTED)
+        val params = pixelParamsCaptor.firstValue
+        assertEquals(LAUNCH_SOURCE, params[LAUNCH_SOURCE_PARAM])
+    }
+
+    @Test
+    fun whenFinishedSuccessfullyThenFullFlowDurationCorrect() = runTest {
+        startJourney()
+        atTime(5_000) { testee.finishedWithSuccess() }
+        assertEquals(5_000, captureDurations().fullFlow)
+    }
+
+    @Test
+    fun whenFinishedWithErrorThenFullFlowDurationCorrect() = runTest {
+        startJourney()
+        atTime(100) { testee.finishedWithError(WebViewError(A_STEP)) }
+        assertEquals(100, captureDurations().fullFlow)
+    }
+
+    @Test
+    fun whenFinishedWithCancellationThenFullFlowDurationCorrect() = runTest {
+        startJourney()
+        atTime(200) { testee.cancelled(A_STEP) }
+        assertEquals(200, captureDurations().fullFlow)
+    }
+
+    @Test
+    fun whenRestartedThenFullFlowDurationUsesRestartTimeCorrectly() = runTest {
+        startJourney()
+        atTime(100) { startJourney() } // restart
+        atTime(400) { testee.finishedWithSuccess() }
+        assertEquals(300, captureDurations().fullFlow)
+    }
+
+    @Test
+    fun whenFinishedWithNoWaitingForExportTimeThenDurationIs0() = runTest {
+        startJourney()
+        testee.finishedWithSuccess()
+        assertEquals(0L, captureDurations().waitingForExport)
+    }
+
+    @Test
+    fun whenFinishedWithSingleWaitingForExportPeriodThenDurationIsCorrect() = runTest {
+        startJourney()
+
+        testee.startedWaitingForExport() // start waiting
+        atTime(2_500) { testee.stoppedWaitingForExport() } // stop waiting
+
+        testee.finishedWithSuccess()
+        assertEquals(2_500, captureDurations().waitingForExport)
+    }
+
+    @Test
+    fun whenFinishedWithMultipleWaitingForExportPeriodsThenDurationIsCorrectlySummed() = runTest {
+        startJourney()
+
+        atTime(0) { testee.startedWaitingForExport() } // start waiting
+        atTime(100) { testee.stoppedWaitingForExport() } // stop waiting after 100ms
+
+        atTime(2_000) { testee.startedWaitingForExport() } // start waiting again
+        atTime(3_000) { testee.stoppedWaitingForExport() } // stop waiting after 1s
+
+        testee.finishedWithSuccess()
+        assertEquals(1_100, captureDurations().waitingForExport)
+    }
+
+    @Test
+    fun whenStartedWaitingForExportCalledMultipleTimesWithoutStoppingThenOnlyFirstCallStartsWaiting() = runTest {
+        startJourney()
+
+        atTime(0) { testee.startedWaitingForExport() } // first call, should start waiting
+        atTime(100) { testee.startedWaitingForExport() } // second call, should be ignored
+        atTime(200) { testee.startedWaitingForExport() } // third call, should be ignored
+        atTime(500) { testee.stoppedWaitingForExport() } // stop waiting after 500ms
+
+        testee.finishedWithSuccess()
+        assertEquals(500, captureDurations().waitingForExport)
+    }
+
+    @Test
+    fun whenStoppedWaitingForExportCalledWithoutPriorNowWaitingThenDurationRemainsZero() = runTest {
+        startJourney()
+
+        atTime(100) { testee.stoppedWaitingForExport() } // called without starting waiting
+
+        testee.finishedWithSuccess()
+        assertEquals(0L, captureDurations().waitingForExport)
+    }
+
+    @Test
+    fun whenFinishedWithSuccessThenSuccessPixelFiredWithCorrectParameters() = runTest {
+        startJourney()
+        testee.finishedWithSuccess()
+
+        verifyPixelFired(BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_SUCCESS)
+
+        val params = pixelParamsCaptor.firstValue
+        assertEquals(LAUNCH_SOURCE, params[LAUNCH_SOURCE_PARAM])
+        assertEquals(FULL_FLOW_BUCKET, params[DURATION_FULL_FLOW_PARAM])
+        assertEquals(WAITING_FOR_EXPORT_BUCKET, params[DURATION_WAITING_FOR_EXPORT_PARAM])
+    }
+
+    @Test
+    fun whenFinishedWithCancellationThenCancelledPixelFiredWithCorrectParameters() = runTest {
+        startJourney()
+        testee.cancelled(A_STEP)
+
+        verifyPixelFired(BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED)
+
+        val params = pixelParamsCaptor.firstValue
+        assertEquals(LAUNCH_SOURCE, params[LAUNCH_SOURCE_PARAM])
+        assertEquals(FULL_FLOW_BUCKET, params[DURATION_FULL_FLOW_PARAM])
+        assertEquals(WAITING_FOR_EXPORT_BUCKET, params[DURATION_WAITING_FOR_EXPORT_PARAM])
+        assertEquals(A_STEP, params[STEP_REACHED_PARAM])
+    }
+
+    @Test
+    fun whenFinishedWithErrorThenErrorPixelFiredWithCorrectParameters() = runTest {
+        startJourney()
+        testee.finishedWithError(AN_ERROR_REASON)
+
+        verifyPixelFired(BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR)
+
+        val params = pixelParamsCaptor.firstValue
+        assertEquals(LAUNCH_SOURCE, params[LAUNCH_SOURCE_PARAM])
+        assertEquals(FULL_FLOW_BUCKET, params[DURATION_FULL_FLOW_PARAM])
+        assertEquals(WAITING_FOR_EXPORT_BUCKET, params[DURATION_WAITING_FOR_EXPORT_PARAM])
+        assertEquals(AN_ERROR_REASON_PARAM, params[ERROR_REASON_PARAM])
+    }
+
+    @Test
+    fun whenFinishedWithWebAutomationErrorThenErrorPixelFiredWithCorrectParameters() = runTest {
+        startJourney()
+        testee.finishedWithError(WebAutomationError(A_STEP))
+
+        verifyPixelFired(BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR)
+
+        val params = pixelParamsCaptor.firstValue
+        assertEquals("${ERROR_REASON_AUTOMATION_PARAM}-${A_STEP}", params[ERROR_REASON_PARAM])
+    }
+
+    private fun verifyPixelFired(pixelName: Pixel.PixelName) {
+        verify(pixel).fire(
+            pixel = eq(pixelName),
+            parameters = pixelParamsCaptor.capture(),
+            encodedParameters = anyOrNull(),
+            type = eq(Count),
+        )
+    }
+
+    fun startJourney() {
+        testee.started(LAUNCH_SOURCE)
+    }
+
+    private fun captureDurations(): Durations {
+        verify(flowDurationBucketing, times(2)).bucket(durationCaptor.capture())
+
+        val fullFlowDuration = durationCaptor.allValues[0]
+        val waitingForExportDuration = durationCaptor.allValues[1]
+        return Durations(fullFlow = fullFlowDuration, waitingForExport = waitingForExportDuration)
+    }
+
+    private fun atTime(
+        time: Long,
+        function: () -> Unit,
+    ) {
+        whenever(mockTimeProvider.currentTimeMillis()).thenReturn(time)
+        function()
+    }
+
+    private data class Durations(
+        val fullFlow: Long,
+        val waitingForExport: Long,
+    )
+
+    private companion object {
+        private const val FULL_FLOW_BUCKET = "full-flow-bucket"
+        private const val WAITING_FOR_EXPORT_BUCKET = "waiting-for-export-bucket"
+        private const val LAUNCH_SOURCE = "testLaunchSource"
+        private const val LAUNCH_SOURCE_PARAM = "launchSource"
+        private const val DURATION_FULL_FLOW_PARAM = "durationFullFlow"
+        private const val DURATION_WAITING_FOR_EXPORT_PARAM = "durationWaitingForExport"
+        private const val STEP_REACHED_PARAM = "stepReached"
+        private const val ERROR_REASON_PARAM = "errorReason"
+        private val AN_ERROR_REASON = UserCannotImportReason.ErrorParsingBookmarks
+        private const val AN_ERROR_REASON_PARAM = "parsingBookmarks"
+        private const val ERROR_REASON_AUTOMATION_PARAM = "webAutomation"
+
+        private const val A_STEP = "aStep"
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
@@ -17,6 +17,11 @@
 package com.duckduckgo.savedsites.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+
 enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName {
     /** Bookmarks Screen **/
     MENU_ACTION_BOOKMARKS_PRESSED_DAILY("m_navigation_menu_bookmarks_daily"),
@@ -60,8 +65,29 @@ enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName
     MENU_ACTION_ADD_FAVORITE_PRESSED_DAILY("m_nav_af_p_daily"),
     FAVOURITE_REMOVED("m_favorite_removed"),
     FAVOURITE_DELETED("m_favorite_deleted"),
+
+    /** Bookmark import from Google **/
+    BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_SHOWN("bookmark_import_from_google_dialog_shown"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_DISMISSED("bookmark_import_from_google_dialog_dismissed"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_START_FLOW("bookmark_import_from_google_dialog_startflow"),
+    BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_FROM_FILE("bookmark_import_from_google_dialog_fromfile"),
 }
 
 object SavedSitesPixelParameters {
     const val SORT_MODE = "sort_mode"
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelParamRemovalPlugin::class,
+)
+object SavedSitePixelsRequiringDataCleaning : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            SavedSitesPixelName.BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_SHOWN.pixelName to PixelParameter.removeAtb(),
+            SavedSitesPixelName.BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_DISMISSED.pixelName to PixelParameter.removeAtb(),
+            SavedSitesPixelName.BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_START_FLOW.pixelName to PixelParameter.removeAtb(),
+            SavedSitesPixelName.BOOKMARK_IMPORT_FROM_GOOGLE_PREIMPORT_DIALOG_FROM_FILE.pixelName to PixelParameter.removeAtb(),
+        )
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211724585727142?focus=true 

### Description
Adds observability around bookmark import flow and pre-import dialog.

### Steps to test this PR

Logcat filter: `package:mine message~:"Bookmark-import: |Pixel sent: bookmark_import_from_google"`

#### Import flow (success)
- [x] Fresh install, and visit `Saved Site Dev Settings`
- [x] Tap on `Launch Google Takeout import flow`
- [x] Verify you see `bookmark_import_from_google_flow_started` in the logs, params should match spec
- [x] Successfully import, and verify you see `bookmark_import_from_google_flow_success`, params should match spec (e.g., correct duration buckets)

#### Import flow (cancellation)
- [x] Start the import again, and this time cancel. 
- [x] Verify you see `bookmark_import_from_google_flow_cancelled` in the logs and it includes the `stepReached` alongside durations.

#### Import flow (simulate error)
- [x] Apply patch from below
- [x] Start the import flow, and wait 2 seconds
- [x] Verify you see `bookmark_import_from_google_flow_error` and `errorReason` starts with `webView-` then has the step. (e.g., `webView-takeout-first`)

#### Pre-import dialogs

<img width="20%" height="283" alt="Screenshot 2025-10-28 at 13 07 14" src="https://github.com/user-attachments/assets/132acbe5-b189-4bea-a9eb-ed9d6e73df82" />


- [x] Visit Bookmarks activity, and tap on `Import` (from empty state or overflow; doesn't matter)
- [x] Verify `bookmark_import_from_google_dialog_shown` appears
- [x] Tap the ✖️ to cancel the dialog; verify `bookmark_import_from_google_dialog_dismissed` appears
- [x] Tap to show it again, and this time use the back button to dismiss; verifying same log appears
- [x] Tap to show it again, and this time tap outside of the dialog to dismiss; verifying same log appears
- [x] Tap to show it again, and this time choose `Select Bookmarks File`; verify `bookmark_import_from_google_dialog_fromfile` appeas
- [x] Finally, choose `Import From Google` button and verify `bookmark_import_from_google_dialog_startflow` 


### Patch to force a crash during import

```
Index: autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt	(revision Staged)
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/webflow/ImportGoogleBookmarksWebFlowFragment.kt	(date 1761651295473)
@@ -76,6 +76,7 @@
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.user.agent.api.UserAgentProvider
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -163,6 +164,13 @@
                 viewModel.firstPageLoading()
             }
         }
+
+        // force a deliberate crash to test
+        lifecycleScope.launch {
+            delay(2000)
+            binding?.webView?.loadUrl("chrome://crash")
+        }
+
     }
 
     private fun observeViewState() {
```