### PR TITLE
Move to v2 subscription messaging (FE BE)

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -244,9 +244,6 @@ interface PrivacyProFeature {
     fun refreshSubscriptionPlanFeatures(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun useClientWithCacheForFeatures(): Toggle
-
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun supportsAlternateStripePaymentFlow(): Toggle
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
@@ -279,7 +276,7 @@ interface PrivacyProFeature {
      * The flag is exposed to FE via getFeatureConfig.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun useGetSubscriptionTierOptions(): Toggle
+    fun tierMessagingEnabled(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.subscriptions.impl.billing.PurchaseState
 import com.duckduckgo.subscriptions.impl.billing.RetryPolicy
 import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
 import com.duckduckgo.subscriptions.impl.billing.retry
+import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionFailureErrorType
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.AccessToken
@@ -115,7 +116,10 @@ import kotlin.time.Duration.Companion.milliseconds
 
 interface SubscriptionsManager {
     /**
-     * Returns available purchase options retrieved from Play Store
+     * Returns available purchase options retrieved from Play Store.
+     * Works seamlessly regardless of whether tierMessagingEnabled flag is on or off.
+     * When flag is off, entitlements are constructed from legacy feature strings with default tier "plus".
+     * When flag is on, actual entitlements and tier information from the API are used.
      */
     suspend fun getSubscriptionOffer(): List<SubscriptionOffer>
 
@@ -763,7 +767,7 @@ class RealSubscriptionsManager @Inject constructor(
         val subscription = authRepository.getSubscription()
 
         return if (subscription != null) {
-            getFeaturesInternal(subscription.productId)
+            getEntitlementsForPlan(subscription.productId).map { it.product }.toSet()
         } else {
             emptySet()
         }
@@ -1102,20 +1106,39 @@ class RealSubscriptionsManager @Inject constructor(
                         )
                     }
 
-                    val features = getFeaturesInternal(offer.basePlanId)
+                    val entitlements = getEntitlementsForPlan(offer.basePlanId)
 
-                    if (features.isEmpty()) return@let emptyList()
+                    if (entitlements.isEmpty()) return@let emptyList()
 
                     SubscriptionOffer(
                         planId = offer.basePlanId,
+                        tier = "plus", // Temporary placeholder until we have support multiple tiers
                         pricingPhases = pricingPhases,
                         offerId = offer.offerId,
-                        features = features,
+                        entitlements = entitlements,
                     )
                 }
             }
 
-    private suspend fun getFeaturesInternal(planId: String): Set<String> {
+    /**
+     * Returns entitlements for a plan, working seamlessly regardless of flag state.
+     * When tierMessagingEnabled is ON: Uses actual entitlements from V2 API, with fallback to legacy.
+     * When tierMessagingEnabled is OFF: Converts legacy features to entitlements with default tier "plus".
+     */
+    private suspend fun getEntitlementsForPlan(planId: String): Set<Entitlement> {
+        if (privacyProFeature.get().tierMessagingEnabled().isEnabled()) {
+            val v2Entitlements = authRepository.getFeaturesV2(planId)
+            if (v2Entitlements.isNotEmpty()) {
+                return v2Entitlements
+            }
+            // Fallback to legacy features for smooth runtime flag transitions
+        }
+        return getLegacyFeatures(planId).map { feature ->
+            Entitlement(name = "plus", product = feature) // Temporary name placeholder until we have support multiple tiers
+        }.toSet()
+    }
+
+    private suspend fun getLegacyFeatures(planId: String): Set<String> {
         return if (privacyProFeature.get().featuresApi().isEnabled()) {
             authRepository.getFeatures(planId)
         } else {
@@ -1442,9 +1465,16 @@ sealed class CurrentPurchase {
 data class SubscriptionOffer(
     val planId: String,
     val offerId: String?,
+    val tier: String,
     val pricingPhases: List<PricingPhase>,
-    val features: Set<String>,
-)
+    val entitlements: Set<Entitlement>,
+) {
+    /**
+     * Returns the set of feature/product names from entitlements.
+     * Provided for backward compatibility with code that used the legacy features set.
+     */
+    val features: Set<String> get() = entitlements.map { it.product }.toSet()
+}
 
 data class PricingPhase(
     val priceAmount: BigDecimal,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -410,7 +410,7 @@ class SubscriptionMessagingInterface @Inject constructor(
             val authV2Enabled = privacyProFeature.enableSubscriptionFlowsV2().isEnabled()
             val duckAiSubscriberModelsEnabled = privacyProFeature.duckAiPlus().isEnabled()
             val supportsAlternateStripePaymentFlow = privacyProFeature.supportsAlternateStripePaymentFlow().isEnabled()
-            val useGetSubscriptionTierOptions = privacyProFeature.useGetSubscriptionTierOptions().isEnabled()
+            val useGetSubscriptionTierOptions = privacyProFeature.tierMessagingEnabled().isEnabled()
             val resultJson = JSONObject().apply {
                 put("useSubscriptionsAuthV2", authV2Enabled)
                 put("usePaidDuckAi", duckAiSubscriberModelsEnabled)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsCachedService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsCachedService.kt
@@ -18,8 +18,22 @@ package com.duckduckgo.subscriptions.impl.services
 
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface SubscriptionsCachedService {
+    @Deprecated("Use featuresV2 instead")
     @GET("https://subscriptions.duckduckgo.com/api/products/{sku}/features")
     suspend fun features(@Path("sku") sku: String): FeaturesResponse
+
+    @GET("https://subscriptions.duckduckgo.com/api/v2/features")
+    suspend fun featuresV2(@Query("sku") sku: String): FeaturesV2Response
 }
+
+data class FeaturesV2Response(
+    val features: Map<String, List<TierFeatureResponse>>,
+)
+
+data class TierFeatureResponse(
+    val product: String,
+    val name: String, // e.g. "Plus", "Pro" (Tier)
+)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
@@ -48,7 +48,7 @@ interface SubscriptionsDataStore {
     var freeTrialActive: Boolean
 
     var subscriptionFeatures: String?
-
+    var subscriptionEntitlements: String?
     fun canUseEncryption(): Boolean
 }
 
@@ -228,6 +228,14 @@ internal class SubscriptionsEncryptedDataStore(
             }
         }
 
+    override var subscriptionEntitlements: String?
+        get() = encryptedPreferences?.getString(KEY_SUBSCRIPTION_ENTITLEMENTS, null)
+        set(value) {
+            encryptedPreferences?.edit(commit = true) {
+                putString(KEY_SUBSCRIPTION_ENTITLEMENTS, value)
+            }
+        }
+
     override fun canUseEncryption(): Boolean {
         encryptedPreferences?.edit(commit = true) { putBoolean("test", true) }
         return encryptedPreferences?.getBoolean("test", false) == true
@@ -252,6 +260,7 @@ internal class SubscriptionsEncryptedDataStore(
         const val KEY_STATUS = "KEY_STATUS"
         const val KEY_PRODUCT_ID = "KEY_PRODUCT_ID"
         const val KEY_SUBSCRIPTION_FEATURES = "KEY_SUBSCRIPTION_FEATURES"
+        const val KEY_SUBSCRIPTION_ENTITLEMENTS = "KEY_SUBSCRIPTION_ENTITLEMENTS"
         const val KEY_FREE_TRIAL_ACTIVE = "KEY_FREE_TRIAL_ACTIVE"
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -120,7 +120,11 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     private val subscriptionsService: SubscriptionsService = mock()
     private val authDataStore: FakeSubscriptionsDataStore = FakeSubscriptionsDataStore()
     private val serpPromo = FakeSerpPromo()
-    private val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo)
+
+    @SuppressLint("DenyListedApi")
+    private val privacyProFeature: PrivacyProFeature = FakeFeatureToggleFactory.create(PrivacyProFeature::class.java)
+        .apply { authApiV2().setRawStoredState(State(authApiV2Enabled)) }
+    private val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo, { privacyProFeature })
     private val emailManager: EmailManager = mock()
     private val playBillingManager: PlayBillingManager = mock()
     private val context: Context = mock()
@@ -131,9 +135,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     private val freeTrialConversionWideEvent: FreeTrialConversionWideEvent = mock()
     private val subscriptionRestoreWideEvent: SubscriptionRestoreWideEvent = mock()
 
-    @SuppressLint("DenyListedApi")
-    private val privacyProFeature: PrivacyProFeature = FakeFeatureToggleFactory.create(PrivacyProFeature::class.java)
-        .apply { authApiV2().setRawStoredState(State(authApiV2Enabled)) }
     private val authClient: AuthClient = mock()
     private val pkceGenerator: PkceGenerator = PkceGeneratorImpl()
     private val authJwtValidator: AuthJwtValidator = mock()
@@ -1380,6 +1381,83 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
+    fun whenGetSubscriptionOfferWithTierMessagingEnabledThenReturnEntitlementsFromV2() = runTest {
+        givenTierMessagingEnabled(true)
+        authRepository.setFeaturesV2(
+            MONTHLY_PLAN_US,
+            setOf(Entitlement(name = "plus", product = NETP)),
+        )
+        authRepository.setFeaturesV2(
+            YEARLY_PLAN_US,
+            setOf(Entitlement(name = "plus", product = NETP)),
+        )
+        givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
+
+        val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
+
+        with(subscriptionOffers) {
+            assertTrue(isNotEmpty())
+            assertTrue(any { it.planId == MONTHLY_PLAN_US })
+            assertTrue(any { it.planId == YEARLY_PLAN_US })
+            assertEquals("plus", first().tier)
+            assertEquals(setOf(Entitlement(name = "plus", product = NETP)), first().entitlements)
+            assertEquals(setOf(NETP), first().features)
+        }
+    }
+
+    @Test
+    fun whenGetSubscriptionOfferWithTierMessagingEnabledAndV2EmptyThenFallbackToV1() = runTest {
+        givenTierMessagingEnabled(true)
+        // V2 is empty, but V1 has data
+        authRepository.setFeatures(MONTHLY_PLAN_US, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_US, setOf(NETP))
+        givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
+
+        val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
+
+        with(subscriptionOffers) {
+            assertTrue(isNotEmpty())
+            assertTrue(any { it.planId == MONTHLY_PLAN_US })
+            // When falling back to V1, tier defaults to "plus"
+            assertEquals("plus", first().tier)
+            // Entitlements are created from V1 features with name="plus"
+            assertEquals(setOf(Entitlement(name = "plus", product = NETP)), first().entitlements)
+            assertEquals(setOf(NETP), first().features)
+        }
+    }
+
+    @Test
+    fun whenGetSubscriptionOfferWithTierMessagingDisabledThenUseV1Features() = runTest {
+        givenTierMessagingEnabled(false)
+        authRepository.setFeatures(MONTHLY_PLAN_US, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_US, setOf(NETP))
+        givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
+
+        val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
+
+        with(subscriptionOffers) {
+            assertTrue(isNotEmpty())
+            assertTrue(any { it.planId == MONTHLY_PLAN_US })
+            // When flag OFF, tier defaults to "plus"
+            assertEquals("plus", first().tier)
+            // Entitlements created from V1 features
+            assertEquals(setOf(Entitlement(name = "plus", product = NETP)), first().entitlements)
+            assertEquals(setOf(NETP), first().features)
+        }
+    }
+
+    @Test
+    fun whenGetSubscriptionOfferWithTierMessagingEnabledAndBothStoragesEmptyThenReturnEmptyList() = runTest {
+        givenTierMessagingEnabled(true)
+        // Both V1 and V2 are empty
+        givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
+
+        val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
+
+        assertTrue(subscriptionOffers.isEmpty())
+    }
+
+    @Test
     fun whenCanSupportEncryptionThenReturnTrue() = runTest {
         assertTrue(subscriptionsManager.canSupportEncryption())
     }
@@ -1387,7 +1465,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     @Test
     fun whenCanSupportEncryptionIfCannotThenReturnFalse() = runTest {
         val authDataStore: SubscriptionsDataStore = FakeSubscriptionsDataStore(supportEncryption = false)
-        val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo)
+        val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo, { privacyProFeature })
         whenever(playBillingManager.purchaseState).thenReturn(flowOf())
         subscriptionsManager = RealSubscriptionsManager(
             authService,
@@ -2047,6 +2125,11 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     @SuppressLint("DenyListedApi")
     private fun givenIsLaunchedRow(value: Boolean) {
         privacyProFeature.isLaunchedROW().setRawStoredState(State(remoteEnableState = value))
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun givenTierMessagingEnabled(value: Boolean) {
+        privacyProFeature.tierMessagingEnabled().setRawStoredState(State(remoteEnableState = value))
     }
 
     @SuppressLint("DenyListedApi")

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.impl.internal.DefaultSubscriptionsBaseUrl
 import com.duckduckgo.subscriptions.impl.internal.RealSubscriptionsUrlProvider
+import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import kotlinx.coroutines.flow.flowOf
@@ -76,8 +77,9 @@ class RealSubscriptionsTest {
         SubscriptionOffer(
             planId = "test",
             offerId = null,
+            tier = "plus",
             pricingPhases = emptyList(),
-            features = setOf(SubscriptionsConstants.NETP),
+            entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
         ),
     )
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
@@ -1088,7 +1088,7 @@ class SubscriptionMessagingInterfaceTest {
     private fun givenUseGetSubscriptionTierOptions(enabled: Boolean) {
         val toggle = mock<com.duckduckgo.feature.toggles.api.Toggle>()
         whenever(toggle.isEnabled()).thenReturn(enabled)
-        whenever(privacyProFeature.useGetSubscriptionTierOptions()).thenReturn(toggle)
+        whenever(privacyProFeature.tierMessagingEnabled()).thenReturn(toggle)
     }
 
     private fun checkEquals(expected: JsRequestResponse, actual: JsRequestResponse) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/FakeSubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/FakeSubscriptionsDataStore.kt
@@ -52,4 +52,5 @@ class FakeSubscriptionsDataStore(
     override var freeTrialActive: Boolean = false
     override fun canUseEncryption(): Boolean = supportEncryption
     override var subscriptionFeatures: String? = null
+    override var subscriptionEntitlements: String? = null
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
@@ -10,6 +10,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionOffer
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command.OpenBuyScreen
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command.OpenRestoreScreen
@@ -118,7 +119,9 @@ class ProSettingViewModelTest {
     fun whenDuckAiPlusEnabledIfSubscriptionPlanHasDuckAiThenDuckAiPlusAvailable() = runTest {
         privacyProFeature.duckAiPlus().setRawStoredState(State(true))
         whenever(subscriptionsManager.subscriptionStatus).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(listOf(subscriptionOffer.copy(features = setOf(Product.DuckAiPlus.value))))
+        whenever(
+            subscriptionsManager.getSubscriptionOffer(),
+        ).thenReturn(listOf(subscriptionOffer.copy(entitlements = setOf(Entitlement("plus", Product.DuckAiPlus.value)))))
         whenever(subscriptionsManager.isFreeTrialEligible()).thenReturn(true)
         whenever(subscriptionsManager.blackFridayOfferAvailable()).thenReturn(false)
 
@@ -133,7 +136,9 @@ class ProSettingViewModelTest {
     fun whenDuckAiPlusEnabledIfSubscriptionPlanDoesNotHaveDuckAiThenDuckAiPlusAvailable() = runTest {
         privacyProFeature.duckAiPlus().setRawStoredState(State(true))
         whenever(subscriptionsManager.subscriptionStatus).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(listOf(subscriptionOffer.copy(features = setOf(Product.NetP.value))))
+        whenever(
+            subscriptionsManager.getSubscriptionOffer(),
+        ).thenReturn(listOf(subscriptionOffer.copy(entitlements = setOf(Entitlement("plus", Product.NetP.value)))))
         whenever(subscriptionsManager.isFreeTrialEligible()).thenReturn(true)
         whenever(subscriptionsManager.blackFridayOfferAvailable()).thenReturn(false)
 
@@ -148,7 +153,9 @@ class ProSettingViewModelTest {
     fun whenDuckAiPlusDisabledIfSubscriptionPlanHasDuckAiThenDuckAiPlusAvailableFalse() = runTest {
         privacyProFeature.duckAiPlus().setRawStoredState(State(false))
         whenever(subscriptionsManager.subscriptionStatus).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(listOf(subscriptionOffer.copy(features = setOf(Product.DuckAiPlus.value))))
+        whenever(
+            subscriptionsManager.getSubscriptionOffer(),
+        ).thenReturn(listOf(subscriptionOffer.copy(entitlements = setOf(Entitlement("plus", Product.DuckAiPlus.value)))))
         whenever(subscriptionsManager.isFreeTrialEligible()).thenReturn(true)
         whenever(subscriptionsManager.blackFridayOfferAvailable()).thenReturn(false)
 
@@ -190,7 +197,8 @@ class ProSettingViewModelTest {
     private val subscriptionOffer = SubscriptionOffer(
         planId = "test",
         offerId = null,
+        tier = "plus",
         pricingPhases = emptyList(),
-        features = emptySet(),
+        entitlements = emptySet(),
     )
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_FREE_TRIAL_OFFER_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.Reload
@@ -217,6 +218,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -225,11 +227,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -238,7 +241,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -287,6 +290,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -295,11 +299,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -308,7 +313,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = false))
@@ -337,6 +342,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -345,11 +351,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -358,11 +365,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = MONTHLY_FREE_TRIAL_OFFER_US,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -377,11 +385,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1W",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = YEARLY_FREE_TRIAL_OFFER_US,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -396,7 +405,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1W",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -424,6 +433,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -432,11 +442,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -445,11 +456,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = MONTHLY_FREE_TRIAL_OFFER_US,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -464,11 +476,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1W",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = YEARLY_FREE_TRIAL_OFFER_US,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -483,7 +496,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1W",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -921,6 +934,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -929,11 +943,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -942,7 +957,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -993,6 +1008,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -1001,11 +1017,12 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -1014,7 +1031,7 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP),
+                entitlements = setOf(Entitlement("plus", SubscriptionsConstants.NETP)),
             ),
         )
         privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = false))
@@ -1042,6 +1059,7 @@ class SubscriptionWebViewViewModelTest {
             SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 1.toBigDecimal(),
@@ -1050,11 +1068,15 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1M",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP, SubscriptionsConstants.ITR),
+                entitlements = setOf(
+                    Entitlement("plus", SubscriptionsConstants.NETP),
+                    Entitlement("plus", SubscriptionsConstants.ITR),
+                ),
             ),
             SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
+                tier = "plus",
                 pricingPhases = listOf(
                     PricingPhase(
                         priceAmount = 10.toBigDecimal(),
@@ -1063,7 +1085,10 @@ class SubscriptionWebViewViewModelTest {
                         billingPeriod = "P1Y",
                     ),
                 ),
-                features = setOf(SubscriptionsConstants.NETP, SubscriptionsConstants.ITR),
+                entitlements = setOf(
+                    Entitlement("plus", SubscriptionsConstants.NETP),
+                    Entitlement("plus", SubscriptionsConstants.ITR),
+                ),
             ),
         )
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212502267333651?focus=true 

### Description
Supports BE v2 features endpoint
Enables FE V2 messaging
Introduces FF for transition

### Steps to test this PR

_Feature 1_
- [x] Fresh install internal release (or remove `applicationIdSuffix ".debug"` in `build.gradle`) so it can obtain subscripton products and plans from Play Store
- [x] skip onboarding
- [x] Navigate to settings
- [x] Ensure Subscription option visible
- [x] Purchase Subscription
- [x] Ensure all behave as usual (including duck.ai visibility)

_Feature 2_
- [x] Continue from Feature 1 test
- [x] Go to feature flag inventory -> enable `tierMessagingEnabled`
- [x] Go to settings
- [x] Ensure Subscription settings still present

_Feature 3_
- [x] Fresh install internal release (or remove `applicationIdSuffix ".debug"` in `build.gradle`) so it can obtain subscripton products and plans from Play Store
- [x] skip onboarding
- [x] Navigate to settings
- [x] Ensure Subscription option visible
- [x] Go to feature flag inventory -> enable `tierMessagingEnabled`
- [x] Go to settings
- [x] Ensure Subscription option visible
- [x] Purchase Subscription
- [x] Ensure all behave as usual (including duck.ai visibility)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces tier-based subscriptions with V2 features and minimal-risk fallback.
> 
> - Adds `featuresV2` fetch via `SubscriptionsCachedService` and maps to `Entitlement`; persists per-plan entitlements in new `subscriptionEntitlements` store with Moshi adapters
> - New FF `tierMessagingEnabled` (default ON) to: fetch/store V2 entitlements, expose FE capability in `getFeatureConfig`, and serve new `getSubscriptionTierOptions` JS message
> - Updates `SubscriptionsManager`/`SubscriptionOffer` to use `entitlements` (and `tier`) while keeping `features` as a derived, backward-compatible view; `getFeatures()` now maps from entitlements
> - `AuthRepository.getFeatures` gracefully falls back to V1 features when V2 absent; legacy feature derivation retained when flag OFF
> - Removes unused `useClientWithCacheForFeatures` FF; expands tests across manager, repository, fetcher, messaging, and UI view models to cover V2 and fallback paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28bc2303335106f08ba1247abc5104d7c1437a79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->