### PR TITLE
Migrate MSP to databaseProvider

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/build.gradle
+++ b/malicious-site-protection/malicious-site-protection-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(':browser-api')
     implementation project(':design-system')
     implementation project(':common-utils')
+    implementation project(':data-store-api')
     implementation project(':navigation-api')
     implementation project(':settings-api')
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212086811371662

### Description
Migrate MSP database to databaseProvider

### Steps to test this PR

_Feature 1_
- [x] Open http://privacy-test-pages.site/security/badware/phishing.html
- [x] Check malicious site is blocked as expected

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces direct Room builder with DatabaseProvider-backed setup and adds data-store-api dependency.
> 
> - **Database**:
>   - Migrate `MaliciousSitesDatabase` initialization to `DatabaseProvider.buildRoomDatabase` with `RoomDatabaseConfig` (preserves `ALL_MIGRATIONS`, enables destructive fallback, uses `Custom` executor with queryPoolSize=1, transactionPoolSize=4).
> - **Build**:
>   - Add `implementation project(':data-store-api')` in `malicious-site-protection-impl/build.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71c21f25c722bf397a69f67b0ece7bf71e78275b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->