### PR TITLE
PIR: Add unit tests for JS event handlers

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -101,12 +101,12 @@ class BrokerActionFailedEventHandler @Inject constructor(
             return false
         }
 
-        if (state.runType == RunType.OPTOUT || state.runType == RunType.EMAIL_CONFIRMATION) {
+        return if (state.runType == RunType.OPTOUT || state.runType == RunType.EMAIL_CONFIRMATION) {
             // for optout, for ANY action we retry at most 3 times
-            return state.actionRetryCount < MAX_RETRY_COUNT_OPTOUT
+            state.actionRetryCount < MAX_RETRY_COUNT_OPTOUT
         } else {
             // For scans, we ONLY retry once if the action is expectation
-            return (currentAction is Expectation && state.actionRetryCount < MAX_RETRY_COUNT_SCAN)
+            (currentAction is Expectation && state.actionRetryCount < MAX_RETRY_COUNT_SCAN)
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/CaptchaInfoReceivedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/CaptchaInfoReceivedEventHandler.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.KClass
     scope = AppScope::class,
     boundType = EventHandler::class,
 )
-class CaptchaInforReceivedEventHandler @Inject constructor(
+class CaptchaInfoReceivedEventHandler @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val pirRunStateHandler: PirRunStateHandler,
 ) : EventHandler {

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_OPTOUT
+import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_SCAN
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus.Failure
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class BrokerActionFailedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: BrokerActionFailedEventHandler
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+    private val testCurrentTimeInMillis = 5000L
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+        )
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testClickAction = BrokerAction.Click(
+        id = "click-action-1",
+        elements = emptyList(),
+        selector = null,
+    )
+
+    private val testExpectationAction = BrokerAction.Expectation(
+        id = "expectation-action-1",
+        expectations = emptyList(),
+    )
+
+    private val testError = PirError.JsError.ActionError("Test error")
+
+    @Before
+    fun setUp() {
+        testee = BrokerActionFailedEventHandler(
+            mockPirRunStateHandler,
+            mockCurrentTimeProvider,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsBrokerActionFailedThenEventTypeIsCorrect() {
+        assertEquals(BrokerActionFailed::class, testee.event)
+    }
+
+    @Test
+    fun whenBrokerActionFailedWithAllowRetryFalseThenCompletesBrokerStepWithFailure() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testClickAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = false)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        val stepStatus = nextEvent.stepStatus as Failure
+        assertEquals(testError, stepStatus.error)
+        verify(mockPirRunStateHandler).handleState(any())
+    }
+
+    @Test
+    fun whenOptOutActionFailedWithRetryCountBelowMaxThenRetries() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testClickAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 1,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(2, result.nextState.actionRetryCount)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenOptOutActionFailedAtMaxRetryCountThenFailsBrokerStep() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testClickAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = MAX_RETRY_COUNT_OPTOUT,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        val stepStatus = nextEvent.stepStatus as Failure
+        assertEquals(testError, stepStatus.error)
+    }
+
+    @Test
+    fun whenScanExpectationActionFailedWithRetryCountBelowMaxThenRetries() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testExpectationAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(1, result.nextState.actionRetryCount)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
+    }
+
+    @Test
+    fun whenScanExpectationActionFailedAtMaxRetryCountThenFailsBrokerStep() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testExpectationAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = MAX_RETRY_COUNT_SCAN,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        val stepStatus = nextEvent.stepStatus as Failure
+        assertEquals(testError, stepStatus.error)
+    }
+
+    @Test
+    fun whenScanNonExpectationActionFailedThenFailsImmediately() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testClickAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        val stepStatus = nextEvent.stepStatus as Failure
+        assertEquals(testError, stepStatus.error)
+    }
+
+    @Test
+    fun whenEmailConfirmationActionFailedWithRetryCountBelowMaxThenRetries() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testClickAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 1,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(2, result.nextState.actionRetryCount)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
+    }
+
+    @Test
+    fun whenBrokerActionFailedThenEmitsPixel() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testClickAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = MAX_RETRY_COUNT_OPTOUT,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler).handleState(any())
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
@@ -1,0 +1,693 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageValidate
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordEmailConfirmationCompleted
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordEmailConfirmationNeeded
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordOptOutFailed
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordOptOutSubmitted
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerScanFailed
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerScanSuccess
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteNextBrokerStep
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.JobAttemptData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.LinkFetchData
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.store.PirRepository.GeneratedEmailData
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class BrokerStepCompletedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: BrokerStepCompletedEventHandler
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+    private val testCurrentTimeInMillis = 10000L
+    private val testBrokerStartTime = 5000L
+    private val testStageStartMs = 8000L
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+        )
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testAction1 = BrokerAction.Navigate(
+        id = "action-1",
+        url = "https://example.com",
+    )
+
+    private val testAction2 = BrokerAction.Click(
+        id = "action-2",
+        elements = emptyList(),
+        selector = null,
+    )
+
+    private val testAction3 = BrokerAction.FillForm(
+        id = "action-3",
+        elements = emptyList(),
+        selector = "form",
+    )
+
+    private val testEmailConfirmationJob =
+        EmailConfirmationJobRecord(
+            brokerName = testBrokerName,
+            userProfileId = testProfileQueryId,
+            extractedProfileId = 456L,
+            emailData = EmailData(
+                email = "john@example.com",
+                attemptId = "test-attempt-id",
+            ),
+            linkFetchData = LinkFetchData(
+                emailConfirmationLink = "https://example.com/confirm",
+                linkFetchAttemptCount = 0,
+                lastLinkFetchDateInMillis = 0L,
+            ),
+            jobAttemptData = JobAttemptData(
+                jobAttemptCount = 0,
+                lastJobAttemptDateInMillis = 0L,
+                lastJobAttemptActionId = "",
+            ),
+            dateCreatedInMillis = 10000000L,
+        )
+
+    private val testGeneratedEmailData = GeneratedEmailData(
+        emailAddress = "generated@example.com",
+        pattern = "pattern-123",
+    )
+
+    @Before
+    fun setUp() {
+        testee = BrokerStepCompletedEventHandler(
+            mockPirRunStateHandler,
+            mockCurrentTimeProvider,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsBrokerStepCompletedThenEventTypeIsCorrect() {
+        assertEquals(BrokerStepCompleted::class, testee.event)
+    }
+
+    @Test
+    fun whenNeedsEmailConfirmationTrueThenEmitsEmailConfirmationNeededState() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1, testAction2, testAction3),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            actionRetryCount = 1,
+            attemptId = "attempt-123",
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = true,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordEmailConfirmationNeeded>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals(testExtractedProfile, capturedState.firstValue.extractedProfile)
+        assertEquals("attempt-123", capturedState.firstValue.attemptId)
+        assertEquals("action-3", capturedState.firstValue.lastActionId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedState.firstValue.durationMs)
+        assertEquals(2, capturedState.firstValue.currentActionAttemptCount)
+    }
+
+    @Test
+    fun whenNeedsEmailConfirmationTrueThenIncrementsStepIndexAndReturnsNextEvent() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 3,
+            generatedEmailData = testGeneratedEmailData,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = true,
+            stepStatus = StepStatus.Success,
+        )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(1, result.nextState.currentBrokerStepIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertNull(result.nextState.generatedEmailData)
+        assertEquals(PirStage.VALIDATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        assertEquals(ExecuteNextBrokerStep, result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenManualScanSucceedsThenEmitsBrokerScanSuccessState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1, testAction2),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerScanSuccess>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals(testProfileQueryId, capturedState.firstValue.profileQueryId)
+        assertEquals(testCurrentTimeInMillis, capturedState.firstValue.eventTimeInMillis)
+        assertEquals(testCurrentTimeInMillis - testBrokerStartTime, capturedState.firstValue.totalTimeMillis)
+        assertEquals(testBrokerStartTime, capturedState.firstValue.startTimeInMillis)
+        assertEquals(true, capturedState.firstValue.isManualRun)
+        assertEquals(testAction2, capturedState.firstValue.lastAction)
+    }
+
+    @Test
+    fun whenScheduledScanSucceedsThenEmitsBrokerScanSuccessStateWithManualFalse() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1, testAction2, testAction3),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 3,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerScanSuccess>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(false, capturedState.firstValue.isManualRun)
+        assertEquals(testAction3, capturedState.firstValue.lastAction)
+    }
+
+    @Test
+    fun whenManualScanFailsThenEmitsBrokerScanFailedState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1, testAction2),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val testError = PirError.JsError.ActionError("Test error")
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Failure(error = testError),
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerScanFailed>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals(testProfileQueryId, capturedState.firstValue.profileQueryId)
+        assertEquals(testCurrentTimeInMillis, capturedState.firstValue.eventTimeInMillis)
+        assertEquals(testCurrentTimeInMillis - testBrokerStartTime, capturedState.firstValue.totalTimeMillis)
+        assertEquals(testBrokerStartTime, capturedState.firstValue.startTimeInMillis)
+        assertEquals(true, capturedState.firstValue.isManualRun)
+        assertEquals("validation-error", capturedState.firstValue.errorCategory)
+        assertEquals("Test error", capturedState.firstValue.errorDetails)
+        assertEquals(testAction2, capturedState.firstValue.failedAction)
+    }
+
+    @Test
+    fun whenScheduledScanFailsThenEmitsBrokerScanFailedStateWithManualFalse() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val testError = PirError.UnableToLoadBrokerUrl
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Failure(error = testError),
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerScanFailed>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(false, capturedState.firstValue.isManualRun)
+        assertEquals("network-error", capturedState.firstValue.errorCategory)
+        assertEquals("Unable to load broker url", capturedState.firstValue.errorDetails)
+        assertEquals(testAction1, capturedState.firstValue.failedAction)
+    }
+
+    @Test
+    fun whenOptOutSucceedsThenEmitsTwoStates() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1, testAction2),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            actionRetryCount = 0,
+            attemptId = "attempt-456",
+            brokerStepStartTime = testBrokerStartTime,
+            generatedEmailData = testGeneratedEmailData,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler, times(2)).handleState(any())
+
+        val capturedValidateState = argumentCaptor<BrokerOptOutStageValidate>()
+        val capturedSubmittedState = argumentCaptor<BrokerRecordOptOutSubmitted>()
+        verify(mockPirRunStateHandler).handleState(capturedValidateState.capture())
+        verify(mockPirRunStateHandler).handleState(capturedSubmittedState.capture())
+
+        // Validate state
+        assertEquals(testBroker, capturedValidateState.firstValue.broker)
+        assertEquals("action-2", capturedValidateState.firstValue.actionID)
+        assertEquals("attempt-456", capturedValidateState.firstValue.attemptId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedValidateState.firstValue.durationMs)
+        assertEquals(1, capturedValidateState.firstValue.currentActionAttemptCount)
+
+        // Submitted state
+        assertEquals(testBroker, capturedSubmittedState.firstValue.broker)
+        assertEquals(testExtractedProfile, capturedSubmittedState.firstValue.extractedProfile)
+        assertEquals("attempt-456", capturedSubmittedState.firstValue.attemptId)
+        assertEquals(testBrokerStartTime, capturedSubmittedState.firstValue.startTimeInMillis)
+        assertEquals(testCurrentTimeInMillis, capturedSubmittedState.firstValue.endTimeInMillis)
+        assertEquals("pattern-123", capturedSubmittedState.firstValue.emailPattern)
+    }
+
+    @Test
+    fun whenOptOutSucceedsWithoutEmailDataThenEmailPatternIsNull() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            attemptId = "attempt-789",
+            brokerStepStartTime = testBrokerStartTime,
+            generatedEmailData = null,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedSubmittedState = argumentCaptor<BrokerRecordOptOutSubmitted>()
+        verify(mockPirRunStateHandler).handleState(capturedSubmittedState.capture())
+        assertNull(capturedSubmittedState.firstValue.emailPattern)
+    }
+
+    @Test
+    fun whenOptOutFailsThenEmitsOptOutFailedState() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1, testAction2, testAction3),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            attemptId = "attempt-999",
+            brokerStepStartTime = testBrokerStartTime,
+            generatedEmailData = testGeneratedEmailData,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SOLVE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val testError = PirError.JsError.ActionError("Captcha failed")
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Failure(error = testError),
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordOptOutFailed>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals(testExtractedProfile, capturedState.firstValue.extractedProfile)
+        assertEquals(testBrokerStartTime, capturedState.firstValue.startTimeInMillis)
+        assertEquals(testCurrentTimeInMillis, capturedState.firstValue.endTimeInMillis)
+        assertEquals("attempt-999", capturedState.firstValue.attemptId)
+        assertEquals(testAction2, capturedState.firstValue.failedAction)
+        assertEquals(PirStage.CAPTCHA_SOLVE, capturedState.firstValue.stage)
+        assertEquals("pattern-123", capturedState.firstValue.emailPattern)
+    }
+
+    @Test
+    fun whenEmailConfirmationSucceedsThenEmitsCompletedState() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1, testAction2),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordEmailConfirmationCompleted>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals(true, capturedState.firstValue.isSuccess)
+        assertEquals("action-2", capturedState.firstValue.lastActionId)
+        assertEquals(testCurrentTimeInMillis - testBrokerStartTime, capturedState.firstValue.totalTimeMillis)
+        assertEquals(456L, capturedState.firstValue.extractedProfileId)
+    }
+
+    @Test
+    fun whenEmailConfirmationFailsThenEmitsCompletedStateWithFailure() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val testError = PirError.JsError.ActionError("Email confirmation error")
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Failure(error = testError),
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordEmailConfirmationCompleted>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(false, capturedState.firstValue.isSuccess)
+        assertEquals("action-1", capturedState.firstValue.lastActionId)
+    }
+
+    @Test
+    fun whenBrokerStepCompletedThenStateIsUpdatedCorrectly() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            actionRetryCount = 5,
+            generatedEmailData = testGeneratedEmailData,
+            transactionID = "txn-123",
+            brokerStepStartTime = testBrokerStartTime,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(1, result.nextState.currentBrokerStepIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertNull(result.nextState.generatedEmailData)
+        assertEquals(PirStage.VALIDATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        assertEquals("txn-123", result.nextState.transactionID)
+        assertEquals(testBrokerStartTime, result.nextState.brokerStepStartTime)
+    }
+
+    @Test
+    fun whenBrokerStepCompletedThenReturnsExecuteNextBrokerStepEvent() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction1),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = false,
+            stepStatus = StepStatus.Success,
+        )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(ExecuteNextBrokerStep, result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/CaptchaInfoReceivedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/CaptchaInfoReceivedEventHandlerTest.kt
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageCaptchaSent
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.CaptchaInfoReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class CaptchaInfoReceivedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: CaptchaInfoReceivedEventHandler
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+    private val testCurrentTimeInMillis = 5000L
+    private val testStageStartMs = 2000L
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+        )
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testAction = BrokerAction.GetCaptchaInfo(
+        id = "captcha-action-1",
+        selector = "captcha-selector",
+    )
+
+    @Before
+    fun setUp() {
+        testee = CaptchaInfoReceivedEventHandler(
+            mockCurrentTimeProvider,
+            mockPirRunStateHandler,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsCaptchaInfoReceivedThenEventTypeIsCorrect() {
+        assertEquals(CaptchaInfoReceived::class, testee.event)
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedWithOptOutStepThenEmitsPixel() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 2,
+            attemptId = "attempt-123",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "transaction-456")
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerOptOutStageCaptchaSent>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals("captcha-action-1", capturedState.firstValue.actionID)
+        assertEquals("attempt-123", capturedState.firstValue.attemptId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedState.firstValue.durationMs)
+        assertEquals(3, capturedState.firstValue.currentActionAttemptCount)
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedWithScanStepThenDoesNotEmitPixel() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "transaction-456")
+
+        testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler, never()).handleState(any())
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedThenUpdatesStateWithTransactionId() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentActionIndex = 2,
+            transactionID = "",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = 0,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "new-transaction-789")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals("new-transaction-789", result.nextState.transactionID)
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedThenIncrementsActionIndexAndResetsRetryCount() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentActionIndex = 1,
+            actionRetryCount = 3,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = 0,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "transaction-456")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(2, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedThenReturnsExecuteBrokerStepActionEvent() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = 0,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "transaction-456")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(
+            ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery)),
+            result.nextEvent,
+        )
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenCaptchaInfoReceivedThenPreservesOtherStateFields() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            brokerStepStartTime = 10000L,
+            pendingUrl = "https://example.com",
+            attemptId = "attempt-xyz",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = 5000L,
+            ),
+        )
+        val event = CaptchaInfoReceived(transactionID = "transaction-456")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RunType.SCHEDULED, result.nextState.runType)
+        assertEquals(0, result.nextState.currentBrokerStepIndex)
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(10000L, result.nextState.brokerStepStartTime)
+        assertEquals("https://example.com", result.nextState.pendingUrl)
+        assertEquals("attempt-xyz", result.nextState.attemptId)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageGenerateEmailReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import com.duckduckgo.pir.impl.store.PirRepository.GeneratedEmailData
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class EmailReceivedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: EmailReceivedEventHandler
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+    private val testCurrentTimeInMillis = 5000L
+    private val testStageStartMs = 2000L
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+        )
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testAction = BrokerAction.FillForm(
+        id = "fillform-action-1",
+        elements = emptyList(),
+        selector = "form",
+    )
+
+    private val testGeneratedEmailData = GeneratedEmailData(
+        emailAddress = "generated@example.com",
+        pattern = "pattern-123",
+    )
+
+    @Before
+    fun setUp() {
+        testee = EmailReceivedEventHandler(
+            mockPirRunStateHandler,
+            mockCurrentTimeProvider,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsEmailReceivedThenEventTypeIsCorrect() {
+        assertEquals(EmailReceived::class, testee.event)
+    }
+
+    @Test
+    fun whenEmailReceivedThenUpdatesProfileWithEmailAddress() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        val updatedOptOutStep = result.nextState.brokerStepsToExecute[0] as OptOutStep
+        assertEquals("generated@example.com", updatedOptOutStep.profileToOptOut.email)
+    }
+
+    @Test
+    fun whenEmailReceivedThenUpdatesGeneratedEmailDataInState() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            generatedEmailData = null,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(testGeneratedEmailData, result.nextState.generatedEmailData)
+    }
+
+    @Test
+    fun whenEmailReceivedThenReturnsExecuteBrokerStepActionWithExtractedProfile() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertEquals(testProfileQuery, userProfile.userProfile)
+        assertEquals("generated@example.com", userProfile.extractedProfile?.email)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenEmailReceivedWithOptOutStepThenEmitsPixel() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 1,
+            attemptId = "attempt-456",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerOptOutStageGenerateEmailReceived>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals(testBroker, capturedState.firstValue.broker)
+        assertEquals("fillform-action-1", capturedState.firstValue.actionID)
+        assertEquals("attempt-456", capturedState.firstValue.attemptId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedState.firstValue.durationMs)
+        assertEquals(2, capturedState.firstValue.currentActionAttemptCount) // actionRetryCount + 1
+    }
+
+    @Test
+    fun whenEmailReceivedThenPreservesOtherStateFields() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            brokerStepStartTime = 10000L,
+            transactionID = "transaction-789",
+            pendingUrl = "https://example.com",
+            actionRetryCount = 1,
+            attemptId = "attempt-xyz",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RunType.OPTOUT, result.nextState.runType)
+        assertEquals(0, result.nextState.currentBrokerStepIndex)
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(10000L, result.nextState.brokerStepStartTime)
+        assertEquals("transaction-789", result.nextState.transactionID)
+        assertEquals("https://example.com", result.nextState.pendingUrl)
+        assertEquals(1, result.nextState.actionRetryCount)
+        assertEquals("attempt-xyz", result.nextState.attemptId)
+    }
+
+    @Test
+    fun whenEmailReceivedWithMultipleBrokerStepsThenOnlyUpdatesCurrentStep() = runTest {
+        val optOutStep1 = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val optOutStep2 = OptOutStep(
+            broker = testBroker.copy(name = "broker-2"),
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = "old@example.com"),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep1, optOutStep2),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        val updatedOptOutStep1 = result.nextState.brokerStepsToExecute[0] as OptOutStep
+        val unchangedOptOutStep2 = result.nextState.brokerStepsToExecute[1] as OptOutStep
+        assertEquals("generated@example.com", updatedOptOutStep1.profileToOptOut.email)
+        assertEquals("old@example.com", unchangedOptOutStep2.profileToOptOut.email)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandlerTest.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ErrorReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ErrorReceivedHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: ErrorReceivedHandler
+
+    private val testBroker = Broker(
+        name = "test-broker",
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testAction = BrokerAction.Navigate(
+        id = "action-1",
+        url = "https://example.com",
+    )
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    @Before
+    fun setUp() {
+        testee = ErrorReceivedHandler()
+    }
+
+    @Test
+    fun whenEventIsErrorReceivedThenEventTypeIsCorrect() {
+        assertEquals(ErrorReceived::class, testee.event)
+    }
+
+    @Test
+    fun whenErrorReceivedWithJsErrorThenReturnsBrokerActionFailedWithNoRetry() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val testError = PirError.JsError.ActionError("Test JS error")
+        val event = ErrorReceived(error = testError)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerActionFailed
+        assertEquals(testError, nextEvent.error)
+        assertFalse(nextEvent.allowRetry)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenErrorReceivedWithCaptchaServiceErrorThenReturnsBrokerActionFailedWithNoRetry() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 1,
+            actionRetryCount = 2,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SEND,
+                stageStartMs = 1000L,
+            ),
+        )
+        val testError = PirError.CaptchaServiceError(
+            errorCode = 500,
+            errorDetails = "Service unavailable",
+        )
+        val event = ErrorReceived(error = testError)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerActionFailed
+        assertEquals(testError, nextEvent.error)
+        assertFalse(nextEvent.allowRetry)
+    }
+
+    @Test
+    fun whenErrorReceivedWithEmailErrorThenReturnsBrokerActionFailedWithNoRetry() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = 2000L,
+            ),
+        )
+        val testError = PirError.EmailError(
+            errorCode = 404,
+            error = "Email service error",
+        )
+        val event = ErrorReceived(error = testError)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerActionFailed
+        assertEquals(testError, nextEvent.error)
+        assertFalse(nextEvent.allowRetry)
+    }
+
+    @Test
+    fun whenErrorReceivedWithUnknownErrorThenReturnsBrokerActionFailedWithNoRetry() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val testError = PirError.Unknown("Unknown error occurred")
+        val event = ErrorReceived(error = testError)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerActionFailed
+        assertEquals(testError, nextEvent.error)
+        assertFalse(nextEvent.allowRetry)
+    }
+
+    @Test
+    fun whenErrorReceivedThenStateRemainsCompletelyUnchanged() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 2,
+            currentActionIndex = 5,
+            actionRetryCount = 3,
+            brokerStepStartTime = 5000L,
+            transactionID = "txn-123",
+            attemptId = "attempt-456",
+            pendingUrl = "https://example.com",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = 7000L,
+            ),
+        )
+        val testError = PirError.JsError.ActionError("Error")
+        val event = ErrorReceived(error = testError)
+
+        val result = testee.invoke(state, event)
+
+        // Verify state is completely unchanged
+        assertEquals(state, result.nextState)
+        assertEquals(2, result.nextState.currentBrokerStepIndex)
+        assertEquals(5, result.nextState.currentActionIndex)
+        assertEquals(3, result.nextState.actionRetryCount)
+        assertEquals(5000L, result.nextState.brokerStepStartTime)
+        assertEquals("txn-123", result.nextState.transactionID)
+        assertEquals("attempt-456", result.nextState.attemptId)
+        assertEquals("https://example.com", result.nextState.pendingUrl)
+        assertEquals(PirStage.FILL_FORM, result.nextState.stageStatus.currentStage)
+        assertEquals(7000L, result.nextState.stageStatus.stageStartMs)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageCaptchaSolved
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageSubmit
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerScanActionStarted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.GetEmailForProfile
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.LoadUrl
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.PushJsAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.JobAttemptData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.LinkFetchData
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.DataSource
+import com.duckduckgo.pir.impl.scripts.models.ElementSelector
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ExecuteBrokerStepActionEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: ExecuteBrokerStepActionEventHandler
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+
+    private val testCurrentTimeInMillis = 10000L
+    private val testStageStartMs = 8000L
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+            email = "john@example.com",
+        )
+
+    private val testEmailConfirmationJob =
+        EmailConfirmationJobRecord(
+            brokerName = testBrokerName,
+            userProfileId = testProfileQueryId,
+            extractedProfileId = 456L,
+            emailData = EmailData(
+                email = "john@example.com",
+                attemptId = "test-attempt-id",
+            ),
+            linkFetchData = LinkFetchData(
+                emailConfirmationLink = "https://example.com/confirm",
+                linkFetchAttemptCount = 0,
+                lastLinkFetchDateInMillis = 0L,
+            ),
+            jobAttemptData = JobAttemptData(
+                jobAttemptCount = 0,
+                lastJobAttemptDateInMillis = 0L,
+                lastJobAttemptActionId = "",
+            ),
+            dateCreatedInMillis = 10000000L,
+        )
+
+    @Before
+    fun setUp() {
+        testee = ExecuteBrokerStepActionEventHandler(
+            mockPirRunStateHandler,
+            mockCurrentTimeProvider,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsExecuteBrokerStepActionThenEventTypeIsCorrect() {
+        assertEquals(ExecuteBrokerStepAction::class, testee.event)
+    }
+
+    @Test
+    fun whenAllActionsCompletedThenReturnsBrokerStepCompletedSuccess() = runTest {
+        val action1 = BrokerAction.Navigate(id = "action-1", url = "https://example.com")
+        val action2 = BrokerAction.Click(id = "action-2", elements = emptyList(), selector = null)
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action1, action2),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        assertTrue(nextEvent.stepStatus is StepStatus.Success)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenOptOutActionNeedsEmailAndNoEmailThenRequestsEmailGeneration() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-1",
+            elements = listOf(
+                ElementSelector(
+                    type = "email",
+                    selector = "input[name='email']",
+                    parent = null,
+                    multiple = null,
+                    min = null,
+                    max = null,
+                    failSilently = null,
+                ),
+            ),
+            selector = "form",
+        )
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_GENERATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as GetEmailForProfile
+        assertEquals("action-1", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals(testExtractedProfile.copy(email = ""), sideEffect.extractedProfile)
+        assertEquals(testProfileQuery, sideEffect.profileQuery)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenEmailConfirmationActionNeedsEmailAndNoEmailThenRequestsEmailGeneration() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-1",
+            elements = listOf(
+                ElementSelector(
+                    type = "email",
+                    selector = "input[name='email']",
+                    parent = null,
+                    multiple = null,
+                    min = null,
+                    max = null,
+                    failSilently = null,
+                ),
+            ),
+            selector = "form",
+        )
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_GENERATE, result.nextState.stageStatus.currentStage)
+        assertTrue(result.sideEffect is GetEmailForProfile)
+    }
+
+    @Test
+    fun whenOptOutEmailConfirmationActionThenEmitsPixelAndCompletes() = runTest {
+        val action = BrokerAction.EmailConfirmation(id = "action-confirm", pollingTime = "5000")
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 1,
+            attemptId = "attempt-123",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        // Verify pixel emission
+        val capturedPixel = argumentCaptor<BrokerOptOutStageSubmit>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals("action-confirm", capturedPixel.firstValue.actionID)
+        assertEquals("attempt-123", capturedPixel.firstValue.attemptId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedPixel.firstValue.durationMs)
+        assertEquals(2, capturedPixel.firstValue.currentActionAttemptCount)
+
+        // Verify state and event
+        assertEquals(PirStage.EMAIL_CONFIRM_HALTED, result.nextState.stageStatus.currentStage)
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(true, nextEvent.needsEmailConfirmation)
+        assertTrue(nextEvent.stepStatus is StepStatus.Success)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenEmailConfirmationStepWithValidLinkThenLoadsConfirmationUrl() = runTest {
+        val action = BrokerAction.EmailConfirmation(id = "action-confirm", pollingTime = "5000")
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals("https://example.com/confirm", result.nextState.pendingUrl)
+        val sideEffect = result.sideEffect as LoadUrl
+        assertEquals("https://example.com/confirm", sideEffect.url)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenEmailConfirmationStepWithEmptyLinkThenFailsStep() = runTest {
+        val action = BrokerAction.EmailConfirmation(id = "action-confirm", pollingTime = "5000")
+        val jobWithEmptyLink = testEmailConfirmationJob.copy(
+            linkFetchData = LinkFetchData(
+                emailConfirmationLink = "",
+                linkFetchAttemptCount = 0,
+                lastLinkFetchDateInMillis = 0L,
+            ),
+        )
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = jobWithEmptyLink,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(true, nextEvent.needsEmailConfirmation)
+        assertTrue(nextEvent.stepStatus is StepStatus.Failure)
+        val failure = nextEvent.stepStatus as StepStatus.Failure
+        assertTrue(failure.error is PirError.Unknown)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenSolveCaptchaActionWithoutSolutionThenRequestsCaptchaSolution() = runTest {
+        val action = BrokerAction.SolveCaptcha(id = "action-captcha", selector = "captcha-input")
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            transactionID = "txn-123",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.CAPTCHA_SOLVE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as AwaitCaptchaSolution
+        assertEquals("action-captcha", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals("txn-123", sideEffect.transactionID)
+        assertEquals(0, sideEffect.attempt)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenSolveCaptchaActionWithSolutionThenPushesToJs() = runTest {
+        val action = BrokerAction.SolveCaptcha(id = "action-captcha", selector = "captcha-input")
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            attemptId = "attempt-456",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.CAPTCHA_SOLVE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val solveCaptchaData = PirScriptRequestData.SolveCaptcha(
+            token = "captcha-token",
+        )
+        val event = ExecuteBrokerStepAction(solveCaptchaData)
+
+        val result = testee.invoke(state, event)
+
+        // Verify pixel emission
+        val capturedPixel = argumentCaptor<BrokerOptOutStageCaptchaSolved>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals("action-captcha", capturedPixel.firstValue.actionID)
+        assertEquals("attempt-456", capturedPixel.firstValue.attemptId)
+        assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedPixel.firstValue.durationMs)
+        assertEquals(1, capturedPixel.firstValue.currentActionAttemptCount)
+
+        // Verify PushJsAction
+        val sideEffect = result.sideEffect as PushJsAction
+        assertEquals("action-captcha", sideEffect.actionId)
+        assertEquals(action, sideEffect.action)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenScanStepNavigateActionThenEmitsPixelAndPushesToJs() = runTest {
+        val action = BrokerAction.Navigate(id = "action-nav", url = "https://example.com")
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 2,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        // Verify pixel emission
+        val capturedPixel = argumentCaptor<BrokerScanActionStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals(testProfileQueryId, capturedPixel.firstValue.profileQueryId)
+        assertEquals(3, capturedPixel.firstValue.currentActionAttemptCount)
+        assertEquals(action, capturedPixel.firstValue.currentAction)
+
+        // Verify PushJsAction
+        val sideEffect = result.sideEffect as PushJsAction
+        assertEquals("action-nav", sideEffect.actionId)
+        assertEquals(action, sideEffect.action)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenClickActionThen10SecondDelay() = runTest {
+        val action = BrokerAction.Click(id = "action-click", elements = emptyList(), selector = null)
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        assertEquals(10_000L, sideEffect.pushDelay)
+        assertEquals(PirStage.FILL_FORM, result.nextState.stageStatus.currentStage)
+    }
+
+    @Test
+    fun whenExpectationActionThen10SecondDelay() = runTest {
+        val action = BrokerAction.Expectation(id = "action-expect", expectations = emptyList())
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        assertEquals(10_000L, sideEffect.pushDelay)
+        assertEquals(PirStage.SUBMIT, result.nextState.stageStatus.currentStage)
+    }
+
+    @Test
+    fun whenOptOutFillFormActionThen5SecondDelay() = runTest {
+        val action = BrokerAction.FillForm(id = "action-fill", elements = emptyList(), selector = "form")
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        assertEquals(5_000L, sideEffect.pushDelay)
+        assertEquals(PirStage.FILL_FORM, result.nextState.stageStatus.currentStage)
+    }
+
+    @Test
+    fun whenGetCaptchaInfoActionThenStageIsCaptchaParse() = runTest {
+        val action = BrokerAction.GetCaptchaInfo(id = "action-captcha", selector = "captcha")
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.CAPTCHA_PARSE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+    }
+
+    @Test
+    fun whenOptOutActionNeedsExtractedProfileThenIncludesIt() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-fill",
+            elements = emptyList(),
+            selector = "form",
+            dataSource = DataSource.EXTRACTED_PROFILE,
+        )
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val userData = sideEffect.requestParamsData as UserProfile
+        assertEquals(testProfileQuery, userData.userProfile)
+        assertEquals("John Doe", userData.extractedProfile?.name)
+        assertEquals("john@example.com", userData.extractedProfile?.email)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteNextBrokerStepEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteNextBrokerStepEventHandlerTest.kt
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordEmailConfirmationStarted
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerRecordOptOutStarted
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerScanStarted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteNextBrokerStep
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.CompleteExecution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.JobAttemptData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.LinkFetchData
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ExecuteNextBrokerStepEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: ExecuteNextBrokerStepEventHandler
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+    private val mockPirRunStateHandler: PirRunStateHandler = mock()
+
+    private val testCurrentTimeInMillis = 10000L
+    private val testProfileQueryId = 123L
+    private val testBrokerName = "test-broker"
+
+    private val testBroker = Broker(
+        name = testBrokerName,
+        fileName = "test-broker.json",
+        url = "https://test-broker.com",
+        version = "1.0",
+        parent = null,
+        addedDatetime = 124354,
+        removedAt = 0L,
+    )
+
+    private val testAction = BrokerAction.Navigate(
+        id = "action-1",
+        url = "https://example.com",
+    )
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = testProfileQueryId,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = testProfileQueryId,
+            brokerName = testBrokerName,
+            name = "John Doe",
+        )
+
+    private val testEmailConfirmationJob =
+        EmailConfirmationJobRecord(
+            brokerName = testBrokerName,
+            userProfileId = testProfileQueryId,
+            extractedProfileId = 456L,
+            emailData = EmailData(
+                email = "john@example.com",
+                attemptId = "test-attempt-id",
+            ),
+            linkFetchData = LinkFetchData(
+                emailConfirmationLink = "https://example.com/confirm",
+                linkFetchAttemptCount = 0,
+                lastLinkFetchDateInMillis = 0L,
+            ),
+            jobAttemptData = JobAttemptData(
+                jobAttemptCount = 0,
+                lastJobAttemptDateInMillis = 0L,
+                lastJobAttemptActionId = "",
+            ),
+            dateCreatedInMillis = 10000000L,
+        )
+
+    @Before
+    fun setUp() {
+        testee = ExecuteNextBrokerStepEventHandler(
+            mockCurrentTimeProvider,
+            mockPirRunStateHandler,
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTimeInMillis)
+    }
+
+    @Test
+    fun whenEventIsExecuteNextBrokerStepThenEventTypeIsCorrect() {
+        assertEquals(ExecuteNextBrokerStep::class, testee.event)
+    }
+
+    @Test
+    fun whenAllBrokersExecutedThenReturnsCompleteExecutionSideEffect() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 1, // Beyond the list
+            currentActionIndex = 5,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertEquals(CompleteExecution, result.sideEffect)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenCurrentBrokerStepIndexEqualsListSizeThenCompletes() = runTest {
+        val scanStep1 = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val scanStep2 = ScanStep(
+            broker = testBroker.copy(name = "broker-2"),
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep1, scanStep2),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 2, // Equals size
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(CompleteExecution, result.sideEffect)
+    }
+
+    @Test
+    fun whenManualScanBrokerThenEmitsBrokerScanStartedPixelAndResetsState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 5,
+            actionRetryCount = 3,
+            brokerStepStartTime = 1000L,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.VALIDATE,
+                stageStartMs = 2000L,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        // Verify pixel emission
+        val capturedPixel = argumentCaptor<BrokerScanStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals(testCurrentTimeInMillis, capturedPixel.firstValue.eventTimeInMillis)
+
+        // Verify state updates
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(testCurrentTimeInMillis, result.nextState.brokerStepStartTime)
+        assertEquals(PirStage.START, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+
+        // Verify next event
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as UserProfile).userProfile)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenScheduledScanBrokerThenEmitsBrokerScanStartedPixel() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        testee.invoke(state, event)
+
+        val capturedPixel = argumentCaptor<BrokerScanStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals(testCurrentTimeInMillis, capturedPixel.firstValue.eventTimeInMillis)
+    }
+
+    @Test
+    fun whenOptOutBrokerThenEmitsBrokerRecordOptOutStartedPixel() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            attemptId = "attempt-789",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        val capturedPixel = argumentCaptor<BrokerRecordOptOutStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals(testExtractedProfile, capturedPixel.firstValue.extractedProfile)
+        assertEquals("attempt-789", capturedPixel.firstValue.attemptId)
+
+        // Verify state updates
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(PirStage.START, result.nextState.stageStatus.currentStage)
+    }
+
+    @Test
+    fun whenEmailConfirmationBrokerThenEmitsEmailConfirmationStartedPixel() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        val capturedPixel = argumentCaptor<BrokerRecordEmailConfirmationStarted>()
+        verify(mockPirRunStateHandler).handleState(capturedPixel.capture())
+        assertEquals(testBroker, capturedPixel.firstValue.broker)
+        assertEquals(456L, capturedPixel.firstValue.extractedProfileId)
+        assertEquals("action-1", capturedPixel.firstValue.firstActionId)
+
+        // Verify stage is EMAIL_CONFIRM_DECOUPLED for email confirmation
+        assertEquals(PirStage.EMAIL_CONFIRM_DECOUPLED, result.nextState.stageStatus.currentStage)
+    }
+
+    @Test
+    fun whenExecuteNextBrokerStepThenResetsActionIndexAndRetryCount() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 10,
+            actionRetryCount = 5,
+            brokerStepStartTime = 5000L,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.VALIDATE,
+                stageStartMs = 7000L,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(testCurrentTimeInMillis, result.nextState.brokerStepStartTime)
+    }
+
+    @Test
+    fun whenExecuteNextBrokerStepThenPreservesOtherStateFields() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.SCHEDULED,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            transactionID = "txn-123",
+            attemptId = "attempt-456",
+            pendingUrl = "https://example.com",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RunType.SCHEDULED, result.nextState.runType)
+        assertEquals(testProfileQuery, result.nextState.profileQuery)
+        assertEquals("txn-123", result.nextState.transactionID)
+        assertEquals("attempt-456", result.nextState.attemptId)
+        assertEquals("https://example.com", result.nextState.pendingUrl)
+    }
+
+    @Test
+    fun whenExecuteNextBrokerStepThenReturnsExecuteBrokerStepActionEvent() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteNextBrokerStep
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val requestData = nextEvent.actionRequestData as UserProfile
+        assertEquals(testProfileQuery, requestData.userProfile)
+        assertNull(requestData.extractedProfile)
+        assertNull(result.sideEffect)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/LoadUrlCompleteEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/LoadUrlCompleteEventHandlerTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirJobConstants.DBP_INITIAL_URL
+import com.duckduckgo.pir.impl.common.PirJobConstants.RECOVERY_URL
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus.Failure
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteNextBrokerStep
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.LoadUrlComplete
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class LoadUrlCompleteEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: LoadUrlCompleteEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    @Before
+    fun setUp() {
+        testee = LoadUrlCompleteEventHandler()
+    }
+
+    @Test
+    fun whenEventIsLoadUrlCompleteThenEventTypeIsCorrect() {
+        assertEquals(LoadUrlComplete::class, testee.event)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteAndPendingUrlIsNullThenReturnsStateUnchanged() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = null,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = "https://example.com")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertNull(result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithInitialUrlThenStartsBrokerStepExecution() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = DBP_INITIAL_URL,
+                currentBrokerStepIndex = 5,
+                currentActionIndex = 3,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = DBP_INITIAL_URL)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentBrokerStepIndex)
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(ExecuteNextBrokerStep, result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithRecoveryUrlThenCompletesBrokerStepWithFailure() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = RECOVERY_URL,
+                currentBrokerStepIndex = 2,
+                currentActionIndex = 4,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = RECOVERY_URL)
+
+        val result = testee.invoke(state, event)
+
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(2, result.nextState.currentBrokerStepIndex)
+        assertEquals(4, result.nextState.currentActionIndex)
+        assertEquals(
+            BrokerStepCompleted(
+                needsEmailConfirmation = false,
+                stepStatus = Failure(error = PirError.UnableToLoadBrokerUrl),
+            ),
+            result.nextEvent,
+        )
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithNormalUrlThenProceedsToNextAction() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = "https://broker.com/page",
+                currentBrokerStepIndex = 1,
+                currentActionIndex = 2,
+                actionRetryCount = 1,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.FILL_FORM,
+                    stageStartMs = 1000L,
+                ),
+            )
+        val event = LoadUrlComplete(url = "https://broker.com/page")
+
+        val result = testee.invoke(state, event)
+
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(1, result.nextState.currentBrokerStepIndex)
+        assertEquals(3, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(
+            ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery)),
+            result.nextEvent,
+        )
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithRedirectedUrlThenStillProceedsToNextAction() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = "https://broker.com/original",
+                currentBrokerStepIndex = 0,
+                currentActionIndex = 1,
+                actionRetryCount = 2,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = "https://broker.com/redirected")
+
+        val result = testee.invoke(state, event)
+
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(0, result.nextState.currentBrokerStepIndex)
+        assertEquals(2, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(
+            ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery)),
+            result.nextEvent,
+        )
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithInitialUrlAndNonZeroIndicesThenResetsToZero() = runTest {
+        val state =
+            State(
+                runType = RunType.SCHEDULED,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = DBP_INITIAL_URL,
+                currentBrokerStepIndex = 10,
+                currentActionIndex = 5,
+                actionRetryCount = 3,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = DBP_INITIAL_URL)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentBrokerStepIndex)
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(3, result.nextState.actionRetryCount)
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(ExecuteNextBrokerStep, result.nextEvent)
+    }
+
+    @Test
+    fun whenLoadUrlCompleteWithNormalUrlThenResetsActionRetryCount() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = "https://example.com",
+                currentActionIndex = 0,
+                actionRetryCount = 5,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlComplete(url = "https://example.com")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.actionRetryCount)
+        assertEquals(1, result.nextState.currentActionIndex)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/LoadUrlFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/LoadUrlFailedEventHandlerTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirJobConstants.RECOVERY_URL
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus.Failure
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.LoadUrlFailed
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.LoadUrl
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.PirError
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class LoadUrlFailedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: LoadUrlFailedEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    @Before
+    fun setUp() {
+        testee = LoadUrlFailedEventHandler()
+    }
+
+    @Test
+    fun whenEventIsLoadUrlFailedThenEventTypeIsCorrect() {
+        assertEquals(LoadUrlFailed::class, testee.event)
+    }
+
+    @Test
+    fun whenLoadUrlFailedAndPendingUrlIsNullThenReturnsStateUnchanged() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = null,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlFailed(url = "https://example.com")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertNull(result.nextEvent)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlFailedAndUrlIsRecoveryUrlThenCompletesBrokerStepWithFailure() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = RECOVERY_URL,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlFailed(url = RECOVERY_URL)
+
+        val result = testee.invoke(state, event)
+
+        assertNull(result.nextState.pendingUrl)
+        assertEquals(
+            BrokerStepCompleted(
+                needsEmailConfirmation = false,
+                stepStatus = Failure(error = PirError.UnableToLoadBrokerUrl),
+            ),
+            result.nextEvent,
+        )
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenLoadUrlFailedAndUrlIsNotRecoveryUrlThenTriesRecovery() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = "https://broker.com",
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlFailed(url = "https://broker.com")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RECOVERY_URL, result.nextState.pendingUrl)
+        assertEquals(LoadUrl(RECOVERY_URL), result.sideEffect)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenLoadUrlFailedOnNormalUrlThenAttemptsRecoveryByLoadingRecoveryUrl() = runTest {
+        val failedUrl = "https://example.com/page"
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = failedUrl,
+                currentBrokerStepIndex = 2,
+                currentActionIndex = 5,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.FILL_FORM,
+                    stageStartMs = 1000L,
+                ),
+            )
+        val event = LoadUrlFailed(url = failedUrl)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RECOVERY_URL, result.nextState.pendingUrl)
+        assertEquals(LoadUrl(RECOVERY_URL), result.sideEffect)
+        assertNull(result.nextEvent)
+        assertEquals(2, result.nextState.currentBrokerStepIndex)
+        assertEquals(5, result.nextState.currentActionIndex)
+    }
+
+    @Test
+    fun whenLoadUrlFailedOnRecoveryUrlThenClearsPendingUrlAndFailsBrokerStep() = runTest {
+        val state =
+            State(
+                runType = RunType.SCHEDULED,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = RECOVERY_URL,
+                currentBrokerStepIndex = 1,
+                currentActionIndex = 3,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.START,
+                    stageStartMs = 2000L,
+                ),
+            )
+        val event = LoadUrlFailed(url = RECOVERY_URL)
+
+        val result = testee.invoke(state, event)
+
+        assertNull(result.nextState.pendingUrl)
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        val stepStatus = nextEvent.stepStatus as Failure
+        assertEquals(PirError.UnableToLoadBrokerUrl, stepStatus.error)
+        assertNull(result.sideEffect)
+        assertEquals(1, result.nextState.currentBrokerStepIndex)
+        assertEquals(3, result.nextState.currentActionIndex)
+    }
+
+    @Test
+    fun whenLoadUrlFailedWithDifferentUrlButHasPendingUrlThenTriesRecovery() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                pendingUrl = "https://original.com",
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = LoadUrlFailed(url = "https://redirected.com")
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RECOVERY_URL, result.nextState.pendingUrl)
+        assertEquals(LoadUrl(RECOVERY_URL), result.sideEffect)
+        assertNull(result.nextEvent)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryAwaitCaptchaSolutionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryAwaitCaptchaSolutionEventHandlerTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryAwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RetryAwaitCaptchaSolutionEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: RetryAwaitCaptchaSolutionEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    @Before
+    fun setUp() {
+        testee = RetryAwaitCaptchaSolutionEventHandler()
+    }
+
+    @Test
+    fun whenEventIsRetryAwaitCaptchaSolutionThenEventTypeIsCorrect() {
+        assertEquals(RetryAwaitCaptchaSolution::class, testee.event)
+    }
+
+    @Test
+    fun whenRetryAwaitCaptchaSolutionThenReturnsAwaitCaptchaSolutionSideEffect() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SOLVE,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryAwaitCaptchaSolution(
+                actionId = "action-1",
+                brokerName = "test-broker",
+                transactionID = "transaction-123",
+                attempt = 0,
+            )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertEquals(
+            AwaitCaptchaSolution(
+                actionId = "action-1",
+                brokerName = "test-broker",
+                transactionID = "transaction-123",
+                attempt = 1,
+            ),
+            result.sideEffect,
+        )
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenRetryAwaitCaptchaSolutionWithHigherAttemptThenIncrementsAttempt() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SOLVE,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryAwaitCaptchaSolution(
+                actionId = "action-1",
+                brokerName = "test-broker",
+                transactionID = "transaction-123",
+                attempt = 5,
+            )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as AwaitCaptchaSolution
+        assertEquals(6, sideEffect.attempt)
+    }
+
+    @Test
+    fun whenRetryAwaitCaptchaSolutionThenPreservesActionIdAndBrokerName() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SOLVE,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryAwaitCaptchaSolution(
+                actionId = "action-captcha-123",
+                brokerName = "some-broker",
+                transactionID = "txn-456",
+                attempt = 2,
+            )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as AwaitCaptchaSolution
+        assertEquals("action-captcha-123", sideEffect.actionId)
+        assertEquals("some-broker", sideEffect.brokerName)
+        assertEquals("txn-456", sideEffect.transactionID)
+        assertEquals(3, sideEffect.attempt)
+    }
+
+    @Test
+    fun whenRetryAwaitCaptchaSolutionThenStateRemainsUnchanged() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                currentBrokerStepIndex = 3,
+                currentActionIndex = 5,
+                actionRetryCount = 2,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SOLVE,
+                    stageStartMs = 1000L,
+                ),
+            )
+        val event =
+            RetryAwaitCaptchaSolution(
+                actionId = "action-1",
+                brokerName = "test-broker",
+                transactionID = "transaction-123",
+                attempt = 0,
+            )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertEquals(3, result.nextState.currentBrokerStepIndex)
+        assertEquals(5, result.nextState.currentActionIndex)
+        assertEquals(2, result.nextState.actionRetryCount)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryGetCaptchaSolutionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryGetCaptchaSolutionEventHandlerTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryGetCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.GetCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.GetCaptchaInfoResponse.ResponseData
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RetryGetCaptchaSolutionEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: RetryGetCaptchaSolutionEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val testResponseData =
+        ResponseData(
+            siteKey = "test-site-key",
+            url = "https://example.com",
+            type = "recaptcha",
+        )
+
+    @Before
+    fun setUp() {
+        testee = RetryGetCaptchaSolutionEventHandler()
+    }
+
+    @Test
+    fun whenEventIsRetryGetCaptchaSolutionThenEventTypeIsCorrect() {
+        assertEquals(RetryGetCaptchaSolution::class, testee.event)
+    }
+
+    @Test
+    fun whenRetryGetCaptchaSolutionThenReturnsGetCaptchaSolutionSideEffect() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SEND,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryGetCaptchaSolution(
+                actionId = "action-1",
+                responseData = testResponseData,
+            )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertEquals(
+            GetCaptchaSolution(
+                actionId = "action-1",
+                responseData = testResponseData,
+                isRetry = true,
+            ),
+            result.sideEffect,
+        )
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenRetryGetCaptchaSolutionThenSetsIsRetryToTrue() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SEND,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryGetCaptchaSolution(
+                actionId = "action-1",
+                responseData = testResponseData,
+            )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as GetCaptchaSolution
+        assertTrue(sideEffect.isRetry)
+    }
+
+    @Test
+    fun whenRetryGetCaptchaSolutionWithNullResponseDataThenPassesNullResponseData() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SEND,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryGetCaptchaSolution(
+                actionId = "action-1",
+                responseData = null,
+            )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as GetCaptchaSolution
+        assertNull(sideEffect.responseData)
+        assertEquals("action-1", sideEffect.actionId)
+        assertTrue(sideEffect.isRetry)
+    }
+
+    @Test
+    fun whenRetryGetCaptchaSolutionThenPreservesActionId() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SEND,
+                    stageStartMs = 0,
+                ),
+            )
+        val event =
+            RetryGetCaptchaSolution(
+                actionId = "action-captcha-456",
+                responseData = testResponseData,
+            )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as GetCaptchaSolution
+        assertEquals("action-captcha-456", sideEffect.actionId)
+        assertEquals(testResponseData, sideEffect.responseData)
+    }
+
+    @Test
+    fun whenRetryGetCaptchaSolutionThenStateRemainsUnchanged() = runTest {
+        val state =
+            State(
+                runType = RunType.OPTOUT,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                currentBrokerStepIndex = 2,
+                currentActionIndex = 4,
+                actionRetryCount = 1,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.CAPTCHA_SEND,
+                    stageStartMs = 5000L,
+                ),
+            )
+        val event =
+            RetryGetCaptchaSolution(
+                actionId = "action-1",
+                responseData = testResponseData,
+            )
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertEquals(2, result.nextState.currentBrokerStepIndex)
+        assertEquals(4, result.nextState.currentActionIndex)
+        assertEquals(1, result.nextState.actionRetryCount)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/StartedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/StartedEventHandlerTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirJobConstants.DBP_INITIAL_URL
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.Started
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.LoadUrl
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class StartedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: StartedEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    @Before
+    fun setUp() {
+        testee = StartedEventHandler()
+    }
+
+    @Test
+    fun whenEventIsStartedThenEventTypeIsCorrect() {
+        assertEquals(Started::class, testee.event)
+    }
+
+    @Test
+    fun whenStartedEventThenSetsPendingUrlToInitialUrl() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = Started
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(DBP_INITIAL_URL, result.nextState.pendingUrl)
+    }
+
+    @Test
+    fun whenStartedEventThenGeneratesAttemptId() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                attemptId = "",
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = Started
+
+        val result = testee.invoke(state, event)
+
+        assertNotEquals("", result.nextState.attemptId)
+    }
+
+    @Test
+    fun whenStartedEventThenReturnsLoadUrlSideEffect() = runTest {
+        val state =
+            State(
+                runType = RunType.MANUAL,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = Started
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(LoadUrl(url = DBP_INITIAL_URL), result.sideEffect)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenStartedEventThenPreservesOtherStateFields() = runTest {
+        val state =
+            State(
+                runType = RunType.SCHEDULED,
+                brokerStepsToExecute = emptyList(),
+                profileQuery = testProfileQuery,
+                currentBrokerStepIndex = 5,
+                currentActionIndex = 3,
+                brokerStepStartTime = 1000L,
+                transactionID = "test-transaction-id",
+                actionRetryCount = 2,
+                stageStatus = PirStageStatus(
+                    currentStage = PirStage.OTHER,
+                    stageStartMs = 0,
+                ),
+            )
+        val event = Started
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(RunType.SCHEDULED, result.nextState.runType)
+        assertEquals(5, result.nextState.currentBrokerStepIndex)
+        assertEquals(3, result.nextState.currentActionIndex)
+        assertEquals(1000L, result.nextState.brokerStepStartTime)
+        assertEquals("test-transaction-id", result.nextState.transactionID)
+        assertEquals(2, result.nextState.actionRetryCount)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1212381653445208?focus=true

### Description
Adds missing unit tests for the JS event handlers.

### Steps to test this PR
Ensure the unit tests pass

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extensive unit tests covering PIR JS event handlers (state transitions, side effects, pixels, retries) and fixes a handler class name; also simplifies retry decision logic.
> 
> - **Tests (new, extensive)**:
>   - `BrokerActionFailedEventHandlerTest`: verifies retry limits, expectation-only retries for scans, failure pixel emission.
>   - `BrokerStepCompletedEventHandlerTest`: validates success/failure outcomes, email confirmation flow, stage timing, and state resets.
>   - `CaptchaInfoReceivedEventHandlerTest`: asserts transaction ID handling, next-action progression, and pixel emission for opt-out.
>   - `EmailReceivedEventHandlerTest`: ensures email propagation to `ExtractedProfile`, generated email state, pixel emission, and next action.
>   - `ErrorReceivedHandlerTest`: maps various errors to `BrokerActionFailed` with no retry; state remains unchanged.
>   - `ExecuteBrokerStepActionEventHandlerTest`: covers side effects (`PushJsAction`, `LoadUrl`, captcha/email flows), delays, pixels, and data sourcing.
>   - `ExecuteNextBrokerStepEventHandlerTest`: starts next broker step, emits start pixels, resets indices, completes execution when done.
>   - `LoadUrlCompleteEventHandlerTest` / `LoadUrlFailedEventHandlerTest`: handle initial/recovery URLs, advance/abort flows, and retries.
>   - `RetryAwaitCaptchaSolutionEventHandlerTest` / `RetryGetCaptchaSolutionEventHandlerTest`: increment attempts and re-dispatch side effects.
>   - `StartedEventHandlerTest`: initializes attempt ID and kicks off initial URL load.
> - **Minor fixes**:
>   - Rename `CaptchaInforReceivedEventHandler` to `CaptchaInfoReceivedEventHandler`.
>   - Simplify `shouldRetryFailedAction` with an expression `return` while preserving behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55bc3fd22f1da871609876657a7fc2929bd01d8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->