### PR TITLE
GHA: PR Comment is only needed when the PR is opened or reopened

### DIFF
--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Add comment with PR link in Asana task
-        if: ${{ github.actor == github.event.pull_request.user.login && github.event.action == 'ready_for_review' }}
+        if: ${{ github.actor == github.event.pull_request.user.login && ( github.event.action == 'opened' || github.event.action == 'reopened') }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1212516660573065?focus=true

### Description
Comment on Asana only when the PR is ready for review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the PR workflow to include the ready_for_review trigger and only add the Asana comment on opened/reopened events by the PR author.
> 
> - **GitHub Actions** (`.github/workflows/action-pr-opened.yaml`):
>   - Add `ready_for_review` to `pull_request.types`.
>   - Restrict Asana comment step to run only when the actor is the PR author and the action is `opened` or `reopened`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a83e0ec971002911cc22abbd56e112d5d312bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->