### PR TITLE
Fix crash in custom tab when trying to open url in ddg app and no activity is found to handle the intent

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1465,7 +1465,12 @@ class BrowserTabFragment :
             Intent(Intent.ACTION_VIEW).apply {
                 data = Uri.parse(url)
             }
-        startActivity(intent)
+
+        if (requireActivity().packageManager.resolveActivity(intent, 0) != null) {
+            startActivity(intent)
+        } else {
+            showToast(R.string.unableToOpenLink)
+        }
     }
 
     private fun launchPopupMenu(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211466988037185?focus=true

### Description
Added a check before launching external links to verify if there's an app that can handle the intent. If no app is found, a toast message is displayed to inform the user that the link cannot be opened.

### Steps to test this PR

_External link handling_
- [x] Disable Google Play Store on the device where you are tesing 
- [x] Go to developer settings and open the following url in custom tab https://codepen.io/pen/
- [x] In the HTML box paste the following code 

`<button onclick="window.open('market://details?id=com.duckduckgo.mobile.android', '_syste')">Go to playstore to app page</button>`

- [x] After the “Go to playstore” button is rendered click it 
- [x] An error page should be displayed 
- [x] Go to the menu and click on “Open in DuckDuckGo”
- [x] The app should not crash 

| Before  | After |
| ------ | ----- |
|[before_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/36a608e0-0b4e-4464-b2de-ab3b6f038d3d.mp4" />](https://app.graphite.com/user-attachments/video/36a608e0-0b4e-4464-b2de-ab3b6f038d3d.mp4)|[after_fix.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d576bb66-0c39-4554-bbd6-2601b5ca3e03.mp4" />](https://app.graphite.com/user-attachments/video/d576bb66-0c39-4554-bbd6-2601b5ca3e03.mp4)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add intent-resolution check before launching URL from custom tab (“Open in DuckDuckGo”); show a toast if no handler exists to prevent a crash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f5da87da2e2b7629bfc2f61ee48de70f3982e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->