### PR TITLE
Update customs tabs workflow to use playRelease

### DIFF
--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Assemble internal release APK
-        run: ./gradlew assembleInternalRelease -Pforce-default-variant -x lint
+      - name: Assemble play release APK
+        run: ./gradlew assemblePlayRelease -Pforce-default-variant -x lint
 
       - name: Move APK to new folder
         if: always()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212234244576704?focus=true

### Description

- Sets the APK used to `playRelease` instead of `internalRelease` for custom tabs maestro tests.

### Steps to test this PR

- [ ] Code review
