### PR TITLE
[Android] "What’s New" promo message: Make the ModalSurfaceActivity handle any remote message we support

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageViewModel.Comman
 import com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageViewModel.Command.SharePromoLinkRMF
 import com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageViewModel.Command.SubmitUrl
 import com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageViewModel.ViewState
+import com.duckduckgo.remote.messaging.impl.ui.RemoteMessageDismissListener
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -103,6 +104,8 @@ class RemoteMessageView @JvmOverloads constructor(
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[RemoteMessageViewModel::class.java]
     }
 
+    var listener: RemoteMessageDismissListener? = null
+
     private val conflatedStateJob = ConflatedJob()
     private val conflatedCommandJob = ConflatedJob()
 
@@ -134,6 +137,9 @@ class RemoteMessageView @JvmOverloads constructor(
             showRemoteMessage(viewState.message, viewState.newMessage)
         } else {
             binding.messageCta.gone()
+            if (viewState.newMessage) {
+                listener?.onDismiss()
+            }
         }
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
@@ -137,7 +137,7 @@ class RemoteMessageView @JvmOverloads constructor(
             showRemoteMessage(viewState.message, viewState.newMessage)
         } else {
             binding.messageCta.gone()
-            if (viewState.newMessage) {
+            if (viewState.dismissed) {
                 listener?.onDismiss()
             }
         }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageViewModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageViewModel.kt
@@ -38,7 +38,6 @@ import com.duckduckgo.remote.messaging.api.Action.Url
 import com.duckduckgo.remote.messaging.api.Action.UrlInContext
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
-import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.survey.api.SurveyParameterManager
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -47,7 +46,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -100,9 +98,6 @@ class RemoteMessageViewModel @Inject constructor(
 
         viewModelScope.launch(dispatchers.io()) {
             remoteMessagingModel.getActiveMessages()
-                .map { message ->
-                    if (message?.surfaces?.contains(Surface.NEW_TAB_PAGE) == true) message else null
-                }
                 .flowOn(dispatchers.io())
                 .onEach { message ->
                     withContext(dispatchers.main()) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageViewModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageViewModel.kt
@@ -64,6 +64,7 @@ class RemoteMessageViewModel @Inject constructor(
     data class ViewState(
         val message: RemoteMessage? = null,
         val newMessage: Boolean = false,
+        val dismissed: Boolean = false,
     )
 
     sealed class Command {
@@ -102,6 +103,7 @@ class RemoteMessageViewModel @Inject constructor(
                 .onEach { message ->
                     withContext(dispatchers.main()) {
                         val newMessage = message?.id != lastRemoteMessageSeen?.id
+                        val dismissed = newMessage && message == null && lastRemoteMessageSeen != null
                         if (newMessage) {
                             lastRemoteMessageSeen = message
                         }
@@ -110,6 +112,7 @@ class RemoteMessageViewModel @Inject constructor(
                             viewState.value.copy(
                                 message = message,
                                 newMessage = newMessage,
+                                dismissed = dismissed,
                             ),
                         )
                     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/CardsListRemoteMessageView.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/CardsListRemoteMessageView.kt
@@ -95,7 +95,7 @@ class CardsListRemoteMessageView @JvmOverloads constructor(
     private val conflatedStateJob = ConflatedJob()
     private val conflatedCommandJob = ConflatedJob()
 
-    var listener: CardsListRemoteMessageListener? = null
+    var listener: RemoteMessageDismissListener? = null
     var messageId: String? = null
 
     override fun onAttachedToWindow() {
@@ -243,9 +243,5 @@ class CardsListRemoteMessageView @JvmOverloads constructor(
         context?.let {
             globalActivityStarter.start(it, DeeplinkActivityParams(screenName = screen, jsonArguments = payload), null)
         }
-    }
-
-    interface CardsListRemoteMessageListener {
-        fun onDismiss()
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.onEach
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(ModalSurfaceActivityFromMessageId::class)
-class ModalSurfaceActivity : DuckDuckGoActivity(), CardsListRemoteMessageView.CardsListRemoteMessageListener {
+class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener {
 
     private val viewModel: ModalSurfaceViewModel by bindViewModel()
     private val binding: ActivityModalSurfaceBinding by viewBinding()
@@ -76,6 +76,9 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), CardsListRemoteMessageView.Ca
             binding.cardsListRemoteMessageView.messageId = viewState.messageId
             binding.cardsListRemoteMessageView.listener = this
             binding.cardsListRemoteMessageView.show()
+        } else {
+            binding.remoteMessageView.listener = this
+            binding.remoteMessageView.show()
         }
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
@@ -73,10 +74,13 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener 
         if (viewState == null) return
 
         if (viewState.showCardsListView) {
+            binding.remoteMessageView.gone()
             binding.cardsListRemoteMessageView.messageId = viewState.messageId
             binding.cardsListRemoteMessageView.listener = this
             binding.cardsListRemoteMessageView.show()
         } else {
+            // RemoteMessageView fetches the active message from RemoteMessageModel, so no messageId is needed
+            binding.cardsListRemoteMessageView.gone()
             binding.remoteMessageView.listener = this
             binding.remoteMessageView.show()
         }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
@@ -71,18 +71,20 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener 
     }
 
     private fun render(viewState: ModalSurfaceViewModel.ViewState?) {
-        if (viewState == null) return
-
-        if (viewState.showCardsListView) {
-            binding.remoteMessageView.gone()
-            binding.cardsListRemoteMessageView.messageId = viewState.messageId
-            binding.cardsListRemoteMessageView.listener = this
-            binding.cardsListRemoteMessageView.show()
-        } else {
-            // RemoteMessageView fetches the active message from RemoteMessageModel, so no messageId is needed
-            binding.cardsListRemoteMessageView.gone()
-            binding.remoteMessageView.listener = this
-            binding.remoteMessageView.show()
+        when (viewState) {
+            is ModalSurfaceViewModel.ViewState.CardsList -> {
+                binding.remoteMessageView.gone()
+                binding.cardsListRemoteMessageView.messageId = viewState.messageId
+                binding.cardsListRemoteMessageView.listener = this
+                binding.cardsListRemoteMessageView.show()
+            }
+            is ModalSurfaceViewModel.ViewState.Message -> {
+                // RemoteMessageView fetches the active message from RemoteMessageModel, so no messageId is needed
+                binding.cardsListRemoteMessageView.gone()
+                binding.remoteMessageView.listener = this
+                binding.remoteMessageView.show()
+            }
+            null -> { }
         }
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceActivity.kt
@@ -45,9 +45,15 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener 
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        setupToolbar()
         initialise()
         setupObservers()
         setupBackNavigationHandler()
+    }
+
+    private fun setupToolbar() {
+        setSupportActionBar(binding.includeToolbar.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     override fun onDismiss() {
@@ -73,6 +79,7 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener 
     private fun render(viewState: ModalSurfaceViewModel.ViewState?) {
         when (viewState) {
             is ModalSurfaceViewModel.ViewState.CardsList -> {
+                binding.includeToolbar.root.gone()
                 binding.remoteMessageView.gone()
                 binding.cardsListRemoteMessageView.messageId = viewState.messageId
                 binding.cardsListRemoteMessageView.listener = this
@@ -80,12 +87,18 @@ class ModalSurfaceActivity : DuckDuckGoActivity(), RemoteMessageDismissListener 
             }
             is ModalSurfaceViewModel.ViewState.Message -> {
                 // RemoteMessageView fetches the active message from RemoteMessageModel, so no messageId is needed
+                binding.includeToolbar.root.show()
                 binding.cardsListRemoteMessageView.gone()
                 binding.remoteMessageView.listener = this
                 binding.remoteMessageView.show()
             }
             null -> { }
         }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        viewModel.onBackPressed()
+        return true
     }
 
     private fun processCommand(command: Command) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceViewModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceViewModel.kt
@@ -53,6 +53,9 @@ class ModalSurfaceViewModel @Inject constructor(
         if (messageType == Content.MessageType.CARDS_LIST) {
             lastRemoteMessageIdSeen = messageId
             _viewState.value = ViewState(messageId = messageId, showCardsListView = true)
+        } else {
+            lastRemoteMessageIdSeen = messageId
+            _viewState.value = ViewState(messageId = messageId, showCardsListView = false)
         }
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceViewModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/ModalSurfaceViewModel.kt
@@ -50,13 +50,11 @@ class ModalSurfaceViewModel @Inject constructor(
         val messageId = activityParams?.messageId ?: return
         val messageType = activityParams.messageType
 
-        if (messageType == Content.MessageType.CARDS_LIST) {
-            lastRemoteMessageIdSeen = messageId
-            _viewState.value = ViewState(messageId = messageId, showCardsListView = true)
-        } else {
-            lastRemoteMessageIdSeen = messageId
-            _viewState.value = ViewState(messageId = messageId, showCardsListView = false)
-        }
+        lastRemoteMessageIdSeen = messageId
+        _viewState.value = ViewState(
+            messageId = messageId,
+            showCardsListView = messageType == Content.MessageType.CARDS_LIST,
+        )
     }
 
     fun onDismiss() {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/RemoteMessageDismissListener.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/ui/RemoteMessageDismissListener.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl.ui
+
+/**
+ * Listener interface for remote message views to notify their container when dismissed.
+ * Used by views that display remote messages on a modal surface.
+ */
+interface RemoteMessageDismissListener {
+    fun onDismiss()
+}

--- a/remote-messaging/remote-messaging-impl/src/main/res/layout/activity_modal_surface.xml
+++ b/remote-messaging/remote-messaging-impl/src/main/res/layout/activity_modal_surface.xml
@@ -24,4 +24,10 @@
         android:layout_height="match_parent"
         android:visibility="gone"/>
 
+    <com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageView
+        android:id="@+id/remoteMessageView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
 </FrameLayout>

--- a/remote-messaging/remote-messaging-impl/src/main/res/layout/activity_modal_surface.xml
+++ b/remote-messaging/remote-messaging-impl/src/main/res/layout/activity_modal_surface.xml
@@ -14,20 +14,32 @@
   ~ limitations under the License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.duckduckgo.remote.messaging.impl.ui.CardsListRemoteMessageView
-        android:id="@+id/cardsListRemoteMessageView"
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar"
+        android:visibility="gone" />
+
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
+        android:layout_height="match_parent">
 
-    <com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageView
-        android:id="@+id/remoteMessageView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
+        <com.duckduckgo.remote.messaging.impl.ui.CardsListRemoteMessageView
+            android:id="@+id/cardsListRemoteMessageView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
 
-</FrameLayout>
+        <com.duckduckgo.remote.messaging.impl.newtab.RemoteMessageView
+            android:id="@+id/remoteMessageView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/newtab/RemoteMessageViewModelTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/newtab/RemoteMessageViewModelTest.kt
@@ -74,13 +74,15 @@ class RemoteMessageViewModelTest {
     }
 
     @Test
-    fun whenViewModelInitialisedWithMessageAndModalSurfaceThenViewStateEmitInitStateWithNoMessageToShow() = runTest {
+    fun whenViewModelInitialisedWithMessageAndModalSurfaceThenViewStateEmitInitStateCorrectMessageToShow() = runTest {
         val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), listOf(Surface.MODAL))
         whenever(remoteMessageModel.getActiveMessages()).thenReturn(flowOf(remoteMessage))
         testee.onStart(mockLifecycleOwner)
         testee.viewState.test {
             expectMostRecentItem().also {
-                assertFalse(it.newMessage)
+                assertTrue(it.newMessage)
+                assertTrue(it.message?.id == remoteMessage.id)
+                assertTrue(it.message?.content == remoteMessage.content)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1212304890091987?focus=true

### Description

Added support for standard remote messages in the modal surface activity, which previously only supported cards list messages. This change allows both types of messages to be displayed in a modal context.

Key changes:
- Created a common `RemoteMessageDismissListener` interface to handle message dismissal for both message types
- Updated `RemoteMessageView` to support the dismiss listener
- Modified `ModalSurfaceViewModel` to handle non-cards list messages
- Added `RemoteMessageView` to the modal surface layout

### Steps to test this PR

_Standard Remote Messages in Modal Surface_
- [ ] Verify that standard remote messages can be displayed in the modal surface
- [ ] Confirm that dismissing a standard remote message triggers the dismiss listener
- [ ] Check that both cards list and standard remote messages work correctly in the modal surface

_Dismiss Behavior_
- [ ] Verify that the dismiss listener is called when a message is dismissed
- [ ] Confirm that the activity closes properly after message dismissal

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modal surface can now display standard remote messages in addition to cards list, using a shared dismiss listener with updated view models and layout.
> 
> - **UI / Activity**:
>   - Modal surface (`ModalSurfaceActivity`) now renders either `CardsListRemoteMessageView` or `RemoteMessageView`, toggling toolbar visibility accordingly.
>   - Layout `activity_modal_surface.xml` updated to include toolbar and `RemoteMessageView` container.
> - **Views**:
>   - `RemoteMessageView`: adds `RemoteMessageDismissListener` and emits `onDismiss` when message is dismissed; wiring for commands unchanged.
>   - `CardsListRemoteMessageView`: replaces local listener with shared `RemoteMessageDismissListener` and removes inner interface.
>   - New `RemoteMessageDismissListener` interface shared across views.
> - **ViewModels**:
>   - `ModalSurfaceViewModel`: refactors `ViewState` to sealed classes (`CardsList`, `Message`); handles back navigation (including cards list dismiss pixel) and dismissal uniformly.
>   - `RemoteMessageViewModel`: adds `dismissed` flag in `ViewState`; simplifies active message stream (no surface filtering) and tracks new/dismissed transitions.
> - **Tests**:
>   - Update tests for new sealed `ViewState`, dismiss behavior, and support for modal-surface messages in `RemoteMessageViewModel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aa7c92db5166336fbbb2d2b7ee01afd8d09ea3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->