### PR TITLE
GHA: Filter open GHA by PR author

### DIFF
--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -2,7 +2,7 @@ name: 'Pull Request opened -> Comment on task and add it to Android Release Boar
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 jobs:
   process-internal-pr:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212509376050676?focus=true

### Description
Filter action by PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate Asana comment to PR author and run task lookup for all PRs targeting `develop` (including drafts).
> 
> - **CI • GitHub Actions** (`.github/workflows/action-pr-opened.yaml`):
>   - **Asana comment step**: Add condition `github.actor == github.event.pull_request.user.login` to only post when the PR author triggers the workflow.
>   - **Find Asana Task ID step**: Remove draft check; now runs when `base.ref == 'develop'` regardless of draft status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cee734ac0d0278c57c8e345afd0b7f3dbfc9323. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->