### PR TITLE
Use newer GHA for creating release-blocking asana tasks

### DIFF
--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -80,7 +80,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -175,17 +175,17 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
         id: create-failure-task
-        uses: honeycombio/gha-create-asana-task@main
+        uses: duckduckgo/native-github-asana-sync@v2.0
         with:
-          asana-secret: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
-          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
-          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
           asana-task-name: GH Workflow Failure - End to end tests (Robin)
           asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -83,17 +83,17 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: honeycombio/gha-create-asana-task@main
+        uses: duckduckgo/native-github-asana-sync@v2.0
         with:
-          asana-secret: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
-          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
-          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
           asana-task-name: GH Workflow Failure - Privacy tests
           asana-task-description: The privacy workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -141,7 +141,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -133,7 +133,7 @@ jobs:
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212290323894126?focus=true 

### Description
Ensures we are using `duckduckgo/native-github-asana-sync[create-asana-task]` instead of the older `honeycombio/gha-create-asana-task` for asana tasks that need to be flagged as release blockers (the latter doesn't return the required task ID)

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use duckduckgo/native-github-asana-sync for task creation and only add release blockers when a taskId is returned.
> 
> - **CI Workflows**:
>   - Replace Asana task creation with `duckduckgo/native-github-asana-sync@v2.0` and update inputs (`asana-pat`, `asana-project`, `asana-section`, `action: 'create-asana-task'`) in:
>     - `.github/workflows/end-to-end-robintest.yml`
>     - `.github/workflows/privacy.yml`
>   - Add conditional guard `failure() && steps.create-failure-task.outputs.taskId != ''` before adding tasks as release blockers and use `action: 'add-task-asana-project'` with `asana-task-id` in:
>     - `.github/workflows/custom-tabs-nightly.yml`
>     - `.github/workflows/end-to-end-robintest.yml`
>     - `.github/workflows/privacy.yml`
>     - `.github/workflows/update-content-scope.yml`
>     - `.github/workflows/update-ref-tests.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abec4f154af48d3eb66637cece3f8ed62debf837. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->