### PR TITLE
Android: Migrate to Remote Config v5

### DIFF
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -29,4 +29,4 @@ enum class PrivacyFeatureName(
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"

--- a/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
+++ b/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
@@ -70,7 +70,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:primaryText="Supported Version"
-                    app:secondaryText="v4"
+                    app:secondaryText="v5"
             />
 
             <com.duckduckgo.common.ui.view.listitem.TwoLineListItem


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1212450213858607?focus=true

### Description

Bump privacy config version to v5: updated the remote privacy configuration URL to use v5 instead of v4 and the internal settings screen to reflect this change.

### Steps to test this PR

_Privacy Config Version Update_
- [ ] Verify the app fetches the config from the new URL: `https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json`
- [ ] Check that the internal settings screen displays "v5" as the supported version
- [ ] Ensure all privacy features continue to work correctly with the new config version

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates privacy configuration to version `v5`.
> 
> - Updates `PRIVACY_REMOTE_CONFIG_URL` to `https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json` in `PrivacyFeatureName.kt`
> - Changes internal settings label to display supported version `v5` in `activity_privacy_config_internal_settings.xml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc35fd9f99171812146665718e3b7407b92917a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->