### PR TITLE
Bump to url-predictor 0.3.13

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -36,6 +36,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class, boundType = OmnibarEntryConverter::class)
@@ -70,6 +71,7 @@ class QueryUrlConverter @Inject constructor(
             is QueryOrigin.FromAutocomplete -> queryOrigin.isNav
             is QueryOrigin.FromUser, QueryOrigin.FromBookmark -> {
                 if (useUrlPredictor && queryUrlPredictor.isReady()) {
+                    logcat { "Using urlPredictor" }
                     var queryClassification = queryUrlPredictor.classify(input = searchQuery)
 
                     if (extractUrlFromQuery) {

--- a/versions.properties
+++ b/versions.properties
@@ -86,7 +86,7 @@ version.com.duckduckgo.netguard..netguard-android=1.10.2
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.7.0
 
-version.com.duckduckgo.urlpredictor..url-predictor-android=0.3.10
+version.com.duckduckgo.urlpredictor..url-predictor-android=0.3.13
 
 version.com.frybits.harmony..harmony=1.2.6
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1198194956794324/task/1212418083406977?focus=true

### Description
Update the url-predictor library to 0.3.13

### Steps to test this PR

_Test_
- [x] install app and make sure `useUrlPredictor` FF is enabled
- [x] open a new tab and navigate to blogspot.com
- [x] Expected: it loads the blogger page
- [x] open new tab and navigate to gov.cz
- [x] Expected: it loads the gov page
- [x] Repeat steps above from develop
- [x] Expected: it searches instead of navigating to those pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the url-predictor library to 0.3.13 and adds a debug log when the predictor is used in QueryUrlConverter.
> 
> - **Dependencies**
>   - Bump `com.duckduckgo.urlpredictor..url-predictor-android` to `0.3.13` in `versions.properties`.
> - **Omnibar**
>   - In `app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt`, add `logcat` import and a debug log when `useUrlPredictor` is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1620567350b2d0cc59df625096620307506c184b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->