### PR TITLE
Migrate downloads to DatabaseProvider

### DIFF
--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(path: ':statistics-api')
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':downloads-store')
+    implementation project(path: ':data-store-api')
 
     implementation AndroidX.core.ktx
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/di/DownloadsModule.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/di/DownloadsModule.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.downloads.impl.di
 
-import android.content.Context
-import androidx.room.Room
+import com.duckduckgo.data.store.api.DatabaseProvider
+import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.store.DownloadsDatabase
 import com.squareup.anvil.annotations.ContributesTo
@@ -31,9 +31,13 @@ class DownloadsModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun provideDownloadsDatabase(context: Context): DownloadsDatabase {
-        return Room.databaseBuilder(context, DownloadsDatabase::class.java, "downloads.db")
-            .fallbackToDestructiveMigration()
-            .build()
+    fun provideDownloadsDatabase(databaseProvider: DatabaseProvider): DownloadsDatabase {
+        return databaseProvider.buildRoomDatabase(
+            DownloadsDatabase::class.java,
+            "downloads.db",
+            config = RoomDatabaseConfig(
+                fallbackToDestructiveMigration = true,
+            ),
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212075417798701?focus=true

### Description
Migrate downloads to DatabaseProvider as part of an initiative to increase performance

### Steps to test this PR

_Feature 1_
- [x] Smoke test downloads

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace direct Room builder with DatabaseProvider-backed Room database and add `:data-store-api` dependency.
> 
> - **Downloads DB initialization**:
>   - Replace `Room.databaseBuilder` with `DatabaseProvider.buildRoomDatabase` in `DownloadsModule` using `RoomDatabaseConfig(fallbackToDestructiveMigration = true)`.
>   - Update DI to provide `DownloadsDatabase` via `DatabaseProvider` (remove `Context` usage).
> - **Dependencies**:
>   - Add `implementation project(path: ':data-store-api')` in `downloads/downloads-impl/build.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3e87fb2b660da88ecaf0b6ab5cfd79563b03f87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->