### PR TITLE
Extend sync crypto to support byte arrays

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -567,11 +567,11 @@ class SavedSitesSyncDataProviderTest {
 }
 
 class FakeCrypto : SyncCrypto {
-    override fun encrypt(text: String): String {
-        return text
-    }
+    override fun encrypt(text: String) = text
 
-    override fun decrypt(data: String): String {
-        return data
-    }
+    override fun decrypt(data: String) = data
+
+    override fun encrypt(data: ByteArray): ByteArray = data
+
+    override fun decrypt(data: ByteArray): ByteArray = data
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCrypto.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCrypto.kt
@@ -22,4 +22,8 @@ class FakeCrypto : SyncCrypto {
     override fun encrypt(text: String) = text
 
     override fun decrypt(data: String) = data
+
+    override fun encrypt(data: ByteArray): ByteArray = data
+
+    override fun decrypt(data: ByteArray): ByteArray = data
 }

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithmTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithmTest.kt
@@ -245,12 +245,12 @@ class SavedSitesSyncPersisterAlgorithmTest {
     }
 
     class FakeCrypto : SyncCrypto {
-        override fun encrypt(text: String): String {
-            return text
-        }
+        override fun encrypt(text: String) = text
 
-        override fun decrypt(data: String): String {
-            return data
-        }
+        override fun decrypt(data: String) = data
+
+        override fun encrypt(data: ByteArray): ByteArray = data
+
+        override fun decrypt(data: ByteArray): ByteArray = data
     }
 }

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncCrypto.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncCrypto.kt
@@ -22,14 +22,28 @@ interface SyncCrypto {
     /**
      * Encrypts a blob of text
      * @param text to encrypt
-     * @return text encrypted
+     * @return text encrypted (Base64 encoded)
      */
     fun encrypt(text: String): String
 
     /**
      * Decrypts a blob of text
-     * @param text to decrypt
+     * @param data text to decrypt
      * @return text decrypted
      */
     fun decrypt(data: String): String
+
+    /**
+     * Encrypts a byte array
+     * @param data raw bytes to encrypt
+     * @return encrypted byte array
+     */
+    fun encrypt(data: ByteArray): ByteArray
+
+    /**
+     * Decrypts a byte array
+     * @param data encrypted byte array
+     * @return decrypted byte array
+     */
+    fun decrypt(data: ByteArray): ByteArray
 }

--- a/sync/sync-settings-impl/src/test/java/com/duckduckgo/sync/settings/impl/FakeCrypto.kt
+++ b/sync/sync-settings-impl/src/test/java/com/duckduckgo/sync/settings/impl/FakeCrypto.kt
@@ -22,4 +22,8 @@ class FakeCrypto : SyncCrypto {
     override fun encrypt(text: String) = text
 
     override fun decrypt(data: String) = data
+
+    override fun encrypt(data: ByteArray): ByteArray = data
+
+    override fun decrypt(data: ByteArray): ByteArray = data
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212290226255081?focus=true 

### Description
Adds sync crypto support for byte arrays, adding the ability to encrypt and decrypt them similar to the existing functions which support strings only.

There's a few extra changes required because of needing to extend the test suite, as well as a few `FakeCrypto` implementations for testing, each needing tweaked. 

But the core change is:
- add the new APIs which accept a byte array
- change the existing APIs to first convert `String -> Byte Array` as they are doing now already, then invoke the other function so that the logic is shared between the two impls.

### Steps to test this PR
- QA optional
- Can smoke test sync still works ok; e.g., set up two devices and update a password on one of them, make sure it syncs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends sync crypto to handle raw bytes and aligns behavior across string/byte paths.
> 
> - Adds ByteArray `encrypt`/`decrypt` APIs to `SyncCrypto` and notes Base64 output for string encryption
> - Implements ByteArray support in `RealSyncCrypto` with error recording, early returns on empty inputs
> - Expands `SyncLib`/`SyncNativeLib` with byte-array overloads and new `EncryptBytesResult`/`DecryptBytesResult`; string methods now delegate to byte-array logic internally
> - Updates and adds tests to cover byte-array paths and exception cases; adjusts `FakeCrypto` test doubles across modules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56dcf70c43019f1c2fa0b8e7b114e10981ddab0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->