### PR TITLE
Maestro: Use copyTextFrom annd pasteText

### DIFF
--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -50,9 +50,6 @@ tags:
                 text: "convert.ad-company.site"
             - action: back
             - action: back
-#            - longPressOn:
-#                id: "omnibarTextInput"
-#            - tapOn: "Copy"
             - copyTextFrom:
                 id: "omnibarTextInput"
             - action: back


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212304925005476?focus=true

### Description
This PR fixes the Privacy tests, using copyTextFrom instead of relying on the device

### Steps to test this PR
https://github.com/duckduckgo/Android/actions/runs/19944510894

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces long-press copy/paste with Maestro copyTextFrom/pasteText in the privacy test flow for URL reuse after clearing data.
> 
> - **Maestro privacy test** (`.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml`):
>   - Replace long-press + system "Copy"/"Paste" interactions with `copyTextFrom` and `pasteText` on `omnibarTextInput`.
>   - Keep flow intact: copy current URL, clear data via fire button, paste and revisit URL to re-assert protections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1a18bad5e77b6aa4860f03b3993deb63e899ea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->