### PR TITLE
Bookmark added confirmation dialog tidy-ups

### DIFF
--- a/PixelDefinitions/pixels/sync_promotion.json5
+++ b/PixelDefinitions/pixels/sync_promotion.json5
@@ -1,0 +1,23 @@
+{
+    "sync_setup_promo_bookmark_added_dialog_shown": {
+        "description": "User added a bookmark and we showed the sync setup promo in the bookmark added dialog",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_setup_promo_bookmark_added_dialog_dismissed": {
+        "description": "User manually chose to hide the sync setup promo in the bookmark added dialog",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_setup_promo_bookmark_added_dialog_confirmed": {
+        "description": "User chose to set up sync from the promo in the bookmark added dialog",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
@@ -31,7 +31,7 @@ import android.widget.LinearLayout
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import com.duckduckgo.app.bookmarks.BookmarkAddedPromotionPlugin
+import com.duckduckgo.app.bookmarks.BookmarkAddedDialogPlugin
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetAddBookmarkBinding
 import com.duckduckgo.common.ui.view.gone
@@ -54,7 +54,7 @@ import com.google.android.material.R as MaterialR
 class BookmarkAddedConfirmationDialog(
     context: Context,
     private val bookmarkFolder: BookmarkFolder?,
-    private val promoPlugins: PluginPoint<BookmarkAddedPromotionPlugin>,
+    private val promoPlugins: PluginPoint<BookmarkAddedDialogPlugin>,
 ) : BottomSheetDialog(context) {
 
     abstract class EventListener {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialogFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialogFactory.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.bookmarks.dialog
 
 import android.content.Context
-import com.duckduckgo.app.bookmarks.BookmarkAddedPromotionPlugin
+import com.duckduckgo.app.bookmarks.BookmarkAddedDialogPlugin
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
@@ -31,7 +31,7 @@ interface BookmarkAddedConfirmationDialogFactory {
 
 @ContributesBinding(AppScope::class)
 class ReadyBookmarkAddedConfirmationDialogFactory @Inject constructor(
-    private val plugins: PluginPoint<BookmarkAddedPromotionPlugin>,
+    private val plugins: PluginPoint<BookmarkAddedDialogPlugin>,
 ) : BookmarkAddedConfirmationDialogFactory {
     override fun create(context: Context, bookmarkFolder: BookmarkFolder?): BookmarkAddedConfirmationDialog {
         return BookmarkAddedConfirmationDialog(context, bookmarkFolder, plugins)

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -25,7 +25,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import androidx.work.WorkManager
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesPluginPoint
-import com.duckduckgo.app.bookmarks.BookmarkAddedPromotionPlugin
+import com.duckduckgo.app.bookmarks.BookmarkAddedDialogPlugin
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
@@ -389,5 +389,5 @@ class BrowserModule {
 @Qualifier
 annotation class IndonesiaNewTabSection
 
-@ContributesPluginPoint(scope = AppScope::class, boundType = BookmarkAddedPromotionPlugin::class)
-private interface BookmarkAddedPromotionPluginPoint
+@ContributesPluginPoint(scope = AppScope::class, boundType = BookmarkAddedDialogPlugin::class)
+private interface BookmarkAddedDialogPluginPoint

--- a/app/src/main/res/layout/bottom_sheet_add_bookmark.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_bookmark.xml
@@ -21,8 +21,7 @@
     android:layout_height="match_parent"
     android:background="@drawable/rounded_top_corners_bottom_sheet_drawable"
     android:orientation="vertical"
-    android:paddingTop="@dimen/actionBottomSheetVerticalPadding"
-    android:paddingBottom="@dimen/actionBottomSheetVerticalPadding">
+    android:paddingTop="@dimen/actionBottomSheetVerticalPadding">
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/bookmarksBottomSheetDialogTitle"
@@ -68,9 +67,12 @@
         android:id="@+id/promotionContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_4"
-        android:layout_marginEnd="@dimen/keyline_4"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:orientation="vertical" />
+        android:layout_marginTop="@dimen/keyline_2"
+        android:background="?attr/daxColorBackground"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/keyline_4"
+        android:paddingTop="@dimen/keyline_4"
+        android:paddingEnd="@dimen/keyline_4"
+        android:paddingBottom="@dimen/keyline_4" />
 
 </com.duckduckgo.app.bookmarks.dialog.TouchObservingLinearLayout>

--- a/browser-api/src/main/java/com/duckduckgo/app/bookmarks/BookmarkAddedDialogPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/bookmarks/BookmarkAddedDialogPlugin.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.bookmarks
 
 import android.view.View
 
-interface BookmarkAddedPromotionPlugin {
+interface BookmarkAddedDialogPlugin {
 
     /**
      * Returns a view to be displayed in the bookmark added confirmation dialog, or null if the promotion should not be shown.
@@ -27,6 +27,6 @@ interface BookmarkAddedPromotionPlugin {
     suspend fun getView(): View?
 
     companion object {
-        const val PRIORITY_KEY_BOOKMARK_ADDED_PROMOTION = 100
+        const val PRIORITY_KEY_SETUP_SYNC = 100
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -115,6 +115,9 @@ interface SyncPixels {
     fun fireSetupDeepLinkFlowAbandoned()
     fun fireUserConfirmedToTurnOffSync()
     fun fireUserConfirmedToTurnOffSyncAndDelete(connectedDevices: Int)
+    fun fireSetupSyncPromoBookmarkAddedDialogDismissed()
+    fun fireSetupSyncPromoBookmarkAddedDialogConfirmed()
+    fun fireSetupSyncPromoBookmarkAddedDialogShown()
 }
 
 @ContributesBinding(AppScope::class)
@@ -338,6 +341,18 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE, parameters = params)
     }
 
+    override fun fireSetupSyncPromoBookmarkAddedDialogDismissed() {
+        pixel.fire(SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED)
+    }
+
+    override fun fireSetupSyncPromoBookmarkAddedDialogConfirmed() {
+        pixel.fire(SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED)
+    }
+
+    override fun fireSetupSyncPromoBookmarkAddedDialogShown() {
+        pixel.fire(SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN)
+    }
+
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
         val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
@@ -452,6 +467,9 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_ENDED_SUCCESS("sync_setup_ended_successful"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC("sync_disabled"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE("sync_disabledanddeleted"),
+    SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
+    SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED("sync_setup_promo_bookmark_added_dialog_dismissed"),
+    SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED("sync_setup_promo_bookmark_added_dialog_confirmed"),
 }
 
 object SyncPixelParameters {
@@ -485,6 +503,9 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
         return listOf(
             SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC.pixelName to removeAtb(),
             SyncPixelName.SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE.pixelName to removeAtb(),
+            SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN.pixelName to removeAtb(),
+            SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED.pixelName to removeAtb(),
+            SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED.pixelName to removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212003250163578?focus=true 

### Description

A few tidy-ups and follow ups, addressing design feedback:

- renaming plugin as per [API proposal: plugin to support promos in "bookmark added" dialog](https://app.asana.com/1/137249556945/project/1202552961248957/task/1211992330673639)
- add background color, as per [Background color](https://app.asana.com/1/137249556945/project/1142021229838617/task/1211996865062845?focus=true)
- pixels, as per [Pixel spec](https://app.asana.com/1/137249556945/task/1212015185910458)


### Steps to test this PR

**Logcat filter:** `message~:"Sync-promo|Pixel sent: sync_setup_promo"`
**Testing patch**: optionally, you can apply the patch below to make testing easier. it configures the 🔥 button to show the bookmark addd dialog.

#### Pixels
- [ ] optionally, apply the patch below
- [x] fresh install app, and make the "add bookmark" dialog show
- [x] Verify `sync_setup_promo_bookmark_added_dialog_shown` in logs
- [x] Tap on `Sync Bookmarks Across Devices`; verify `sync_setup_promo_bookmark_added_dialog_confirmed` in logs
- [x] Return, then tap on overflow and `Hide`; verify `sync_setup_promo_bookmark_added_dialog_dismissed` in logs

### Patch (makes Fire button show "add bookmark" dialog)
```
Index: app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt	(revision Staged)
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt	(date 1763724981700)
@@ -1252,9 +1252,11 @@
     }
 
     private fun onFireButtonPressed() {
-        val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
-        browserActivity?.launchFire(launchedFromFocusedNtp = isFocusedNtp)
-        viewModel.onFireMenuSelected()
+        // val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
+        // browserActivity?.launchFire(launchedFromFocusedNtp = isFocusedNtp)
+        // viewModel.onFireMenuSelected()
+        val folder = com.duckduckgo.savedsites.api.models.BookmarkFolder(name = "", parentId = "")
+        bookmarkAddedConfirmationDialogFactory.create(requireActivity(), folder).show()
     }
 
     private fun onBrowserMenuButtonPressed() {
```