### PR TITLE
Fix: Toolbar navigation button not centered

### DIFF
--- a/design-system/src/main/res/layout/include_default_toolbar.xml
+++ b/design-system/src/main/res/layout/include_default_toolbar.xml
@@ -31,6 +31,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/daxColorToolbar"
         android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:buttonGravity="center_vertical"
         app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
 
     <View

--- a/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
+++ b/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
@@ -36,6 +36,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/daxColorToolbar"
         android:theme="@style/TabSwitcher.Widget.Toolbar"
+        app:buttonGravity="center_vertical"
         app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
 
 </com.google.android.material.appbar.AppBarLayout>

--- a/design-system/src/main/res/layout/include_tab_switcher_toolbar_top.xml
+++ b/design-system/src/main/res/layout/include_tab_switcher_toolbar_top.xml
@@ -31,6 +31,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/daxColorToolbar"
         android:theme="@style/TabSwitcher.Widget.Toolbar"
+        app:buttonGravity="center_vertical"
         app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
 
     <View


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211720464454564?focus=true

### Description

This PR centers the navigation button vertically in all toolbars across the app.

### Steps to test this PR

_Top omnibar position_
- [x] Go to the tab manager
- [x] Verify the back button is centered vertically

_Bottom omnibar position_
- [x] Go to the tab manager
- [x] Verify the back button is centered vertically

_Other screens_
- [x] Go to Settings
- [x] Verify the back button is centered vertically
- [x] Try opening other settings screens
- [x] Verify the back button is centered vertically

### UI changes
| Top tab manager  | Bottom tab manager | Other screens |
| ------ | ----- | ----- |
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1e9f5560-ae10-495b-a336-e4a25dd1faf4" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b5fa451f-eb16-419c-b6f0-f52e5d1ecb51" />|<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/fe75e437-0136-460c-aea5-7c7c4f9ae405" />

