### PR TITLE
Round down yearly plan savings %

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -466,7 +466,7 @@ class RealSubscriptionsManager @Inject constructor(
             val totalMonthlyAnnual = monthlyPriceAmount * 12.toBigDecimal()
             val savingsAmount = totalMonthlyAnnual - yearlyPriceAmount
             val savingsPercentage = ((savingsAmount / totalMonthlyAnnual) * 100.toBigDecimal())
-                .setScale(0, RoundingMode.HALF_UP)
+                .setScale(0, RoundingMode.DOWN)
                 .toInt()
 
             SwitchPlanPricingInfo(

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -2022,7 +2022,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertEquals("$9.99", result!!.currentPrice)
         assertEquals("$99.99", result.targetPrice)
         assertEquals("$8.33", result.yearlyMonthlyEquivalent)
-        assertEquals(17, result.savingsPercentage)
+        assertEquals(16, result.savingsPercentage)
     }
 
     @Test
@@ -2042,7 +2042,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertEquals("$99.99", result!!.currentPrice)
         assertEquals("$9.99", result.targetPrice)
         assertEquals("$8.33", result.yearlyMonthlyEquivalent)
-        assertEquals(17, result.savingsPercentage)
+        assertEquals(16, result.savingsPercentage)
     }
 
     @Test
@@ -2072,8 +2072,8 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         assertNotNull(result)
         assertEquals("€7.50", result!!.yearlyMonthlyEquivalent)
-        // Savings: (8.99 * 12 - 89.99) / (8.99 * 12) * 100 = 16.58% ≈ 17%
-        assertEquals(17, result.savingsPercentage)
+        // Savings: (8.99 * 12 - 89.99) / (8.99 * 12) * 100 = 16.58% rounds down to 16%
+        assertEquals(16, result.savingsPercentage)
     }
 
     @Test
@@ -2091,8 +2091,8 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         val result = subscriptionsManager.getSwitchPlanPricing(isUpgrade = true)
 
         assertNotNull(result)
-        // Savings: (10 * 12 - 100) / (10 * 12) * 100 = 16.666...% rounds to 17%
-        assertEquals(17, result!!.savingsPercentage)
+        // Savings: (10 * 12 - 100) / (10 * 12) * 100 = 16.666...% rounds down to 16%
+        assertEquals(16, result!!.savingsPercentage)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211855463961045?focus=true

### Description
Change rounding strategy from HALF_UP to ROUND_DOWN

### Steps to test this PR

_Pre steps_
- [x] Apply patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Upgrade_
- [x] Install from branch
- [x] Purchase a test monthly subscription (Free Trial)
- [x] Cancel and wait until Free Trial expires **OR** wait until free trial is renewed to a paid monthly subscription
- [x] If expired after canceled, purchase a monthly subscription again
- [x] Go to Subscription Settings
- [x] Check Switch option is there with updated text "Switch to Yearly and Save 16%"
- [x] Select Switch option
- [x] Check copy for upgrade option is correct (16%)

_Downgrade_
- [x] Switch to yearly
- [x] Wait until screen refreshes
- [x] Select switch option
- [x] Check copy for downgrade option is correct (16%)

### No UI changes
