### PR TITLE
Remove VPN menu item pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8137,48 +8137,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenVpnMenuClickedWithNotSubscribedStateThenPixelFiredWithPillStatus() {
-        testee.browserViewState.value = browserViewState().copy(
-            vpnMenuState = VpnMenuState.NotSubscribed,
-        )
-
-        testee.onVpnMenuClicked()
-
-        verify(mockPixel).fire(
-            AppPixelName.MENU_ACTION_VPN_PRESSED,
-            mapOf(PixelParameter.STATUS to "pill"),
-        )
-    }
-
-    @Test
-    fun whenVpnMenuClickedWithNotSubscribedNoPillStateThenPixelFiredWithNoPillStatus() {
-        testee.browserViewState.value = browserViewState().copy(
-            vpnMenuState = VpnMenuState.NotSubscribedNoPill,
-        )
-
-        testee.onVpnMenuClicked()
-
-        verify(mockPixel).fire(
-            AppPixelName.MENU_ACTION_VPN_PRESSED,
-            mapOf(PixelParameter.STATUS to "no_pill"),
-        )
-    }
-
-    @Test
-    fun whenVpnMenuClickedWithSubscribedStateThenPixelFiredWithSubscribedStatus() {
-        testee.browserViewState.value = browserViewState().copy(
-            vpnMenuState = VpnMenuState.Subscribed(isVpnEnabled = true),
-        )
-
-        testee.onVpnMenuClicked()
-
-        verify(mockPixel).fire(
-            AppPixelName.MENU_ACTION_VPN_PRESSED,
-            mapOf(PixelParameter.STATUS to "subscribed"),
-        )
-    }
-
-    @Test
     fun whenDuckChatNativeNewChatRequested() = runTest {
         val expectedEvent = SubscriptionEventData(
             featureName = "event1",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4513,26 +4513,15 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onVpnMenuClicked() {
-        val vpnMenuState = currentBrowserViewState().vpnMenuState
-        val statusParam = when (vpnMenuState) {
-            VpnMenuState.NotSubscribed -> {
-                command.value = LaunchPrivacyPro("https://duckduckgo.com/pro?origin=funnel_appmenu_android".toUri())
-                "pill"
-            }
-
-            VpnMenuState.NotSubscribedNoPill -> {
-                command.value = LaunchPrivacyPro("https://duckduckgo.com/pro?origin=funnel_appmenu_android".toUri())
-                "no_pill"
-            }
-
+        when (currentBrowserViewState().vpnMenuState) {
             is VpnMenuState.Subscribed -> {
                 command.value = LaunchVpnManagement
-                "subscribed"
             }
-
-            VpnMenuState.Hidden -> "" // Should not happen as menu item should not be visible
+            VpnMenuState.Hidden -> {} // Should not happen as menu item should not be visible
+            else -> {
+                command.value = LaunchPrivacyPro("https://duckduckgo.com/pro?origin=funnel_appmenu_android".toUri())
+            }
         }
-        pixel.fire(AppPixelName.MENU_ACTION_VPN_PRESSED, mapOf(PixelParameter.STATUS to statusParam))
     }
 
     fun onAutoConsentPopUpHandled(isCosmetic: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -266,7 +266,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     MENU_ACTION_APP_LINKS_OPEN_PRESSED("m_nav_app_links_open_menu_item_pressed"),
     MENU_ACTION_DOWNLOADS_PRESSED("m_nav_downloads_menu_item_pressed"),
     MENU_ACTION_AUTOFILL_PRESSED("m_nav_autofill_menu_item_pressed"),
-    MENU_ACTION_VPN_PRESSED("m_nav_vpn_menu_item_pressed"),
 
     FIREPROOF_WEBSITE_ADDED("m_fw_a"),
     FIREPROOF_WEBSITE_REMOVE("m_fw_r"),

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -71,7 +71,6 @@ interface Pixel {
         const val IS_TAB_SWITCHER_BUTTON_SHOWN = "is_tab_switcher_button_shown"
         const val IS_FIRE_BUTTON_SHOWN = "is_fire_button_shown"
         const val IS_BROWSER_MENU_BUTTON_SHOWN = "is_browser_menu_button_shown"
-        const val STATUS = "status"
     }
 
     object PixelValues {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211580356861432?focus=true

### Description
Remove temporary pixel for when VPN menu item is selected

### Steps to test this PR _(Optional)_

_Pre-steps_
- [ ] Apply PPro patch -> https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Not Subscribed_
- [ ] Fresh install
- [ ] Open a new tab page
- [ ] VPN menu item will show with yellow pill "TRY FOR FREE"
- [ ] Tap on VPN menu item
- [ ] Check in Logcat pixel is **not** sent: `Pixel sent: m_nav_vpn_menu_item_pressed with params: {status=pill}`

_Not Subscribed & No Pill_
- [ ] Open a new tab
- [ ] Open overflow menu at least 3 more times
- [ ] Open a new tab
- [ ] Open overflow menu
- [ ] VPN menu item doesn't have the yellow 'TRY FOR FREE' pill anymore
- [ ] Tab on VPN item
- [ ] Check in Logcat pixel is **not** sent: `Pixel sent: m_nav_vpn_menu_item_pressed with params: {status=no_pill}`

_Subscribed_
- [ ] Purchase a test subscription
- [ ] Go to browser and open a new tab
- [ ] Open overflow menu
- [ ] Tap on VPN menu item
- [ ] Check in Logcat pixel is **not** sent: `Pixel sent: m_nav_vpn_menu_item_pressed with params: {status=subscribed}`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the VPN menu click pixel (and status param), simplifies `onVpnMenuClicked`, and deletes related tests.
> 
> - **Browser logic**:
>   - Simplify `onVpnMenuClicked` in `BrowserTabViewModel`; remove pixel firing and status handling, keep navigation only (`LaunchVpnManagement` or `LaunchPrivacyPro`).
> - **Analytics**:
>   - Remove pixel `AppPixelName.MENU_ACTION_VPN_PRESSED` from `AppPixelName`.
>   - Remove `Pixel.PixelParameter.STATUS` from `Pixel`.
> - **Tests**:
>   - Delete VPN menu click pixel tests from `BrowserTabViewModelTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c2b606866023e95d0aa75f1b318f76b4e8aba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->