### PR TITLE
Migrate httpsupgrade to DatabaseProvider

### DIFF
--- a/httpsupgrade/httpsupgrade-impl/build.gradle
+++ b/httpsupgrade/httpsupgrade-impl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':statistics-api')
     implementation project(':httpsupgrade-api')
     implementation project(':httpsupgrade-store')
+    implementation project(path: ':data-store-api')
 
     implementation AndroidX.room.runtime
     implementation Google.dagger

--- a/httpsupgrade/httpsupgrade-impl/src/main/java/com/duckduckgo/httpsupgrade/impl/di/HttpsModule.kt
+++ b/httpsupgrade/httpsupgrade-impl/src/main/java/com/duckduckgo/httpsupgrade/impl/di/HttpsModule.kt
@@ -17,9 +17,10 @@
 package com.duckduckgo.httpsupgrade.impl.di
 
 import android.content.Context
-import androidx.room.Room
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.store.BinaryDataStore
+import com.duckduckgo.data.store.api.DatabaseProvider
+import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.httpsupgrade.api.HttpsEmbeddedDataPersister
 import com.duckduckgo.httpsupgrade.api.HttpsUpgradeDataDownloader
@@ -43,13 +44,15 @@ object HttpsModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun provideAppDatabase(
-        context: Context,
-    ): HttpsUpgradeDatabase {
-        return Room.databaseBuilder(context, HttpsUpgradeDatabase::class.java, "httpsupgrade.db")
-            .addMigrations(*HttpsUpgradeDatabase.ALL_MIGRATIONS.toTypedArray())
-            .fallbackToDestructiveMigration()
-            .build()
+    fun provideAppDatabase(databaseProvider: DatabaseProvider): HttpsUpgradeDatabase {
+        return databaseProvider.buildRoomDatabase(
+            HttpsUpgradeDatabase::class.java,
+            "httpsupgrade.db",
+            config = RoomDatabaseConfig(
+                fallbackToDestructiveMigration = true,
+                migrations = HttpsUpgradeDatabase.ALL_MIGRATIONS,
+            ),
+        )
     }
 
     @Provides


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212147998192569?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [x] Smoke test https-upgrade

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence wiring for `HttpsUpgradeDatabase`, so misconfiguration could break DB initialization or migrations at startup, but behavior is intended to remain equivalent.
> 
> **Overview**
> Switches `HttpsUpgradeDatabase` provisioning in `HttpsModule` from direct `Room.databaseBuilder` usage to the shared `DatabaseProvider.buildRoomDatabase`, passing a `RoomDatabaseConfig` with the existing migrations and destructive-migration fallback.
> 
> Adds a new dependency on `:data-store-api` to support the provider/config types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8513d989fdca461117d14d72935d13766ad92fff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->