### PR TITLE
Fix swapped pool sizes in MSP database

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
@@ -62,7 +62,7 @@ class MaliciousSiteModule {
             RoomDatabaseConfig(
                 migrations = ALL_MIGRATIONS.toList(),
                 fallbackToDestructiveMigration = true,
-                executor = Custom(queryPoolSize = 1, transactionPoolSize = 4),
+                executor = Custom(queryPoolSize = 4, transactionPoolSize = 1),
             ),
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204920898013511/task/1212423247632279?focus=true

### Description
Fix swapped pool sizes for MSP executors has highlighted [here](https://github.com/duckduckgo/Android/pull/7194#discussion_r2618583932)

### Steps to test this PR
n/a

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects Room executor configuration by setting `queryPoolSize=4` and `transactionPoolSize=1` for `MaliciousSitesDatabase`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0777df7bedce432422fe1647b640fc96ed0d41df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->