### PR TITLE
RMF: subscriptionFreeTrialActive Matching Attribute

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFSubscriptionFreeTrialActiveMatchingAttribute.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFSubscriptionFreeTrialActiveMatchingAttribute.kt
@@ -21,8 +21,7 @@ import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
 import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
 import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
 import com.duckduckgo.remote.messaging.api.MatchingAttribute
-import com.duckduckgo.subscriptions.api.ActiveOfferType
-import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -37,15 +36,12 @@ import javax.inject.Inject
 )
 @SingleInstanceIn(AppScope::class)
 class RMFSubscriptionFreeTrialActiveMatchingAttribute @Inject constructor(
-    private val subscriptionsManager: SubscriptionsManager,
+    private val authRepository: AuthRepository,
 ) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
     override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         return when (matchingAttribute) {
             is SubscriptionFreeTrialActiveMatchingAttribute -> {
-                val hasActiveTrial = subscriptionsManager.getSubscription()
-                    ?.activeOffers
-                    ?.any { it == ActiveOfferType.TRIAL } == true
-                hasActiveTrial == matchingAttribute.remoteValue
+                authRepository.isFreeTrialActive() == matchingAttribute.remoteValue
             }
 
             else -> null


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1211809773817997?focus=true

### Description
Adding new `subscriptionFreeTrialActive` matching attribute

### Steps to test this PR

_Pre steps_
- [x] Apply patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Set `RemoteMessagingService` API to `https://api.jsonblob.com/019aa2b9-6aaa-7cda-826c-bf0c06ae0db0`

_subscriptionFreeTrialActive_
- [x] Fresh install
- [x] Skip onboarding
- [x] Check Remote Message is not visible
- [x] Purchase a test subscription (Free Trial)
- [x] Go to browser > tap Fire Button > Clear Data
- [x] Wait a few seconds until message is shown
- [x] Wait 3 minutes until Free Trial is renewed to a paid subscription
- [x] Go to browser > tap Fire Button > Clear Data
- [x] Check message has been removed

### No UI changes
