### PR TITLE
[Fix Bug] <handleAppLink ignores shouldHaltWebNavigation for same-domain app links after first trigger> #7097

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -62,7 +62,7 @@ class DuckDuckGoAppLinksHandler @Inject constructor() : AppLinksHandler {
                     previousUrl = urlString
                     launchAppLink()
                     hasTriggeredForDomain = true
-                    if (shouldTrigger) return true
+                    return shouldTrigger || shouldHaltWebNavigation
                 }
                 return false
             }


### PR DESCRIPTION
I found the handler and implemented the fix: same-domain navigations now return shouldHaltWebNavigation when an app link is launched.
- Change made in app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
- In the same-domain branch, after launching the app link, the function now returns shouldTrigger || shouldHaltWebNavigation instead of always returning false unless shouldTrigger was true.

Summary
Updated DuckDuckGoAppLinksHandler.handleAppLink to consistently respect shouldHaltWebNavigation on subsequent same-domain app links, while preserving alwaysTriggerList behavior.

Contribution by Gittensor, learn more at https://gittensor.io/
