### PR TITLE
Support privacy specs on attributed metrics

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/metrics/AdClickAttributedMetric.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/metrics/AdClickAttributedMetric.kt
@@ -64,7 +64,7 @@ class RealAdClickAttributedMetric @Inject constructor(
 
     companion object {
         private const val EVENT_NAME = "ad_click"
-        private const val PIXEL_NAME = "user_average_ad_clicks_past_week"
+        private const val PIXEL_NAME = "attributed_metric_average_ad_clicks_past_week"
         private const val FEATURE_TOGGLE_NAME = "adClickCountAvg"
         private const val FEATURE_EMIT_TOGGLE_NAME = "canEmitAdClickCountAvg"
         private const val DAYS_WINDOW = 7
@@ -108,6 +108,7 @@ class RealAdClickAttributedMetric @Inject constructor(
         val stats = getEventStats()
         val params = mutableMapOf(
             "count" to getBucketValue(stats.rollingAverage.roundToInt()).toString(),
+            "version" to bucketConfig.await().version.toString(),
         )
         if (!hasCompleteDataWindow()) {
             params["dayAverage"] = daysSinceInstalled().toString()

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/metrics/RealAdClickAttributedMetricTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/metrics/RealAdClickAttributedMetricTest.kt
@@ -63,7 +63,7 @@ class RealAdClickAttributedMetricTest {
         )
         whenever(attributedMetricConfig.getBucketConfiguration()).thenReturn(
             mapOf(
-                "user_average_ad_clicks_past_week" to MetricBucket(
+                "attributed_metric_average_ad_clicks_past_week" to MetricBucket(
                     buckets = listOf(2, 5),
                     version = 0,
                 ),
@@ -79,7 +79,7 @@ class RealAdClickAttributedMetricTest {
     }
 
     @Test fun whenPixelNameRequestedThenReturnCorrectName() {
-        assertEquals("user_average_ad_clicks_past_week", testee.getPixelName())
+        assertEquals("attributed_metric_average_ad_clicks_past_week", testee.getPixelName())
     }
 
     @Test fun whenAdClickAndDaysInstalledIsZeroThenDoNotEmitMetric() = runTest {
@@ -222,12 +222,12 @@ class RealAdClickAttributedMetricTest {
                 ),
             )
 
-            val params = testee.getMetricParameters()
+            val count = testee.getMetricParameters()["count"]
 
             assertEquals(
                 "For $clicksAvg clicks, should return bucket $expectedBucket",
-                mapOf("count" to expectedBucket.toString()),
-                params,
+                expectedBucket.toString(),
+                count,
             )
         }
     }
@@ -253,6 +253,21 @@ class RealAdClickAttributedMetricTest {
                 tag,
             )
         }
+    }
+
+    @Test fun whenGetMetricParametersThenReturnVersion() = runTest {
+        givenDaysSinceInstalled(7)
+        whenever(attributedMetricClient.getEventStats("ad_click", 7)).thenReturn(
+            EventStats(
+                daysWithEvents = 1,
+                rollingAverage = 1.0,
+                totalEvents = 1,
+            ),
+        )
+
+        val version = testee.getMetricParameters()["version"]
+
+        assertEquals("0", version)
     }
 
     private fun givenDaysSinceInstalled(days: Int) {

--- a/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/referral/AppReferrerDataStore.kt
@@ -57,6 +57,8 @@ class AppReferenceSharePreferences @Inject constructor(
         }
     }
 
+    override fun getOriginAttributeCampaign(): String? = utmOriginAttributeCampaign
+
     override var campaignSuffix: String?
         get() = preferences.getString(KEY_CAMPAIGN_SUFFIX, null)
         set(value) = preferences.edit(true) { putString(KEY_CAMPAIGN_SUFFIX, value) }

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClient.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClient.kt
@@ -19,10 +19,13 @@ package com.duckduckgo.app.attributed.metrics.impl
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetric
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetricClient
 import com.duckduckgo.app.attributed.metrics.api.EventStats
+import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
 import com.duckduckgo.app.attributed.metrics.store.EventRepository
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import com.duckduckgo.browser.api.install.AppInstall
+import com.duckduckgo.browser.api.referrer.AppReferrer
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -41,6 +44,9 @@ class RealAttributedMetricClient @Inject constructor(
     private val eventRepository: EventRepository,
     private val pixel: Pixel,
     private val metricsState: AttributedMetricsState,
+    private val appReferrer: AppReferrer,
+    private val dateUtils: AttributedMetricsDateUtils,
+    private val appInstall: AppInstall,
 ) : AttributedMetricClient {
 
     override fun collectEvent(eventName: String) {
@@ -77,7 +83,6 @@ class RealAttributedMetricClient @Inject constructor(
             }
         }
 
-    // TODO: Pending adding default attributed metrics and removing default prefix from pixel names
     override fun emitMetric(metric: AttributedMetric) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (!metricsState.isActive() || !metricsState.canEmitMetrics()) {
@@ -91,11 +96,23 @@ class RealAttributedMetricClient @Inject constructor(
             val params = metric.getMetricParameters()
             val tag = metric.getTag()
             val pixelTag = "${pixelName}_$tag"
-            pixel.fire(pixelName = pixelName, parameters = params, type = Unique(pixelTag)).also {
+
+            val origin = appReferrer.getOriginAttributeCampaign()
+            val paramsMutableMap = params.toMutableMap()
+            if (!origin.isNullOrBlank()) {
+                paramsMutableMap["origin"] = origin
+            } else {
+                paramsMutableMap["install_date"] = getInstallDate()
+            }
+            pixel.fire(pixelName = pixelName, parameters = paramsMutableMap, type = Unique(pixelTag)).also {
                 logcat(tag = "AttributedMetrics") {
-                    "Fired pixel $pixelName with params $params"
+                    "Fired pixel $pixelName with params $paramsMutableMap"
                 }
             }
         }
+    }
+
+    private fun getInstallDate(): String {
+        return dateUtils.getDateFromTimestamp(appInstall.getInstallationTimestamp())
     }
 }

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptor.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptor.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.pixels
+
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import logcat.logcat
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelInterceptorPlugin::class,
+)
+class AttributedMetricPixelInterceptor @Inject constructor() : Interceptor, PixelInterceptorPlugin {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+        var url = chain.request().url
+        val pixel = chain.request().url.pathSegments.last()
+        if (pixel.startsWith(ATTRIBUTED_METRICS_PIXEL_PREFIX)) {
+            url = url.toUrl().toString().replace("android_${DeviceInfo.FormFactor.PHONE.description}", "android").toHttpUrl()
+            logcat(tag = "AttributedMetrics") {
+                "Pixel renamed to: $url"
+            }
+        }
+        return chain.proceed(request.url(url).build())
+    }
+
+    override fun getInterceptor() = this
+
+    companion object {
+        const val ATTRIBUTED_METRICS_PIXEL_PREFIX = "attributed_metric"
+    }
+}

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelRemovalInterceptor.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelRemovalInterceptor.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.pixels
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelParamRemovalPlugin::class,
+)
+object AttributedMetricPixelRemovalInterceptor : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            ATTRIBUTED_METRICS_PIXEL_PREFIX to PixelParameter.removeAll(),
+        )
+    }
+
+    private const val ATTRIBUTED_METRICS_PIXEL_PREFIX = "attributed_metric"
+}

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetric.kt
@@ -49,7 +49,7 @@ class RetentionMonthAttributedMetric @Inject constructor(
 ) : AttributedMetric, AtbLifecyclePlugin {
 
     companion object {
-        private const val PIXEL_NAME_FIRST_MONTH = "user_retention_month"
+        private const val PIXEL_NAME_FIRST_MONTH = "attributed_metric_retention_month"
         private const val DAYS_IN_4_WEEKS = 28 // we consider 1 month after 4 weeks
         private const val MONTH_DAY_THRESHOLD = DAYS_IN_4_WEEKS + 1
         private const val START_MONTH_THRESHOLD = 2
@@ -103,7 +103,11 @@ class RetentionMonthAttributedMetric @Inject constructor(
         val month = getMonthSinceInstall()
         if (month < START_MONTH_THRESHOLD) return emptyMap()
 
-        return mutableMapOf("count" to bucketMonth(month).toString())
+        val params = mutableMapOf(
+            "count" to bucketMonth(month).toString(),
+            "version" to bucketConfig.await().version.toString(),
+        )
+        return params
     }
 
     override suspend fun getTag(): String {

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetric.kt
@@ -49,7 +49,7 @@ class RetentionWeekAttributedMetric @Inject constructor(
 ) : AttributedMetric, AtbLifecyclePlugin {
 
     companion object {
-        private const val PIXEL_NAME_FIRST_WEEK = "user_retention_week"
+        private const val PIXEL_NAME_FIRST_WEEK = "attributed_metric_retention_week"
         private const val FEATURE_TOGGLE_NAME = "retention"
         private const val FEATURE_EMIT_TOGGLE_NAME = "canEmitRetention"
     }
@@ -98,7 +98,12 @@ class RetentionWeekAttributedMetric @Inject constructor(
     override suspend fun getMetricParameters(): Map<String, String> {
         val week = getWeekSinceInstall()
         if (week == -1) return emptyMap()
-        return mutableMapOf("count" to bucketValue(getWeekSinceInstall()).toString())
+
+        val params = mutableMapOf(
+            "count" to bucketValue(getWeekSinceInstall()).toString(),
+            "version" to bucketConfig.await().version.toString(),
+        )
+        return params
     }
 
     override suspend fun getTag(): String {

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/search/SearchDaysAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/search/SearchDaysAttributedMetric.kt
@@ -59,7 +59,7 @@ class SearchDaysAttributedMetric @Inject constructor(
 
     companion object {
         private const val EVENT_NAME = "ddg_search_days"
-        private const val PIXEL_NAME = "user_active_past_week"
+        private const val PIXEL_NAME = "attributed_metric_active_past_week"
         private const val DAYS_WINDOW = 7
         private const val FEATURE_TOGGLE_NAME = "searchDaysAvg"
         private const val FEATURE_EMIT_TOGGLE_NAME = "canEmitSearchDaysAvg"
@@ -124,6 +124,7 @@ class SearchDaysAttributedMetric @Inject constructor(
         val stats = attributedMetricClient.getEventStats(EVENT_NAME, DAYS_WINDOW)
         val params = mutableMapOf(
             "days" to getBucketValue(stats.daysWithEvents).toString(),
+            "version" to bucketConfiguration.await().version.toString(),
         )
         if (!hasCompleteDataWindow) {
             params["daysSinceInstalled"] = daysSinceInstalled.toString()

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/AttributedMetricsDateUtils.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/AttributedMetricsDateUtils.kt
@@ -97,6 +97,14 @@ interface AttributedMetricsDateUtils {
      * @return The calculated date as a string in "yyyy-MM-dd" format (in ET)
      */
     fun getDateMinusDays(days: Int): String
+
+    /**
+     * Converts a timestamp to a formatted date string in Eastern Time.
+     *
+     * @param timestamp The timestamp in milliseconds since epoch (Unix timestamp)
+     * @return The date as a string in "yyyy-MM-dd" format (in ET)
+     */
+    fun getDateFromTimestamp(timestamp: Long): String
 }
 
 @ContributesBinding(AppScope::class)
@@ -125,6 +133,12 @@ class RealAttributedMetricsDateUtils @Inject constructor() : AttributedMetricsDa
     }
 
     override fun getDateMinusDays(days: Int): String = getCurrentZonedDateTime().minusDays(days.toLong()).format(DATE_FORMATTER)
+
+    override fun getDateFromTimestamp(timestamp: Long): String {
+        val instant = Instant.ofEpochMilli(timestamp)
+        val zonedDateTime = instant.atZone(ET_ZONE)
+        return zonedDateTime.format(DATE_FORMATTER)
+    }
 
     private fun getCurrentZonedDateTime(): ZonedDateTime = ZonedDateTime.now(ET_ZONE)
 

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/EventDao.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/EventDao.kt
@@ -65,6 +65,6 @@ interface EventDao {
         day: String,
     ): Int?
 
-    @Query("DELETE FROM event_metrics WHERE day < :day")
-    suspend fun deleteEventsOlderThan(day: String)
+    @Query("delete from event_metrics")
+    suspend fun deleteAllEvents()
 }

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/EventRepository.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/store/EventRepository.kt
@@ -32,7 +32,7 @@ interface EventRepository {
         days: Int,
     ): EventStats
 
-    suspend fun deleteOldEvents(olderThanDays: Int)
+    suspend fun deleteAllEvents()
 }
 
 @ContributesBinding(AppScope::class)
@@ -70,10 +70,9 @@ class RealEventRepository @Inject constructor(
         )
     }
 
-    override suspend fun deleteOldEvents(olderThanDays: Int) {
+    override suspend fun deleteAllEvents() {
         coroutineScope.launch {
-            val cutoffDay = attributedMetricsDateUtils.getDateMinusDays(olderThanDays)
-            eventDao.deleteEventsOlderThan(cutoffDay)
+            eventDao.deleteAllEvents()
         }
     }
 }

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/FakeAttributedMetricsDateUtils.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/FakeAttributedMetricsDateUtils.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.attributed.metrics
 import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
@@ -38,9 +39,16 @@ class FakeAttributedMetricsDateUtils(var testDate: LocalDate) : AttributedMetric
 
     override fun getDateMinusDays(days: Int): String = getCurrentLocalDate().minusDays(days.toLong()).format(DATE_FORMATTER)
 
+    override fun getDateFromTimestamp(timestamp: Long): String {
+        val instant = Instant.ofEpochMilli(timestamp)
+        val zonedDateTime = instant.atZone(ET_ZONE)
+        return zonedDateTime.format(DATE_FORMATTER)
+    }
+
     private fun getCurrentLocalDate(): LocalDate = testDate
 
     companion object {
         private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        private val ET_ZONE = ZoneId.of("America/New_York")
     }
 }

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/AttributeMetricsConfigTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/AttributeMetricsConfigTest.kt
@@ -90,11 +90,11 @@ class AttributeMetricsConfigTest {
     fun whenFeatureDisabledThenReturnEmptyBucketConfig() = runTest {
         val settings = """
             {
-                "user_active_past_week": {
+                "attributed_metric_active_past_week": {
                     "buckets": [2, 4],
                     "version": 0
                 },
-                "user_average_searches_past_week": {
+                "attributed_metric_average_searches_past_week": {
                     "buckets": [5, 9],
                     "version": 1
                 }
@@ -129,11 +129,11 @@ class AttributeMetricsConfigTest {
     fun whenFeatureEnabledAndValidSettingsThenReturnBucketConfig() = runTest {
         val settings = """
             {
-                "user_active_past_week": {
+                "attributed_metric_active_past_week": {
                     "buckets": [2, 4],
                     "version": 0
                 },
-                "user_average_searches_past_week": {
+                "attributed_metric_average_searches_past_week": {
                     "buckets": [5, 9],
                     "version": 1
                 }
@@ -150,11 +150,11 @@ class AttributeMetricsConfigTest {
 
         assertEquals(
             mapOf(
-                "user_active_past_week" to MetricBucket(
+                "attributed_metric_active_past_week" to MetricBucket(
                     buckets = listOf(2, 4),
                     version = 0,
                 ),
-                "user_average_searches_past_week" to MetricBucket(
+                "attributed_metric_average_searches_past_week" to MetricBucket(
                     buckets = listOf(5, 9),
                     version = 1,
                 ),

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClientTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClientTest.kt
@@ -19,9 +19,12 @@ package com.duckduckgo.app.attributed.metrics.impl
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetric
 import com.duckduckgo.app.attributed.metrics.api.EventStats
+import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
 import com.duckduckgo.app.attributed.metrics.store.EventRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import com.duckduckgo.browser.api.install.AppInstall
+import com.duckduckgo.browser.api.referrer.AppReferrer
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -45,6 +48,9 @@ class RealAttributedMetricClientTest {
     private val mockEventRepository: EventRepository = mock()
     private val mockPixel: Pixel = mock()
     private val mockMetricsState: AttributedMetricsState = mock()
+    private val appReferrer: AppReferrer = mock()
+    private val appInstall: AppInstall = mock()
+    private val dateUtils: AttributedMetricsDateUtils = mock()
 
     private lateinit var testee: RealAttributedMetricClient
 
@@ -56,6 +62,9 @@ class RealAttributedMetricClientTest {
             eventRepository = mockEventRepository,
             pixel = mockPixel,
             metricsState = mockMetricsState,
+            appReferrer = appReferrer,
+            dateUtils = dateUtils,
+            appInstall = appInstall,
         )
     }
 
@@ -100,14 +109,36 @@ class RealAttributedMetricClientTest {
     }
 
     @Test
-    fun whenEmitMetricAndClientActiveMetricIsEmitted() = runTest {
+    fun whenEmitMetricAndClientActiveWithOriginThenMetricIsEmittedWithOrigin() = runTest {
         val testMetric = TestAttributedMetric()
         whenever(mockMetricsState.isActive()).thenReturn(true)
         whenever(mockMetricsState.canEmitMetrics()).thenReturn(true)
+        whenever(appReferrer.getOriginAttributeCampaign()).thenReturn("campaign_origin")
 
         testee.emitMetric(testMetric)
 
-        verify(mockPixel).fire(pixelName = "test_pixel", parameters = mapOf("param" to "value"), type = Unique("test_pixel_test_tag"))
+        verify(mockPixel).fire(
+            pixelName = "test_pixel",
+            parameters = mapOf("param" to "value", "origin" to "campaign_origin"),
+            type = Unique("test_pixel_test_tag"),
+        )
+    }
+
+    @Test
+    fun whenEmitMetricAndClientActiveWithoutOriginThenMetricIsEmittedWithInstallDate() = runTest {
+        val testMetric = TestAttributedMetric()
+        whenever(mockMetricsState.isActive()).thenReturn(true)
+        whenever(mockMetricsState.canEmitMetrics()).thenReturn(true)
+        whenever(appReferrer.getOriginAttributeCampaign()).thenReturn(null)
+        whenever(dateUtils.getDateFromTimestamp(any())).thenReturn("2025-01-01")
+
+        testee.emitMetric(testMetric)
+
+        verify(mockPixel).fire(
+            pixelName = "test_pixel",
+            parameters = mapOf("param" to "value", "install_date" to "2025-01-01"),
+            type = Unique("test_pixel_test_tag"),
+        )
     }
 
     @Test
@@ -118,7 +149,11 @@ class RealAttributedMetricClientTest {
 
         testee.emitMetric(testMetric)
 
-        verify(mockPixel, never()).fire(pixelName = "test_pixel", parameters = mapOf("param" to "value"), type = Unique("test_pixel_test_tag"))
+        verify(mockPixel, never()).fire(
+            pixelName = "test_pixel",
+            parameters = mapOf("param" to "value"),
+            type = Unique("test_pixel_test_tag"),
+        )
     }
 
     @Test

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetricTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetricTest.kt
@@ -68,11 +68,11 @@ class SearchAttributedMetricTest {
         )
         whenever(attributedMetricConfig.getBucketConfiguration()).thenReturn(
             mapOf(
-                "user_average_searches_past_week_first_month" to MetricBucket(
+                "attributed_metric_average_searches_past_week_first_month" to MetricBucket(
                     buckets = listOf(5, 9),
                     version = 0,
                 ),
-                "user_average_searches_past_week" to MetricBucket(
+                "attributed_metric_average_searches_past_week" to MetricBucket(
                     buckets = listOf(5, 9),
                     version = 0,
                 ),
@@ -115,21 +115,21 @@ class SearchAttributedMetricTest {
     fun whenDaysSinceInstalledLessThan4WThenReturnFirstMonthPixelName() {
         givenDaysSinceInstalled(15)
 
-        assertEquals("user_average_searches_past_week_first_month", testee.getPixelName())
+        assertEquals("attributed_metric_average_searches_past_week_first_month", testee.getPixelName())
     }
 
     @Test
     fun whenDaysSinceInstalledMoreThan4WThenReturnRegularPixelName() {
         givenDaysSinceInstalled(45)
 
-        assertEquals("user_average_searches_past_week", testee.getPixelName())
+        assertEquals("attributed_metric_average_searches_past_week", testee.getPixelName())
     }
 
     @Test
     fun whenDaysSinceInstalledIsEndOf4WThenReturnFirstMonthPixelName() {
         givenDaysSinceInstalled(28)
 
-        assertEquals("user_average_searches_past_week_first_month", testee.getPixelName())
+        assertEquals("attributed_metric_average_searches_past_week_first_month", testee.getPixelName())
     }
 
     @Test
@@ -220,11 +220,11 @@ class SearchAttributedMetricTest {
     fun given7dAverageThenReturnCorrectAverageBucketInParams() = runTest {
         whenever(attributedMetricConfig.getBucketConfiguration()).thenReturn(
             mapOf(
-                "user_average_searches_past_week_first_month" to MetricBucket(
+                "attributed_metric_average_searches_past_week_first_month" to MetricBucket(
                     buckets = listOf(5, 9),
                     version = 0,
                 ),
-                "user_average_searches_past_week" to MetricBucket(
+                "attributed_metric_average_searches_past_week" to MetricBucket(
                     buckets = listOf(5, 9),
                     version = 0,
                 ),
@@ -255,12 +255,12 @@ class SearchAttributedMetricTest {
                 ),
             )
 
-            val params = testee.getMetricParameters()
+            val realBucket = testee.getMetricParameters()["count"]
 
             assertEquals(
                 "For $avg searches, should return bucket $bucket",
-                mapOf("count" to bucket.toString()),
-                params,
+                bucket.toString(),
+                realBucket,
             )
         }
     }
@@ -331,6 +331,22 @@ class SearchAttributedMetricTest {
 
             verify(attributedMetricClient).getEventStats(eq("ddg_search"), eq(7))
         }
+
+    @Test
+    fun whenGetMetricParametersThenReturnVersion() = runTest {
+        givenDaysSinceInstalled(7)
+        whenever(attributedMetricClient.getEventStats(any(), any())).thenReturn(
+            EventStats(
+                totalEvents = 16,
+                daysWithEvents = 3,
+                rollingAverage = 5.3,
+            ),
+        )
+
+        val version = testee.getMetricParameters()["version"]
+
+        assertEquals("0", version)
+    }
 
     private fun givenDaysSinceInstalled(days: Int) {
         whenever(appInstall.getInstallationTimestamp()).thenReturn(123L)

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/store/RealAttributedMetricsDateUtilsTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/store/RealAttributedMetricsDateUtilsTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.store
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@RunWith(AndroidJUnit4::class)
+class RealAttributedMetricsDateUtilsTest {
+
+    private lateinit var testee: RealAttributedMetricsDateUtils
+
+    @Before
+    fun setup() {
+        testee = RealAttributedMetricsDateUtils()
+    }
+
+    @Test
+    fun whenGetCurrentDateThenReturnsFormattedDateInET() {
+        val result = testee.getCurrentDate()
+
+        // Verify it matches the expected format yyyy-MM-dd
+        val dateRegex = Regex("\\d{4}-\\d{2}-\\d{2}")
+        assertTrue("Date should match yyyy-MM-dd format", dateRegex.matches(result))
+
+        // Verify it's parseable
+        val parsedDate = LocalDate.parse(result, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        assertTrue("Date should be parseable", parsedDate != null)
+    }
+
+    @Test
+    fun whenGetDateFromTimestampThenReturnsDateInET() {
+        // 2024-01-01 00:00:00 UTC (which is 2023-12-31 19:00:00 EST)
+        val timestamp = 1704067200000L
+
+        val result = testee.getDateFromTimestamp(timestamp)
+
+        assertEquals("2023-12-31", result)
+    }
+
+    @Test
+    fun whenGetDateFromTimestampForMiddayUTCThenReturnsCorrectDateInET() {
+        // 2024-06-15 12:00:00 UTC (which is 2024-06-15 08:00:00 EDT)
+        val timestamp = 1718452800000L
+
+        val result = testee.getDateFromTimestamp(timestamp)
+
+        assertEquals("2024-06-15", result)
+    }
+
+    @Test
+    fun whenGetDateFromTimestampForMidnightETThenReturnsCorrectDate() {
+        // 2024-07-04 04:00:00 UTC (which is 2024-07-04 00:00:00 EDT)
+        val timestamp = 1720065600000L
+
+        val result = testee.getDateFromTimestamp(timestamp)
+
+        assertEquals("2024-07-04", result)
+    }
+
+    @Test
+    fun whenGetDateMinusDaysThenReturnsDateInPast() {
+        val currentDate = testee.getCurrentDate()
+        val sevenDaysAgo = testee.getDateMinusDays(7)
+
+        val current = LocalDate.parse(currentDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val past = LocalDate.parse(sevenDaysAgo, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+        assertEquals(7, current.toEpochDay() - past.toEpochDay())
+    }
+
+    @Test
+    fun whenGetDateMinusDaysWithZeroThenReturnsCurrentDate() {
+        val currentDate = testee.getCurrentDate()
+        val result = testee.getDateMinusDays(0)
+
+        assertEquals(currentDate, result)
+    }
+
+    @Test
+    fun whenGetDateMinusDaysWithOneThenReturnsYesterday() {
+        val currentDate = testee.getCurrentDate()
+        val yesterday = testee.getDateMinusDays(1)
+
+        val current = LocalDate.parse(currentDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val past = LocalDate.parse(yesterday, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+        assertEquals(1, current.toEpochDay() - past.toEpochDay())
+    }
+
+    @Test
+    fun whenDaysSinceWithDateStringThenReturnsPositiveForPastDate() {
+        val sevenDaysAgo = testee.getDateMinusDays(7)
+
+        val result = testee.daysSince(sevenDaysAgo)
+
+        assertEquals(7, result)
+    }
+
+    @Test
+    fun whenDaysSinceWithDateStringForTodayThenReturnsZero() {
+        val result = testee.daysSince(testee.getCurrentDate())
+
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun whenGetDateMinusDaysWithLargeNumberThenReturnsCorrectDate() {
+        val currentDate = testee.getCurrentDate()
+        val thirtyDaysAgo = testee.getDateMinusDays(30)
+
+        val current = LocalDate.parse(currentDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val past = LocalDate.parse(thirtyDaysAgo, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+        assertEquals(30, current.toEpochDay() - past.toEpochDay())
+    }
+
+    @Test
+    fun whenDaysSinceWithDateStringForPastMonthThenReturnsCorrectDays() {
+        val thirtyDaysAgo = testee.getDateMinusDays(30)
+
+        val result = testee.daysSince(thirtyDaysAgo)
+
+        assertEquals(30, result)
+    }
+}

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/store/RealEventRepositoryTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/store/RealEventRepositoryTest.kt
@@ -144,18 +144,16 @@ class RealEventRepositoryTest {
         }
 
     @Test
-    fun whenDeleteOldEventsThenRemoveOnlyOlderThanSpecified() =
+    fun whenDeleteAllEventsThenRemoveAllEvents() =
         runTest {
             // Setup data
             eventDao.insertEvent(EventEntity("test_event", count = 1, day = "2025-10-03"))
             eventDao.insertEvent(EventEntity("test_event", count = 1, day = "2025-10-02"))
             eventDao.insertEvent(EventEntity("test_event", count = 1, day = "2025-09-03"))
 
-            testDateProvider.testDate = LocalDate.of(2025, 10, 3)
-            repository.deleteOldEvents(olderThanDays = 5)
+            repository.deleteAllEvents()
 
             val remainingEvents = eventDao.getEventsByNameAndTimeframe("test_event", "2025-09-03", "2025-10-03")
-            assert(remainingEvents.size == 2)
-            assert(remainingEvents.none { it.day == "2025-09-03" })
+            assert(remainingEvents.isEmpty())
         }
 }

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/referrer/AppReferrer.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/referrer/AppReferrer.kt
@@ -23,4 +23,9 @@ interface AppReferrer {
      * Sets the attribute campaign origin.
      */
     fun setOriginAttributeCampaign(origin: String?)
+
+    /**
+     * Returns campaign origin if it exists.
+     */
+    fun getOriginAttributeCampaign(): String?
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetric.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetric.kt
@@ -57,7 +57,7 @@ class DuckAiAttributedMetric @Inject constructor(
 
     companion object {
         private const val EVENT_NAME = "submit_prompt"
-        private const val PIXEL_NAME = "user_average_duck_ai_usage_past_week"
+        private const val PIXEL_NAME = "attributed_metric_average_duck_ai_usage_past_week"
         private const val FEATURE_TOGGLE_NAME = "aiUsageAvg"
         private const val FEATURE_EMIT_TOGGLE_NAME = "canEmitAIUsageAvg"
         private const val DAYS_WINDOW = 7
@@ -84,6 +84,7 @@ class DuckAiAttributedMetric @Inject constructor(
         val stats = getEventStats()
         val params = mutableMapOf(
             "count" to getBucketValue(stats.rollingAverage.roundToInt()).toString(),
+            "version" to bucketConfig.await().version.toString(),
         )
         if (!hasCompleteDataWindow()) {
             params["dayAverage"] = daysSinceInstalled().toString()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/metrics/SubscriptionStatusAttributedMetric.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/metrics/SubscriptionStatusAttributedMetric.kt
@@ -55,7 +55,7 @@ class SubscriptionStatusAttributedMetric @Inject constructor(
 ) : AttributedMetric, MainProcessLifecycleObserver {
 
     companion object {
-        private const val PIXEL_NAME = "user_subscribed"
+        private const val PIXEL_NAME = "attributed_metric_subscribed"
         private const val FEATURE_TOGGLE_NAME = "subscriptionRetention"
         private const val FEATURE_EMIT_TOGGLE_NAME = "canEmitSubscriptionRetention"
     }
@@ -109,6 +109,7 @@ class SubscriptionStatusAttributedMetric @Inject constructor(
         val isOnTrial = authRepository.isFreeTrialActive()
         val params = mutableMapOf(
             "month" to getBucketValue(daysSinceSubscribed, isOnTrial).toString(),
+            "version" to bucketConfig.await().version.toString(),
         )
         return params
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/metrics/SubscriptionStatusAttributedMetricTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/metrics/SubscriptionStatusAttributedMetricTest.kt
@@ -68,7 +68,7 @@ class SubscriptionStatusAttributedMetricTest {
         givenFFStatus(metricEnabled = true, canEmitMetric = true)
         whenever(attributedMetricConfig.getBucketConfiguration()).thenReturn(
             mapOf(
-                "subscriptionRetention" to MetricBucket(
+                "attributed_metric_subscribed" to MetricBucket(
                     buckets = listOf(0, 1),
                     version = 0,
                 ),
@@ -88,7 +88,7 @@ class SubscriptionStatusAttributedMetricTest {
 
     @Test
     fun whenPixelNameRequestedThenReturnCorrectName() {
-        assertEquals("user_subscribed", testee.getPixelName())
+        assertEquals("attributed_metric_subscribed", testee.getPixelName())
     }
 
     @Test
@@ -161,9 +161,19 @@ class SubscriptionStatusAttributedMetricTest {
         givenDaysSinceSubscribed(7)
         whenever(authRepository.isFreeTrialActive()).thenReturn(true)
 
-        val params = testee.getMetricParameters()
+        val monthBucket = testee.getMetricParameters()["month"]
 
-        assertEquals(mapOf("month" to "0"), params)
+        assertEquals("0", monthBucket)
+    }
+
+    @Test
+    fun whenGetMetricParametersThenReturnVersion() = runTest {
+        givenDaysSinceSubscribed(7)
+        whenever(authRepository.isFreeTrialActive()).thenReturn(false)
+
+        val version = testee.getMetricParameters()["version"]
+
+        assertEquals("0", version)
     }
 
     @Test
@@ -186,15 +196,15 @@ class SubscriptionStatusAttributedMetricTest {
             111 to "2", // end of month 4 -> bucket 2
         )
 
-        daysSubscribedExpectedBuckets.forEach { (days, bucket) ->
+        daysSubscribedExpectedBuckets.forEach { (days, expectedBucket) ->
             givenDaysSinceSubscribed(days)
 
-            val params = testee.getMetricParameters()
+            val realMonthBucket = testee.getMetricParameters()["month"]
 
             assertEquals(
-                "For $days days subscribed, should return bucket $bucket",
-                mapOf("month" to bucket.toString()),
-                params,
+                "For $days days subscribed, should return bucket $expectedBucket",
+                expectedBucket,
+                realMonthBucket,
             )
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetric.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetric.kt
@@ -46,7 +46,7 @@ class SyncDevicesAttributeMetric @Inject constructor(
 ) : AttributedMetric, MainProcessLifecycleObserver {
 
     companion object {
-        private const val PIXEL_NAME = "user_synced_device"
+        private const val PIXEL_NAME = "attributed_metric_synced_device"
         private const val FEATURE_TOGGLE_NAME = "syncDevices"
     }
 
@@ -77,7 +77,11 @@ class SyncDevicesAttributeMetric @Inject constructor(
 
     override suspend fun getMetricParameters(): Map<String, String> {
         val connectedDevices = connectedDevicesObserver.observeConnectedDevicesCount().value
-        return mapOf("device_count" to getBucketValue(connectedDevices).toString())
+        val params = mutableMapOf(
+            "device_count" to getBucketValue(connectedDevices).toString(),
+            "version" to bucketConfig.await().version.toString(),
+        )
+        return params
     }
 
     override suspend fun getTag(): String {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetricTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetricTest.kt
@@ -61,7 +61,7 @@ class SyncDevicesAttributeMetricTest {
         whenever(attributedMetricConfig.metricsToggles()).thenReturn(listOf(syncToggle.syncDevices()))
         whenever(attributedMetricConfig.getBucketConfiguration()).thenReturn(
             mapOf(
-                "syncDevices" to MetricBucket(
+                "attributed_metric_synced_device" to MetricBucket(
                     buckets = listOf(1),
                     version = 0,
                 ),
@@ -80,7 +80,7 @@ class SyncDevicesAttributeMetricTest {
 
     @Test
     fun whenPixelNameRequestedThenReturnCorrectName() {
-        assertEquals("user_synced_device", testee.getPixelName())
+        assertEquals("attributed_metric_synced_device", testee.getPixelName())
     }
 
     @Test
@@ -125,12 +125,12 @@ class SyncDevicesAttributeMetricTest {
         deviceCountExpectedBuckets.forEach { (devices, bucket) ->
             connectedDevicesFlow.emit(devices)
 
-            val params = testee.getMetricParameters()
+            val realbucket = testee.getMetricParameters()["device_count"]
 
             assertEquals(
                 "For $devices devices, should return bucket $bucket",
-                mapOf("device_count" to bucket.toString()),
-                params,
+                bucket.toString(),
+                realbucket,
             )
         }
     }
@@ -156,6 +156,15 @@ class SyncDevicesAttributeMetricTest {
                 tag,
             )
         }
+    }
+
+    @Test
+    fun whenGetMetricParametersThenReturnVersion() = runTest {
+        connectedDevicesFlow.emit(1)
+
+        val version = testee.getMetricParameters()["version"]
+
+        assertEquals("0", version)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211382919613023?focus=true

### Description
Remove default params from attributed metrics pixels.
Pixel renaming to use `attributed_metric` as prefix.
Add version as metric param (representing bucket version).
Includes sending origin, or install date as fallback.
Removes stored data outside monitoring window.


### Steps to test this PR
This will be tested by privacy team to ensure:
- we don't include default params
- we strip form factor from pixel (no phone / tablet)
- we include origin or install date
- buckets include their version

Go to `PrivacyFeatureName` class and replace url by `https://api.jsonblob.com/019a4fb1-89b3-7971-8c77-ab77969a5874`
So it can be smoke tested optionally, to validate those parts.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
