### PR TITLE
Remove the siteErrorHandlerKillSwitch feature flag

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -104,7 +104,6 @@ import com.duckduckgo.app.browser.history.NavigationHistoryEntry
 import com.duckduckgo.app.browser.httperrors.HttpCodeSiteErrorHandler
 import com.duckduckgo.app.browser.httperrors.HttpErrorPixelName
 import com.duckduckgo.app.browser.httperrors.HttpErrorPixels
-import com.duckduckgo.app.browser.httperrors.SiteErrorHandlerKillSwitch
 import com.duckduckgo.app.browser.httperrors.StringSiteErrorHandler
 import com.duckduckgo.app.browser.logindetection.FireproofDialogsEventHandler
 import com.duckduckgo.app.browser.logindetection.LoginDetected
@@ -118,7 +117,8 @@ import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.OmnibarType
-import com.duckduckgo.app.browser.omnibar.QueryOrigin.*
+import com.duckduckgo.app.browser.omnibar.QueryOrigin.FromBookmark
+import com.duckduckgo.app.browser.omnibar.QueryOrigin.FromUser
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.remotemessage.RemoteMessagingModel
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
@@ -579,8 +579,6 @@ class BrowserTabViewModelTest {
     private val mockAdditionalDefaultBrowserPrompts: AdditionalDefaultBrowserPrompts = mock()
     val mockStack: WebBackForwardList = mock()
 
-    private val mockSiteErrorHandlerKillSwitch: SiteErrorHandlerKillSwitch = mock()
-    private val mockSiteErrorHandlerKillSwitchToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
     private val mockSiteErrorHandler: StringSiteErrorHandler = mock()
     private val mockSiteHttpErrorHandler: HttpCodeSiteErrorHandler = mock()
     private val mockSubscriptionsJSHelper: SubscriptionsJSHelper = mock()
@@ -766,8 +764,6 @@ class BrowserTabViewModelTest {
                 defaultBrowserPromptsExperimentShowPopupMenuItemFlow,
             )
 
-            whenever(mockSiteErrorHandlerKillSwitch.self()).thenReturn(mockSiteErrorHandlerKillSwitchToggle)
-
             fakeContentScopeScriptsSubscriptionEventPluginPoint = FakeContentScopeScriptsSubscriptionEventPluginPoint()
 
             whenever(mockDuckChat.getDuckChatUrl(any(), any())).thenReturn(duckChatURL)
@@ -847,7 +843,6 @@ class BrowserTabViewModelTest {
                     tabStatsBucketing = mockTabStatsBucketing,
                     additionalDefaultBrowserPrompts = mockAdditionalDefaultBrowserPrompts,
                     swipingTabsFeature = swipingTabsFeatureProvider,
-                    siteErrorHandlerKillSwitch = mockSiteErrorHandlerKillSwitch,
                     siteErrorHandler = mockSiteErrorHandler,
                     siteHttpErrorHandler = mockSiteHttpErrorHandler,
                     subscriptionsJSHelper = mockSubscriptionsJSHelper,
@@ -5303,25 +5298,6 @@ class BrowserTabViewModelTest {
                 url = "example2.com",
                 httpErrorCodes = emptyList(),
                 hasBrowserError = true,
-            )
-        }
-
-    @Test
-    fun whenErrorHandlerKilledAndPageIsChangedWithHttpErrorThenPrivacyProtectionsPopupManagerIsNotified() =
-        runTest {
-            whenever(mockSiteErrorHandlerKillSwitchToggle.isEnabled()).thenReturn(false)
-            testee.recordHttpErrorCode(statusCode = 404, url = "example2.com")
-
-            updateUrl(
-                originalUrl = "example.com",
-                currentUrl = "example2.com",
-                isBrowserShowing = true,
-            )
-
-            verify(mockPrivacyProtectionsPopupManager).onPageLoaded(
-                url = "example2.com",
-                httpErrorCodes = listOf(404),
-                hasBrowserError = false,
             )
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/httperrors/SiteErrorHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httperrors/SiteErrorHandler.kt
@@ -16,12 +16,8 @@
 
 package com.duckduckgo.app.browser.httperrors
 
-import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.browser.BrowserTabViewModel
 import com.duckduckgo.app.global.model.Site
-import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import javax.inject.Inject
 
 interface SiteErrorHandler<T> {
@@ -83,14 +79,4 @@ class HttpCodeSiteErrorHandlerImpl @Inject constructor() : HttpCodeSiteErrorHand
     override fun assignError(site: Site, error: Int) {
         site.onHttpErrorDetected(error)
     }
-}
-
-@ContributesRemoteFeature(
-    scope = AppScope::class,
-    featureName = "siteErrorHandlerKillSwitch",
-)
-interface SiteErrorHandlerKillSwitch {
-
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun self(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212002086443929?focus=true

### Description

This PR removes the `siteErrorHandlerKillSwitch` feature flag. 

One thing I added is that the error handling code is now run on the IO thread in a coroutine to minimize blocking of the main thread when setting the `site` value.

### Steps to test this PR

- Open `amazon.com` (either from SERP or manually)
- Type in **manually** `amazon.com` and load the page multiple times.
- Verify that address bar keeps showing the correct URL (including
HTTPS) and privacy shield.
- Opening privacy dashboard should always show that protections are
active and that the site is secure.

You can also try with `abc.com`, `cnn.com` (which always should show
`edition.cnn.com`).
