### PR TITLE
Tag LGC when nightly job is successful

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,6 @@ on:
     - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:
 
-env:
-  GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1212502548756445?focus=true 

### Description
Tag LGC when nightly job is successful

### Steps to test this PR

_Feature 1_
- [ ] Check [job](https://github.com/duckduckgo/Android/actions/runs/20342434179) is successful and creates a tag with the timestamp

### UI changes
n/a




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add CI job that, on successful nightly, creates and pushes an `LGC-<UTC timestamp>` tag for the current commit.
> 
> - **CI (GitHub Actions)**:
>   - Add `tag_lgc_when_successful` job that runs after `code_formatting`, `unit_tests`, `lint`, and `android_tests` succeed.
>     - Configures git with bot credentials and updates `origin` using `secrets.GT_DAXMOBILE`.
>     - Creates and pushes an `LGC-<UTC timestamp>` tag pointing to `${{ github.sha }}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d875437e7c584fa3fb2be82dbe71ceb9f67bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->