### PR TITLE
Add option to clear data in Data Clearing settings (copy)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -49,6 +49,7 @@ import androidx.webkit.ServiceWorkerClientCompat
 import androidx.webkit.ServiceWorkerControllerCompat
 import androidx.webkit.WebViewFeature
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.BrowserActivity.Companion.DUCK_AI_ANIM_READY_DELAY_MS
 import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.animations.slideAndFadeInFromLeft
 import com.duckduckgo.app.browser.animations.slideAndFadeInFromRight
@@ -73,21 +74,17 @@ import com.duckduckgo.app.downloads.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
-import com.duckduckgo.app.firebutton.FireButtonStore
 import com.duckduckgo.app.global.ApplicationClearDataState
-import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.sanitize
 import com.duckduckgo.app.global.view.ClearDataAction
-import com.duckduckgo.app.global.view.FireDialog
+import com.duckduckgo.app.global.view.FireDialogProvider
 import com.duckduckgo.app.global.view.renderIfChanged
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.FIRE_DIALOG_CANCEL
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
-import com.duckduckgo.app.settings.clear.OnboardingExperimentFireAnimationHelper
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
@@ -95,7 +92,6 @@ import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.DefaultSnackbar
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
@@ -159,9 +155,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
     lateinit var dataClearerForegroundAppRestartPixel: DataClearerForegroundAppRestartPixel
 
     @Inject
-    lateinit var userEventsStore: UserEventsStore
-
-    @Inject
     lateinit var serviceWorkerClientCompat: ServiceWorkerClientCompat
 
     @Inject
@@ -177,13 +170,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     @Inject lateinit var dispatcherProvider: DispatcherProvider
 
     @Inject
-    lateinit var fireButtonStore: FireButtonStore
-
-    @Inject
     lateinit var externalIntentProcessingState: ExternalIntentProcessingState
-
-    @Inject
-    lateinit var appBuildConfig: AppBuildConfig
 
     @Inject
     lateinit var maliciousSiteBlockerWebViewIntegration: RealMaliciousSiteBlockerWebViewIntegration
@@ -207,12 +194,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
     lateinit var syncUrlIdentifier: SyncUrlIdentifier
 
     @Inject
-    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
-
-    @Inject
-    lateinit var onboardingExperimentFireAnimationHelper: OnboardingExperimentFireAnimationHelper
-
-    @Inject
     lateinit var omnibarEntryConverter: OmnibarEntryConverter
 
     @Inject
@@ -220,6 +201,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var newAddressBarOptionManager: NewAddressBarOptionManager
+
+    @Inject
+    lateinit var fireDialogProvider: FireDialogProvider
 
     private val lastActiveTabs = TabList()
 
@@ -812,20 +796,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         val params = mapOf(PixelParameter.FROM_FOCUSED_NTP to launchedFromFocusedNtp.toString())
         pixel.fire(AppPixelName.FORGET_ALL_PRESSED_BROWSING, params)
 
-        val dialog =
-            FireDialog(
-                context = this,
-                clearPersonalDataAction = clearPersonalDataAction,
-                pixel = pixel,
-                settingsDataStore = settingsDataStore,
-                userEventsStore = userEventsStore,
-                appCoroutineScope = appCoroutineScope,
-                dispatcherProvider = dispatcherProvider,
-                fireButtonStore = fireButtonStore,
-                appBuildConfig = appBuildConfig,
-                onboardingDesignExperimentManager = onboardingDesignExperimentManager,
-                onboardingExperimentFireAnimationHelper = onboardingExperimentFireAnimationHelper,
-            )
+        val dialog = fireDialogProvider.createFireDialog(context = this)
         dialog.setOnShowListener { currentTab?.onFireDialogVisibilityChanged(isVisible = true) }
         dialog.setOnCancelListener {
             pixel.fire(FIRE_DIALOG_CANCEL)

--- a/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.browser.databinding.ActivityDataClearingBinding
 import com.duckduckgo.app.fire.fireproofwebsite.ui.FireproofWebsitesActivity
 import com.duckduckgo.app.firebutton.FireButtonViewModel.AutomaticallyClearData
 import com.duckduckgo.app.firebutton.FireButtonViewModel.Command
+import com.duckduckgo.app.global.view.FireDialogProvider
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.FireAnimationActivity
 import com.duckduckgo.app.settings.clear.ClearWhatOption
@@ -61,6 +62,9 @@ class FireButtonActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
 
+    @Inject
+    lateinit var fireDialogProvider: FireDialogProvider
+
     private val viewModel: FireButtonViewModel by bindViewModel()
     private val binding: ActivityDataClearingBinding by viewBinding()
 
@@ -86,6 +90,7 @@ class FireButtonActivity : DuckDuckGoActivity() {
             automaticallyClearWhenSetting.setClickListener { viewModel.onAutomaticallyClearWhenClicked() }
             selectedFireAnimationSetting.setClickListener { viewModel.userRequestedToChangeFireAnimation() }
             clearDuckAiDataSetting.setOnCheckedChangeListener { _, isChecked -> viewModel.onClearDuckAiDataToggled(isChecked) }
+            clearDataAction.setClickListener { viewModel.onClearDataActionClicked() }
         }
     }
 
@@ -97,6 +102,7 @@ class FireButtonActivity : DuckDuckGoActivity() {
                     updateAutomaticClearDataOptions(it.automaticallyClearData, it.clearDuckAiData)
                     updateSelectedFireAnimation(it.selectedFireAnimation)
                     updateClearDuckAiDataSetting(it.clearDuckAiData, it.showClearDuckAiDataSetting)
+                    updateClearDataAction(it.clearDuckAiData)
                 }
             }.launchIn(lifecycleScope)
 
@@ -133,12 +139,23 @@ class FireButtonActivity : DuckDuckGoActivity() {
         binding.clearDuckAiDataSetting.visibility = if (isVisible) View.VISIBLE else View.GONE
     }
 
+    private fun updateClearDataAction(clearDuckAiData: Boolean) {
+        if (clearDuckAiData) {
+            binding.clearDataAction.setPrimaryText(resources.getString(R.string.fireClearAllPlusDuckChats))
+            binding.clearDataAction.setSecondaryText(resources.getString(R.string.settingsClearDataActionPlusDuckChatsSecondaryText))
+        } else {
+            binding.clearDataAction.setPrimaryText(resources.getString(R.string.fireClearAll))
+            binding.clearDataAction.setSecondaryText(resources.getString(R.string.settingsClearDataActionSecondaryText))
+        }
+    }
+
     private fun processCommand(it: Command) {
         when (it) {
             is Command.LaunchFireproofWebsites -> launchFireproofWebsites()
             is Command.ShowClearWhatDialog -> launchAutomaticallyClearWhatDialog(it.option, it.clearDuckAi)
             is Command.ShowClearWhenDialog -> launchAutomaticallyClearWhenDialog(it.option)
             is Command.LaunchFireAnimationSettings -> launchFireAnimationSelector(it.animation)
+            is Command.LaunchFireDialog -> launchFireDialog()
         }
     }
 
@@ -268,6 +285,11 @@ class FireButtonActivity : DuckDuckGoActivity() {
                 },
             )
             .show()
+    }
+
+    private fun launchFireDialog() {
+        val dialog = fireDialogProvider.createFireDialog(context = this)
+        dialog.show()
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonViewModel.kt
@@ -58,6 +58,7 @@ class FireButtonViewModel @Inject constructor(
         val selectedFireAnimation: FireAnimation = FireAnimation.HeroFire,
         val clearDuckAiData: Boolean = false,
         val showClearDuckAiDataSetting: Boolean = false,
+        val clerDataWithDuckAiChats: Boolean = false,
     )
 
     data class AutomaticallyClearData(
@@ -75,6 +76,7 @@ class FireButtonViewModel @Inject constructor(
 
         data class ShowClearWhenDialog(val option: ClearWhenOption) : Command()
         data class LaunchFireAnimationSettings(val animation: FireAnimation) : Command()
+        data object LaunchFireDialog : Command()
     }
 
     private val viewState = MutableStateFlow(ViewState())
@@ -211,6 +213,10 @@ class FireButtonViewModel @Inject constructor(
         } else {
             pixel.fire(AppPixelName.SETTINGS_CLEAR_DUCK_AI_DATA_TOGGLED_OFF)
         }
+    }
+
+    fun onClearDataActionClicked() {
+        viewModelScope.launch { command.send(Command.LaunchFireDialog) }
     }
 
     private fun ClearWhatOption.pixelEvent(): Pixel.PixelName {

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialogProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialogProvider.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.view
+
+import android.content.Context
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.firebutton.FireButtonStore
+import com.duckduckgo.app.global.events.db.UserEventsStore
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
+import com.duckduckgo.app.settings.clear.OnboardingExperimentFireAnimationHelper
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+interface FireDialogProvider {
+    fun createFireDialog(context: Context): FireDialog
+}
+
+@ContributesBinding(scope = AppScope::class)
+@SingleInstanceIn(scope = AppScope::class)
+class FireDialogLauncherImpl @Inject constructor() : FireDialogProvider {
+
+    @Inject
+    lateinit var clearPersonalDataAction: ClearDataAction
+
+    @Inject
+    lateinit var pixel: Pixel
+
+    @Inject
+    lateinit var settingsDataStore: SettingsDataStore
+
+    @Inject
+    lateinit var userEventsStore: UserEventsStore
+
+    @AppCoroutineScope
+    @Inject
+    lateinit var appCoroutineScope: CoroutineScope
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    lateinit var fireButtonStore: FireButtonStore
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
+
+    @Inject
+    lateinit var onboardingExperimentFireAnimationHelper: OnboardingExperimentFireAnimationHelper
+
+    override fun createFireDialog(context: Context): FireDialog = FireDialog(
+        context = context,
+        clearPersonalDataAction = clearPersonalDataAction,
+        pixel = pixel,
+        settingsDataStore = settingsDataStore,
+        userEventsStore = userEventsStore,
+        appCoroutineScope = appCoroutineScope,
+        dispatcherProvider = dispatcherProvider,
+        fireButtonStore = fireButtonStore,
+        appBuildConfig = appBuildConfig,
+        onboardingDesignExperimentManager = onboardingDesignExperimentManager,
+        onboardingExperimentFireAnimationHelper = onboardingExperimentFireAnimationHelper,
+    )
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -47,15 +47,9 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarObserv
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
-import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.downloads.DownloadsActivity
-import com.duckduckgo.app.firebutton.FireButtonStore
-import com.duckduckgo.app.global.events.db.UserEventsStore
-import com.duckduckgo.app.global.view.ClearDataAction
-import com.duckduckgo.app.global.view.FireDialog
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
+import com.duckduckgo.app.global.view.FireDialogProvider
 import com.duckduckgo.app.settings.SettingsActivity
-import com.duckduckgo.app.settings.clear.OnboardingExperimentFireAnimationHelper
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
@@ -77,7 +71,6 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowUndoBookmarkM
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowUndoDeleteTabsMessage
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.button.ButtonType
@@ -101,7 +94,6 @@ import kotlinx.coroutines.launch
 import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
-import java.util.ArrayList
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
@@ -121,9 +113,6 @@ class TabSwitcherActivity :
     lateinit var settingsDataStore: SettingsDataStore
 
     @Inject
-    lateinit var clearPersonalDataAction: ClearDataAction
-
-    @Inject
     lateinit var gridViewColumnCalculator: GridViewColumnCalculator
 
     @Inject
@@ -136,22 +125,6 @@ class TabSwitcherActivity :
     lateinit var faviconManager: FaviconManager
 
     @Inject
-    lateinit var userEventsStore: UserEventsStore
-
-    @Inject
-    @AppCoroutineScope
-    lateinit var appCoroutineScope: CoroutineScope
-
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
-    lateinit var fireButtonStore: FireButtonStore
-
-    @Inject
-    lateinit var appBuildConfig: AppBuildConfig
-
-    @Inject
     lateinit var duckChat: DuckChat
 
     @Inject
@@ -161,10 +134,7 @@ class TabSwitcherActivity :
     lateinit var tabManagerFeatureFlags: TabManagerFeatureFlags
 
     @Inject
-    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
-
-    @Inject
-    lateinit var onboardingExperimentFireAnimationHelper: OnboardingExperimentFireAnimationHelper
+    lateinit var fireDialogProvider: FireDialogProvider
 
     @Inject
     lateinit var omnibarRepository: OmnibarRepository
@@ -655,20 +625,7 @@ class TabSwitcherActivity :
     }
 
     private fun onFireButtonClicked() {
-        val dialog =
-            FireDialog(
-                context = this,
-                clearPersonalDataAction = clearPersonalDataAction,
-                pixel = pixel,
-                settingsDataStore = settingsDataStore,
-                userEventsStore = userEventsStore,
-                appCoroutineScope = appCoroutineScope,
-                dispatcherProvider = dispatcherProvider,
-                fireButtonStore = fireButtonStore,
-                appBuildConfig = appBuildConfig,
-                onboardingDesignExperimentManager = onboardingDesignExperimentManager,
-                onboardingExperimentFireAnimationHelper = onboardingExperimentFireAnimationHelper,
-            )
+        val dialog = fireDialogProvider.createFireDialog(context = this)
         dialog.show()
     }
 

--- a/app/src/main/res/layout/activity_data_clearing.xml
+++ b/app/src/main/res/layout/activity_data_clearing.xml
@@ -80,6 +80,19 @@
                 app:secondaryText="@string/settingsClearAiDataDeleteMessage"
                 app:showSwitch="true" />
 
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/clearDataActionDivider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/clearDataAction"
+                android:layout_width="match_parent"
+                app:leadingIcon="@drawable/ic_fire_24"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/fireClearAll"
+                app:secondaryText="@string/settingsClearDataActionSecondaryText"/>
+
         </LinearLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Изчистване на данни</string>
-    <string name="fireClearAll">Изчистване на всички раздели и данни</string>
-    <string name="fireClearAllPlusDuckChats">Изчистване на всички раздели, данни и чатове с Duck.ai</string>
     <string name="fireCancel">Отмени</string>
     <string name="fireDataCleared">Данните са изчистени</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Vymazat data</string>
-    <string name="fireClearAll">Vymazat všechny karty a data</string>
-    <string name="fireClearAllPlusDuckChats">Vymazat všechny karty, data a chaty Duck.ai</string>
     <string name="fireCancel">Zrušit</string>
     <string name="fireDataCleared">Data vymazána</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Ryd data</string>
-    <string name="fireClearAll">Ryd alle faner og data</string>
-    <string name="fireClearAllPlusDuckChats">Ryd alle faner, data og Duck.ai-chats</string>
     <string name="fireCancel">Annuller</string>
     <string name="fireDataCleared">Data ryddet</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Daten löschen</string>
-    <string name="fireClearAll">Alle Tabs schließen und Daten löschen</string>
-    <string name="fireClearAllPlusDuckChats">Alle Tabs, Daten und Duck.ai-Chats löschen</string>
     <string name="fireCancel">Abbrechen</string>
     <string name="fireDataCleared">Daten gelöscht</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Εκκαθάριση δεδομένων</string>
-    <string name="fireClearAll">Εκκαθάριση όλων των καρτελών και δεδομένων</string>
-    <string name="fireClearAllPlusDuckChats">Εκκαθάριση όλων των καρτελών, δεδομένων και συνομιλιών Duck.ai</string>
     <string name="fireCancel">Ακύρωση</string>
     <string name="fireDataCleared">Εκκαθάριση δεδομένων</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Borrar datos</string>
-    <string name="fireClearAll">Borrar todos los datos y pestañas</string>
-    <string name="fireClearAllPlusDuckChats">Borra todas las pestañas, datos y chats de Duck.ai</string>
     <string name="fireCancel">Cancelar</string>
     <string name="fireDataCleared">Datos eliminados</string>
 

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Kustuta andmed</string>
-    <string name="fireClearAll">Kustuta kõik vahekaardid ja andmed</string>
-    <string name="fireClearAllPlusDuckChats">Kustuta kõik vahekaardid, andmed ja Duck.ai vestlused</string>
     <string name="fireCancel">Tühista</string>
     <string name="fireDataCleared">Andmed on kustutatud</string>
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Poista tiedot</string>
-    <string name="fireClearAll">Poista kaikki välilehdet ja tiedot</string>
-    <string name="fireClearAllPlusDuckChats">Tyhjennä kaikki välilehdet, tiedot ja Duck.ai-keskustelut</string>
     <string name="fireCancel">Peruuta</string>
     <string name="fireDataCleared">Tiedot poistettu</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Effacer les données</string>
-    <string name="fireClearAll">Effacer tous les onglets et données</string>
-    <string name="fireClearAllPlusDuckChats">Effacer tous les onglets, données et chats Duck.ai</string>
     <string name="fireCancel">Annuler</string>
     <string name="fireDataCleared">Données effacées</string>
 

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Obriši podatke</string>
-    <string name="fireClearAll">Obriši sve kartice i podatke</string>
-    <string name="fireClearAllPlusDuckChats">Izbriši sve kartice, podatke i razgovore s Duck.ai</string>
     <string name="fireCancel">Odustani</string>
     <string name="fireDataCleared">Podaci su obrisani</string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Adatok törlése</string>
-    <string name="fireClearAll">Összes lap és adat törlése</string>
-    <string name="fireClearAllPlusDuckChats">Összes lap, adat és Duck.ai-csevegés törlése</string>
     <string name="fireCancel">Mégse</string>
     <string name="fireDataCleared">Adatok törölve</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Elimina dati</string>
-    <string name="fireClearAll">Elimina tutte le schede e i dati</string>
-    <string name="fireClearAllPlusDuckChats">Cancella tutte le schede, i dati e le chat di Duck.ai</string>
     <string name="fireCancel">Annulla</string>
     <string name="fireDataCleared">I dati sono stati eliminati</string>
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Valyti duomenis</string>
-    <string name="fireClearAll">Valyti visas korteles ir duomenis</string>
-    <string name="fireClearAllPlusDuckChats">Išvalyti visus skirtukus, duomenis ir „Duck.ai“ pokalbius</string>
     <string name="fireCancel">Atšaukti</string>
     <string name="fireDataCleared">Duomenys išvalyti</string>
 

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -126,8 +126,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Notīrīt datus</string>
-    <string name="fireClearAll">Notīrīt visas cilnes un datus</string>
-    <string name="fireClearAllPlusDuckChats">Notīrīt visas cilnes, datus un Duck.ai tērzējumus</string>
     <string name="fireCancel">Atcelt</string>
     <string name="fireDataCleared">Dati ir notīrīti</string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Slett data</string>
-    <string name="fireClearAll">Lukk alle faner og slett data</string>
-    <string name="fireClearAllPlusDuckChats">Fjern alle faner, data og Duck.ai-chatter</string>
     <string name="fireCancel">Avbryt</string>
     <string name="fireDataCleared">Data slettet</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Gegevens wissen</string>
-    <string name="fireClearAll">Alle tabbladen en gegevens wissen</string>
-    <string name="fireClearAllPlusDuckChats">Alle tabbladen, gegevens en Duck.ai-chats wissen</string>
     <string name="fireCancel">Annuleren</string>
     <string name="fireDataCleared">Gegevens gewist</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Wyczyść dane</string>
-    <string name="fireClearAll">Wyczyść wszystkie karty i dane</string>
-    <string name="fireClearAllPlusDuckChats">Wyczyść wszystkie karty, dane i czaty Duck.ai</string>
     <string name="fireCancel">Anuluj</string>
     <string name="fireDataCleared">Dane zostały usunięte</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Limpar dados</string>
-    <string name="fireClearAll">Limpar todos os separadores e dados</string>
-    <string name="fireClearAllPlusDuckChats">Limpar todos os separadores, dados e conversas do Duck.ai</string>
     <string name="fireCancel">Cancelar</string>
     <string name="fireDataCleared">Dados limpos</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -126,8 +126,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Ștergere date</string>
-    <string name="fireClearAll">Șterge toate filele și datele</string>
-    <string name="fireClearAllPlusDuckChats">Șterge toate filele, datele și chaturile Duck.ai</string>
     <string name="fireCancel">Anulează</string>
     <string name="fireDataCleared">Date șterse</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Сбросить данные</string>
-    <string name="fireClearAll">Закрыть вкладки и удалить данные</string>
-    <string name="fireClearAllPlusDuckChats">Закрыть все вкладки и стереть все данные и чаты Duck.ai</string>
     <string name="fireCancel">Отменить</string>
     <string name="fireDataCleared">Данные сброшены</string>
 

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Vymazať údaje</string>
-    <string name="fireClearAll">Vymazať všetky karty a údaje</string>
-    <string name="fireClearAllPlusDuckChats">Vymazať všetky karty, údaje a chaty Duck.ai</string>
     <string name="fireCancel">Zrušiť</string>
     <string name="fireDataCleared">Údaje boli vymazané</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -127,8 +127,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Počisti podatke</string>
-    <string name="fireClearAll">Počisti vse zavihke in podatke</string>
-    <string name="fireClearAllPlusDuckChats">Počisti vse zavihke, podatke in klepete Duck.ai</string>
     <string name="fireCancel">Preklic</string>
     <string name="fireDataCleared">Podatki izbrisani</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Rensa data</string>
-    <string name="fireClearAll">Rensa alla flikar och data</string>
-    <string name="fireClearAllPlusDuckChats">Rensa alla flikar, data och Duck.ai-chattar</string>
     <string name="fireCancel">Avbryt</string>
     <string name="fireDataCleared">Data rensad</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -125,8 +125,6 @@
 
     <!-- Fire -->
     <string name="fireMenu">Verileri Temizle</string>
-    <string name="fireClearAll">Tüm Sekmeleri ve Verileri Temizle</string>
-    <string name="fireClearAllPlusDuckChats">Tüm Sekmeleri, Verileri ve Duck.ai Sohbetlerini Temizle</string>
     <string name="fireCancel">İptal</string>
     <string name="fireDataCleared">Veri silindi</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,8 +124,8 @@
 
     <!-- Fire -->
     <string name="fireMenu">Clear Data</string>
-    <string name="fireClearAll">Clear All Tabs And Data</string>
-    <string name="fireClearAllPlusDuckChats">Clear All Tabs, Data, and Duck.ai Chats</string>
+    <string name="fireClearAll">Clear Tabs and Data</string>
+    <string name="fireClearAllPlusDuckChats">Clear Tabs, Data, and Duck.ai Chats</string>
     <string name="fireCancel">Cancel</string>
     <string name="fireDataCleared">Data cleared</string>
 
@@ -246,6 +246,8 @@
     <string name="settingsAutomaticallyClearWhenAppExit60Minutes">App exit, inactive for 1 hour</string>
     <string name="settingsClearAiDataTitle">Clear Duck.ai Chats</string>
     <string name="settingsClearAiDataDeleteMessage">Fire Button will also delete Duck.ai history, including pinned chats.</string>
+    <string name="settingsClearDataActionSecondaryText">Clears all tabs and data for any sites you haven\'t fireproofed.</string>
+    <string name="settingsClearDataActionPlusDuckChatsSecondaryText">Clears all tabs, Duck.ai chats, and data for any sites you haven\'t fireproofed.</string>
 
     <!-- About Activity -->
     <string name="aboutActivityTitle">About DuckDuckGo</string>

--- a/app/src/test/java/com/duckduckgo/app/firebutton/FireButtonViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/firebutton/FireButtonViewModelTest.kt
@@ -332,6 +332,17 @@ internal class FireButtonViewModelTest {
         )
     }
 
+    @Test
+    fun `when clear data button clicked then Fire Dialog launched`() = runTest {
+        testee.commands().test {
+            testee.onClearDataActionClicked()
+
+            assertEquals(Command.LaunchFireDialog, awaitItem())
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
     private fun givenSelectedFireAnimation(fireAnimation: FireAnimation) {
         whenever(mockAppSettingsDataStore.selectedFireAnimation).thenReturn(fireAnimation)
         whenever(mockAppSettingsDataStore.isCurrentlySelected(fireAnimation)).thenReturn(true)


### PR DESCRIPTION
**Note: this is a rebased copy of https://github.com/duckduckgo/Android/pull/7096 to see if we can re-trigger the translation job.**

Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211878032869780?focus=true

### Description
Adds a new fire button to the Data Clearing settings screen.

:warning: This is ready for review but will need to wait for translations before merging.

### Steps to test this PR

- [x] Go to Settings → Data Clearing.
- [x] Try the new fire button.
- [x] Open Duck.ai (from anywhere).
- [x] Go to Settings → Data Clearing.
- [x] See the option to clear Duck.ai chats and enable it.
- [x] See how the copy on the fire button and confirmation button changes.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="480" height="1071" alt="clear_data_and_chat_light_before" src="https://github.com/user-attachments/assets/b97652c9-c3f6-44f6-b74e-dade70cb7fb9" />|<img width="480" height="1071" alt="clear_data_and_chat_light" src="https://github.com/user-attachments/assets/4597987a-4b55-48c8-a3f5-8d33c8b06ed1" />|
