### PR TITLE
remove tablet form factor from attr metrics

### DIFF
--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptor.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptor.kt
@@ -37,7 +37,10 @@ class AttributedMetricPixelInterceptor @Inject constructor() : Interceptor, Pixe
         var url = chain.request().url
         val pixel = chain.request().url.pathSegments.last()
         if (pixel.startsWith(ATTRIBUTED_METRICS_PIXEL_PREFIX)) {
-            url = url.toUrl().toString().replace("android_${DeviceInfo.FormFactor.PHONE.description}", "android").toHttpUrl()
+            url = url.toUrl().toString()
+                .replace("android_${DeviceInfo.FormFactor.PHONE.description}", "android")
+                .replace("android_${DeviceInfo.FormFactor.TABLET.description}", "android")
+                .toHttpUrl()
             logcat(tag = "AttributedMetrics") {
                 "Pixel renamed to: $url"
             }

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptorTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/pixels/AttributedMetricPixelInterceptorTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.attributed.metrics.pixels
+
+import com.duckduckgo.common.test.api.FakeChain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class AttributedMetricPixelInterceptorTest {
+
+    private lateinit var interceptor: AttributedMetricPixelInterceptor
+
+    @Before
+    fun setup() {
+        interceptor = AttributedMetricPixelInterceptor()
+    }
+
+    @Test
+    fun `when pixel is attributed metric with phone form factor then form factor is removed from url`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/attributed_metric_test_android_phone"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/attributed_metric_test_android",
+            result.request.url.toString(),
+        )
+    }
+
+    @Test
+    fun `when pixel is attributed metric with tablet form factor then form factor is removed from url`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/attributed_metric_test_android_tablet"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/attributed_metric_test_android",
+            result.request.url.toString(),
+        )
+    }
+
+    @Test
+    fun `when pixel is attributed metric with query params then form factor is removed and params preserved`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/attributed_metric_test_android_phone?param1=value1&param2=value2"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/attributed_metric_test_android?param1=value1&param2=value2",
+            result.request.url.toString(),
+        )
+    }
+
+    @Test
+    fun `when pixel is attributed metric with tablet and query params then form factor is removed and params preserved`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/attributed_metric_test_android_tablet?param1=value1"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/attributed_metric_test_android?param1=value1",
+            result.request.url.toString(),
+        )
+    }
+
+    @Test
+    fun `when pixel is not an attributed metric then url is unchanged`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/other_pixel_android_phone"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/other_pixel_android_phone",
+            result.request.url.toString(),
+        )
+    }
+
+    @Test
+    fun `when pixel already has android without form factor then url is unchanged`() {
+        val pixelUrl = "https://improving.duckduckgo.com/t/attributed_metric_test_android"
+
+        val result = interceptor.intercept(FakeChain(pixelUrl))
+
+        assertEquals(
+            "https://improving.duckduckgo.com/t/attributed_metric_test_android",
+            result.request.url.toString(),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1113117197328546/task/1212461248352352?focus=true 

### Description
Removes tablet from pixel suffix from attributed metrics

### Steps to test this PR
Added unit tests for the change, qa-optional.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Interceptor now replaces both android_phone and android_tablet pixel suffixes with android for attributed metrics.
> 
> - **Attributed metrics**:
>   - **Pixel normalization** in `AttributedMetricPixelInterceptor`: also strip `android_${DeviceInfo.FormFactor.TABLET.description}` to `android` (in addition to `PHONE`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a1e51408447d8d7767434e929335291387ad81f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->