### PR TITLE
Set password last-used timestamp upon creation

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
@@ -167,11 +167,14 @@ class SecureStoreBackedAutofillStore @Inject constructor(
 
         logcat(INFO) { "Saving login credentials for $url. username=${credentials.username}" }
 
+        val timestamp = lastUpdatedTimeProvider.getInMillis()
+
         val loginDetails = WebsiteLoginDetails(
             domain = url,
             username = credentials.username,
             domainTitle = credentials.domainTitle,
-            lastUpdatedMillis = lastUpdatedTimeProvider.getInMillis(),
+            lastUpdatedMillis = timestamp,
+            lastUsedInMillis = timestamp,
         )
         val webSiteLoginCredentials = WebsiteLoginDetailsWithCredentials(
             details = loginDetails,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
@@ -547,7 +547,10 @@ class SecureStoreBackedAutofillStoreTest {
         )
         testee.saveCredentials(url, credentials)
 
-        assertEquals(credentials.copy(domain = "example.com", lastUpdatedMillis = UPDATED_INITIAL_LAST_UPDATED), testee.getCredentials(url)[0])
+        assertEquals(
+            credentials.copy(domain = "example.com", lastUpdatedMillis = UPDATED_INITIAL_LAST_UPDATED, lastUsedMillis = UPDATED_INITIAL_LAST_UPDATED),
+            testee.getCredentials(url)[0],
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1206929637235170?focus=true

### Description
Set last used timestamp for any new credentials created either via the Save prompt or manually. It will not be set / updated via any password edit or update actions. 

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
