### PR TITLE
Update content scope scripts to version 11.45.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -3214,6 +3214,7 @@
      * @property {boolean} [context.top] - true if the condition applies to the top frame
      * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      * @property {boolean} [internal] - true if the condition applies to internal builds
+     * @property {boolean} [preview] - true if the condition applies to preview builds
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -3241,7 +3242,8 @@
         minSupportedVersion: this._matchMinSupportedVersion,
         maxSupportedVersion: this._matchMaxSupportedVersion,
         injectName: this._matchInjectNameConditional,
-        internal: this._matchInternalConditional
+        internal: this._matchInternalConditional,
+        preview: this._matchPreviewConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -3342,6 +3344,17 @@
       const isInternal = __privateGet(this, _args)?.platform?.internal;
       if (isInternal === void 0) return false;
       return Boolean(conditionBlock.internal) === Boolean(isInternal);
+    }
+    /**
+     * Takes a condition block and returns true if the preview state matches the condition.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchPreviewConditional(conditionBlock) {
+      if (conditionBlock.preview === void 0) return false;
+      const isPreview = __privateGet(this, _args)?.platform?.preview;
+      if (isPreview === void 0) return false;
+      return Boolean(conditionBlock.preview) === Boolean(isPreview);
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -4797,6 +4797,7 @@
      * @property {boolean} [context.top] - true if the condition applies to the top frame
      * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      * @property {boolean} [internal] - true if the condition applies to internal builds
+     * @property {boolean} [preview] - true if the condition applies to preview builds
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4824,7 +4825,8 @@
         minSupportedVersion: this._matchMinSupportedVersion,
         maxSupportedVersion: this._matchMaxSupportedVersion,
         injectName: this._matchInjectNameConditional,
-        internal: this._matchInternalConditional
+        internal: this._matchInternalConditional,
+        preview: this._matchPreviewConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4925,6 +4927,17 @@
       const isInternal = __privateGet(this, _args)?.platform?.internal;
       if (isInternal === void 0) return false;
       return Boolean(conditionBlock.internal) === Boolean(isInternal);
+    }
+    /**
+     * Takes a condition block and returns true if the preview state matches the condition.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchPreviewConditional(conditionBlock) {
+      if (conditionBlock.preview === void 0) return false;
+      const isPreview = __privateGet(this, _args)?.platform?.preview;
+      if (isPreview === void 0) return false;
+      return Boolean(conditionBlock.preview) === Boolean(isPreview);
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4766,6 +4766,7 @@
      * @property {boolean} [context.top] - true if the condition applies to the top frame
      * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      * @property {boolean} [internal] - true if the condition applies to internal builds
+     * @property {boolean} [preview] - true if the condition applies to preview builds
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4793,7 +4794,8 @@
         minSupportedVersion: this._matchMinSupportedVersion,
         maxSupportedVersion: this._matchMaxSupportedVersion,
         injectName: this._matchInjectNameConditional,
-        internal: this._matchInternalConditional
+        internal: this._matchInternalConditional,
+        preview: this._matchPreviewConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4894,6 +4896,17 @@
       const isInternal = __privateGet(this, _args)?.platform?.internal;
       if (isInternal === void 0) return false;
       return Boolean(conditionBlock.internal) === Boolean(isInternal);
+    }
+    /**
+     * Takes a condition block and returns true if the preview state matches the condition.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchPreviewConditional(conditionBlock) {
+      if (conditionBlock.preview === void 0) return false;
+      const isPreview = __privateGet(this, _args)?.platform?.preview;
+      if (isPreview === void 0) return false;
+      return Boolean(conditionBlock.preview) === Boolean(isPreview);
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4610,6 +4610,7 @@
      * @property {boolean} [context.top] - true if the condition applies to the top frame
      * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      * @property {boolean} [internal] - true if the condition applies to internal builds
+     * @property {boolean} [preview] - true if the condition applies to preview builds
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4637,7 +4638,8 @@
         minSupportedVersion: this._matchMinSupportedVersion,
         maxSupportedVersion: this._matchMaxSupportedVersion,
         injectName: this._matchInjectNameConditional,
-        internal: this._matchInternalConditional
+        internal: this._matchInternalConditional,
+        preview: this._matchPreviewConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4738,6 +4740,17 @@
       const isInternal = __privateGet(this, _args)?.platform?.internal;
       if (isInternal === void 0) return false;
       return Boolean(conditionBlock.internal) === Boolean(isInternal);
+    }
+    /**
+     * Takes a condition block and returns true if the preview state matches the condition.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchPreviewConditional(conditionBlock) {
+      if (conditionBlock.preview === void 0) return false;
+      const isPreview = __privateGet(this, _args)?.platform?.preview;
+      if (isPreview === void 0) return false;
+      return Boolean(conditionBlock.preview) === Boolean(isPreview);
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.34.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.44.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.45.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4b7100465e1d738d472eac0a866cfd2c8c02ea35",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f1e417fa4863e30023415948757a728a32675f46",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+      "version": "24.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
+      "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -542,7 +542,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.34.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.4.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.44.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.45.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1760787856"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211779259435180/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run