### PR TITLE
feat: new plugin to handle new shorter URL display

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/urlDisplay/RealUrlDisplayPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlDisplay/RealUrlDisplayPlugin.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.urlDisplay
+
+import android.content.Context
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
+class RealUrlDisplayPlugin @Inject constructor(
+    private val settingsDataStore: SettingsDataStore,
+    private val browserConfigFeature: AndroidBrowserConfigFeature,
+    private val context: Context,
+) : PrivacyConfigCallbackPlugin {
+    override fun onPrivacyConfigDownloaded() {
+        // User has explicitly set their preference - always honor it
+        if (settingsDataStore.hasUrlPreferenceSet()) {
+            return
+        }
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        val isNewInstall = packageInfo.firstInstallTime == packageInfo.lastUpdateTime
+        val defaultValue = !(isNewInstall && browserConfigFeature.shorterUrlDefault().isEnabled())
+        settingsDataStore.isFullUrlEnabled = defaultValue
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -221,4 +221,13 @@ interface AndroidBrowserConfigFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun newCustomTab(): Toggle
+
+    /*
+     * Controls default URL display for new users only.
+     * @return `true` when the remote config has the global "shorterUrlDefault" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun shorterUrlDefault(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -88,6 +88,11 @@ interface SettingsDataStore {
     var isFullUrlEnabled: Boolean
     var clearDuckAiData: Boolean
 
+    /**
+     * Check if user has explicitly set their URL display preference.
+     */
+    fun hasUrlPreferenceSet(): Boolean
+
     fun isCurrentlySelected(clearWhatOption: ClearWhatOption): Boolean
 
     fun isCurrentlySelected(clearWhenOption: ClearWhenOption): Boolean
@@ -229,6 +234,8 @@ class SettingsSharedPreferences @Inject constructor(
     override var isFullUrlEnabled: Boolean
         get() = preferences.getBoolean(KEY_IS_FULL_URL_ENABLED, true)
         set(enabled) = preferences.edit { putBoolean(KEY_IS_FULL_URL_ENABLED, enabled) }
+
+    override fun hasUrlPreferenceSet(): Boolean = preferences.contains(KEY_IS_FULL_URL_ENABLED)
 
     override var clearDuckAiData: Boolean
         get() = preferences.getBoolean(KEY_CLEAR_DUCK_AI_DATA, false)

--- a/app/src/test/java/com/duckduckgo/app/Fakes.kt
+++ b/app/src/test/java/com/duckduckgo/app/Fakes.kt
@@ -192,6 +192,10 @@ class FakeSettingsDataStore :
             store["isFullUrlEnabled"] = value
         }
 
+    override fun hasUrlPreferenceSet(): Boolean {
+        return store.containsKey("isFullUrlEnabled")
+    }
+
     override var clearDuckAiData: Boolean
         get() = store["clearDuckAiData"] as Boolean? ?: false
         set(value) {

--- a/app/src/test/java/com/duckduckgo/app/browser/urlDisplay/UrlDisplayPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/urlDisplay/UrlDisplayPluginTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.urlDisplay
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class UrlDisplayPluginTest {
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val settingsDataStore = mock<SettingsDataStore>()
+    private val browserConfigFeature = mock<AndroidBrowserConfigFeature>()
+    private val shorterUrlToggle = mock<Toggle>()
+    private val context = mock<Context>()
+    private val packageManager = mock<PackageManager>()
+    private lateinit var testee: PrivacyConfigCallbackPlugin
+
+    @Before
+    fun setup() {
+        whenever(context.packageManager).thenReturn(packageManager)
+        whenever(browserConfigFeature.shorterUrlDefault()).thenReturn(shorterUrlToggle)
+
+        testee = RealUrlDisplayPlugin(
+            settingsDataStore = settingsDataStore,
+            browserConfigFeature = browserConfigFeature,
+            context = context,
+        )
+    }
+
+    @Test
+    fun whenUserHasExplicitPreferenceSet_thenNothingChange() {
+        // Given: User has explicitly set preference to true
+        whenever(settingsDataStore.hasUrlPreferenceSet()).thenReturn(true)
+
+        // When
+        testee.onPrivacyConfigDownloaded()
+
+        // Then: Settings data store is never called
+        verify(settingsDataStore, atLeastOnce()).hasUrlPreferenceSet()
+        verify(settingsDataStore, never()).isFullUrlEnabled
+    }
+
+    @Test
+    fun whenExistingUserAlreadyInstalledApp_thenSetFullUrlToTrue() {
+        // Given: User already migrated (flag is set)
+        whenever(settingsDataStore.hasUrlPreferenceSet()).thenReturn(false)
+        val packageInfo = PackageInfo().apply {
+            firstInstallTime = 1000L
+            lastUpdateTime = 2000L
+        }
+        whenever(packageManager.getPackageInfo(context.packageName, 0)).thenReturn(packageInfo)
+
+        // When
+        testee.onPrivacyConfigDownloaded()
+
+        // Then: isFullUrlEnabled is changed to true
+        verify(settingsDataStore, atLeastOnce()).hasUrlPreferenceSet()
+        verify(settingsDataStore, atLeastOnce()).isFullUrlEnabled = true
+    }
+
+    @Test
+    fun whenNewUserAndRemoteConfigDisabled_thenSetFullUrlToTrue() {
+        // Given: New user (no preference, fresh install)
+        whenever(settingsDataStore.hasUrlPreferenceSet()).thenReturn(false)
+        val packageInfo = PackageInfo().apply {
+            firstInstallTime = 1000L
+            lastUpdateTime = 1000L
+        }
+        whenever(packageManager.getPackageInfo(context.packageName, 0)).thenReturn(packageInfo)
+        whenever(shorterUrlToggle.isEnabled()).thenReturn(false)
+
+        // When
+        testee.onPrivacyConfigDownloaded()
+
+        // Then
+        verify(settingsDataStore, atLeastOnce()).isFullUrlEnabled = true
+    }
+
+    @Test
+    fun whenNewUserAndRemoteConfigEnabled_thenSetFullUrlToFalse() {
+        // Given: New user (no preference, fresh install)
+        whenever(settingsDataStore.hasUrlPreferenceSet()).thenReturn(false)
+        val packageInfo = PackageInfo().apply {
+            firstInstallTime = 1000L
+            lastUpdateTime = 1000L
+        }
+        whenever(packageManager.getPackageInfo(context.packageName, 0)).thenReturn(packageInfo)
+        whenever(shorterUrlToggle.isEnabled()).thenReturn(true)
+
+        // When
+        testee.onPrivacyConfigDownloaded()
+
+        // Then
+        verify(settingsDataStore, atLeastOnce()).isFullUrlEnabled = false
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212071899795122?focus=true

### Description

### Steps to test this PR

_Keep original full url preference_
- [ ] Install the application before this contribution
- [ ] Launch the application a first time with this version
- [ ] Install the application with this contribution as an update on the existing one
- [ ] Launch the application and you should see the full url in the address bar

_Keep original shorter url preference_
- [ ] Install the application before this contribution
- [ ] Launch the application a first time with this version
- [ ] Turn off the full url preference in the settings
- [ ] Install the application with this contribution as an update on the existing one
- [ ] Launch the application and you should see the shorter url in the address bar

_Fresh new install should use shorter url as default preference_
- [ ] Install the application with this contribution without any existing DuckDuckGo application on your device
- [ ] Launch the application and you should see the shorter url in the address bar

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/4eceb2bb-5634-4fbb-a29e-a9eee7fd7755" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/a1b484e7-82c2-4bc2-8073-0e6ce85f6efa" /> |
