### PR TITLE
Fix Forward button in NTP menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -62,6 +62,7 @@ object BrowserMenuViewStateFactory {
             showDuckChatOption = browserViewState.showDuckChatOption,
             vpnMenuState = browserViewState.vpnMenuState,
             showAutofill = browserViewState.showAutofill,
+            canGoForward = browserViewState.canGoForward,
         )
     }
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenu.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenu.kt
@@ -430,10 +430,10 @@ class BrowserMenu(
         showCommonItems()
 
         backMenuItem.isEnabled = false
-        forwardMenuItem.isEnabled = false
         refreshMenuItem.isEnabled = false
-
         newTabMenuItem.isVisible = true
+
+        forwardMenuItem.isEnabled = viewState.canGoForward
         duckChatMenuItem.isVisible = viewState.showDuckChatOption
         autofillMenuItem.isVisible = viewState.showAutofill
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
@@ -54,6 +54,7 @@ sealed class BrowserMenuViewState {
         val isPrivacyProtectionDisabled: Boolean = false,
     ) : BrowserMenuViewState()
     data class NewTabPage(
+        val canGoForward: Boolean = false,
         val showDuckChatOption: Boolean = false,
         val vpnMenuState: VpnMenuState = VpnMenuState.Hidden,
         val showAutofill: Boolean = false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1212197403877138?focus=true

### Description
This PR fixes the NTP menu so the forward arrow is enabled

### Steps to test this PR

_Forward menu_
- [x] Fresh app install
- [x] Open a new tab
- [x] Open browser menu, verify Forward arrow is not enabled
- [x] Navigate to a couple sites
- [x] Navigate back to NTP
- [x] Open browser menu, verify Forward arrow is enabled
- [x] Tap on it, and verify it navigates accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable the Forward button in the New Tab Page menu when forward navigation is available.
> 
> - **Browser menu state/model**:
>   - Add `canGoForward` to `BrowserMenuViewState.NewTabPage`.
>   - Populate `NewTabPage.canGoForward` from `BrowserViewState` in `BrowserMenuViewStateFactory`.
> - **UI rendering**:
>   - In `BrowserMenu.renderNewTabPageMenu`, set `forwardMenuItem.isEnabled` from `viewState.canGoForward` (back/refresh remain disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b979b12cea0f427cf089f3f8fde65ec66d0e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->