### PR TITLE
Update origin handling logic (Attributed Metrics)

### DIFF
--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/AttributedMetricsConfigFeature.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/AttributedMetricsConfigFeature.kt
@@ -70,4 +70,7 @@ interface AttributedMetricsConfigFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun syncDevices(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun sendOriginParam(): Toggle
 }

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/OriginParamManager.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/OriginParamManager.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.impl
+
+import com.duckduckgo.app.attributed.metrics.AttributedMetricsConfigFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface OriginParamManager {
+    /**
+     * Determines whether the origin parameter should be included to metric based on the remote config.
+     *
+     * @return true if the origin should be included in the metric, false if not
+     */
+    fun shouldSendOrigin(origin: String?): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealOriginParamManager @Inject constructor(
+    private val attributedMetricsConfigFeature: AttributedMetricsConfigFeature,
+    private val moshi: Moshi,
+) : OriginParamManager {
+    private val sendOriginParamAdapter: JsonAdapter<SendOriginParamSettings> by lazy {
+        moshi.adapter(SendOriginParamSettings::class.java)
+    }
+
+    // Cache parsed substrings. It's expected this to be a short list and not change frequently.
+    private val cachedSubstrings: List<String> by lazy {
+        kotlin.runCatching {
+            attributedMetricsConfigFeature.sendOriginParam().getSettings()
+                ?.let { sendOriginParamAdapter.fromJson(it) }
+                ?.originCampaignSubstrings
+        }.getOrNull() ?: emptyList()
+    }
+
+    override fun shouldSendOrigin(origin: String?): Boolean {
+        // If toggle is disabled, don't send origin
+        if (!attributedMetricsConfigFeature.sendOriginParam().isEnabled()) {
+            return false
+        }
+
+        // If origin is null or blank, can't send it
+        if (origin.isNullOrBlank()) {
+            return false
+        }
+
+        // If no substrings configured, don't send origin
+        if (cachedSubstrings.isEmpty()) {
+            return false
+        }
+
+        // Check if origin matches any of the configured substrings (case-insensitive)
+        return cachedSubstrings.any { substring ->
+            origin.contains(substring, ignoreCase = true)
+        }
+    }
+}

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClient.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/RealAttributedMetricClient.kt
@@ -47,6 +47,7 @@ class RealAttributedMetricClient @Inject constructor(
     private val appReferrer: AppReferrer,
     private val dateUtils: AttributedMetricsDateUtils,
     private val appInstall: AppInstall,
+    private val originParamManager: OriginParamManager,
 ) : AttributedMetricClient {
 
     override fun collectEvent(eventName: String) {
@@ -99,7 +100,7 @@ class RealAttributedMetricClient @Inject constructor(
 
             val origin = appReferrer.getOriginAttributeCampaign()
             val paramsMutableMap = params.toMutableMap()
-            if (!origin.isNullOrBlank()) {
+            if (!origin.isNullOrBlank() && originParamManager.shouldSendOrigin(origin)) {
                 paramsMutableMap["origin"] = origin
             } else {
                 paramsMutableMap["install_date"] = getInstallDate()

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/SendOriginParamSettings.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/impl/SendOriginParamSettings.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.impl
+
+import com.squareup.moshi.Json
+
+data class SendOriginParamSettings(
+    @Json(name = "originCampaignSubstrings") val originCampaignSubstrings: List<String> = emptyList(),
+)

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/OriginParamManagerTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/impl/OriginParamManagerTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.impl
+
+import com.duckduckgo.app.attributed.metrics.AttributedMetricsConfigFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class OriginParamManagerTest {
+
+    private val mockAttributedMetricsConfigFeature: AttributedMetricsConfigFeature = mock()
+    private val mockSendOriginParamToggle: Toggle = mock()
+    private val moshi = Moshi.Builder().build()
+
+    private lateinit var testee: RealOriginParamManager
+
+    @Before
+    fun setup() {
+        whenever(mockAttributedMetricsConfigFeature.sendOriginParam()).thenReturn(mockSendOriginParamToggle)
+    }
+
+    @Test
+    fun whenToggleDisabledThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(false)
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_paid_test")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenOriginIsNullThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin(null)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenOriginIsBlankThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("   ")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenSubstringListIsEmptyThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":[]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_paid_test")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenOriginMatchesSubstringThenReturnsTrue() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_paid_test")
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenOriginDoesNotMatchSubstringThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_organic_test")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenOriginMatchesAnyOfMultipleSubstringsThenReturnsTrue() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid","sponsored","affiliate"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_sponsored_search")
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenMatchingIsCaseInsensitiveThenReturnsTrue() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val resultUpperCase = testee.shouldSendOrigin("campaign_PAID_test")
+        val resultMixedCase = testee.shouldSendOrigin("campaign_PaId_test")
+
+        assertTrue(resultUpperCase)
+        assertTrue(resultMixedCase)
+    }
+
+    @Test
+    fun whenSettingsParsingFailsThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("invalid json")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_paid_test")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenSettingsIsNullThenReturnsFalse() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn(null)
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val result = testee.shouldSendOrigin("campaign_paid_test")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenOriginContainsSubstringWithinWordThenReturnsTrue() {
+        whenever(mockSendOriginParamToggle.isEnabled()).thenReturn(true)
+        whenever(mockSendOriginParamToggle.getSettings()).thenReturn("""{"originCampaignSubstrings":["paid"]}""")
+        testee = RealOriginParamManager(mockAttributedMetricsConfigFeature, moshi)
+
+        val resultHipaid = testee.shouldSendOrigin("funnel_hipaid_us")
+        val resultPaidctv = testee.shouldSendOrigin("funnel_paidctv_us")
+        val resultPaid = testee.shouldSendOrigin("funnel_paid_us")
+
+        assertTrue(resultHipaid)
+        assertTrue(resultPaidctv)
+        assertTrue(resultPaid)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212002979565345?focus=true

### Description
Updates logic to decide if we should add origin in our attributed metrics.
This now relies on remote config.
if enabled, we validate if origin includes specific substrings, otherwise we don't include.

### Steps to test this PR

Update the `PrivacyFeatureName` `PRIVACY_REMOTE_CONFIG_URL` with `https://duckduckgo.github.io/privacy-configuration/pr-4110/v4/android-config.json`

Use logcat filter `package:mine message~:"attributed_metric"`

_Feature 1_
- [x] Fresh install (removing local folder)
- [x] Launch and wait for Skip onboarding to appear.
- [x] skip onboarding
- [x] Go to internal Attribute Metrics
- [x] Add search events, add ad clicks, add duck ai events
- [x] update app retention atb and search atb with random values
- [x] Update origin with `funnel_paid_test`
- [x] put install date in the past, 1mo works
- [x] restart (fire button)
- [x] you should see some pixels from attributed metrics, they should contain `origin`

_Feature 2_
- [x] Go to internal Attribute Metrics
- [x] update app retention atb and search atb with NEW random values
- [x] Update origin with `funnel_test`
- [x] restart (fire button)
- [x] you should see some pixels from attributed metrics, even if ignored, they should contain `install_date` now

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
