### PR TITLE
Add observability around atb-related initialization timeouts

### DIFF
--- a/PixelDefinitions/pixels/app_initialization_timeout.json5
+++ b/PixelDefinitions/pixels/app_initialization_timeout.json5
@@ -1,0 +1,23 @@
+{
+    "timeout_waiting_for_referrer": {
+        "description": "Referrer data was not obtained in time",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "timeout_atb_pre_initializer_plugin": {
+        "description": "A pre-ATB initialization plugin timed out",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "plugin",
+                "description": "The class name of the plugin which timed out",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/di/StubStatisticsModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.statistics.api.PixelSender.SendPixelResult
 import com.duckduckgo.app.statistics.api.PixelSender.SendPixelResult.PIXEL_SENT
 import com.duckduckgo.app.statistics.api.StatisticsService
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.pixels.AtbInitializationPluginPixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -117,8 +118,9 @@ class StubStatisticsModule {
         statisticsUpdater: StatisticsUpdater,
         listeners: PluginPoint<AtbInitializerListener>,
         dispatcherProvider: DispatcherProvider,
+        pixelSender: AtbInitializationPluginPixelSender,
     ): MainProcessLifecycleObserver {
-        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, dispatcherProvider)
+        return AtbInitializer(appCoroutineScope, statisticsDataStore, statisticsUpdater, listeners, dispatcherProvider, pixelSender)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -124,6 +124,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.SEARCH_WIDGET_ADDED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.SEARCH_WIDGET_DELETED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.SETTINGS_APPEARANCE_IS_TRACKER_COUNT_IN_TAB_SWITCHER_TOGGLED.pixelName to PixelParameter.removeAll(),
+            AppPixelName.TIMEOUT_WAITING_FOR_APP_REFERRER.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -461,4 +461,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     BROWSER_NAV_TABS_PRESSED("m_browser_nav_tabs_pressed"),
     BROWSER_NAV_TABS_LONG_PRESSED("m_browser_nav_tabs_long_pressed"),
     BROWSER_NAV_MENU_PRESSED("m_browser_nav_menu_pressed"),
+
+    TIMEOUT_WAITING_FOR_APP_REFERRER("timeout_waiting_for_referrer"),
 }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/AtbInitializationPluginPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/AtbInitializationPluginPixelSender.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.pixels
+
+import com.duckduckgo.app.statistics.pixels.StatisticsPixelName.ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import logcat.LogPriority
+import logcat.logcat
+import javax.inject.Inject
+
+interface AtbInitializationPluginPixelSender {
+    fun pluginTimedOut(pluginName: String)
+}
+
+@ContributesBinding(AppScope::class)
+class RealAtbInitializationPluginPixelSender @Inject constructor(
+    private val pixel: Pixel,
+) : AtbInitializationPluginPixelSender {
+
+    override fun pluginTimedOut(pluginName: String) {
+        logcat(LogPriority.ERROR) { "AtbInitializer: pre-init plugin timed out [$pluginName]" }
+
+        val params = mapOf(
+            "plugin" to pluginName,
+        )
+        pixel.fire(ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT, parameters = params, emptyMap())
+    }
+}
+
+@ContributesMultibinding(AppScope::class)
+class AtbInitializerPluginPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT.pixelName to PixelParameter.removeAtb(),
+        )
+    }
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
@@ -24,4 +24,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 enum class StatisticsPixelName(override val pixelName: String) : PixelName {
     BROWSER_DAILY_ACTIVE_FEATURE_STATE("m_browser_feature_daily_active_user_d"),
     RETENTION_SEGMENTS("m_retention_segments"),
+
+    ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT("timeout_atb_pre_initializer_plugin"),
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1212017534631022?focus=true 

### Description
Add pixel for when timeouts happen in app initialisation paths:
- when a pre-ATB-initialization plugin times out
- when the app times out waiting for a referrer 

### Steps to test this PR

Add logcat filter: `message~:message~:"Waiting for referrer|Initializing ATB|Variants update|Initialized ATB|ull referrer stri|Result determined|for referrer|posting initial|WebView passkey support|wv|timed out|AtbInitializer|Pixel interceptor: .*atb_pre_initializer_plugin_timeout|Pixel interceptor: .*timeout_atb_pre_initializer_plugin|interceptor.*timeout_waiting_for_referrer"`

#### Happy path
- [x] Fresh install `playDebug` variant and launch the app
- [x] Verify you see logs for:
```
AtbInitializer: About to initialize ATB; running 3 pre ATB initialization plugins
AtbInitializer: Running pre-ATB init plugin [ReinstallAtbListener]
AtbInitializer: Running pre-ATB init plugin [AuraExperimentManager]
AtbInitializer: Running pre-ATB init plugin [PlayStoreAppReferrerStateListener]
```

#### Force timeout in app referrer

- [x] Apply patch from [Patch: Referrer timeout](https://app.asana.com/1/137249556945/task/1212197533093318?focus=true)
- [x] Fresh install `playDebug` variant and launch app
- [x] Verify you see logs for `LaunchViewModel timed out waiting for referrer`
- [x] Verify you see pixel in logs for `timeout_waiting_for_referrer`

#### Force timeout in pre-ATB-init plugin

- [x] Delete all local changes
- [x] Apply patch from [Patch: pre-ATB init plugin timeout](https://app.asana.com/1/137249556945/task/1212197533093320?focus=true)
- [x] Fresh install and launch app
- [x] Verify you see pixel in logs for `timeout_atb_pre_initializer_plugin` with param `plugin=ReinstallAtbListener`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emit pixels when app referrer wait or pre-ATB initialization plugins time out, with wiring, parameter cleaning, and tests.
> 
> - **Telemetry/Pixels**:
>   - Add `timeout_waiting_for_referrer` and `timeout_atb_pre_initializer_plugin` (with `plugin` param) in `PixelDefinitions/.../app_initialization_timeout.json5`.
>   - Introduce `AtbInitializationPluginPixelSender` and send `ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT` from `AtbInitializer` on plugin timeout.
>   - `LaunchViewModel` fires `AppPixelName.TIMEOUT_WAITING_FOR_APP_REFERRER` on referrer wait timeout.
> - **Interceptors**:
>   - Update `PixelParamRemovalInterceptor` to remove ATB/app version where required, including for `TIMEOUT_WAITING_FOR_APP_REFERRER` and `ATB_PRE_INITIALIZER_PLUGIN_TIMEOUT`.
> - **DI**:
>   - Inject `AtbInitializationPluginPixelSender` into `AtbInitializer`; update `StubStatisticsModule` accordingly.
> - **Tests**:
>   - Add/extend tests for `AtbInitializer` timeout behavior and pixel emission; add `LaunchViewModel` test asserting referrer-timeout pixel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1990f71d2564e34f02bbfaa2a2e454dcc90953ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->