### PR TITLE
Intercept duck.ai domain before redirect

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -532,9 +532,9 @@ class RealDuckChat @Inject constructor(
 
         if (isDuckChatBang(uri)) return true
 
-        if (uri.host != DUCKDUCKGO_HOST) {
-            return false
-        }
+        if (uri.host == DUCK_AI_HOST || uri.toString() == DUCK_AI_HOST) return true
+        if (uri.host != DUCKDUCKGO_HOST) return false
+
         return runCatching {
             val queryParameters = uri.queryParameterNames
             queryParameters.contains(CHAT_QUERY_NAME) && uri.getQueryParameter(CHAT_QUERY_NAME) == CHAT_QUERY_VALUE
@@ -671,6 +671,7 @@ class RealDuckChat @Inject constructor(
     companion object {
         private const val DUCK_CHAT_WEB_LINK = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
         private const val DUCKDUCKGO_HOST = "duckduckgo.com"
+        private const val DUCK_AI_HOST = "duck.ai"
         private const val CHAT_QUERY_NAME = "ia"
         private const val CHAT_QUERY_VALUE = "chat"
         private const val PROMPT_QUERY_NAME = "prompt"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -421,6 +421,16 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenUriHostIsDuckAiThenIsDuckChatUrlReturnsTrue() {
+        assertTrue(testee.isDuckChatUrl("https://duck.ai".toUri()))
+    }
+
+    @Test
+    fun whenUriStringIsDuckAiThenIsDuckChatUrlReturnsTrue() {
+        assertTrue(testee.isDuckChatUrl("duck.ai".toUri()))
+    }
+
+    @Test
     fun whenWasOpenedBeforeQueriedThenRepoStateIsReturned() = runTest {
         whenever(mockDuckChatFeatureRepository.wasOpenedBefore()).thenReturn(true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211821550799922?focus=true

### Description
- Intercepts duck.ai domain in order to prevent a blank page when navigating back

### Steps to test this PR

- [x] Type in duck.ai
- [x] After Duck.ai has opened go back
- [x] Verify that the WebView is not blank

### UI changes
Before

https://github.com/user-attachments/assets/d80ec8c0-e4ec-4e21-a699-bd34c68d2183

After

https://github.com/user-attachments/assets/75241851-9b46-402e-9228-e611549b05cf



