### PR TITLE
Fire Dialog: New feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -249,10 +249,10 @@ interface AndroidBrowserConfigFeature {
 
     /**
      * Controls the fire dialog and data clearing options.
-     * @return `true` when the remote config has the global "newDataClearingOptions" androidBrowserConfig
+     * @return `true` when the remote config has the global "moreGranularDataClearingOptions" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun newDataClearingOptions(): Toggle
+    fun moreGranularDataClearingOptions(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1212237610087258?focus=true

### Description

This PR just adds a new feature flag that will be used in subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `moreGranularDataClearingOptions` feature flag (default false) to `AndroidBrowserConfigFeature` for fire dialog/data clearing options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 717cf3290f0d33f34a206170f5eea8815e69294a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->