### PR TITLE
Fix 5_-_AddressBarSpoof,_downloadpath.yaml maestro test

### DIFF
--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -1,6 +1,5 @@
 appId: com.duckduckgo.mobile.android
 tags:
-    ## This tag will be updated to securityTest once we close the https://app.asana.com/1/137249556945/project/1211724162604201/task/1212015085457815?focus=true task
     - securityTest
 ---
 - retry:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1212353743199513?focus=true
### Description
Updated the security test for address bar spoofing during downloads. Changed the test tag from `securityTestInternal` to `securityTest` and updated the assertion to check for "Search" instead of "about:blank" in the omnibar during downloads.

### Steps to test this PR

_Security Test Verification_
- [ ] 5_-_AddressBarSpoof,_downloadpath.yaml passes

### UI changes
No UI changes in this PR, only test modifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches test tag to `securityTest` and updates omnibar assertion to expect "Search" during download.
> 
> - **Security Tests**:
>   - Update `tags` in `maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml` to `securityTest`.
>   - Change assertion to verify `omnibarTextInput` copies "Search" instead of `about:blank` during download flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed9542ca27e52fadb5f15e6e610a199cbc85ec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->