### PR TITLE
Fix flaky matching for "Watch on YouTube" button

### DIFF
--- a/.maestro/duckplayer/direct_duckplayer_youtube.yaml
+++ b/.maestro/duckplayer/direct_duckplayer_youtube.yaml
@@ -1,4 +1,5 @@
 appId: com.duckduckgo.mobile.android
+androidWebViewHierarchy: devtools
 name: "DuckPlayer: Direct > Duck Player > YouTube"
 tags:
   - duckplayer


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210626814037951/task/1212336937501299?focus=true 

### Description
Fix flaky matching for "Watch on YouTube" button by using `androidWebViewHierarchy: devtools`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `androidWebViewHierarchy: devtools` in `.maestro/duckplayer/direct_duckplayer_youtube.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d469fdacb5929b0bb0a9a6cfaee7f7f8246b734. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->