### PR TITLE
Use Accent/Content-Primary color for check blue drawable

### DIFF
--- a/android-design-system/design-system/src/main/res/drawable/ic_check_blue_24.xml
+++ b/android-design-system/design-system/src/main/res/drawable/ic_check_blue_24.xml
@@ -24,5 +24,5 @@
       android:fillColor="?attr/daxColorAccentBlue"/>
   <path
       android:pathData="M16.775,9.214c0.296,0.29 0.3,0.765 0.011,1.06l-4.494,4.589c-0.785,0.8 -2.074,0.8 -2.859,0l-2.219,-2.265a0.75,0.75 0,0 1,1.072 -1.05l2.219,2.265c0.196,0.2 0.519,0.2 0.715,0l4.494,-4.588a0.75,0.75 0,0 1,1.061 -0.01Z"
-      android:fillColor="#fff"/>
+      android:fillColor="?attr/daxColorAccentContentPrimary"/>
 </vector>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1211090170664910?focus=true

### Description

* Fix color (T-Accent/Content-Primary) of check in dark mode when selecting tabs in Tabs Viewer
* Be sure the light mode is still working as expected
* Be sure the list mode in Tabs Viewer is also impacted by this change

### Steps to test this PR

_Check icon in dark mode_
- [ ] Change your system theme in dark mode
- [ ] Open the app with this contribution
- [ ] Go to tabs viewer screen
- [ ] Enter in select mode from menu
- [ ] Select a tab
- [ ] Check color icon should be updated as expected in Asana task

_Check icon in light mode_
- [ ] Change your system theme in light mode
- [ ] Open the app with this contribution
- [ ] Go to tabs viewer screen
- [ ] Enter in select mode from menu
- [ ] Select a tab
- [ ] Check color is the exact same color as before

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6792de61-8e01-4da3-a618-8fe1457f6777" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/926ee0bb-b8b4-40fc-b7a6-0dcc24f37cfe" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/38e743a6-f743-4768-9ae9-45891da80d4d" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/0622b18d-9d83-4647-b920-f2f6f5ff1516" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/3c588689-2cbb-4811-a19c-cad09243294d" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/dd0777ff-7cd2-41bc-b6ef-067ec71bd25e" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/d12fa630-6c41-44fc-a3b7-b371747b3125" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/5cbfa003-ba57-433a-8563-9134189e7997" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/f65346e5-f830-4f74-84c2-5cb630c14a1d" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/df5b9009-d6b5-438b-9831-a51e372df13c" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/3ef1984f-beec-49e5-afc9-e705c160fb74" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/dd771b25-e2a8-4406-bd92-f800d79fe9af" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the checkmark fill to `?attr/daxColorAccentContentPrimary` for proper themed (dark/light) rendering.
> 
> - **Design System / Drawable**:
>   - Update `android-design-system/design-system/src/main/res/drawable/ic_check_blue_24.xml`:
>     - Change checkmark path `fillColor` from `#fff` to `?attr/daxColorAccentContentPrimary` to use themed accent content color.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa37c1e4d0036270ec0f27854351043073e1b45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->