### PR TITLE
Remove JobInfoSchedulerService from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -509,6 +509,11 @@
 
         <service android:name="com.duckduckgo.app.notification.NotificationHandlerService" />
 
+        <service
+            android:name="com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService"
+            tools:node="remove"
+            tools:ignore="MissingClass" />
+
         <receiver android:name=".shortcut.ShortcutReceiver" android:exported="false" />
 
         <receiver


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211816347754330?focus=true

### Description

- Removes `JobInfoSchedulerService` from the manifest merger

### Steps to test this PR

- [ ] Testing steps in task
