### PR TITLE
Fix cookie flush ANR

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -691,13 +691,17 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
     override fun onPause() {
         downloadMessagesJob.cancel()
         simpleWebview.onPause()
-        cookieManager.flush()
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            cookieManager.flush()
+        }
         super.onPause()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        cookieManager.flush()
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            cookieManager.flush()
+        }
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212259714028284?focus=true

### Description

- Moves `cookieManager.flush()` to `io` in `DuckChatWebViewFragment`.

### Steps to test this PR

- [ ] Enable FF Inventory -> “standaloneMigration`
- [ ] Kill the app
- [ ] Go to Duck.ai
- [ ] Migrate
- [ ] Kill the app
- [ ] Go to Duck.ai
- [ ] Verify that the update dialog is not visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs `CookieManager.flush()` asynchronously on IO during `onPause` and `onDestroyView` to avoid blocking the UI.
> 
> - **Lifecycle (DuckChat WebView)**
>   - In `duckchat/.../DuckChatWebViewFragment.kt`, run `cookieManager.flush()` inside `appCoroutineScope.launch(dispatcherProvider.io())` during `onPause` and `onDestroyView` instead of calling it directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a29844be9cfeef34d81ef113b11d5c222aeea2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->