### PR TITLE
Free Trial conversion WideEvent pixel definition

### DIFF
--- a/PixelDefinitions/pixels/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/wide_free_trial_conversion.json5
@@ -1,0 +1,50 @@
+// Wide event pixel for Free Trial conversion flow monitoring
+// https://app.asana.com/1/137249556945/task/1211999907583853?focus=true
+{
+    "wide_free-trial-conversion": {
+        "description": "Monitors free trial user journey from activation to conversion or expiration",
+        "owners": ["nalcalag"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            {
+                "key": "feature.name",
+                "description": "Feature identifier for this wide pixel",
+                "enum": ["free-trial-conversion"]
+            },
+            {
+                "key": "feature.data.ext.free_trial_plan",
+                "description": "The base plan ID of the free trial product activated",
+                "enum": [
+                    "ddg.privacy.pro.monthly.renews.us",
+                    "ddg.privacy.pro.monthly.renews.row",
+                    "ddg.privacy.pro.yearly.renews.us",
+                    "ddg.privacy.pro.yearly.renews.row"
+                ]
+            },
+            {
+                "key": "feature.data.ext.failure_reason",
+                "description": "Reason for failure. Only present on FAILURE events.",
+                "enum": ["expired", "timeout"]
+            },
+            {
+                "key": "feature.data.ext.step.vpn_activated_d1.success",
+                "description": "true if VPN was successfully activated within first day of Free Trial",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "feature.data.ext.step.vpn_activated_d2_to_d7.success",
+                "description": "true if VPN was successfully activated between D2-D7 of Free Trial",
+                "enum": ["true", "false"]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212343233377167?focus=true

### Description
- Pixel definition for https://github.com/duckduckgo/Android/pull/7309 (implementation currently behind a feature flag)
- Relevant class: `FreeTrialConversionWideEvent.kt`
- The flow is started when a user starts a Free Trial and it finishes when the Free Trial is expired/converted into a paid subscription.

### Steps to test this PR
- [ ] Tested in https://github.com/duckduckgo/Android/pull/7309
- [ ] CI checks are green

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `wide_free-trial-conversion` pixel definition to track free trial flow from activation to conversion/expiration with plan, failure, and activation-step parameters.
> 
> - **Pixels**:
>   - **New wide pixel**: `PixelDefinitions/pixels/wide_free_trial_conversion.json5`
>     - Key: `wide_free-trial-conversion`; triggers: `other`; suffixes: `daily_count_short`, `form_factor`.
>     - Parameters: standard wide pixel fields plus feature-specific:
>       - `feature.name` = `free-trial-conversion`.
>       - `feature.data.ext.free_trial_plan` with allowed plan IDs.
>       - `feature.data.ext.failure_reason` (`expired`, `timeout`).
>       - Activation steps: `feature.data.ext.step.vpn_activated_d1.success`, `...d2_to_d7.success` (both `true`/`false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aa007da61e18f6263e1f40737e62f5afad00b52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->