### PR TITLE
Update content scope scripts to version 12.3.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -673,6 +673,24 @@
       return Reflect.get(target, prop, receiver);
     };
   }
+  function wrapFunction(functionValue, realTarget) {
+    return new Proxy(realTarget, {
+      get(target, prop, receiver) {
+        if (prop === "toString") {
+          const method = Reflect.get(target, prop, receiver).bind(target);
+          Object.defineProperty(method, "toString", {
+            value: functionToString.bind(functionToString),
+            enumerable: false
+          });
+          return method;
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      apply(_2, thisArg, argumentsList) {
+        return Reflect.apply(functionValue, thisArg, argumentsList);
+      }
+    });
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -4020,7 +4038,7 @@
     }
     return dataToSend;
   }
-  var _activeShareRequest, _activeScreenLockRequest;
+  var _activeShareRequest, _activeScreenLockRequest, _webNotifications;
   var WebCompat = class extends ContentFeature {
     constructor() {
       super(...arguments);
@@ -4028,6 +4046,8 @@
       __privateAdd(this, _activeShareRequest, null);
       /** @type {Promise<any> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
+      /** @type {Map<string, object>} */
+      __privateAdd(this, _webNotifications, /* @__PURE__ */ new Map());
       // Opt in to receive configuration updates from initial ping responses
       __publicField(this, "listenForConfigUpdates", true);
     }
@@ -4046,6 +4066,9 @@
       }
       if (this.getFeatureSettingEnabled("notification")) {
         this.notificationFix();
+      }
+      if (this.getFeatureSettingEnabled("webNotifications")) {
+        this.webNotificationsFix();
       }
       if (this.getFeatureSettingEnabled("permissions")) {
         const settings = this.getFeatureSetting("permissions");
@@ -4175,6 +4198,160 @@
         "function requestPermission() { [native code] }"
       );
       this.defineProperty(window.Notification, "requestPermission", {
+        value: wrappedRequestPermission,
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
+    }
+    /**
+     * Web Notifications polyfill that communicates with native code for permission
+     * management and notification display.
+     */
+    webNotificationsFix() {
+      var _id;
+      if (!globalThis.isSecureContext) {
+        return;
+      }
+      const feature = this;
+      const settings = this.getFeatureSetting("webNotifications") || {};
+      const nativeEnabled = settings.nativeEnabled !== false;
+      const nativeNotify = nativeEnabled ? (name, data) => feature.notify(name, data) : () => {
+      };
+      const nativeRequest = nativeEnabled ? (name, data) => feature.request(name, data) : () => Promise.resolve({ permission: "denied" });
+      const nativeSubscribe = nativeEnabled ? (name, cb) => feature.subscribe(name, cb) : () => () => {
+      };
+      let permission = nativeEnabled ? "default" : "denied";
+      class NotificationPolyfill {
+        /**
+         * @param {string} title
+         * @param {NotificationOptions} [options]
+         */
+        constructor(title, options = {}) {
+          /** @type {string} */
+          __privateAdd(this, _id);
+          /** @type {string} */
+          __publicField(this, "title");
+          /** @type {string} */
+          __publicField(this, "body");
+          /** @type {string} */
+          __publicField(this, "icon");
+          /** @type {string} */
+          __publicField(this, "tag");
+          /** @type {any} */
+          __publicField(this, "data");
+          // Event handlers
+          /** @type {((this: Notification, ev: Event) => any) | null} */
+          __publicField(this, "onclick", null);
+          /** @type {((this: Notification, ev: Event) => any) | null} */
+          __publicField(this, "onclose", null);
+          /** @type {((this: Notification, ev: Event) => any) | null} */
+          __publicField(this, "onerror", null);
+          /** @type {((this: Notification, ev: Event) => any) | null} */
+          __publicField(this, "onshow", null);
+          __privateSet(this, _id, crypto.randomUUID());
+          this.title = String(title);
+          this.body = options.body ? String(options.body) : "";
+          this.icon = options.icon ? String(options.icon) : "";
+          this.tag = options.tag ? String(options.tag) : "";
+          this.data = options.data;
+          __privateGet(feature, _webNotifications).set(__privateGet(this, _id), this);
+          nativeNotify("showNotification", {
+            id: __privateGet(this, _id),
+            title: this.title,
+            body: this.body,
+            icon: this.icon,
+            tag: this.tag
+          });
+        }
+        /**
+         * @returns {'default' | 'denied' | 'granted'}
+         */
+        static get permission() {
+          return permission;
+        }
+        /**
+         * @param {NotificationPermissionCallback} [deprecatedCallback]
+         * @returns {Promise<NotificationPermission>}
+         */
+        static async requestPermission(deprecatedCallback) {
+          try {
+            const result = await nativeRequest("requestPermission", {});
+            const resultPermission = (
+              /** @type {NotificationPermission} */
+              result?.permission || "denied"
+            );
+            permission = resultPermission;
+            if (deprecatedCallback) {
+              deprecatedCallback(resultPermission);
+            }
+            return resultPermission;
+          } catch (e) {
+            permission = "denied";
+            if (deprecatedCallback) {
+              deprecatedCallback("denied");
+            }
+            return "denied";
+          }
+        }
+        /**
+         * @returns {number}
+         */
+        static get maxActions() {
+          return 2;
+        }
+        close() {
+          if (!__privateGet(feature, _webNotifications).has(__privateGet(this, _id))) {
+            return;
+          }
+          nativeNotify("closeNotification", { id: __privateGet(this, _id) });
+          __privateGet(feature, _webNotifications).delete(__privateGet(this, _id));
+          if (typeof this.onclose === "function") {
+            try {
+              this.onclose(new Event("close"));
+            } catch (e) {
+            }
+          }
+        }
+      }
+      _id = new WeakMap();
+      const wrappedNotification = wrapFunction(NotificationPolyfill, NotificationPolyfill);
+      const wrappedRequestPermission = wrapToString(
+        NotificationPolyfill.requestPermission.bind(NotificationPolyfill),
+        NotificationPolyfill.requestPermission,
+        "function requestPermission() { [native code] }"
+      );
+      nativeSubscribe("notificationEvent", (data) => {
+        const notification = __privateGet(this, _webNotifications).get(data.id);
+        if (!notification) return;
+        const eventName = `on${data.event}`;
+        if (typeof notification[eventName] === "function") {
+          try {
+            notification[eventName](new Event(data.event));
+          } catch (e) {
+          }
+        }
+        if (data.event === "close") {
+          __privateGet(this, _webNotifications).delete(data.id);
+        }
+      });
+      this.defineProperty(globalThis, "Notification", {
+        value: wrappedNotification,
+        writable: true,
+        configurable: true,
+        enumerable: false
+      });
+      this.defineProperty(globalThis.Notification, "permission", {
+        get: () => permission,
+        configurable: true,
+        enumerable: true
+      });
+      this.defineProperty(globalThis.Notification, "maxActions", {
+        get: () => 2,
+        configurable: true,
+        enumerable: true
+      });
+      this.defineProperty(globalThis.Notification, "requestPermission", {
         value: wrappedRequestPermission,
         writable: true,
         configurable: true,
@@ -4746,6 +4923,7 @@
   };
   _activeShareRequest = new WeakMap();
   _activeScreenLockRequest = new WeakMap();
+  _webNotifications = new WeakMap();
   var web_compat_default = WebCompat;
 
   // src/features/fingerprinting-hardware.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.34.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.2.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.3.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.38.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.38.0.tgz",
-      "integrity": "sha512-JJipJG0R9zUSrce5DBH7TmKsHaHF3wID7n/WqLfkVegiJMiuo44foLynePnMp0Og9IZ2c4j+INGR0QT68mUjAw==",
+      "version": "14.39.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.39.0.tgz",
+      "integrity": "sha512-g5y74oDx1e5vkbcnCufQpVaZFFw3V9AIdEVBzwAnZPV3cftSEDnc13FrrMyW34DcYurz4s/X9ea49+zM9CsUvA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#63ce8ef5a5e07df14f5aff57c9077b9df679dfee",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#125825ac6adb00bb2930cb793af6d46adc560e9f",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.34.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.2.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.3.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates content-scope-scripts to 12.3.0, adding a Web Notifications polyfill to Android builds and minor related plumbing.
> 
> - **Android content scripts (`@duckduckgo/content-scope-scripts`)**:
>   - **Web Notifications**: Add `webNotificationsFix` with a `Notification` polyfill (permission handling, show/close via native bridge, event callbacks, `maxActions`).
>   - Wire feature behind `webNotifications` setting in `WebCompat.init()`.
>   - Add `_webNotifications` store (WeakMap) and event subscription handling.
>   - Add `wrapFunction` helper and use it to wrap `Notification` constructor; wrap `requestPermission` with native-like `toString`.
> - **Dependencies**:
>   - Bump `@duckduckgo/content-scope-scripts` to `12.3.0` (hash updated).
>   - Lockfile refresh also updates `@duckduckgo/autoconsent` to `14.39.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 326159a0bf6612e8dcf58286c9987ba0e0b2bbe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->