### PR TITLE
Migrate broken-site to DatabaseProvider

### DIFF
--- a/broken-site/broken-site-impl/build.gradle
+++ b/broken-site/broken-site-impl/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation project(path: ':statistics-api')
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':broken-site-store')
+    implementation project(path: ':data-store-api')
 
     implementation AndroidX.core.ktx
 

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/di/BrokenSiteModule.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/di/BrokenSiteModule.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.brokensite.impl.di
 
-import android.content.Context
-import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.brokensite.impl.BrokenSitePromptDataStore
 import com.duckduckgo.brokensite.impl.BrokenSiteRefreshesInMemoryStore
@@ -26,6 +24,8 @@ import com.duckduckgo.brokensite.impl.RealBrokenSiteReportRepository
 import com.duckduckgo.brokensite.store.ALL_MIGRATIONS
 import com.duckduckgo.brokensite.store.BrokenSiteDatabase
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.DatabaseProvider
+import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -57,10 +57,14 @@ class BrokenSiteModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun provideBrokenSiteDatabase(context: Context): BrokenSiteDatabase {
-        return Room.databaseBuilder(context, BrokenSiteDatabase::class.java, "broken_site.db")
-            .fallbackToDestructiveMigration()
-            .addMigrations(*ALL_MIGRATIONS)
-            .build()
+    fun provideBrokenSiteDatabase(databaseProvider: DatabaseProvider): BrokenSiteDatabase {
+        return databaseProvider.buildRoomDatabase(
+            BrokenSiteDatabase::class.java,
+            "broken_site.db",
+            config = RoomDatabaseConfig(
+                fallbackToDestructiveMigration = true,
+                migrations = ALL_MIGRATIONS,
+            ),
+        )
     }
 }

--- a/broken-site/broken-site-store/src/main/java/com/duckduckgo/brokensite/store/BrokenSiteDatabase.kt
+++ b/broken-site/broken-site-store/src/main/java/com/duckduckgo/brokensite/store/BrokenSiteDatabase.kt
@@ -31,4 +31,4 @@ abstract class BrokenSiteDatabase : RoomDatabase() {
     abstract fun brokenSiteDao(): BrokenSiteDao
 }
 
-val ALL_MIGRATIONS = emptyArray<Migration>()
+val ALL_MIGRATIONS = emptyList<Migration>()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212075417642054?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the broken-site Room database is instantiated and configured, which could affect app startup/database access if the provider wiring or config differs from the previous direct Room builder usage.
> 
> **Overview**
> Migrates broken-site’s Room database construction from a direct `Room.databaseBuilder` call to the shared `DatabaseProvider.buildRoomDatabase`, passing configuration via `RoomDatabaseConfig` (including destructive fallback and migrations).
> 
> Adds the `:data-store-api` dependency to support the provider, and updates `ALL_MIGRATIONS` to be a `List<Migration>` (instead of an array) to match the new configuration API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0f7c3c9d654ace1ef0f0cef5cb861b895b2dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->