### PR TITLE
Update mic site permissions check

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerImpl.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
-import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsFeature
+import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
 import logcat.logcat
@@ -44,7 +44,7 @@ class SitePermissionsManagerImpl @Inject constructor(
     private val sitePermissionsRepository: SitePermissionsRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val context: Context,
-    private val microphoneSitePermissionsFeature: MicrophoneSitePermissionsFeature,
+    private val microphoneSitePermissionsDomainRecoveryFeature: MicrophoneSitePermissionsDomainRecoveryFeature,
 ) : SitePermissionsManager {
 
     private suspend fun getSitePermissionsGranted(
@@ -70,7 +70,7 @@ class SitePermissionsManagerImpl @Inject constructor(
 
         logcat { "Permissions: sitePermissionsAllowedToAsk in $url ${sitePermissionsAllowedToAsk.asList()}" }
 
-        val sitePermissionsGranted = if (microphoneSitePermissionsFeature.self().isEnabled()) {
+        val sitePermissionsGranted = if (microphoneSitePermissionsDomainRecoveryFeature.self().isEnabled()) {
             getSitePermissionsGranted(url, tabId, sitePermissionsAllowedToAsk).filter { permission ->
                 if (permission == PermissionRequest.RESOURCE_AUDIO_CAPTURE && AUDIO_CAPTURE_PERMISSION_DOMAINS.contains(url.extractDomain())) {
                     ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED &&

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/MicrophoneSitePermissionsDomainRecoveryFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/feature/MicrophoneSitePermissionsDomainRecoveryFeature.kt
@@ -22,9 +22,9 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "microphoneSitePermissions",
+    featureName = "microphoneSitePermissionsDomainRecovery",
 )
-interface MicrophoneSitePermissionsFeature {
+interface MicrophoneSitePermissionsDomainRecoveryFeature {
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsManagerTest.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
-import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsFeature
+import com.duckduckgo.site.permissions.impl.feature.MicrophoneSitePermissionsDomainRecoveryFeature
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsEntity
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -52,7 +52,9 @@ class SitePermissionsManagerTest {
     private val mockPackageManager = mock<PackageManager>()
     private val mockLocationManager = mock<LocationManager>()
     private val mockContext = mock<Context>()
-    private val fakeMicrophoneSitePermissionsFeature = FakeFeatureToggleFactory.create(MicrophoneSitePermissionsFeature::class.java)
+    private val fakeMicrophoneSitePermissionsDomainRecoveryFeature = FakeFeatureToggleFactory.create(
+        MicrophoneSitePermissionsDomainRecoveryFeature::class.java,
+    )
 
     private val testee = SitePermissionsManagerImpl(
         mockPackageManager,
@@ -60,7 +62,7 @@ class SitePermissionsManagerTest {
         mockSitePermissionsRepository,
         coroutineRule.testDispatcherProvider,
         mockContext,
-        fakeMicrophoneSitePermissionsFeature,
+        fakeMicrophoneSitePermissionsDomainRecoveryFeature,
     )
 
     private val url = "https://domain.com/whatever"
@@ -69,7 +71,7 @@ class SitePermissionsManagerTest {
     @Before
     fun before() {
         whenever(mockPackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)).thenReturn(true)
-        fakeMicrophoneSitePermissionsFeature.self().setRawStoredState(Toggle.State(false))
+        fakeMicrophoneSitePermissionsDomainRecoveryFeature.self().setRawStoredState(Toggle.State(false))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212347629297471?focus=true

### Description

- Fixes an issue where mic permissions were not handled correctly when requested by site and app permissions were set to “Ask every time” or “Don’t allow”.

### Steps to test this PR

- [ ] Testing steps in task



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a toggleable check that only grants site microphone access for `duck.ai`/`duckduckgo.com` when Android `RECORD_AUDIO` and `MODIFY_AUDIO_SETTINGS` are granted, with wiring and tests updated.
> 
> - **Site permissions logic**:
>   - Feature-gate mic permission handling via `MicrophoneSitePermissionsDomainRecoveryFeature` (default enabled).
>   - For `RESOURCE_AUDIO_CAPTURE` on `duck.ai`/`duckduckgo.com`, auto-accept only if Android `RECORD_AUDIO` and `MODIFY_AUDIO_SETTINGS` are granted; otherwise exclude from auto-accept.
>   - Inject `Context` and use `ContextCompat.checkSelfPermission`; add `AUDIO_CAPTURE_PERMISSION_DOMAINS` list.
> - **Feature toggle**:
>   - New remote feature interface `MicrophoneSitePermissionsDomainRecoveryFeature` contributed to `AppScope` with default `TRUE`.
> - **Tests**:
>   - Update `SitePermissionsManagerTest` to inject `Context` and fake toggle; default toggle set to disabled in tests; constructor adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2bd0481a8dd9bfa83866fd37bfa42da4d88bfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->