### PR TITLE
Update GHA release blocker step to only check for failure instead of task id

### DIFF
--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -80,7 +80,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -185,7 +185,7 @@ jobs:
           asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -93,7 +93,7 @@ jobs:
           asana-task-description: The privacy workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -141,7 +141,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -133,7 +133,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        if: ${{ failure() }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212304808774088?focus=true 

### Description
For release blockers, only check if there was a failure and not for a populated taskId as that isn't working

### Steps to test this PR

- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the "Adding as a release blocker" step to run on any workflow failure across multiple GHA workflows.
> 
> - **CI Workflows**:
>   - Update `if` condition for `Adding as a release blocker` from `failure() && steps.create-failure-task.outputs.taskId != ''` to `failure()` in:
>     - `.github/workflows/custom-tabs-nightly.yml`
>     - `.github/workflows/end-to-end-robintest.yml`
>     - `.github/workflows/privacy.yml`
>     - `.github/workflows/update-content-scope.yml`
>     - `.github/workflows/update-ref-tests.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c78ae86e662544f2afeb3cdfb70c864dee880588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->