### PR TITLE
Check WebView capabilities when determining if bookmark import possible

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImpl.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImpl.kt
@@ -37,11 +37,12 @@ class ImportFromGoogleImpl @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val globalActivityStarter: GlobalActivityStarter,
     private val context: Context,
+    private val webViewCapabilityChecker: ImportGoogleBookmarksWebViewCapabilityChecker,
 ) : ImportFromGoogle {
 
     override suspend fun getBookmarksImportLaunchIntent(): Intent? {
         return withContext(dispatchers.io()) {
-            if (autofillFeature.canImportBookmarksFromGoogleTakeout().isEnabled()) {
+            if (autofillFeature.canImportBookmarksFromGoogleTakeout().isEnabled() && webViewCapabilityChecker.webViewCapableOfImporting()) {
                 val launchSource = getLaunchSource()
                 globalActivityStarter.startIntent(context, ImportBookmarksViaGoogleTakeoutScreen(launchSource))
             } else {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportGoogleBookmarksWebViewCapabilityChecker.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/ImportGoogleBookmarksWebViewCapabilityChecker.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing
+
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface ImportGoogleBookmarksWebViewCapabilityChecker {
+    suspend fun webViewCapableOfImporting(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultImportGoogleBookmarksWebViewCapabilityChecker @Inject constructor(
+    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+) : ImportGoogleBookmarksWebViewCapabilityChecker {
+
+    override suspend fun webViewCapableOfImporting(): Boolean {
+        val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
+        val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
+        return webViewWebMessageSupport && webViewDocumentStartJavascript
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/ImportFromGoogleImplTest.kt
@@ -54,6 +54,8 @@ class ImportFromGoogleImplTest {
 
     private val globalActivityStarter: GlobalActivityStarter = mock()
 
+    private val webViewCapabilityChecker: ImportGoogleBookmarksWebViewCapabilityChecker = mock()
+
     private val context: Context = mock()
 
     private lateinit var testee: ImportFromGoogleImpl
@@ -65,6 +67,7 @@ class ImportFromGoogleImplTest {
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             globalActivityStarter = globalActivityStarter,
             context = context,
+            webViewCapabilityChecker = webViewCapabilityChecker,
         )
 
         whenever(
@@ -82,9 +85,17 @@ class ImportFromGoogleImplTest {
     }
 
     @Test
-    fun `Launch intent is not null when feature is enabled`() = runTest {
+    fun `Launch intent is not null when feature is enabled and WebView is capable`() = runTest {
         configureFeatureState(isEnabled = true)
+        whenever(webViewCapabilityChecker.webViewCapableOfImporting()).thenReturn(true)
         assertNotNull(testee.getBookmarksImportLaunchIntent())
+    }
+
+    @Test
+    fun `Launch intent is null when feature is enabled but WebView is not capable`() = runTest {
+        configureFeatureState(isEnabled = true)
+        whenever(webViewCapabilityChecker.webViewCapableOfImporting()).thenReturn(false)
+        assertNull(testee.getBookmarksImportLaunchIntent())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211794988737145?focus=true 

### Description
Adds WebView capability checks when determining if bookmark importing is possible

### Steps to test this PR
ℹ️ QA optional
- [ ] To test,  run the app on a device with old `Webview` and tap on `Import Bookmarks` button inside `Bookmarks` activity. Verify it launches straight into the "old" flow to choose a file to import directly (no dialog, no offer to do the web flow)