### PR TITLE
Update pixel definition to be an enum type

### DIFF
--- a/PixelDefinitions/pixels/app_initialization_timeout.json5
+++ b/PixelDefinitions/pixels/app_initialization_timeout.json5
@@ -16,7 +16,8 @@
             {
                 "key": "plugin",
                 "description": "The class name of the plugin which timed out",
-                "type": "string"
+                "type": "string",
+                "enum": ["AuraExperimentManager", "EmptyReferrerStateListener", "PlayStoreAppReferrerStateListener", "ReinstallAtbListener"]
             }
         ]
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211195376835743?focus=true 

### Description
Add `enum` type to pixel definition.

### Steps to test this PR
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain the `plugin` parameter in `timeout_atb_pre_initializer_plugin` to a defined enum in `app_initialization_timeout` pixel definitions.
> 
> - **Pixels**:
>   - Update `PixelDefinitions/pixels/app_initialization_timeout.json5`:
>     - For `timeout_atb_pre_initializer_plugin`, constrain `parameters[].plugin` to an enum: `"AuraExperimentManager"`, `"EmptyReferrerStateListener"`, `"PlayStoreAppReferrerStateListener"`, `"ReinstallAtbListener"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 590b5162473fb519fd0fc2a1470ddf5c9427eee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->