### PR TITLE
PoC: Fix external Custom Tab auth callbacks

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2229,13 +2229,25 @@ class BrowserTabFragment :
             }
 
             is Command.HandleNonHttpAppLink -> {
-                openExternalDialog(
-                    intent = it.nonHttpAppLink.intent,
-                    fallbackUrl = it.nonHttpAppLink.fallbackUrl,
-                    fallbackIntent = it.nonHttpAppLink.fallbackIntent,
-                    useFirstActivityFound = false,
-                    headers = it.headers,
-                )
+                if (isActiveCustomTab() && isLaunchedFromExternalApp) {
+                    // For external Custom Tabs, non-HTTP(s) schemes are frequently used as auth callbacks
+                    // back into the originating app. Prompting here can break the flow and cause the app
+                    // to restart/loop the login process.
+                    launchNonHttpAppLinkFromExternalCustomTab(
+                        intent = it.nonHttpAppLink.intent,
+                        fallbackUrl = it.nonHttpAppLink.fallbackUrl,
+                        fallbackIntent = it.nonHttpAppLink.fallbackIntent,
+                        headers = it.headers,
+                    )
+                } else {
+                    openExternalDialog(
+                        intent = it.nonHttpAppLink.intent,
+                        fallbackUrl = it.nonHttpAppLink.fallbackUrl,
+                        fallbackIntent = it.nonHttpAppLink.fallbackIntent,
+                        useFirstActivityFound = false,
+                        headers = it.headers,
+                    )
+                }
             }
 
             is Command.ExtractUrlFromCloakedAmpLink -> {
@@ -2747,6 +2759,50 @@ class BrowserTabFragment :
                 }
             } else {
                 launchDialogForIntent(it, pm, intent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
+            }
+        }
+    }
+
+    private fun launchNonHttpAppLinkFromExternalCustomTab(
+        intent: Intent,
+        fallbackUrl: String? = null,
+        fallbackIntent: Intent? = null,
+        headers: Map<String, String> = emptyMap(),
+    ) {
+        // Only act if the fragment is still active; avoids launching from background tabs.
+        if (!isActiveCustomTab()) return
+
+        context?.let { context ->
+            val pm = context.packageManager
+            val activities = pm.queryIntentActivities(intent, 0)
+
+            when {
+                activities.isEmpty() -> {
+                    when {
+                        fallbackIntent != null -> {
+                            runCatching { context.startActivity(fallbackIntent) }
+                                .onFailure { showToast(R.string.unableToOpenLink) }
+                        }
+
+                        fallbackUrl != null -> {
+                            webView?.loadUrl(fallbackUrl, headers)
+                        }
+
+                        else -> showToast(R.string.unableToOpenLink)
+                    }
+                }
+
+                activities.size == 1 -> {
+                    runCatching { context.startActivity(intent) }
+                        .onFailure { showToast(R.string.unableToOpenLink) }
+                }
+
+                else -> {
+                    val title = getString(R.string.openExternalApp)
+                    val chooser = Intent.createChooser(intent, title)
+                    runCatching { context.startActivity(chooser) }
+                        .onFailure { showToast(R.string.unableToOpenLink) }
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -108,8 +108,19 @@ class CustomTabActivity : DuckDuckGoActivity() {
     }
 
     companion object {
-        fun intent(context: Context, flags: Int, text: String?, toolbarColor: Int, isExternal: Boolean): Intent {
-            return Intent(context, CustomTabActivity::class.java).apply {
+        fun intent(
+            context: Context,
+            originalIntent: Intent?,
+            flags: Int,
+            text: String?,
+            toolbarColor: Int,
+            isExternal: Boolean,
+        ): Intent {
+            // Preserve Custom Tabs extras from the original caller intent (e.g., session binder),
+            // while still routing to our CustomTabActivity implementation.
+            val base = originalIntent?.let { Intent(it) } ?: Intent()
+            return base.apply {
+                setClass(context, CustomTabActivity::class.java)
                 addFlags(flags)
                 putExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, toolbarColor)
                 putExtra(Intent.EXTRA_TEXT, text)

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -72,7 +72,8 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
         startActivity(
             CustomTabActivity.intent(
                 context = this,
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK and Intent.FLAG_ACTIVITY_CLEAR_TASK and Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
+                originalIntent = intent,
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
                 text = intentText,
                 toolbarColor = toolbarColor,
                 isExternal = isExternal,


### PR DESCRIPTION
Avoid prompting on non-HTTP(s) callback intents when running as an external Custom Tab to prevent OAuth/app-link flows from looping back to the start. Also preserve original Custom Tabs extras when routing into CustomTabActivity and fix incorrect flag bitmasking.

Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211773313492727?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid prompts for non-HTTP(s) app-link callbacks in external Custom Tabs, preserve original Custom Tabs extras when launching, and fix intent flag composition.
> 
> - **Custom Tabs behavior**
>   - For `Command.HandleNonHttpAppLink`, when in an active external Custom Tab, launch non-HTTP(s) intents directly via `launchNonHttpAppLinkFromExternalCustomTab(...)` (with fallback intent/URL handling and chooser) instead of prompting.
>   - Add `BrowserTabFragment.launchNonHttpAppLinkFromExternalCustomTab(...)` to handle direct launches and fallbacks.
> - **Intent preservation**
>   - Update `CustomTabActivity.intent(...)` to accept `originalIntent` and copy Custom Tabs extras (e.g., session) before routing to `CustomTabActivity`.
> - **Flag fix**
>   - In `IntentDispatcherActivity.showCustomTab`, pass `originalIntent = intent` and fix flags from bitwise AND to OR: `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK | FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 502ddd2ab84bdcfd3eca306694b080f7150bb5da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->