### PR TITLE
Ensure bookmark added dialog is showing before trying to dismiss it

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
@@ -45,6 +45,7 @@ import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import logcat.logcat
 import com.duckduckgo.mobile.android.R as CommonR
@@ -136,7 +137,9 @@ class BookmarkAddedConfirmationDialog(
     private fun startAutoDismissTimer() {
         autoDismissDialogJob += lifecycleScope.launch {
             delay(BOOKMARKS_BOTTOM_SHEET_DURATION)
-            dismiss()
+            if (isShowing && isActive) {
+                dismiss()
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212257779790425?focus=true 

### Description
Adds a guard to ensure the dialog is showing, and that the cancellation timer is still active, before trying to dismiss the dialog.

### Steps to test this PR
- QA optional
- [optional] add a bookmark; don't interact with the "bookmark added" dialog and ensure it dismisses itself after a few seconds