### PR TITLE
[Android] "What’s New" promo message: Add feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -229,4 +229,12 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun showInputScreenOnboarding(): Toggle
+
+    /**
+     * @return `true` when the remote config has the global "remoteMessageModalSurface" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun remoteMessageModalSurface(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1212270032663826?focus=true

### Description

Added a new toggle for the "remoteMessageModalSurface" feature in the AndroidBrowserConfigFeature interface. This toggle defaults to FALSE and will be controlled by remote configuration.

### Steps to test this PR

Code review only.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `remoteMessageModalSurface` toggle (default false) to `AndroidBrowserConfigFeature` for remote-config control.
> 
> - **AndroidBrowserConfigFeature**:
>   - Add new toggle `remoteMessageModalSurface` with default `false` to control the modal surface via remote config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4686be8d22e1b091d3e8839932106dec71c10a63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->