### PR TITLE
Fix link for help center for duck ai

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/FeedbackHelpUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/FeedbackHelpUrlProvider.kt
@@ -83,7 +83,7 @@ class RealFeedbackHelpUrlProvider @Inject constructor(
         private const val HELP_PAGE_PPRO_ITR = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/identity-theft-restoration/"
         private const val HELP_PAGE_PPRO_ITR_IRIS = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/identity-theft-restoration/iris/"
         private const val HELP_PAGE_DUCK_AI_ACCESS_SUBSCRIPTION_MODELS =
-            "https://duckduckgo.com/duckduckgo-help-pages/duckai/access-subscriber-AI-models"
+            "https://duckduckgo.com/duckduckgo-help-pages/duckai/subscriber-only-ai"
         private const val HELP_PAGE_DUCK_AI_LOGIN_THIRD_PARTY_BROWSER = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/activating"
         private const val HELP_PAGE_DUCK_AI_OTHER = "https://duckduckgo.com/duckduckgo-help-pages/duckai"
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212392784625805?focus=true 

### Description
Fixed the link for duck ai help center in the feedback flow

### Steps to test this PR
QA-Optional
Video: https://app.asana.com/app/asana/-/get_asset?asset_id=1212401965736899

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Duck AI subscriber-only help URL constant in FeedbackHelpUrlProvider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc0716f9e946fc8561189d023a6aff06d980b3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->