### PR TITLE
Create new feature flag for handling about blank web pages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -203,4 +203,14 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun reportWebViewCapabilities(): Toggle
+
+    /**
+     * @return `true` when the remote config has the global "handleAboutBlank" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    // @Toggle.InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.InternalAlwaysEnabled
+    fun handleAboutBlank(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: 
https://app.asana.com/1/137249556945/project/1211724162604201/task/1211850430148973?focus=true

### Description

Added a new toggle `handleAboutBlank()` to the `AndroidBrowserConfigFeature` interface. This toggle is internally always enabled and defaults to `false`. It will be used to determine whether the app should handle "about:blank" URLs based on remote configuration.

### Steps to test this PR

_Handle About Blank Feature_
- [x] Verify that the new toggle is properly annotated with `@Toggle.InternalAlwaysEnabled`
- [x] Verify that the toggle defaults to `false` when remote config is not present

### UI changes
No UI or functional changes in this PR.