### PR TITLE
PIR: Fix stored setCustomStatsPixelsLastSentMs

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOut24HourSubmissionSuccessRateReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOut24HourSubmissionSuccessRateReporter.kt
@@ -75,8 +75,8 @@ class RealOptOut24HourSubmissionSuccessRateReporter @Inject constructor(
                     }
                 }
 
-                logcat { "PIR-CUSTOM-STATS: Updating last send date to $endDate" }
-                pirRepository.setCustomStatsPixelsLastSentMs(endDate)
+                logcat { "PIR-CUSTOM-STATS: Updating last send date to $now" }
+                pirRepository.setCustomStatsPixelsLastSentMs(now)
             }
         }
     }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealOptOut24HourSubmissionSuccessRateReporterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealOptOut24HourSubmissionSuccessRateReporterTest.kt
@@ -127,7 +127,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = testBroker1.url,
             optOutSuccessRate = 0.5,
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -173,7 +173,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = testBroker1.url,
             optOutSuccessRate = 0.75,
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -278,7 +278,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = testBroker2.url,
             optOutSuccessRate = 0.8,
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -330,7 +330,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = eq(testBroker2.url),
             optOutSuccessRate = any(),
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -357,14 +357,13 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
         toTest.attemptFirePixel()
 
         verify(mockPirPixelSender, never()).reportBrokerCustomStateOptOutSubmitRate(any(), any())
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
     fun whenShouldFirePixelThenUsesCorrectDateRange() = runTest {
         val startDate = baseTime
         val now = baseTime + twentyFourHours + oneHour
-        val expectedEndDate = now - twentyFourHours
         val jobRecord = createOptOutJobRecord(
             extractedProfileId = 1L,
             brokerName = testBroker1.name,
@@ -388,9 +387,9 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
         verify(mockOptOutSubmitRateCalculator).calculateOptOutSubmitRate(
             allActiveOptOutJobsForBroker = eq(listOf(jobRecord)),
             startDateMs = eq(startDate),
-            endDateMs = eq(expectedEndDate),
+            endDateMs = eq(now - twentyFourHours),
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(expectedEndDate)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -442,7 +441,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = testBroker2.url,
             optOutSuccessRate = 0.9,
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     @Test
@@ -540,7 +539,7 @@ class RealOptOut24HourSubmissionSuccessRateReporterTest {
             brokerUrl = eq(testBroker2.url),
             optOutSuccessRate = any(),
         )
-        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now - twentyFourHours)
+        verify(mockPirRepository).setCustomStatsPixelsLastSentMs(now)
     }
 
     private fun createOptOutJobRecord(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205142657210376/task/1212258504673457?focus=true 

### Description
Fix set CustomStatsPixelsLastSentMs to now (when it was actually sent)

### Steps to test this PR
Tests should pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Store `CustomStatsPixelsLastSentMs` as the current time when pixels are sent (not `now - 24h`), updating logs and tests accordingly.
> 
> - **PIR custom stats (24h submission rate)**:
>   - Persist `setCustomStatsPixelsLastSentMs` with `now` after sending pixels.
>   - Retain calculation window end as `now - 24h` when computing success rates.
>   - Update log message and all affected tests/expectations to the new timestamp behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b95bd9a3c0384b23c0cd8eda4876638990d67bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->