### PR TITLE
Send a pixel when the Duck.ai 1x1 widget (pinned shortcut) is installed

### DIFF
--- a/PixelDefinitions/pixels/widgets.json5
+++ b/PixelDefinitions/pixels/widgets.json5
@@ -1,0 +1,52 @@
+// Widget pixels
+{
+    "m_duckai_only_widget_added": {
+        "description": "Triggered when a Duck AI widget (pinned shortcut) is added on home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_and_favorites_widget_added": {
+        "description": "Triggered when a Search and Favorites widget is added on home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_and_favorites_widget_deleted": {
+        "description": "Triggered when a Search and Favorites widget is removed from home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_widget_added": {
+        "description": "Triggered when a Simple Search widget is added on home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_widget_deleted": {
+        "description": "Triggered when a Simple Search widget is removed from home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_only_widget_added": {
+        "description": "Triggered when a Search Only (no AI) widget is added on home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    },
+    "m_search_only_widget_deleted": {
+        "description": "Triggered when a Search Only (no AI) widget is removed from home screen",
+        "owners": ["anikiki"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", "atb"]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
+++ b/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
@@ -3,18 +3,29 @@ package com.duckduckgo.widget
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.di.scopes.ActivityScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /**
  * This activity is capable of handling requests to create a shortcut.
  * Exists purely to be able to add the Duck.ai shortcut on the home screen from the widget picker.
  */
-class DuckAiPinShortcutActivity : AppCompatActivity() {
+@InjectWith(ActivityScope::class)
+class DuckAiPinShortcutActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var pixel: Pixel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,6 +34,7 @@ class DuckAiPinShortcutActivity : AppCompatActivity() {
             val shortcutInfo = createShortcutInfo(this)
             ShortcutManagerCompat.reportShortcutUsed(this, SHORTCUT_ID)
             setResult(RESULT_OK, ShortcutManagerCompat.createShortcutResultIntent(this, shortcutInfo))
+            duckAiPinShortcutAdded()
         } else {
             setResult(RESULT_OK)
         }
@@ -43,6 +55,12 @@ class DuckAiPinShortcutActivity : AppCompatActivity() {
             .setIcon(IconCompat.createWithResource(context, R.drawable.duckai_64))
             .setIntent(shortcutIntent)
             .build()
+    }
+
+    private fun duckAiPinShortcutAdded() {
+        lifecycleScope.launch {
+            pixel.fire(AppPixelName.DUCKAI_ONLY_WIDGET_ADDED)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1212362059388930?focus=true

### Description

Add a new pixel for the Duck AI pinned shortcut. 

The implementation fires a pixel event when a Duck AI widget is added to the home screen.
### Steps to test this PR

_Duck AI Widget added_
- [x] Add a Duck AI widget to the home screen and verify the `m_duckai_only_widget_added` pixel is fired

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fires `DUCKAI_ONLY_WIDGET_ADDED` when the Duck AI pinned shortcut is added and adds widget pixel definitions.
> 
> - **Analytics / Pixels**:
>   - Add `PixelDefinitions/pixels/widgets.json5` with widget pixel definitions, including `m_duckai_only_widget_added`.
> - **Android**:
>   - `DuckAiPinShortcutActivity`:
>     - Switch to `DuckDuckGoActivity` and enable DI with `@InjectWith(ActivityScope::class)`.
>     - Inject `Pixel` and fire `AppPixelName.DUCKAI_ONLY_WIDGET_ADDED` after successful shortcut pin request.
>     - Minor wiring: use `lifecycleScope` to launch pixel firing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b300c151e1142caa095fac86ac0ebe482d1fb78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->