### PR TITLE
fix: Update youtube related E2E tests and fix the flow

### DIFF
--- a/.maestro/duckplayer/common/assert_youtube_visible.yaml
+++ b/.maestro/duckplayer/common/assert_youtube_visible.yaml
@@ -8,7 +8,7 @@ appId: com.duckduckgo.mobile.android
 
 # Wait for video to load
 - assertVisible:
-      text: "https://m.youtube.com/watch?v=3ml7yeKBUhc"
+      text: ".*m.youtube.com.*"
 
 - assertNotVisible:
       text: "duck://player/.*"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1212315779149988?focus=true

### Description

Update existing youtube related E2E tests after enabling short URL option.

### Steps to test this PR

- [ ] Make sure existing flow which are using `assert_youtube_visible` pass (e.g. `ask_serp_organic_youtube.yaml`)
- [ ] Make sure existing flows which care using `assert_duckplayer_visible` pass and matching the text correctly (currently optional)
- [ ] Make sure `DuckPlayer: Direct > Duck Player > Playback` (local test only) passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalize YouTube URL check in `assert_youtube_visible` to a regex match to support varied `m.youtube.com` URLs.
> 
> - **E2E tests (DuckPlayer)**:
>   - Update `/.maestro/duckplayer/common/assert_youtube_visible.yaml`:
>     - Change `assertVisible` text from a specific video URL to regex `".*m.youtube.com.*"` to match any mobile YouTube URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66228f151c5d2d55b79c6b5b8363f4823a27ad8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->