### PR TITLE
Add cosmetic setting for Input Screen onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckChat
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -86,6 +87,7 @@ class WelcomePageViewModel @Inject constructor(
     private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     private val onboardingStore: OnboardingStore,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val duckChat: DuckChat,
 ) : ViewModel() {
     private val _commands = Channel<Command>(1, DROP_OLDEST)
     val commands: Flow<Command> = _commands.receiveAsFlow()
@@ -200,6 +202,7 @@ class WelcomePageViewModel @Inject constructor(
                     } else {
                         pixel.fire(PREONBOARDING_SEARCH_ONLY_SELECTED)
                     }
+                    duckChat.setCosmeticInputScreenUserSetting(inputScreenSelected)
                     onboardingStore.storeInputScreenSelection(inputScreenSelected)
                     _commands.send(Finish)
                 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
@@ -79,6 +80,7 @@ class WelcomePageViewModelTest {
     private val mockAndroidBrowserConfigFeature: AndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(
         AndroidBrowserConfigFeature::class.java,
     )
+    private val mockDuckChat: DuckChat = mock()
 
     private fun createViewModel(): WelcomePageViewModel {
         return WelcomePageViewModel(
@@ -92,6 +94,7 @@ class WelcomePageViewModelTest {
             mockOnboardingDesignExperimentManager,
             mockOnboardingStore,
             mockAndroidBrowserConfigFeature,
+            mockDuckChat,
         )
     }
 
@@ -107,6 +110,7 @@ class WelcomePageViewModelTest {
             mockOnboardingDesignExperimentManager,
             mockOnboardingStore,
             mockAndroidBrowserConfigFeature,
+            mockDuckChat,
         )
     }
 
@@ -429,6 +433,7 @@ class WelcomePageViewModelTest {
             }
             verify(mockPixel).fire(PREONBOARDING_AICHAT_SELECTED)
             verify(mockOnboardingStore).storeInputScreenSelection(true)
+            verify(mockDuckChat).setCosmeticInputScreenUserSetting(true)
         }
 
     @Test
@@ -444,6 +449,7 @@ class WelcomePageViewModelTest {
             }
             verify(mockPixel).fire(PREONBOARDING_SEARCH_ONLY_SELECTED)
             verify(mockOnboardingStore).storeInputScreenSelection(false)
+            verify(mockDuckChat).setCosmeticInputScreenUserSetting(false)
         }
 
     @Test

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -75,7 +75,13 @@ interface DuckChat {
     suspend fun setInputScreenUserSetting(enabled: Boolean)
 
     /**
+     * Cosmetically sets the input screen user setting.
+     */
+    suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean)
+
+    /**
      * Observes whether Duck.ai input screen with a mode switch is enabled or disabled.
+     * Note: This will return true if cosmetically set (so not actually enabled, may be shown as enabled for onboarding purposes)
      */
     fun observeInputScreenUserSettingEnabled(): Flow<Boolean>
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -345,6 +345,10 @@ class RealDuckChat @Inject constructor(
         cacheUserSettings()
     }
 
+    override suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean) {
+        duckChatFeatureRepository.setCosmeticInputScreenUserSetting(enabled)
+    }
+
     override suspend fun setShowInBrowserMenuUserSetting(showDuckChat: Boolean) =
         withContext(dispatchers.io()) {
             duckChatFeatureRepository.setShowInBrowserMenu(showDuckChat)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -31,6 +31,8 @@ interface DuckChatFeatureRepository {
 
     suspend fun setInputScreenUserSetting(enabled: Boolean)
 
+    suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean)
+
     suspend fun setShowInBrowserMenu(showDuckChat: Boolean)
 
     suspend fun setShowInAddressBar(showDuckChat: Boolean)
@@ -84,6 +86,10 @@ class RealDuckChatFeatureRepository @Inject constructor(
 
     override suspend fun setInputScreenUserSetting(enabled: Boolean) {
         duckChatDataStore.setInputScreenUserSetting(enabled)
+    }
+
+    override suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean) {
+        duckChatDataStore.setCosmeticInputScreenUserSetting(enabled)
     }
 
     override suspend fun setShowInBrowserMenu(showDuckChat: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -755,6 +755,20 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `when enable cosmetic input screen user setting then repository updated`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(true)
+
+        verify(mockDuckChatFeatureRepository).setCosmeticInputScreenUserSetting(true)
+    }
+
+    @Test
+    fun `when disable cosmetic input screen user setting then repository updated`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(false)
+
+        verify(mockDuckChatFeatureRepository).setCosmeticInputScreenUserSetting(false)
+    }
+
+    @Test
     fun `input screen feature - when enabled then emit enabled`() = runTest {
         assertTrue(testee.showInputScreen.value)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -72,6 +72,10 @@ class FakeDuckChat(
         inputScreenUserSettingEnabled.value = enabled
     }
 
+    override suspend fun setCosmeticInputScreenUserSetting(enabled: Boolean) {
+        // No-op for testing
+    }
+
     override fun observeInputScreenUserSettingEnabled(): Flow<Boolean> {
         return inputScreenUserSettingEnabled
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
@@ -74,6 +74,20 @@ class DuckChatFeatureRepositoryTest {
     }
 
     @Test
+    fun `when setCosmeticInputScreenUserSetting then set in data store`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(true)
+
+        verify(mockDataStore).setCosmeticInputScreenUserSetting(true)
+    }
+
+    @Test
+    fun `when setCosmeticInputScreenUserSetting false then set in data store`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(false)
+
+        verify(mockDataStore).setCosmeticInputScreenUserSetting(false)
+    }
+
+    @Test
     fun whenObserveDuckChatUserEnabledThenObserveDataStore() = runTest {
         whenever(mockDataStore.observeDuckChatUserEnabled()).thenReturn(flowOf(true, false))
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -168,6 +168,78 @@ class SharedPreferencesDuckChatDataStoreTest {
     }
 
     @Test
+    fun `when setCosmeticInputScreenUserSetting then cosmetic value is stored`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(true)
+        assertTrue(testee.isCosmeticInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when cosmetic is true and actual is false then isInputScreenUserSettingEnabled returns true`() = runTest {
+        testee.setInputScreenUserSetting(false)
+        testee.setCosmeticInputScreenUserSetting(true)
+        assertTrue(testee.isInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when cosmetic is true and actual is true then isInputScreenUserSettingEnabled returns true`() = runTest {
+        testee.setInputScreenUserSetting(true)
+        testee.setCosmeticInputScreenUserSetting(true)
+        assertTrue(testee.isInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when cosmetic is false and actual is false then isInputScreenUserSettingEnabled returns false`() = runTest {
+        testee.setInputScreenUserSetting(false)
+        testee.setCosmeticInputScreenUserSetting(false)
+        assertFalse(testee.isInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when cosmetic is false and actual is true then isInputScreenUserSettingEnabled returns true`() = runTest {
+        testee.setInputScreenUserSetting(true)
+        testee.setCosmeticInputScreenUserSetting(false)
+        assertTrue(testee.isInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when setInputScreenUserSetting then cosmetic setting is cleared`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(true)
+        assertTrue(testee.isCosmeticInputScreenUserSettingEnabled())
+
+        testee.setInputScreenUserSetting(false)
+        assertFalse(testee.isCosmeticInputScreenUserSettingEnabled())
+    }
+
+    @Test
+    fun `when observeInputScreenUserSettingEnabled with cosmetic is true then receive updates`() = runTest {
+        val results = mutableListOf<Boolean>()
+        val job = launch {
+            testee.observeInputScreenUserSettingEnabled()
+                .take(2)
+                .toList(results)
+        }
+        testee.setCosmeticInputScreenUserSetting(true)
+        job.join()
+
+        assertEquals(listOf(false, true), results)
+    }
+
+    @Test
+    fun `when observeInputScreenUserSettingEnabled and cosmetic is cleared then receive updates`() = runTest {
+        testee.setCosmeticInputScreenUserSetting(true)
+        val results = mutableListOf<Boolean>()
+        val job = launch {
+            testee.observeInputScreenUserSettingEnabled()
+                .take(2)
+                .toList(results)
+        }
+        testee.setInputScreenUserSetting(false)
+        job.join()
+
+        assertEquals(listOf(true, false), results)
+    }
+
+    @Test
     fun whenObserveDuckChatUserEnabledThenReceiveUpdates() = runTest {
         val results = mutableListOf<Boolean>()
         val job = launch {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212269119509991?focus=true

### Description

- Adds `setCosmeticInputScreenUserSetting` which sets the user's pre-onboarding choice cosmetically so that when they visit settings this choice is reflected.

### Steps to test this PR

- [ ] In pre-onboarding, select “Search & Duck.ai” and tap next
- [ ] Go to AI Features before onboarding is complete
- [ ] Verify that "Search & Duck.ai" is selected 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a cosmetic Duck.ai Input Screen setting used during onboarding, with API/repo/datastore support and comprehensive tests.
> 
> - **DuckChat API/Impl**:
>   - Add `setCosmeticInputScreenUserSetting` to `DuckChat` and implement in `RealDuckChat`.
>   - Update `observeInputScreenUserSettingEnabled` to reflect cosmetic state.
> - **Repository/DataStore**:
>   - Add cosmetic setting plumbing (`DuckChatFeatureRepository`, `DuckChatDataStore`).
>   - Store cosmetic flag (`DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING`), include in enabled OR-logic, and clear cosmetic flag when actual setting is persisted.
>   - Expose `isCosmeticInputScreenUserSettingEnabled` and related observers.
> - **Onboarding**:
>   - Inject `DuckChat` into `WelcomePageViewModel` and call `duckChat.setCosmeticInputScreenUserSetting` on Input Screen selection.
> - **Tests**:
>   - Add/extend unit tests for API impl, repository, datastore (including OR logic and clearing), onboarding ViewModel, and test fakes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f38cd7b11f9445d380f1c11d1765c71549bc4be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->