### PR TITLE
Store the pixel fired only if the api call succeeds

### DIFF
--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
@@ -108,16 +108,20 @@ class RxPixelSender @Inject constructor(
     ): Single<PixelSender.SendPixelResult> = Single.fromCallable {
         runBlocking {
             if (shouldFirePixel(pixelName, type)) {
-                api.fire(
-                    pixelName,
-                    getDeviceFactor(),
-                    getAtbInfo(),
-                    addDeviceParametersTo(parameters),
-                    encodedParameters,
-                    devMode = shouldFirePixelsAsDev,
-                ).blockingAwait()
-                storePixelFired(pixelName, type)
-                PixelSender.SendPixelResult.PIXEL_SENT
+                try {
+                    api.fire(
+                        pixelName,
+                        getDeviceFactor(),
+                        getAtbInfo(),
+                        addDeviceParametersTo(parameters),
+                        encodedParameters,
+                        devMode = shouldFirePixelsAsDev,
+                    ).blockingAwait()
+                    storePixelFired(pixelName, type)
+                    PixelSender.SendPixelResult.PIXEL_SENT
+                } catch (e: Exception) {
+                    throw e
+                }
             } else {
                 PixelSender.SendPixelResult.PIXEL_IGNORED
             }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -362,6 +362,26 @@ class RxPixelSenderTest {
     }
 
     @Test
+    fun whenDailyPixelFireFailsThenPixelIsNotStored() = runTest {
+        givenPixelApiFails()
+
+        testee.sendPixel(TEST.pixelName, emptyMap(), emptyMap(), Daily("tag"))
+            .test().assertError(RuntimeException::class.java)
+
+        assertTrue(pixelFiredRepository.dailyPixelsFiredToday.isEmpty())
+    }
+
+    @Test
+    fun whenUniquePixelFireFailsThenPixelIsNotStored() = runTest {
+        givenPixelApiFails()
+
+        testee.sendPixel(TEST.pixelName, emptyMap(), emptyMap(), Daily("tag"))
+            .test().assertError(RuntimeException::class.java)
+
+        assertTrue(pixelFiredRepository.uniquePixelsFired.isEmpty())
+    }
+
+    @Test
     fun whenDailyPixelHasAlreadyBeenFiredAndUsesTagTodayThenItIsNotFiredAgain() = runTest {
         pixelFiredRepository.dailyPixelsFiredToday += "tag"
 


### PR DESCRIPTION
Task/Issue URL: 

### Description

This PR enhances the pixel sending mechanism to prevent storing pixels that fail to send. Previously, when a pixel send operation failed, the pixel was still marked as sent in the repository, which could lead to inconsistent tracking. Now, if an exception occurs during the pixel sending process, the pixel is not stored in the repository, ensuring that only successfully sent pixels are recorded.

### Steps to test this PR

_Pixel Sending Error Handling_
- [ ] Verify that when a pixel fails to send, it is not marked as sent in the repository
- [ ] Confirm that daily pixels are not stored in the repository when sending fails
- [ ] Confirm that unique pixels are not stored in the repository when sending fails
- [ ] Verify that successful pixel sends continue to be properly recorded