### PR TITLE
Digital Asset Links Setup: add assets statements to android manifest in application metadata

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -65,4 +65,15 @@
 
     <!-- ADS -->
     <string name="ads_demo_activity_title" translatable="false">Android Design System Demo</string>
+
+    <!-- Digital Asset Links -->
+    <string name="asset_statements">
+      [{
+        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
+        \"target\": {
+          \"namespace\": \"web\",
+          \"site\": \"https://duckduckgo.com\"
+        }
+      }]
+    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,15 +25,6 @@
     <string name="open">Open</string>
     <string name="cancel">Cancel</string>
     <string name="search">Search</string>
-    <string name="asset_statements" translatable="false">
-      [{
-        \"relation\": [\"delegate_permission/common.handle_all_urls\"],
-        \"target\": {
-          \"namespace\": \"web\",
-          \"site\": \"https://duckduckgo.com\"
-        }
-      }]
-    </string>
 
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Visit Settings to search and browse with DuckDuckGo every time.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1212259565494539?focus=true

### Description
Added Digital Asset Links support to enable seamless web-to-app transitions from duckduckgo.com. This implementation adds the required asset statements metadata to the AndroidManifest.xml and defines the asset statements JSON in strings.xml, establishing a trusted relationship between our app and the DuckDuckGo website.

### Steps to test this PR

_Verify App Links functionality_

### UI changes
No UI changes in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AndroidManifest metadata referencing a new asset_statements string that defines Digital Asset Links for https://duckduckgo.com.
> 
> - **Android**:
>   - **Manifest**: Add `meta-data` entry `asset_statements` referencing `@string/asset_statements`.
>   - **Resources**: Introduce `strings` entry `asset_statements` containing Digital Asset Links JSON targeting `https://duckduckgo.com` with `delegate_permission/common.handle_all_urls`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce4f8bbe4ff9faebe7a9c67be23cb9d33400f139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->