### PR TITLE
Fix failing Duck Player test when bot detection is triggered

### DIFF
--- a/.github/workflows/duckplayer.yml
+++ b/.github/workflows/duckplayer.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: 'fix/cris/duck-player-test-failed-on-bot-detection'
 
       - name: Set up JDK version
         uses: actions/setup-java@v4


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210626814037951/task/1211963296480297?focus=true

### Description
* Don't tap 'app' overlay if bot detection error message is shown

### Steps to test this PR

_Feature 1_
- [ ] Check [workflow](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/app/app_01hkqhj1thevwtn9ym8a2ctn2r/upload/mupload_01kaehj7m4en2sa93rgz038mj3?sort=name&status=FAILURE) passes


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
