### PR TITLE
Add maestro test to cover deeplink to SERP with a search query

### DIFF
--- a/.maestro/deeplink/deeplink_to_serp_with_query.yaml
+++ b/.maestro/deeplink/deeplink_to_serp_with_query.yaml
@@ -1,0 +1,15 @@
+appId: com.duckduckgo.mobile.android
+name: "ReleaseTest: Deeplink to SERP with search query"
+tags:
+  - releaseTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - openLink:
+          link: duck://https://duckduckgo.com?q=why%20use%20duckduckgo
+
+      - copyTextFrom:
+          id: "omnibarTextInput"
+
+      - assertTrue: ${maestro.copiedText == "why use duckduckgo" }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1211762418336942?focus=true

### Description
Added a Maestro test to verify that deeplinks to SERP with search queries work correctly. The test opens a deeplink to DuckDuckGo with a predefined search query and verifies that the query is properly displayed in the omnibar.

### Steps to test this PR

_Deeplink to SERP test_
- [x] Run the Maestro test using `.maestro/deeplink/deeplink_to_serp_with_query.yaml`

### UI changes
No UI changes in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Maestro test that opens a SERP deeplink with a query and verifies it appears in the omnibar.
> 
> - **Tests (Maestro)**:
>   - Add `/.maestro/deeplink/deeplink_to_serp_with_query.yaml` to validate SERP deeplink behavior.
>     - Retries up to `3` times.
>     - `openLink` to `duck://https://duckduckgo.com?q=why%20use%20duckduckgo`.
>     - `copyTextFrom` `omnibarTextInput` and `assertTrue` it equals `"why use duckduckgo"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42c1ffd6eb2037b2e5a4f790ad643a9cb994df3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->