### PR TITLE
PIR: Remove TODO for pixels

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOutConfirmationReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOutConfirmationReporter.kt
@@ -49,7 +49,7 @@ class RealOptOutConfirmationReporter @Inject constructor(
         withContext(dispatcherProvider.io()) {
             val activeBrokers = pirRepository.getAllActiveBrokerObjects().associateBy { it.name }
             val allValidRequestedOptOutJobs = pirSchedulingRepository.getAllValidOptOutJobRecords().filter {
-                it.status == REQUESTED || it.status == REMOVED // TODO: Filter out removed by user
+                it.status == REQUESTED || it.status == REMOVED
             }
 
             if (activeBrokers.isEmpty() || allValidRequestedOptOutJobs.isEmpty()) return@withContext


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211877701264248?focus=true

### Description
Removes the TODO to add special handling for opt outs removed by user when it comes to pixels. It's not needed as we mark that opt out as deprecated and it's status is REMOVED_BY_USER meaning it won't be picked up for pixel processing. Additionally, the related extracted profiles are marked as deprecated, so they also won't be picked up.

### Steps to test this PR
QA is optional - you can run a new scan and wait until opt outs are submitted, trigger the weekly pixel, then remove a record from dashboard and trigger the weekly pixel again. The removed profile should not be counted.

### UI changes
No UI changes