### PR TITLE
Increase gradle max heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 android.useAndroidX=true
 android.uniquePackageNames = true
 android.nonTransitiveRClass=true
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC
 org.gradle.caching=true
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211978642439036?focus=true 

### Description
Increase gradle max heap size to prevent seeing out of memory errors during intensive actions like running `./gradlew lint` locally

### Steps to test this PR
- qa optional / make sure CI checks succeed