### PR TITLE
GHA: Analyze Maestro Flows

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -7,26 +7,6 @@ on:
       ref:
         description: 'This is an example of an input'
         required: true
-      flow_results_json:
-        description: 'Maestro flow results JSON to feed the analyzer'
-        required: true
-        default: '[{"status":"SUCCESS"}]'
-      console_url:
-        description: 'Optional console URL for logging / tasks'
-        required: false
-        default: ''
-      upload_status:
-        description: 'Optional upload status for logging'
-        required: false
-        default: 'SUCCESS'
-      app_binary_id:
-        description: 'Optional app binary ID for logging'
-        required: false
-        default: '123412412'
-      treat_canceled_as_failure:
-        description: 'Treat CANCELED flows as failures (true/false)'
-        required: false
-        default: 'false'
 
 env:
   ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -44,37 +24,3 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GT_DAXMOBILE }}
           ref: ${{ github.event.inputs.ref }}
-
-      - name: Analyze Maestro Flow Results
-        if: always()
-        id: analyze-maestro
-        uses: ./.github/actions/maestro-flow-analyzer
-        with:
-          flow_results_json: ${{ github.event.inputs.flow_results_json }}
-          console_url: ${{ github.event.inputs.console_url }}
-          upload_status: ${{ github.event.inputs.upload_status }}
-          app_binary_id: ${{ github.event.inputs.app_binary_id }}
-          treat_canceled_as_failure: ${{ github.event.inputs.treat_canceled_as_failure }}
-
-      - name: Show analyzer output
-        if: always()
-        run: |
-          echo "flow_summary_status=${{ steps.analyze-maestro.outputs.flow_summary_status }}"
-          echo "flow_summary_message<<'EOF'"
-          echo "${{ steps.analyze-maestro.outputs.flow_summary_message }}"
-          echo "EOF"
-
-      - name: Create Asana task when Maestro not successful
-        if: ${{ always() && steps.analyze-maestro.outputs.flow_summary_status != 'success' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: GH Workflow - Maestro run issue (test_workflow)
-          asana-task-description: |
-            **Run:** https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
-            **Console:** ${{ github.event.inputs.console_url }}
-            **Summary:**
-            ${{ steps.analyze-maestro.outputs.flow_summary_message }}
-          action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1212443750141255?focus=true

### Description
This PR adds a local GHA to analyse Maestro flows

### Steps to test this PR
See task

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a composite GitHub Action that parses Maestro Cloud flow results and outputs a derived status and summary message.
> 
> - **GitHub Actions**:
>   - **New composite action** at `.github/actions/maestro-flow-analyzer/action.yml`:
>     - Inputs: `flow_results_json` (required), optional `console_url`, `upload_status`, `app_binary_id`, `treat_canceled_as_failure`.
>     - Outputs: `flow_summary_status` (`success|failure|canceled_present|empty_results|unknown_format`), `flow_summary_message` (multi-line summary).
>     - Logic: validates JSON; detects `ERROR` and `CANCELED` flows (optional failure on canceled); handles empty/unknown formats; aggregates brief error/canceled details; writes results to `GITHUB_OUTPUT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1664f5faef7ab1d259dfcd6e5c53194d90c30c48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->