### PR TITLE
Handle null widget manager that can crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/widget/ui/WidgetCapabilities.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/ui/WidgetCapabilities.kt
@@ -35,7 +35,10 @@ class AppWidgetCapabilities @Inject constructor(
 ) : WidgetCapabilities {
 
     override val supportsAutomaticWidgetAdd: Boolean
-        get() = AppWidgetManager.getInstance(context).isRequestPinAppWidgetSupported
+        get() {
+            val manager = AppWidgetManager.getInstance(context) ?: return false
+            return manager.isRequestPinAppWidgetSupported
+        }
 
     override val hasInstalledWidgets: Boolean
         get() = context.hasInstalledWidgets
@@ -43,7 +46,7 @@ class AppWidgetCapabilities @Inject constructor(
 
 val Context.hasInstalledWidgets: Boolean
     get() {
-        val manager = AppWidgetManager.getInstance(this)
+        val manager = AppWidgetManager.getInstance(this) ?: return false
         val hasDarkWidget = manager.getAppWidgetIds(ComponentName(this, SearchWidget::class.java)).any()
         val hasLightWidget = manager.getAppWidgetIds(ComponentName(this, SearchWidgetLight::class.java)).any()
         val hasSearchOnlyWidget = manager.getAppWidgetIds(ComponentName(this, SearchOnlyWidget::class.java)).any()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1211775631522634?focus=true

### Description
Safely return null if widget manager is not available.
Adds method for consumers to query if AppWidgetSupported.

### Steps to test this PR
Just test widget can be added as usual.


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
