### PR TITLE
Adds missing param to retention metric

### DIFF
--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetric.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.attributed.metrics.api.AttributedMetricClient
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetricConfig
 import com.duckduckgo.app.attributed.metrics.api.MetricBucket
 import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.browser.api.install.AppInstall
@@ -46,6 +47,7 @@ class RetentionMonthAttributedMetric @Inject constructor(
     private val attributedMetricClient: AttributedMetricClient,
     private val dateUtils: AttributedMetricsDateUtils,
     private val attributedMetricConfig: AttributedMetricConfig,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
 ) : AttributedMetric, AtbLifecyclePlugin {
 
     companion object {
@@ -104,6 +106,7 @@ class RetentionMonthAttributedMetric @Inject constructor(
         if (month < START_MONTH_THRESHOLD) return emptyMap()
 
         val params = mutableMapOf(
+            "default_browser" to defaultBrowserDetector.isDefaultBrowser().toString(),
             "count" to bucketMonth(month).toString(),
             "version" to bucketConfig.await().version.toString(),
         )

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetric.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.attributed.metrics.api.AttributedMetricClient
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetricConfig
 import com.duckduckgo.app.attributed.metrics.api.MetricBucket
 import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.browser.api.install.AppInstall
@@ -46,6 +47,7 @@ class RetentionWeekAttributedMetric @Inject constructor(
     private val attributedMetricClient: AttributedMetricClient,
     private val dateUtils: AttributedMetricsDateUtils,
     private val attributedMetricConfig: AttributedMetricConfig,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
 ) : AttributedMetric, AtbLifecyclePlugin {
 
     companion object {
@@ -100,6 +102,7 @@ class RetentionWeekAttributedMetric @Inject constructor(
         if (week == -1) return emptyMap()
 
         val params = mutableMapOf(
+            "default_browser" to defaultBrowserDetector.isDefaultBrowser().toString(),
             "count" to bucketValue(getWeekSinceInstall()).toString(),
             "version" to bucketConfig.await().version.toString(),
         )

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetricTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/retention/RetentionMonthAttributedMetricTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.attributed.metrics.api.AttributedMetricClient
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetricConfig
 import com.duckduckgo.app.attributed.metrics.api.MetricBucket
 import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.browser.api.install.AppInstall
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -49,6 +50,7 @@ class RetentionMonthAttributedMetricTest {
     private val attributedMetricConfig: AttributedMetricConfig = mock()
     private val appInstall: AppInstall = mock()
     private val dateUtils: AttributedMetricsDateUtils = mock()
+    private val defaultBrowserDetector: DefaultBrowserDetector = mock()
     private val retentionToggle = FakeFeatureToggleFactory.create(AttributedMetricsConfigFeature::class.java)
 
     private lateinit var testee: RetentionMonthAttributedMetric
@@ -75,6 +77,7 @@ class RetentionMonthAttributedMetricTest {
             attributedMetricClient = attributedMetricClient,
             dateUtils = dateUtils,
             attributedMetricConfig = attributedMetricConfig,
+            defaultBrowserDetector = defaultBrowserDetector,
         )
     }
 
@@ -217,6 +220,26 @@ class RetentionMonthAttributedMetricTest {
         val version = testee.getMetricParameters()["version"]
 
         assertEquals("0", version)
+    }
+
+    @Test
+    fun whenIsDefaultBrowserThenReturnDefaultBrowserTrue() = runTest {
+        givenDaysSinceInstalled(29)
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+
+        val defaultBrowser = testee.getMetricParameters()["default_browser"]
+
+        assertEquals("true", defaultBrowser)
+    }
+
+    @Test
+    fun whenIsNotDefaultBrowserThenReturnDefaultBrowserFalse() = runTest {
+        givenDaysSinceInstalled(29)
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+
+        val defaultBrowser = testee.getMetricParameters()["default_browser"]
+
+        assertEquals("false", defaultBrowser)
     }
 
     private fun givenDaysSinceInstalled(days: Int) {

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetricTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/retention/RetentionWeekAttributedMetricTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.attributed.metrics.api.AttributedMetricClient
 import com.duckduckgo.app.attributed.metrics.api.AttributedMetricConfig
 import com.duckduckgo.app.attributed.metrics.api.MetricBucket
 import com.duckduckgo.app.attributed.metrics.store.AttributedMetricsDateUtils
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.browser.api.install.AppInstall
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -49,6 +50,7 @@ class RetentionWeekAttributedMetricTest {
     private val attributedMetricConfig: AttributedMetricConfig = mock()
     private val appInstall: AppInstall = mock()
     private val dateUtils: AttributedMetricsDateUtils = mock()
+    private val defaultBrowserDetector: DefaultBrowserDetector = mock()
     private val retentionToggle = FakeFeatureToggleFactory.create(AttributedMetricsConfigFeature::class.java)
 
     private lateinit var testee: RetentionWeekAttributedMetric
@@ -75,6 +77,7 @@ class RetentionWeekAttributedMetricTest {
             appInstall = appInstall,
             dateUtils = dateUtils,
             attributedMetricConfig = attributedMetricConfig,
+            defaultBrowserDetector = defaultBrowserDetector,
         )
     }
 
@@ -225,6 +228,26 @@ class RetentionWeekAttributedMetricTest {
         val version = testee.getMetricParameters()["version"]
 
         assertEquals("0", version)
+    }
+
+    @Test
+    fun whenIsDefaultBrowserThenReturnDefaultBrowserTrue() = runTest {
+        givenDaysSinceInstalled(7)
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+
+        val defaultBrowser = testee.getMetricParameters()["default_browser"]
+
+        assertEquals("true", defaultBrowser)
+    }
+
+    @Test
+    fun whenIsNotDefaultBrowserThenReturnDefaultBrowserFalse() = runTest {
+        givenDaysSinceInstalled(7)
+        whenever(defaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+
+        val defaultBrowser = testee.getMetricParameters()["default_browser"]
+
+        assertEquals("false", defaultBrowser)
     }
 
     private fun givenDaysSinceInstalled(days: Int) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1212461264788061?focus=true 

### Description
Adds default_browser param to retention metric 

### Steps to test this PR
Simple change, unit test covers

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `default_browser` parameter to weekly and monthly retention attributed metrics and updates tests accordingly.
> 
> - **Attributed Metrics (Retention)**
>   - Inject `DefaultBrowserDetector` into `RetentionWeekAttributedMetric` and `RetentionMonthAttributedMetric`.
>   - Include `"default_browser"` in `getMetricParameters()` for both metrics.
> - **Tests**
>   - Update `RetentionWeekAttributedMetricTest` and `RetentionMonthAttributedMetricTest` to mock `DefaultBrowserDetector` and assert `default_browser` param values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d815928f86e955d72e91f1db46eb95bd0a1cac3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->