### PR TITLE
Migrate autoconsent to DatabaseProvider

### DIFF
--- a/autoconsent/autoconsent-impl/build.gradle
+++ b/autoconsent/autoconsent-impl/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation project(path: ':browser-api')
     implementation project(path: ':navigation-api')
     implementation project(path: ':settings-api') // temporary until we release new settings
+    implementation project(path: ':data-store-api')
 
     implementation AndroidX.appCompat
     implementation "com.squareup.logcat:logcat:_"

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.autoconsent.impl.di
 
 import android.content.Context
-import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.autoconsent.impl.pixels.AutoconsentPixelManager
 import com.duckduckgo.autoconsent.impl.pixels.RealAutoconsentPixelManager
@@ -25,6 +24,8 @@ import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.autoconsent.impl.store.AutoconsentDatabase
 import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.DatabaseProvider
+import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -49,10 +50,12 @@ object AutoconsentModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun provideAutoconsentDatabase(context: Context): AutoconsentDatabase {
-        return Room.databaseBuilder(context, AutoconsentDatabase::class.java, "autoconsent.db")
-            .fallbackToDestructiveMigration()
-            .build()
+    fun provideAutoconsentDatabase(databaseProvider: DatabaseProvider): AutoconsentDatabase {
+        return databaseProvider.buildRoomDatabase(
+            AutoconsentDatabase::class.java,
+            "autoconsent.db",
+            config = RoomDatabaseConfig(fallbackToDestructiveMigration = true),
+        )
     }
 
     @Provides


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212075417642051?focus=true

### Description
Migrate autoconsent to DatabaseProvider

### Steps to test this PR

_Feature 1_
- [x] Smoke test autoconsent

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates autoconsent to the shared database infrastructure.
> 
> - Replace direct `Room.databaseBuilder` with `DatabaseProvider.buildRoomDatabase` using `RoomDatabaseConfig(fallbackToDestructiveMigration = true)` in `AutoconsentModule`
> - Add `:data-store-api` dependency in `build.gradle` and remove direct `Room` import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36f3f35382c4805ed02f616552e649e7474e3021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->