### PR TITLE
SERP Settings Sync: Return noNativeSettings on first launch

### DIFF
--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/serpsettings/messaging/GetNativeSettingsHandler.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/serpsettings/messaging/GetNativeSettingsHandler.kt
@@ -59,8 +59,8 @@ class GetNativeSettingsHandler @Inject constructor(
                         val settingsString = serpSettingsDataStore.getSerpSettings()
 
                         val settingsJsonObject = if (settingsString.isNullOrEmpty()) {
-                            // Return an empty JSON object if no settings are stored
-                            JSONObject()
+                            // Return noNativeSettings: true until settings have been updated by FE
+                            JSONObject().put(KEY_NO_NATIVE_SETTINGS, true)
                         } else {
                             JSONObject(settingsString)
                         }
@@ -86,5 +86,6 @@ class GetNativeSettingsHandler @Inject constructor(
 
     companion object {
         private const val GET_NATIVE_SETTINGS_METHOD_NAME = "getNativeSettings"
+        private const val KEY_NO_NATIVE_SETTINGS = "noNativeSettings"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1212402385991388?focus=true

### Description

When SERP Settings Sync is enabled and a user launches the app for the first time (or migrates), the getNativeSettings handler now returns  `{ noNativeSettings: true }` instead of an empty JSON object. This signals to the SERP that this is a first launch/migration scenario, allowing the SERP to handle the initial state appropriately.

This is returned until the FE calls the updateNativeSettings and updates the locally stored serp settings.

### Steps to test this PR

See [testing steps](https://app.asana.com/1/137249556945/project/1207908166761516/task/1212517945831187?focus=true)

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `getNativeSettings` now returns `{ noNativeSettings: true }` until settings are stored, otherwise returns the stored JSON.
> 
> - **SERP Settings Sync**
>   - Update `GetNativeSettingsHandler` to return `{ "noNativeSettings": true }` when no settings are stored; otherwise parse and return stored JSON.
>   - Add `KEY_NO_NATIVE_SETTINGS` constant.
> - **Tests**
>   - Adjust expectations to `noNativeSettings: true` for null settings and treat `"{}"` as an empty object.
>   - Add test verifying the flag is returned until settings are persisted, then actual values are returned.
>   - Keep id-handling behavior (no response when `id` is null, response when present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8297170b221f3bd83dbf86b1bbb164fdb2fa320. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->