### PR TITLE
Use LottieTask for choice screen dialog animation

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
@@ -180,11 +180,7 @@ class NewAddressBarOptionBottomSheetDialog(
         lottieTask = LottieCompositionFactory.fromRawRes(context.applicationContext, animationResource)
             .addListener { composition ->
                 lottieTask = null
-                if (!isWindowValid()) return@addListener
-
                 preloadedComposition = composition
-                binding.newAddressBarOptionBottomSheetDialogAnimation.setComposition(composition)
-                binding.newAddressBarOptionBottomSheetDialogAnimation.progress = 0f
 
                 if (pendingShow) {
                     pendingShow = false
@@ -204,16 +200,24 @@ class NewAddressBarOptionBottomSheetDialog(
         if (animationStarted) return
 
         val lottieView = binding.newAddressBarOptionBottomSheetDialogAnimation
-        val composition = preloadedComposition ?: lottieView.composition
-        if (composition != null) {
+
+        preloadedComposition?.let { composition ->
+            if (lottieView.composition == null) {
+                lottieView.setComposition(composition)
+                lottieView.progress = 0f
+            }
+        }
+
+        lottieView.composition?.let { composition ->
             animationStarted = true
             playIntroThenLoop(lottieView, composition.durationFrames.toInt())
-        } else {
-            lottieView.addLottieOnCompositionLoadedListener {
-                if (animationStarted || !isWindowValid()) return@addLottieOnCompositionLoadedListener
-                animationStarted = true
-                playIntroThenLoop(lottieView, it.durationFrames.toInt())
-            }
+            return
+        }
+
+        lottieView.addLottieOnCompositionLoadedListener { composition ->
+            if (animationStarted || !isWindowValid()) return@addLottieOnCompositionLoadedListener
+            animationStarted = true
+            playIntroThenLoop(lottieView, composition.durationFrames.toInt())
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212417948403549?focus=true

### Description

- To ensure compatibility with https://github.com/duckduckgo/Android/pull/7270, use `LottieTask` to load the animation for the `NewAddressBarOptionBottomSheetDialog`.

### Steps to test this PR

- [x] Fresh install
- [x] Select “I’ve been here before” and “Start Browsing” in onboarding
- [x] Kill the app
- [x] Re-open the app
- [x] Verify that choice screen is shown (with animation already visible)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preloads the Lottie composition via LottieTask and defers showing the dialog until ready, then starts an intro-then-loop animation with lifecycle safety checks.
> 
> - **Dialog animation loading (`NewAddressBarOptionBottomSheetDialog`)**
>   - Switch to `LottieTask`/`LottieCompositionFactory` to preload animation composition.
>   - Defer `show()` until composition is ready using `pendingShow`; resume when loaded or on failure.
>   - Start animation on show via `startLottieAnimation()`, playing intro frames then looping the remainder.
>   - Add lifecycle guards (`isWindowValid`, `animationStarted`) and cleanup in `onDetachedFromWindow()`; remove `isLottieLoaded` flag.
> - **Misc**
>   - Add fields `preloadedComposition`, `lottieTask`, `animationStarted` and update `show()`/listeners for safer, deterministic animation startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc886862968e6b88f57e1d919746040ab8b64976. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->