### PR TITLE
Remove LiveData from BrowserViewModel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -354,9 +354,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
         // flows only once, so a separate initialization is necessary
         configureFlowCollectors()
 
-        viewModel.viewState.observe(this) {
-            renderer.renderBrowserViewState(it)
-        }
+        viewModel.viewState
+            .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+            .onEach { renderer.renderBrowserViewState(it) }
+            .launchIn(lifecycleScope)
+
         observeDuckChatSharedCommands()
 
         viewModel.awaitClearDataFinishedNotification()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1211914747426587?focus=true

### Description
This PR moves the ViewState from LiveData to StateFlow. This allows us to avoid reading the value of feature flags in the main thread

### Steps to test this PR
Smoke testing for tab swiping, open, closing tabs and opening from third party.