### PR TITLE
Quick win: Cancel tracker animations on click

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -18,8 +18,6 @@ package com.duckduckgo.app.browser.omnibar
 
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
 import android.os.Build
@@ -39,7 +37,6 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -588,16 +585,6 @@ class OmnibarLayout @JvmOverloads constructor(
         }
         newCustomTabToolbarContainer.customTabInnerContainer.setOnClickListener {
             cancelCustomTabAnimations()
-        }
-        newCustomTabToolbarContainer.customTabInnerContainer.setOnLongClickListener {
-            val domainText = newCustomTabToolbarContainer.customTabDomain.text.toString()
-            if (domainText.isNotEmpty()) {
-                val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clipData = ClipData.newPlainText("URL", viewModel.viewState.value.url)
-                clipboardManager.setPrimaryClip(clipData)
-                Toast.makeText(context, "URL copied to clipboard", Toast.LENGTH_SHORT).show()
-            }
-            true
         }
         trackersAnimation.setOnClickListener {
             cancelAddressBarAnimations()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.app.browser.omnibar
 
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
 import android.os.Build
@@ -37,6 +39,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
@@ -583,6 +586,22 @@ class OmnibarLayout @JvmOverloads constructor(
         duckAISidebar.setOnClickListener {
             omnibarItemPressedListener?.onDuckAISidebarButtonPressed()
         }
+        newCustomTabToolbarContainer.customTabInnerContainer.setOnClickListener {
+            cancelCustomTabAnimations()
+        }
+        newCustomTabToolbarContainer.customTabInnerContainer.setOnLongClickListener {
+            val domainText = newCustomTabToolbarContainer.customTabDomain.text.toString()
+            if (domainText.isNotEmpty()) {
+                val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clipData = ClipData.newPlainText("URL", viewModel.viewState.value.url)
+                clipboardManager.setPrimaryClip(clipData)
+                Toast.makeText(context, "URL copied to clipboard", Toast.LENGTH_SHORT).show()
+            }
+            true
+        }
+        trackersAnimation.setOnClickListener {
+            cancelAddressBarAnimations()
+        }
     }
 
     override fun setLogoClickListener(logoClickListener: LogoClickListener) {
@@ -1022,6 +1041,12 @@ class OmnibarLayout @JvmOverloads constructor(
     private fun cancelAddressBarAnimations() {
         if (this::animatorHelper.isInitialized) {
             animatorHelper.cancelAnimations(omnibarViews())
+        }
+    }
+
+    private fun cancelCustomTabAnimations() {
+        if (this::animatorHelper.isInitialized) {
+            animatorHelper.cancelAnimations(customTabViews())
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -583,9 +583,6 @@ class OmnibarLayout @JvmOverloads constructor(
         duckAISidebar.setOnClickListener {
             omnibarItemPressedListener?.onDuckAISidebarButtonPressed()
         }
-        newCustomTabToolbarContainer.customTabInnerContainer.setOnClickListener {
-            cancelCustomTabAnimations()
-        }
         trackersAnimation.setOnClickListener {
             cancelAddressBarAnimations()
         }
@@ -1167,6 +1164,8 @@ class OmnibarLayout @JvmOverloads constructor(
                     customTabToolbar.setOnClickListener {
                         pixel.fire(CustomTabPixelNames.CUSTOM_TABS_ADDRESS_BAR_CLICKED)
                         pixel.fire(CustomTabPixelNames.CUSTOM_TABS_ADDRESS_BAR_CLICKED_DAILY, type = PixelType.Daily())
+
+                        cancelCustomTabAnimations()
                     }
 
                     daxIcon.setOnClickListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
@@ -209,7 +209,9 @@ class AddressBarTrackersAnimator @Inject constructor(
                                     override fun onAnimationRepeat(p0: Animator) {}
                                 },
                             )
-                            addressBarTrackersBlockedAnimationShieldIcon.playAnimation()
+                            if (isAnimationRunning) {
+                                addressBarTrackersBlockedAnimationShieldIcon.playAnimation()
+                            }
                         },
                     )
                     runningAnimators.add(this)
@@ -236,6 +238,8 @@ class AddressBarTrackersAnimator @Inject constructor(
     fun cancelAnimation() {
         if (!isAnimationRunning) return
 
+        isAnimationRunning = false
+
         trackerCountAnimator.cancelAnimation()
         runningAnimators.forEach { animator ->
             animator.cancel()
@@ -257,8 +261,6 @@ class AddressBarTrackersAnimator @Inject constructor(
             it.gone()
             it.progress = 0F
         }
-
-        isAnimationRunning = false
 
         sceneRoot = null
         animatedIconBackgroundView = null

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -62,6 +62,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
     private lateinit var cookieScene: ViewGroup
     private lateinit var cookieViewBackground: View
     private var cookieCosmeticHide: Boolean = false
+    private var currentShieldViews: List<View> = emptyList()
 
     private var enqueueCookiesAnimation = false
     private var isCookiesAnimationRunning = false
@@ -146,6 +147,8 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
     ) {
         if (isCookiesAnimationRunning || addressBarTrackersAnimator.isAnimationRunning) return
 
+        currentShieldViews = shieldViews
+
         addressBarTrackersAnimator.startAnimation(
             context = context,
             sceneRoot = sceneRoot,
@@ -164,7 +167,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
             },
         )
         sceneRoot.setOnClickListener {
-            cancelAnimations(omnibarViews)
+            cancelAnimations(omnibarViews, shieldViews)
         }
     }
 
@@ -202,12 +205,14 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
 
     override fun cancelAnimations(
         omnibarViews: List<View>,
+        shieldViews: List<View>,
     ) {
         conflatedJob.cancel()
         addressBarTrackersAnimator.cancelAnimation()
         stopTrackersAnimation()
         stopCookiesAnimation()
         omnibarViews.forEach { it.alpha = 1f }
+        shieldViews.forEach { it.alpha = 1f }
     }
 
     private fun tryToStartCookiesAnimation(
@@ -236,7 +241,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
         }
 
         hasCookiesAnimationBeenCanceled = false
-        val allOmnibarViews: List<View> = (omnibarViews).filterNotNull().toList()
+        val allOmnibarViews: List<View> = omnibarViews
         cookieView.show()
         cookieView.alpha = 0F
         if (theme.isLightModeEnabled()) {
@@ -416,6 +421,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
             TransitionManager.go(firstScene)
         }
         shieldAnimation?.alpha = 1f
+        currentShieldViews.forEach { it.alpha = 1f }
         cookieViewBackground.alpha = 0f
         cookieScene.gone()
         cookieView.gone()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -427,10 +427,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
     private fun stopCookiesAnimation() {
         if (!::cookieViewBackground.isInitialized || !::cookieView.isInitialized) return
 
-        hasCookiesAnimationBeenCanceled = true
-        isCookiesAnimationRunning = false
-
-        // Cancel all running animators
+        // Always cancel any pending animators and transitions to prevent glimpses
         runningCookieAnimators.forEach { animator ->
             animator.cancel()
             animator.removeAllListeners()
@@ -446,6 +443,14 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
             TransitionManager.endTransitions(cookieScene)
             cookieScene.gone()
         }
+
+        // If animation was already stopped by user, skip redundant state updates
+        if (hasCookiesAnimationBeenCanceled && !isCookiesAnimationRunning) {
+            return
+        }
+
+        hasCookiesAnimationBeenCanceled = true
+        isCookiesAnimationRunning = false
 
         // Reset view states directly without triggering transitions
         shieldAnimation?.alpha = 1f

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -427,11 +427,6 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
     private fun stopCookiesAnimation() {
         if (!::cookieViewBackground.isInitialized || !::cookieView.isInitialized) return
 
-        // If animation was already stopped, skip redundant cleanup
-        if (hasCookiesAnimationBeenCanceled) {
-            return
-        }
-
         // Set flag BEFORE canceling to prevent callbacks from continuing the old animation
         hasCookiesAnimationBeenCanceled = true
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -163,6 +163,9 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
                     }
             },
         )
+        sceneRoot.setOnClickListener {
+            cancelAnimations(omnibarViews)
+        }
     }
 
     override fun createCookiesAnimation(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserTrackersAnimatorHelper.kt
@@ -92,9 +92,11 @@ interface BrowserTrackersAnimatorHelper {
      * Cancel a running animation.
      *
      * @param omnibarViews are the views that should become visible after canceling the running animation.
+     * @param shieldViews are the shield views that should become visible after canceling the running animation.
      */
     fun cancelAnimations(
         omnibarViews: List<View>,
+        shieldViews: List<View> = emptyList(),
     )
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1212330168162873

### Description

Adds animation canceling when clicked to allow users to start using the browser more quickly.

### Steps to test this PR

_Regular tab_
- [x] Load a website with trackers
- [x] While animation is in progress, tap on it
- [x] Verify the animation is canceled and you can start typing in the address bar

_Custom tab_
- [x] Go to Settings -> Developer settings -> Custom tabs)
- [x] Load a website with trackers
- [x] While animation is in progress, tap on it
- [x] Verify the animation is canceled


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/animation behavior changes limited to canceling and resetting omnibar/custom tab tracker animations; main risk is introducing visual glitches or leaving views in an incorrect alpha/state if cancellation paths are missed.
> 
> **Overview**
> Allows users to interrupt tracker-related address bar animations by tapping, so the omnibar/custom tab toolbar becomes usable immediately.
> 
> Adds click-to-cancel hooks for the trackers animation views (regular tabs and custom tabs), expands `cancelAnimations` to also restore shield view visibility, and hardens cancellation logic to prevent late callbacks from restarting animations (e.g., guard `playAnimation`, flip `isAnimationRunning` earlier, and explicitly cancel/clear pending cookie animators/transitions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e4d1b74dde71d4166aff32fc0c1fb9884bf9fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->