### PR TITLE
Update bookmarks favicons rounded corners

### DIFF
--- a/android-design-system/design-system/src/main/res/layout/view_bookmark_two_line_item.xml
+++ b/android-design-system/design-system/src/main/res/layout/view_bookmark_two_line_item.xml
@@ -35,12 +35,13 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:background="@drawable/list_item_image_circular_background">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/leadingIcon"
             android:layout_width="@dimen/listItemImageMediumSize"
             android:layout_height="@dimen/listItemImageMediumSize"
             android:layout_gravity="center"
-            android:importantForAccessibility="no" />
+            android:importantForAccessibility="no"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.DuckDuckGo.VerySmallComponent" />
 
     </FrameLayout>
 

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -458,6 +458,11 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
+    <style name="ShapeAppearance.DuckDuckGo.VerySmallComponent" parent="ShapeAppearance.MaterialComponents.SmallComponent">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">@dimen/verySmallShapeCornerRadius</item>
+    </style>
+
     <style name="ShapeAppearance.DuckDuckGo.SmallComponent" parent="ShapeAppearance.MaterialComponents.SmallComponent">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/smallShapeCornerRadius</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1211623035425018?focus=true

### Description

Update bookmark favicons rounded corners to very small shape corner radius.

### Steps to test this PR

_Check bookmark filled background favicon corner radius_
- [x] Open the application with this contribution
- [x] Put a website in bookmark with a filled background favicon (e.g. apple.com)
- [x] Go to the bookmark screen
- [x] Check that the radius is using very small shape corner radius (yes, we need good eyes...)

_Check bookmark empty favicon corner radius_
- [x] Open the application with this contribution
- [x] Put a website in bookmark with an empty background favicon (e.g. walmart.com)
- [x] Go to the bookmark screen
- [x] Check there is no effect on the favicon

### UI changes
| Before  | After |
| ------ | ----- |
<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/9d97bed5-80fd-418c-9695-180d75f9fbcd" /> | <img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/68f5fbbf-fe98-47af-a544-9b28790c96e5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use ShapeableImageView with a new very-small corner radius style to round bookmark favicons.
> 
> - **UI/Layout**:
>   - Replace `ImageView` with `ShapeableImageView` in `res/layout/view_bookmark_two_line_item.xml` and apply `app:shapeAppearanceOverlay="@style/ShapeAppearance.DuckDuckGo.VerySmallComponent"` to the leading icon.
> - **Design System/Theming**:
>   - Add `ShapeAppearance.DuckDuckGo.VerySmallComponent` (rounded, `@dimen/verySmallShapeCornerRadius`) in `res/values/design-system-theming.xml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19e02f826d794e9a3a5c0856137a66d430d05ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->