### PR TITLE
Fix 14_-_Single-site,_single-tab,_no-session-after-fire privacy maestro test

### DIFF
--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -50,6 +50,8 @@ tags:
                 text: "convert.ad-company.site"
             - action: back
             - action: back
+            - tapOn:
+                id: "omnibarTextInput"
             - copyTextFrom:
                 id: "omnibarTextInput"
             - action: back


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212338654786313?focus=true

### Description

Fix maestro test `14_-_Single-site,_single-tab,_no-session-after-fire` to fix GitHub Action "End to end tests (Robin)" workflow.

Because we've now a shorter URL by default, the copy/paste without a tap on the omnibar copy a shorter URL and not the full URL format. The tap allows us to get the full URL and copy what we want.

### Steps to test this PR

_Fix privacy maestro test_
- [x] Execute `14_-_Single-site,_single-tab,_no-session-after-fire` with this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a tap on `omnibarTextInput` before copying to ensure the full URL is captured and reused after clearing data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47895ffa5a92ab80cddd6f66b99bdec7dd890b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->