### PR TITLE
Ensure critical test failures show up as release blockers

### DIFF
--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -80,7 +80,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-     if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -185,7 +185,7 @@ jobs:
           asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,6 +182,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
+        if: ${{ steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -93,7 +93,7 @@ jobs:
           asana-task-description: The privacy workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -141,7 +141,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -133,7 +133,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1212069260649527?focus=true 

### Description
When certain automated tests fail, the failure tasks will also now be added to a new `Release Blockers` section in releases project.

### Steps to test this PR

- QA optional