### PR TITLE
Enable FF for showing sync setup promo in bookmark added dialog

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionFeature.kt
@@ -45,6 +45,6 @@ interface SyncPromotionFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun passwords(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun bookmarkAddedDialog(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212016239099418?focus=true 

### Description
Changes default value of feature flag to enable bookmark added dialogs showing sync setup promos.

### Steps to test this PR

- [ ] QA optional 