### PR TITLE
Update content scope scripts to version 12.4.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -5788,7 +5788,7 @@
       }
     });
   }
-  async function getExpandedPerformanceMetrics() {
+  async function getExpandedPerformanceMetrics(timeoutMs = 500) {
     try {
       if (document.readyState !== "complete") {
         return returnError("Document not ready");
@@ -5805,7 +5805,7 @@
       const fcp = paint.find((p) => p.name === "first-contentful-paint");
       let largestContentfulPaint = null;
       if (PerformanceObserver.supportedEntryTypes.includes("largest-contentful-paint")) {
-        largestContentfulPaint = await waitForLCP();
+        largestContentfulPaint = await waitForLCP(timeoutMs);
       }
       const totalResourceSize = resources.reduce((sum, r) => sum + (r.transferSize || 0), 0);
       if (navigation) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7873,7 +7873,7 @@
       }
     });
   }
-  async function getExpandedPerformanceMetrics() {
+  async function getExpandedPerformanceMetrics(timeoutMs = 500) {
     try {
       if (document.readyState !== "complete") {
         return returnError("Document not ready");
@@ -7890,7 +7890,7 @@
       const fcp = paint.find((p) => p.name === "first-contentful-paint");
       let largestContentfulPaint = null;
       if (PerformanceObserver.supportedEntryTypes.includes("largest-contentful-paint")) {
-        largestContentfulPaint = await waitForLCP();
+        largestContentfulPaint = await waitForLCP(timeoutMs);
       }
       const totalResourceSize = resources.reduce((sum, r) => sum + (r.transferSize || 0), 0);
       if (navigation) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.3.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.39.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.39.0.tgz",
-      "integrity": "sha512-g5y74oDx1e5vkbcnCufQpVaZFFw3V9AIdEVBzwAnZPV3cftSEDnc13FrrMyW34DcYurz4s/X9ea49+zM9CsUvA==",
+      "version": "14.41.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.41.0.tgz",
+      "integrity": "sha512-tI4HwdB8sIE/bBVBd5YmewdRYjiI645H1aqQkNxg5HWCx7SFEyI4lNCgF0+iB7nK6UC+gq5JZIgZ4RmZ++MmLg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#125825ac6adb00bb2930cb793af6d46adc560e9f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#6c78291d25eb6a22d647f4a58027935c946afa68",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.12.5.tgz",
-      "integrity": "sha512-d9/zOt8MHG86vuEp7KLaSgjIrx43Vr272nbVacGjDV/ZAbrS2fIKhLb0MulJ/14fPjzYivNniquk8fiKt0wgNQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.0.tgz",
+      "integrity": "sha512-mxape1ivliSPgpzESMVipdC9UZNfuEvypoiJBW0wR+AxMCgJY8Zh5M/1UBXe+y9TvNkvJCU2T/zsF9y2R3pHXA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.12.5",
-        "@ghostery/adblocker-extended-selectors": "^2.12.5",
+        "@ghostery/adblocker-content": "^2.13.0",
+        "@ghostery/adblocker-extended-selectors": "^2.13.0",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.16"
+        "tldts-experimental": "^7.0.18"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.12.5.tgz",
-      "integrity": "sha512-ZIBPWcJpxeWOfFMX63PVhO/sGaUUfHScP88WgdV3pOv5aWsskDMh3Niwa4CHZKqzHs8T1XJDfbLDK3DDXeEHpA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.0.tgz",
+      "integrity": "sha512-6WZrVReCZtF0XvR2T2jK9QAccneFe+HLKhjogRa0ud+Ys7rGwwRZYLOUy3MlVEhJLTeLfA9FLc+bt4K6QovXSQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.12.5"
+        "@ghostery/adblocker-extended-selectors": "^2.13.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.12.5.tgz",
-      "integrity": "sha512-KPHe2QxgyNA7Ei8ndIiWH7h26DpXjtvDXv+D1EIsmjTYSitKd7roCz10Gy7vD4H88JjT/ABZwjnqLo2ZHPEC/Q==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.0.tgz",
+      "integrity": "sha512-YfBQHF9fiBt8CKWb727b/T4qLrYEWXS4E8GSPS8OqeBEvRh6f09oHGZJ0lW3F6sPbEwVjHr2JuLoFJDUciX6bA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -542,7 +542,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.3.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1212314392409046/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps content-scope-scripts to 12.4.0, adding an optional LCP timeout to performance metrics and updating related dependencies.
> 
> - **Content Scope Scripts (Android builds)**:
>   - Update `getExpandedPerformanceMetrics` to accept `timeoutMs = 500` and pass it to `waitForLCP` in `build/android/adsjsContentScope.js` and `build/android/contentScope.js`.
> - **Dependencies**:
>   - Update `@duckduckgo/content-scope-scripts` to `12.4.0` in `package.json`/lockfile.
>   - Refresh transitive deps in lockfile (e.g., `@duckduckgo/autoconsent`, `@ghostery/*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2af8d77207ba5a92351913f7c23350dc535fe9e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->