### PR TITLE
Remove index param in autocomplete click phrase and website pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -22,7 +22,6 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
 import com.duckduckgo.app.autocomplete.impl.AutoCompletePixelNames
 import com.duckduckgo.app.autocomplete.impl.AutoCompleteRepository
-import com.duckduckgo.app.autocomplete.impl.AutocompletePixelParams
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.onboarding.store.AppStage
@@ -304,7 +303,7 @@ class AutoCompleteApi constructor(
         val hasFavoriteResults = suggestions.any { it is AutoCompleteBookmarkSuggestion && it.isFavorite }
         val hasHistoryResults = suggestions.any { it is AutoCompleteHistorySuggestion || it is AutoCompleteHistorySearchSuggestion }
         val hasSwitchToTabResults = suggestions.any { it is AutoCompleteSwitchToTabSuggestion }
-        val params = mutableMapOf(
+        val params = mapOf(
             PixelParameter.SHOWED_BOOKMARKS to hasBookmarkResults.toString(),
             PixelParameter.SHOWED_FAVORITES to hasFavoriteResults.toString(),
             PixelParameter.BOOKMARK_CAPABLE to hasBookmarks.toString(),
@@ -343,11 +342,6 @@ class AutoCompleteApi constructor(
             }
 
             else -> return
-        }
-
-        if (suggestion is AutoCompleteSearchSuggestion) {
-            val clickedSearchSuggestionIndex = suggestions.filter { it is AutoCompleteSearchSuggestion }.indexOf(suggestion)
-            params[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX] = clickedSearchSuggestionIndex.toString()
         }
 
         pixel.fire(pixelName, params)

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
@@ -48,11 +48,3 @@ class AutocompleteParamRemovalPlugin @Inject constructor() : PixelParamRemovalPl
         )
     }
 }
-
-object AutocompletePixelParams {
-    /**
-     * Parameter to capture the index of the selected suggestion within the list of search suggestions
-     * (either [AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION] or [AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION]).
-     */
-    const val PARAM_SEARCH_SUGGESTION_INDEX = "search_suggestion_index"
-}

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -23,7 +23,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
 import com.duckduckgo.app.autocomplete.impl.AutoCompletePixelNames
 import com.duckduckgo.app.autocomplete.impl.AutoCompleteRepository
-import com.duckduckgo.app.autocomplete.impl.AutocompletePixelParams
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.AppStage.NEW
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -1880,120 +1879,6 @@ class AutoCompleteApiTest {
 
         assertEquals("false", argumentCaptor.firstValue[PixelParameter.SHOWED_SWITCH_TO_TAB])
         assertEquals("false", argumentCaptor.firstValue[PixelParameter.SWITCH_TO_TAB_CAPABLE])
-    }
-
-    @Test
-    fun `when search suggestion clicked then search suggestion index parameter is added`() = runTest {
-        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
-        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
-        whenever(mockHistory.hasHistory()).thenReturn(false)
-        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
-
-        val suggestions = listOf(
-            AutoCompleteSearchSuggestion("first", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteSearchSuggestion("second", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteSearchSuggestion("third", isUrl = false, isAllowedInTopHits = false),
-        )
-        val clickedSuggestion = suggestions[1] // second suggestion (index 1)
-
-        testee.fireAutocompletePixel(suggestions, clickedSuggestion)
-
-        val argumentCaptor = argumentCaptor<Map<String, String>>()
-        Mockito.verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION), argumentCaptor.capture(), any(), any())
-
-        assertEquals("1", argumentCaptor.firstValue[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX])
-    }
-
-    @Test
-    fun `when search website suggestion clicked then search suggestion index parameter is added`() = runTest {
-        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
-        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
-        whenever(mockHistory.hasHistory()).thenReturn(false)
-        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
-
-        val suggestions = listOf(
-            AutoCompleteSearchSuggestion("first", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteSearchSuggestion("second", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteSearchSuggestion("third", isUrl = true, isAllowedInTopHits = false), // isUrl = true for website suggestion
-        )
-        val clickedSuggestion = suggestions[2] // third suggestion (index 2)
-
-        testee.fireAutocompletePixel(suggestions, clickedSuggestion)
-
-        val argumentCaptor = argumentCaptor<Map<String, String>>()
-        Mockito.verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION), argumentCaptor.capture(), any(), any())
-
-        assertEquals("2", argumentCaptor.firstValue[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX])
-    }
-
-    @Test
-    fun `when non search suggestion clicked then search suggestion index parameter is not added`() = runTest {
-        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
-        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
-        whenever(mockHistory.hasHistory()).thenReturn(false)
-        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
-
-        val suggestions = listOf(
-            AutoCompleteSearchSuggestion("first", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteBookmarkSuggestion("bookmark", "title", "url"),
-            AutoCompleteSearchSuggestion("second", isUrl = false, isAllowedInTopHits = false),
-        )
-        val clickedSuggestion = AutoCompleteBookmarkSuggestion("bookmark", "title", "url")
-
-        testee.fireAutocompletePixel(suggestions, clickedSuggestion)
-
-        val argumentCaptor = argumentCaptor<Map<String, String>>()
-        Mockito.verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION), argumentCaptor.capture(), any(), any())
-
-        assertFalse(argumentCaptor.firstValue.containsKey(AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX))
-    }
-
-    @Test
-    fun `when search suggestion clicked with mixed suggestions then correct index is calculated`() = runTest {
-        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
-        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
-        whenever(mockHistory.hasHistory()).thenReturn(false)
-        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
-
-        val suggestions = listOf(
-            AutoCompleteBookmarkSuggestion("bookmark1", "title1", "url1"),
-            AutoCompleteSearchSuggestion("first", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteBookmarkSuggestion("bookmark2", "title2", "url2"),
-            AutoCompleteSearchSuggestion("second", isUrl = false, isAllowedInTopHits = false),
-            AutoCompleteSearchSuggestion("third", isUrl = false, isAllowedInTopHits = false),
-        )
-        val clickedSuggestion = suggestions[4] // third search suggestion (index 2 among search suggestions)
-
-        testee.fireAutocompletePixel(suggestions, clickedSuggestion)
-
-        val argumentCaptor = argumentCaptor<Map<String, String>>()
-        Mockito.verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION), argumentCaptor.capture(), any(), any())
-
-        assertEquals("2", argumentCaptor.firstValue[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX])
-    }
-
-    @Test
-    fun `when search website suggestion clicked with mixed suggestions then correct index is calculated`() = runTest {
-        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
-        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
-        whenever(mockHistory.hasHistory()).thenReturn(false)
-        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0))
-
-        val suggestions = listOf(
-            AutoCompleteBookmarkSuggestion("bookmark1", "title1", "url1"),
-            AutoCompleteSearchSuggestion("first", isUrl = true, isAllowedInTopHits = true), // isUrl = true for website suggestion
-            AutoCompleteBookmarkSuggestion("bookmark2", "title2", "url2"),
-            AutoCompleteSearchSuggestion("second", isUrl = true, isAllowedInTopHits = false), // isUrl = true for website suggestion
-            AutoCompleteSearchSuggestion("third", isUrl = false, isAllowedInTopHits = true),
-        )
-        val clickedSuggestion = suggestions[3] // second search suggestion (index 1 among search suggestions)
-
-        testee.fireAutocompletePixel(suggestions, clickedSuggestion)
-
-        val argumentCaptor = argumentCaptor<Map<String, String>>()
-        Mockito.verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION), argumentCaptor.capture(), any(), any())
-
-        assertEquals("1", argumentCaptor.firstValue[AutocompletePixelParams.PARAM_SEARCH_SUGGESTION_INDEX])
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1212373029583380?focus=true

### Description

We want to remove index parameter in the existing pixels  `m_autocomplete_click_phrase` and `m_autocomplete_click_website`

Revert commit 4fdeb945add2440bde3522c8f032096c613b7922 that introduce this specific parameter.

### Steps to test this PR

- [x] Open the app, focus on the omnibar and type in a query.
- [x] Verify that clicking on a search suggestion sends an `m_autocomplete_click_phrase` pixel without `search_suggestion_index` parameter.
- [x] Verify that clicking on a website search suggestion sends an `m_autocomplete_click_website` pixel without `search_suggestion_index` parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the search_suggestion_index parameter from autocomplete click phrase/website pixels and deletes related code/tests.
> 
> - **Analytics/Telemetry**:
>   - Remove `search_suggestion_index` from `fireAutocompletePixel` for `AUTOCOMPLETE_SEARCH_PHRASE_SELECTION` and `AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION`.
>   - Delete `AutocompletePixelParams` and all usages.
>   - Use immutable `mapOf` for pixel params.
> - **Tests**:
>   - Remove tests asserting `search_suggestion_index` presence and index calculations in autocomplete search suggestion clicks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33c00d84735710c79b49a9e61193c2e9a642744c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->