### PR TITLE
Fix: Omnibar E2E tests

### DIFF
--- a/.maestro/omnibar/split_omnibar_search.yaml
+++ b/.maestro/omnibar/split_omnibar_search.yaml
@@ -59,12 +59,14 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "omnibarTextInput"
-      text: "https://www.eff.org/"
+      text: ".*eff.org.*"
     timeout: 10000
 
 # verify that tapping on a favorite opens the web page (SERP in this case)
 - tapOn:
     id: "omnibarTextInput"
+- tapOn:
+    id: "clearTextButton"
 - tapOn:
     id: "quickAccessFavicon"
     childOf:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212309029354196?focus=true

### Description

The PR updates the expect URL after enabling short URL option.

### Steps to test this PR

- [ ] Make sure the [Omnibar E2E tests](https://github.com/duckduckgo/Android/actions/runs/19958880155) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relaxes URL match to a regex and clears the omnibar before selecting a favorite in the split omnibar E2E flow.
> 
> - **E2E tests** (`.maestro/omnibar/split_omnibar_search.yaml`):
>   - Relax URL assertion after submitting `eff.org` from exact match to regex `.*eff.org.*`.
>   - Add `tapOn` `clearTextButton` before tapping a favorite (`quickAccessFavicon`) to ensure a clean omnibar state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa0024925afdc88728331c0a3e903f10cb8e2a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->