### PR TITLE
Move FF checks to io for checking if to wait for privacy config

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/notificationpromptexperiment/NotificationPromptExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/notificationpromptexperiment/NotificationPromptExperimentManager.kt
@@ -93,7 +93,9 @@ class NotificationPromptExperimentManagerImpl @Inject constructor(
         return true
     }
 
-    override suspend fun isWaitForLocalPrivacyConfigEnabled(): Boolean = notificationPromptExperimentToggles.waitForLocalPrivacyConfig().isEnabled()
+    override suspend fun isWaitForLocalPrivacyConfigEnabled(): Boolean = withContext(dispatcherProvider.io()) {
+        notificationPromptExperimentToggles.waitForLocalPrivacyConfig().isEnabled()
+    }
 
     override suspend fun fireDdgSetAsDefault() {
         withContext(dispatcherProvider.io()) {

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
@@ -124,7 +124,9 @@ class RealOnboardingDesignExperimentManager @Inject constructor(
         return true
     }
 
-    override suspend fun isWaitForLocalPrivacyConfigEnabled(): Boolean = onboardingDesignExperimentToggles.waitForLocalPrivacyConfig().isEnabled()
+    override suspend fun isWaitForLocalPrivacyConfigEnabled(): Boolean = withContext(dispatcherProvider.io()) {
+        onboardingDesignExperimentToggles.waitForLocalPrivacyConfig().isEnabled()
+    }
 
     override fun onPrivacyConfigPersisted() {
         privacyPersisted = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211863673169530?focus=true 

### Description
- There are two feature flag checks happening on `main` thread in a hot path for app launching
- This is likely contributing ANRs

Moves the two feature flag checks to `io` instead of happening on `main`

### Steps to test this PR

- [ ] Check that logic around `waitForLocalPrivacyNotificationExperiment` and `waitForLocalPrivacyOnboardingExperiment` are still working as expected 