### PR TITLE
Update app theme to respect system dark mode

### DIFF
--- a/android-design-system/design-system/src/main/res/values-night/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values-night/design-system-theming.xml
@@ -15,6 +15,8 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.DuckDuckGo.App" parent="Theme.DuckDuckGo.Dark" />
+
     <style name="Theme.DuckDuckGo.SplashScreen" parent="Theme.DuckDuckGo.Splash">
         <item name="android:statusBarColor">@color/black</item>
         <item name="android:windowLightStatusBar">false</item>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -90,6 +90,8 @@
         <item name="daxExpandableMenuItemStyle">@style/Widget.DuckDuckGo.DaxExpandableItem</item>
     </style>
 
+    <style name="Theme.DuckDuckGo.App" parent="Theme.DuckDuckGo.Light" />
+
     <style name="Theme.DuckDuckGo" parent="Base.Theme.DuckDuckGo">
 
         <item name="colorPrimary">?attr/daxColorBackground</item>

--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
     <application
         android:largeHeap="true"
-        android:theme="@style/Theme.DuckDuckGo.Light">
+        android:theme="@style/Theme.DuckDuckGo.App">
 
         <!-- This is the Worker Service where VPN workers need to bind into -->
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
         android:roundIcon="${appIconRound}"
         android:dataExtractionRules="@xml/backup_rules_android_12_upwards"
         android:fullBackupContent="@xml/backup_rules_android_11_and_older"
-        android:theme="@style/Theme.DuckDuckGo.Light"
+        android:theme="@style/Theme.DuckDuckGo.App"
         android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
         <meta-data


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211305967101102?focus=true

### Description
Fix the issue when launching the app through shortcuts and a light splash screen is displayed even though the device theme is dark. 

This PR introduces a new theme style `Theme.DuckDuckGo.App` that automatically inherits from either `Theme.DuckDuckGo.Light` or `Theme.DuckDuckGo.Dark` based on the device's theme settings. This allows the app to properly follow the system theme without requiring explicit theme switching logic in the code.

The changes include:
- Adding `Theme.DuckDuckGo.App` style in both default and night resource files
- Updating the application theme in both the main app and VPN implementation to use this new theme

Note: There is a known limitation when changing the app theme from the app settings. In that case the splash screen will have the theme from the system, not from the app, as it is instantiated by the Android system which reads the device settings.

### Steps to test this PR

_Theme switching_
- [ ] Set device to light theme and verify the app uses light theme
- [ ] Set device to dark theme and verify the app automatically switches to dark theme
- [ ] Toggle between light and dark themes to ensure smooth transitions
- [ ] Toggle dark mode on the device and launch the app from any of the shortcuts (the splash screen should have dark theme)
- [ ] Check the fire buton for both light and dark theme 

### UI changes

_Launching the app in dark mode_
| Before | After |
| ------ | ----- |
| [dark_mode_before_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4b521047-b233-40e4-a054-5db750143b42.mp4" />](https://app.graphite.com/user-attachments/video/4b521047-b233-40e4-a054-5db750143b42.mp4) | [dark_mode_after_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/cc00aa83-0b54-42be-9c3a-1f8d54bf7730.mp4" />](https://app.graphite.com/user-attachments/video/cc00aa83-0b54-42be-9c3a-1f8d54bf7730.mp4) |

### Other scenarios testeed 

_Launching the app in light mode_
| Before | After |
| ------ | ----- |
| [light_mode_before_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/69fcc207-0d30-4dd2-a557-790161e807ee.mp4" />](https://app.graphite.com/user-attachments/video/69fcc207-0d30-4dd2-a557-790161e807ee.mp4)| [light_mode_after_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9ea29462-5d39-4c9d-954e-191c8efea95a.mp4" />](https://app.graphite.com/user-attachments/video/9ea29462-5d39-4c9d-954e-191c8efea95a.mp4) |

_Light mode fire button_
| Before | After |
| ------ | ----- |
| [light_mode_fire_button_before.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4a6d3ac7-02a6-41b3-89e9-3e5d833f0cfd.mp4" />](https://app.graphite.com/user-attachments/video/4a6d3ac7-02a6-41b3-89e9-3e5d833f0cfd.mp4) | [light_mode_fire_button_after.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0b8cc02c-2fee-4680-aebc-ffd9a0969a4a.mp4" />](https://app.graphite.com/user-attachments/video/0b8cc02c-2fee-4680-aebc-ffd9a0969a4a.mp4) |

_Dark mode fire button_
| Before | After |
| ------ | ----- |
| [dark_mode_fire_button_before.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9176e4ac-4eb2-4dca-af6a-f27cd5c4b603.mp4" />](https://app.graphite.com/user-attachments/video/9176e4ac-4eb2-4dca-af6a-f27cd5c4b603.mp4)] | [dark_mode_fire_button_after.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/71f1438d-2c86-4873-8f25-1c9068814ee3.mp4" />](https://app.graphite.com/user-attachments/video/71f1438d-2c86-4873-8f25-1c9068814ee3.mp4) |


