### PR TITLE
use the corrent margin for bottom omnibar

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
@@ -43,7 +43,7 @@
     <dimen name="toolbarIconSize">24dp</dimen>
     <dimen name="toolbarIconPadding">3dp</dimen>
     <dimen name="toolbarIcon">40dp</dimen>
-    <dimen name="toolbarSize">60dp</dimen>
+    <dimen name="toolbarSize">64dp</dimen>
 
     <!-- Navigation Bar -->
     <dimen name="navigationBarPaddingTop">8dp</dimen>
@@ -52,7 +52,6 @@
     <dimen name="bottomNavIcon">24dp</dimen>
 
     <!-- Omnibar -->
-    <dimen name="omnibarToolbarSize">64dp</dimen>
     <dimen name="omnibarCookieAnimationBannerHeight">38dp</dimen>
     <dimen name="omnibarCardMarginHorizontal">16dp</dimen>
     <dimen name="omnibarCardMarginEnd">8dp</dimen>

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -56,7 +56,7 @@
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/omnibarToolbarSize"
+                android:layout_height="?attr/actionBarSize"
                 android:clipChildren="false"
                 app:contentInsetEnd="0dp"
                 app:contentInsetStart="0dp"
@@ -429,7 +429,7 @@
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/customTabToolbarContainerWrapper"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/omnibarToolbarSize"
+                android:layout_height="?attr/actionBarSize"
                 android:layout_marginHorizontal="@dimen/keyline_2"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/iconsContainer"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211782086400063?focus=true

### Description

When you are using the omnibar in bottom position, the margin between the omnibar and the bottom of the screen should be defined at 8dp, and not at 4dp.


### Steps to test this PR

_Checking top margin with bottom bar_
- [x] Start the application
- [x] Go to Settings -> Appearance -> Select bottom bar
- [x] Come back to the browser screen 
- [x] Check the top margin is bigger now than before

_Checking bottom margin with top bar_
- [x] Start the application
- [x] Go to Settings -> Appearance -> Select top bar
- [x] Come back to the browser screen 
- [x] Check the top margin is bigger now than before

_Checking bottom margin with split bar_
- [x] Start the application
- [x] Go to Settings -> Appearance -> Select split bar
- [x] Come back to the browser screen 
- [x] Check the top margin is bigger now than before

_Checking omnibar usage outside browser screen_
- [x] Start the application
- [x] Go to Duck.ai screen
- [x] Check the omnibar has the same size than the browser omnibar without breaking UI

_Checking native toolbar_
- [ ] Start the application
- [x] Open bookmarks screen
- [ ] Check the toolbar has the same size than the browser omnibar without breaking UI

### UI changes

| Before  | After |
| ------ | ----- |
<img width="1080" height="257" alt="image" src="https://github.com/user-attachments/assets/af6ee473-cc75-45ac-8433-bc5f6184d654" /> | <img width="1080" height="269" alt="image" src="https://github.com/user-attachments/assets/12309956-a48f-4ff6-96d4-f60c59ba79db" />
<img width="1080" height="240" alt="image" src="https://github.com/user-attachments/assets/17f0e58d-050a-4016-a42c-312faa25cae9" /> | <img width="1080" height="247" alt="image" src="https://github.com/user-attachments/assets/a16a2248-17f2-4fe6-bf0e-599b0b7fd8a7" />
<img width="1080" height="251" alt="image" src="https://github.com/user-attachments/assets/6e72613f-cea4-41e9-8e79-7018005d4ac1" /> | <img width="1080" height="258" alt="image" src="https://github.com/user-attachments/assets/3c49fef3-89c1-42d0-9139-4879ab825625" />
<img width="1080" height="249" alt="image" src="https://github.com/user-attachments/assets/759be51f-e0b0-452b-934d-208f1e678852" /> | <img width="1080" height="249" alt="image" src="https://github.com/user-attachments/assets/e53fce70-2403-446d-86a5-711fec78988f" />
<img width="1080" height="258" alt="image" src="https://github.com/user-attachments/assets/dab07a4b-225b-4449-9cfe-b82f6e6c9412" /> | <img width="1080" height="252" alt="image" src="https://github.com/user-attachments/assets/be6bbbe0-7e85-41aa-8d39-d2618c96271f" />
<img width="1080" height="238" alt="image" src="https://github.com/user-attachments/assets/a142f2f2-3333-4964-a8b3-8266a2d41068" /> | <img width="1080" height="253" alt="image" src="https://github.com/user-attachments/assets/b5fcc2b2-24c8-4a73-973b-90a887433f54" />
<img width="1080" height="353" alt="image" src="https://github.com/user-attachments/assets/2b7d7fc6-81cf-4437-a278-43593195aaed" /> | <img width="1080" height="362" alt="image" src="https://github.com/user-attachments/assets/6d04aa57-1ece-44e5-9dd2-99976b922791" />
<img width="1080" height="377" alt="image" src="https://github.com/user-attachments/assets/88d92a14-4d1a-4d92-8f49-2292b59f7a63" /> | <img width="1080" height="385" alt="image" src="https://github.com/user-attachments/assets/4433092d-01d8-4d26-8715-c77e9f8cd4f0" />
<img width="1080" height="352" alt="image" src="https://github.com/user-attachments/assets/31927a20-2c29-479e-82e6-ad2fc30f20b3" /> | <img width="1080" height="361" alt="image" src="https://github.com/user-attachments/assets/19eb926b-725c-46f9-b94e-742ba3ed6906" />
<img width="1080" height="259" alt="image" src="https://github.com/user-attachments/assets/3111f43d-ca8f-4e14-9f31-f6d1227ffdb7" /> | <img width="1080" height="261" alt="image" src="https://github.com/user-attachments/assets/3881a18a-fe98-4549-9ff9-86d3d0dc016a" />
<img width="1080" height="258" alt="image" src="https://github.com/user-attachments/assets/ccfbf67e-d511-4e34-a045-4b6c3e8d9590" /> | <img width="1080" height="254" alt="image" src="https://github.com/user-attachments/assets/c5060b32-bb62-4dba-97fe-5d385d9d7172" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase toolbar height to 64dp, set bottom omnibar top margin to 8dp, and refactor margin handling with a helper used across omnibar components.
> 
> - **Design System**:
>   - `toolbarSize` increased from `60dp` to `64dp`.
>   - `omnibarCardMarginTop` increased from `4dp` to `8dp`.
> - **Omnibar** (`OmnibarLayout.kt`):
>   - Add `flipOmnibarMargins()` to swap `topMargin`/`bottomMargin` when omnibar is at the bottom.
>   - Apply margin flipping to `omnibarCardShadow`, `iconsContainer`, `shieldIconPulseAnimationContainer`, and new custom tab toolbar layout.
>   - Preserve trackers animation `marginStart` tweak when enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fa4ae87581a28e958f722b6b26b50c1fb599cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->