### PR TITLE
Exclude duck.ai when using fire button

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/indexeddb/IndexedDBManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/indexeddb/IndexedDBManager.kt
@@ -91,7 +91,7 @@ class DuckDuckGoIndexedDBManager @Inject constructor(
                 val host = it.name.split("_").getOrNull(1) ?: return@filter false
                 val isAllowed = allowedDomains.any { domain -> sameOrSubdomain(host, domain) }
 
-                if (clearDuckAiData && sameOrSubdomain(host, DUCKDUCKGO_DOMAIN)) {
+                if (clearDuckAiData && isFromDuckDuckGoDomains(host)) {
                     false
                 } else {
                     isAllowed
@@ -100,7 +100,11 @@ class DuckDuckGoIndexedDBManager @Inject constructor(
             .map { it.name }
     }
 
+    private fun isFromDuckDuckGoDomains(domain: String): Boolean {
+        return DUCKDUCKGO_DOMAINS.any { sameOrSubdomain(domain, it) }
+    }
+
     companion object {
-        const val DUCKDUCKGO_DOMAIN = "duckduckgo.com"
+        val DUCKDUCKGO_DOMAINS = listOf("duckduckgo.com", "duck.ai")
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
@@ -81,7 +81,7 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
                 if (domainForMatchingAllowedKey == null) {
                     db.delete(entry.key)
                     logcat { "WebLocalStorageManager: Deleted key: $key" }
-                } else if (settingsDataStore.clearDuckAiData && domainForMatchingAllowedKey == DUCKDUCKGO_DOMAIN) {
+                } else if (settingsDataStore.clearDuckAiData && DUCKDUCKGO_DOMAINS.contains(domainForMatchingAllowedKey)) {
                     if (keysToDelete.any { key.endsWith(it) }) {
                         db.delete(entry.key)
                         logcat { "WebLocalStorageManager: Deleted key: $key" }
@@ -105,7 +105,7 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
     }
 
     companion object {
-        const val DUCKDUCKGO_DOMAIN = "duckduckgo.com"
+        val DUCKDUCKGO_DOMAINS = listOf("duckduckgo.com", "duck.ai")
     }
 }
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -27,6 +27,7 @@ class AppUrl {
         const val ABOUT = "https://$HOST/about"
         const val PIXEL = "https://improving.duckduckgo.com"
         const val EMAIL_SEGMENT = "email"
+        const val DUCK_AI = "https://duck.ai"
     }
 
     object ParamKey {

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.cookies.impl
 
 import com.duckduckgo.common.utils.AppUrl
+import com.duckduckgo.common.utils.AppUrl.Url.DUCK_AI
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
@@ -90,6 +91,6 @@ class WebViewCookieManager @Inject constructor(
     }
 
     companion object {
-        val DDG_COOKIE_DOMAINS = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES)
+        val DDG_COOKIE_DOMAINS = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES, DUCK_AI)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204474923577240/task/1211993499658484?focus=true 

### Description
Excludes duck.ai when using the fire button

### Steps to test this PR

- [x] Use Duck.ai as normal, adding some chats, upload images, etc
- [x] Settings → Feature Flag Inventory → Enabled `standaloneMigration`
- [x] Close and open the app
- [x] Go to duck ai
- [x] You should see a popup asking to refresh, click there
- [x] Eventually you should see a popup saying "success"
- [x] You should be taken to duck ai
- [x] Your chats, history, etc should all be there.
- [x] Click the back button or back arrow
- [x] Duck ai WebView should close
- [x] Use the fire button
- [x] Go to duck.ai you should not see the refresh popup again and your previous chats should still be available
- [x] To re-test, clear all the cache and data.

