### PR TITLE
Update sync APIs to support deletions

### DIFF
--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/DeletableDataManger.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/DeletableDataManger.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.api.engine
+
+interface DeletableDataManager {
+    /**
+     * Used by the SyncClient to get all the deletions from each syncable feature
+     */
+    fun getDeletions(): SyncDeletionRequest? = null
+
+    /**
+     * Which syncable data type this deletion is for
+     */
+    fun getType(): SyncableType
+
+    /**
+     * Called to notify that the deletion request was successful
+     */
+    fun onSuccess(response: SyncDeletionResponse) {}
+
+    /**
+     * Called to notify that the deletion request failed
+     */
+    fun onError(syncErrorResponse: SyncErrorResponse) {}
+}

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/Models.kt
@@ -60,6 +60,26 @@ data class SyncChangesResponse(
     }
 }
 
+/**
+ * Represents a request to delete a syncable type
+ * @param type The type of syncable data to delete.
+ * @param untilTimestamp An optional timestamp to indicate that only items modified before this timestamp should be deleted.
+ */
+data class SyncDeletionRequest(
+    val type: SyncableType,
+    val untilTimestamp: String? = null,
+)
+
+/**
+ * Represents a response to a sync deletion request.
+ * @param type The type of syncable data that was deleted.
+ * @param untilTimestamp The timestamp provided in @[SyncDeletionRequest] indicating the last modified timestamp up until which deletions should be performed.
+ */
+data class SyncDeletionResponse(
+    val type: SyncableType,
+    val untilTimestamp: String? = null,
+)
+
 data class SyncErrorResponse(
     val type: SyncableType,
     val featureSyncError: FeatureSyncError,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212393987995393?focus=true 

### Description
Updates Sync APIs to support _deletions_. 

This PR adds data classes and callbacks to support deletions, but otherwise doesn't make any functional changes. 

### Steps to test this PR
- qa optional
- Check changes against [API change: New sync engine interfaces for handling deletions](https://app.asana.com/1/137249556945/task/1212392279082571)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce deletion support to the sync API via new models and a manager interface with success/error callbacks.
> 
> - **Sync API**:
>   - **New Interface**: `DeletableDataManager` with `getDeletions()`, `getType()`, and callbacks `onSuccess(SyncDeletionResponse)` / `onError(SyncErrorResponse)`.
>   - **New Models**: `SyncDeletionRequest` and `SyncDeletionResponse` (optional `untilTimestamp`) for deletion operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab4b982901cd04d74b8f637138d29b05f430a124. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->