### PR TITLE
Add app version where ANR happened to ANR pixels

### DIFF
--- a/anrs/anrs-api/src/main/java/com/duckduckgo/anrs/api/AnrRepository.kt
+++ b/anrs/anrs-api/src/main/java/com/duckduckgo/anrs/api/AnrRepository.kt
@@ -33,4 +33,5 @@ data class Anr(
     val timestamp: String,
     val webView: String,
     val customTab: Boolean,
+    val appVersion: String,
 )

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
@@ -45,6 +45,7 @@ class AnrOfflinePixelSender @Inject constructor(
                         ANR_STACKTRACE to ss,
                         ANR_WEBVIEW_VERSION to it.webView,
                         ANR_CUSTOM_TAB to it.customTab.toString(),
+                        ANR_APP_VERSION to it.appVersion,
                     ),
                     mapOf(),
                     Count,
@@ -60,6 +61,7 @@ class AnrOfflinePixelSender @Inject constructor(
         private const val ANR_STACKTRACE = "stackTrace"
         private const val ANR_WEBVIEW_VERSION = "webView"
         private const val ANR_CUSTOM_TAB = "customTab"
+        private const val ANR_APP_VERSION = "v"
     }
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
@@ -20,6 +20,7 @@ import android.os.Debug
 import android.os.Handler
 import android.os.Looper
 import com.duckduckgo.app.anrs.store.AnrsDatabase
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
@@ -61,6 +62,7 @@ internal fun Any.notifyAll() = (this as Object).notifyAll()
 class AnrSupervisorRunnable @Inject constructor(
     private val webViewVersionProvider: WebViewVersionProvider,
     private val customTabDetector: CustomTabDetector,
+    private val appBuildConfig: AppBuildConfig,
     anrsDatabase: AnrsDatabase,
 ) : Runnable {
 
@@ -93,7 +95,13 @@ class AnrSupervisorRunnable @Inject constructor(
                         val e = AnrException(handler.looper.thread)
                         logcat { "In custom tab: ${customTabDetector.isCustomTab()}. ANR Detected: ${e.threadStateMap}." }
 
-                        anrDao.insert(e.asAnrData(webViewVersionProvider.getFullVersion(), customTabDetector.isCustomTab()).asAnrEntity())
+                        anrDao.insert(
+                            e.asAnrData(
+                                webView = webViewVersionProvider.getFullVersion(),
+                                customTab = customTabDetector.isCustomTab(),
+                                appVersion = appBuildConfig.versionName,
+                            ).asAnrEntity(),
+                        )
 
                         // wait until thread responds again
                         callback.wait()

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
@@ -39,6 +39,7 @@ internal data class AnrData(
     val timeStamp: String = FORMATTER_SECONDS.format(LocalDateTime.now()),
     val webView: String,
     val customTab: Boolean,
+    val appVersion: String,
 )
 
 internal fun AnrData.asAnrEntity(): AnrEntity {
@@ -52,10 +53,15 @@ internal fun AnrData.asAnrEntity(): AnrEntity {
         timestamp = timeStamp,
         webView = webView,
         customTab = customTab,
+        appVersion = appVersion,
     )
 }
 
-internal fun Throwable.asAnrData(webView: String, customTab: Boolean): AnrData {
+internal fun Throwable.asAnrData(
+    webView: String,
+    customTab: Boolean,
+    appVersion: String,
+): AnrData {
     return AnrData(
         name = this.toString().replace(": $message", "", true),
         message = message,
@@ -64,6 +70,7 @@ internal fun Throwable.asAnrData(webView: String, customTab: Boolean): AnrData {
         lineNumber = stackTrace.getOrNull(0)?.lineNumber ?: Int.MIN_VALUE,
         webView = webView,
         customTab = customTab,
+        appVersion = appVersion,
     )
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealAnrRepository.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealAnrRepository.kt
@@ -52,6 +52,7 @@ private fun AnrEntity.asAnr(): Anr {
         timestamp = timestamp,
         webView = webView,
         customTab = customTab,
+        appVersion = appVersion,
     )
 }
 

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrEntity.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrEntity.kt
@@ -30,4 +30,5 @@ data class AnrEntity(
     val timestamp: String,
     val webView: String,
     val customTab: Boolean,
+    val appVersion: String,
 )

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrsDatabase.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrsDatabase.kt
@@ -28,7 +28,7 @@ import com.squareup.moshi.Types.newParameterizedType
 
 @Database(
     exportSchema = true,
-    version = 3,
+    version = 4,
     entities = [AnrEntity::class],
 )
 @TypeConverters(AnrTypeConverter::class)
@@ -49,10 +49,17 @@ abstract class AnrsDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_3_TO_4: Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `anr_entity` ADD COLUMN `appVersion` TEXT NOT NULL DEFAULT \"unknown\"")
+            }
+        }
+
         val ALL_MIGRATIONS: List<Migration>
             get() = listOf(
                 MIGRATION_1_TO_2,
                 MIGRATION_2_TO_3,
+                MIGRATION_3_TO_4,
             )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212169318971384?focus=true 

### Description
Adds app version where ANR actually happened which might differ from app version in use when pixel can fire.

### Steps to test this PR

#### Migration

Need to do some prep to test the migration: get an older version installed first and trigger an ANR on it:

- [x] Remove existing app install
- [x] Checkout `develop` branch first
- [x] Apply patch which sets the version to an older one (`5.259.0`). (💡 you might as well install both patches now, both available below)
- [x] Clean install `internalDebug` build type (using `develop` branch)
- [x] Launch the app, and trigger an ANR from `Settings -> Developer Settings -> Trigger ANR`
- [x] Verify in `Database inspector -> anr_database.db` that the ANR exists (with no app version data)

Now, to test the migration:
- [x] Discard the patch, checkout this branch and install `internalDebug`. This should update the app from before, but keep all the data.
- [x] Launch the app
- [x] Verify in `Database inspector -> anr_database.db` that the ANR exists
- [x] Verify that it now has a column for `appVersion` and should say `unknown` for the one created previously

#### Ensure new ANRs get the app version
- [x] Trigger another ANR
- [x] Verify in `Database inspector -> anr_database.db` that the new ANR exists, and has the correct `appVersion`

#### Ensure app version finds its way into pixel params

Logcat filter: `m_anr_exception`

It is annoying to wait for `OfflinePixelWorker` to execute given it's `WorkManager`-controlled. So there is a patch supplied that means pressing the 🔥 button will invoke the worker.

- [x] Apply the fire button patch if you haven't already
- [x] Install the app, and press the 🔥 button
- [x] Verify in logcat that you see `m_anr_exception` with param `v` which is the app version.

### Patch (older app version)
```
Index: app/version/version.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/app/version/version.properties b/app/version/version.properties
--- a/app/version/version.properties	(revision Staged)
+++ b/app/version/version.properties	(date 1764759235690)
@@ -1,1 +1,1 @@
-VERSION=5.259.2
\ No newline at end of file
+VERSION=5.259.0
\ No newline at end of file
```

### Patch (fire button triggers `OfflinePixelWorker` immediately)
```
Index: app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt	(revision Staged)
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt	(date 1764760391360)
@@ -95,6 +95,8 @@
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
 import com.duckduckgo.app.bookmarks.dialog.BookmarkAddedConfirmationDialog
@@ -200,6 +202,7 @@
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.api.OfflinePixelWorker
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
@@ -1247,9 +1250,10 @@
     }
 
     private fun onFireButtonPressed() {
-        val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
-        browserActivity?.launchFire(launchedFromFocusedNtp = isFocusedNtp)
-        viewModel.onFireMenuSelected(omnibar.viewMode)
+        // val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
+        // browserActivity?.launchFire(launchedFromFocusedNtp = isFocusedNtp)
+        // viewModel.onFireMenuSelected(omnibar.viewMode)
+        WorkManager.getInstance(requireActivity()).enqueue(OneTimeWorkRequestBuilder<OfflinePixelWorker>().build())
     }
 
     private fun onBrowserMenuButtonPressed() {
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add app version to ANR model, persist it via Room migration, and send it in ANR pixel param `v`.
> 
> - **Data model & storage**:
>   - Add `appVersion` to `Anr`, `AnrData`, and `AnrEntity` with mapping in `RealAnrRepository`.
>   - Bump Room DB to `version = 4` and add `MIGRATION_3_TO_4` to append `appVersion` column (default `"unknown"`).
> - **ANR capture**:
>   - Inject `AppBuildConfig` into `AnrSupervisorRunnable` and record `appVersion = versionName` when creating `AnrData`.
> - **Pixel sending**:
>   - Include `appVersion` as param `"v"` in `AnrOfflinePixelSender` alongside existing fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f7452ac01bd59317bb4144bd0fb6a327425026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->