### PR TITLE
Enable voice search toggle

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -112,9 +112,9 @@ interface DuckChatFeature {
     /**
      * @return `true` when the remote config has the "duckAiVoiceSearch"
      * sub-feature flag enabled
-     * If the remote feature is not present defaults to `internal`
+     * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun duckAiVoiceSearch(): Toggle
 
     /**

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeature.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeature.kt
@@ -39,8 +39,8 @@ interface VoiceSearchFeature {
 
     /**
      * Kill switch to restart listening when ERROR_NO_MATCH occurs before speech begins
-     * If the remote feature is not present defaults to `internal`
+     * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun restartAfterTimeout(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212058795599704?focus=true

### Description

- Sets `restartAfterTimeout` and `duckAiVoiceSearch` to `TRUE` (was `INTERNAL`)
- This increases the initial timeout of voice search entry and enables the Search + Duck.ai toggle for prod.

### Steps to test this PR

- [ ] Perform a voice search
- [ ] Verify that the “Search + Duck.ai” toggle is present
- [ ] Verify that it does not timeout after a few seconds
