### PR TITLE
Android: Fix flaky tests in ContributesRemoteFeatureCodeGeneratorTest

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -1389,7 +1389,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                                 "rollout": {
                                     "steps": [
                                         {
-                                            "percent": ${rolloutThreshold - 1.0}
+                                            "percent": ${(rolloutThreshold - 1.0).coerceAtLeast(0.0)}
                                         }
                                     ]
                                 }
@@ -3483,7 +3483,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                             "rollout": {
                                 "steps": [
                                     {
-                                        "percent": ${rolloutThreshold - 1}
+                                        "percent": ${(rolloutThreshold - 1).coerceAtLeast(0.0)}
                                     }
                                 ]
                             },
@@ -3573,7 +3573,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                             "rollout": {
                                 "steps": [
                                     {
-                                        "percent": ${rolloutThreshold - 1}
+                                        "percent": ${(rolloutThreshold - 1).coerceAtLeast(0.0)}
                                     }
                                 ]
                             },
@@ -4674,7 +4674,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                             "rollout": {
                                 "steps": [
                                     {
-                                        "percent": ${rolloutThreshold - 1}
+                                        "percent": ${(rolloutThreshold - 1).coerceAtLeast(0.0)}
                                     }
                                 ]
                             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1212496601186702?focus=true

### Description

This PR fixes an issue in the feature toggle tests where rollout percentages could potentially become negative. The fix applies `coerceAtLeast(0.0)` to ensure that rollout percentages are always at least 0%, preventing invalid test configurations.

### Steps to test this PR

_Feature Toggle Tests_
- [ ] Tests are passing.
- [ ] Optional: Run the `ContributesRemoteFeatureCodeGeneratorTest` test suite to verify all tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents negative rollout percentages in test JSON by clamping computed values to at least 0.0.
> 
> - **Tests**:
>   - In `feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt`:
>     - Replace occurrences of `"percent": ${rolloutThreshold - 1}` / `${rolloutThreshold - 1.0}` with `"percent": ${(rolloutThreshold - 1).coerceAtLeast(0.0)}` (or `(rolloutThreshold - 1.0).coerceAtLeast(0.0)`) to avoid negative rollout values during staged rollout tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7878f558a1ce74d6916e4d993a99c27d361b2ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->