### PR TITLE
Add InputScreenOnboardingWideEvent pixel definition

### DIFF
--- a/PixelDefinitions/pixels/wide_input_screen_onboarding.json5
+++ b/PixelDefinitions/pixels/wide_input_screen_onboarding.json5
@@ -1,0 +1,40 @@
+// Wide event pixel for Input Screen onboarding flow monitoring
+// https://app.asana.com/1/137249556945/project/488551667048375/task/1212175606684353
+{
+    "wide_input-screen-onboarding": {
+        "description": "User enables Input Screen during onboarding",
+        "owners": ["joshliebe"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            {
+                "key": "context.name",
+                "description": "Entry point to the Input Screen onboarding flow.",
+                "enum": ["onboarding"]
+            },
+            {
+                "key": "feature.name",
+                "description": "Feature identifier for this wide pixel",
+                "enum": ["input-screen-onboarding"]
+            },
+            {
+                "key": "feature.data.ext.reinstallUser",
+                "description": "true if the user tapped 'I've been here before', false otherwise",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "feature.data.ext.enabled",
+                "description": "true if the Input Screen is enabled, false otherwise. Only present on CANCELLED events.",
+                "enum": ["true", "false"]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212289743658076?focus=true

### Description

- Pixel definition for https://github.com/duckduckgo/Android/pull/7239 (implementation currently behind an `INTERNAL` feature flag)
- Relevant class: `InputScreenOnboardingWideEvent.kt`
- The flow is started from this screen and the Input Screen (“Search & Duck.ai”) is only enabled after onboarding is complete:
<img width="2364" height="2503" alt="combined 1" src="https://github.com/user-attachments/assets/139afe52-795b-4ca8-b4e9-4c55b283decb" />

### Events

1.  `SUCCESS` if the user sees the Input Screen.
2. `CANCELLED` if the user changes the Input Screen setting before seeing the Input Screen.
3. `UNKNOWN` if the user doesn’t see the Input Screen 30 days after selecting “Search & Duck.ai".

### Steps to test this PR

- [ ] Code review


<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> Adds a new wide pixel definition to track Input Screen onboarding events with contextual parameters.
> 
> - **Telemetry / Pixels**:
>   - Add `PixelDefinitions/pixels/wide_input_screen_onboarding.json5`:
>     - Defines `wide_input-screen-onboarding` (description, owners, triggers, suffixes).
>     - Includes parameters for standard wide pixel fields and context keys: `context.name`, `feature.name`, `feature.data.ext.reinstallUser`, `feature.data.ext.enabled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c88b538865be4bdb1a1b8422c2a4af49418a85a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>