### PR TITLE
Create new navigation test for SERP with search query and add it as a new step end-to-end-robintest workflow

### DIFF
--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -80,12 +80,12 @@ jobs:
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          name: deeplinkTest_${{ github.sha }}
+          name: navigationTest_${{ github.sha }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
-          include-tags: deeplinkTest
+          include-tags: navigationTest
 
       - name: Ad click detection flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.8

--- a/.maestro/deeplink/deeplink_to_serp_with_query.yaml
+++ b/.maestro/deeplink/deeplink_to_serp_with_query.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
-name: "Deeplink Test: Deeplink to SERP with search query"
+name: "Navigation Test: Navigate to SERP with duck scheme query"
 tags:
-  - deeplinkTest
+  - navigationTest
 ---
 - retry:
     maxRetries: 3


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1212350440774862?focus=true

### Description
Added a new navigation test to verify that the app correctly handles duck:// schema links to the search engine results page (SERP) with a search query. The test ensures that when a user clicks a `duck://` link with a search query parameter, the app properly opens and displays the search query in the omnibar.

This test was added as a separate step in the End-to-End tests (Robin) workflow.

### Steps to test this PR

_Deeplink Functionality_
- [x] Run the deeplink_to_serp_with_query.yaml test both locally and on the maestro cloud

Test run: https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/flow/run_01kc1jpy6ve1m9ykcg2whrnbzb

### UI changes
No UI changes, only additional test coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Maestro flow to validate duck:// SERP query handling and runs it in the end-to-end Robin workflow via the navigationTest tag.
> 
> - **Tests**:
>   - Add `.maestro/deeplink/deeplink_to_serp_with_query.yaml` to validate `duck://` SERP link opens with the query shown in `omnibarTextInput` (with retries, clean launch, and onboarding skipped).
> - **CI**:
>   - Update `.github/workflows/end-to-end-robintest.yml` to include a new "Deeplink tests" Maestro Cloud step running `include-tags: navigationTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35bce888ce2becb96086ae3483ca899686635809. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->