### PR TITLE
PIR: Add tests for unsupported scan and opt out actions

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
@@ -121,14 +121,15 @@ class FakePirMessagingInterface(moshi: Moshi) : JsMessaging {
                     nextExtractResponseEmpty = false
                     "[]"
                 } else {
+                    val uniqueId = action.id.hashCode().toString().takeLast(8)
                     """
                     [
                         {
                             "name": "John Doe",
                             "fullName": "John Doe",
                             "age": "33",
-                            "profileUrl": "https://www.fake-broker.com/John-Doe/NY/New-York/abc123",
-                            "identifier": "abc123",
+                            "profileUrl": "https://fake-broker.com/profile/$uniqueId",
+                            "identifier": "$uniqueId",
                             "email": "john.doe@example.com",
                             "phoneNumbers": ["+1-555-0101"],
                             "relatives": ["Jane Doe"],

--- a/pir/pir-impl/src/androidTest/resources/fake-broker-optout-unknown-action.json
+++ b/pir/pir-impl/src/androidTest/resources/fake-broker-optout-unknown-action.json
@@ -1,0 +1,115 @@
+{
+  "name": "FakeBrokerOptOutUnknownAction",
+  "url": "fake-broker-optout-unknown-action.com",
+  "version": "0.7.0",
+  "addedDatetime": 1692572400000,
+  "optOutUrl": "https://fake-broker-optout-unknown-action.com/optout",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "unknown-nav-scan-1",
+          "url": "https://www.fake-broker-optout-unknown-action.com/${firstName}-${lastName}/${state|stateFull}/${city}"
+        },
+        {
+          "actionType": "extract",
+          "id": "unknown-extract-1",
+          "selector": "div[role='listitem']",
+          "noResultsSelector": ".no_results_container",
+          "profile": {
+            "name": {
+              "selector": "h3",
+              "beforeText": ","
+            },
+            "age": {
+              "selector": "h3",
+              "afterText": ","
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(text(), 'Reside')]",
+              "afterText": "Resides in"
+            },
+            "profileUrl": {
+              "selector": "a",
+              "identifierType": "path",
+              "identifier": "https://www.fake-broker-optout-unknown-action.com/${firstName}-${lastName}/${state|stateFull}/${city|hyphenated}/${id}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "formOptOut",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "unknown-nav-optout-1",
+          "url": "https://www.fake-broker-optout-unknown-action.com/optout"
+        },
+        {
+          "actionType": "unknownFutureAction",
+          "id": "unknown-action-optout-1",
+          "anotherField": "anotherValue"
+        },
+        {
+          "actionType": "expectation",
+          "id": "unknown-expect-1",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#optout-form",
+              "parent": ".optout_container"
+            }
+          ]
+        },
+        {
+          "actionType": "fillForm",
+          "id": "unknown-fill-1",
+          "selector": ".optout_container",
+          "elements": [
+            {
+              "type": "email",
+              "selector": ".//input[@name='email']"
+            },
+            {
+              "type": "profileUrl",
+              "selector": ".//input[@name='url']"
+            }
+          ]
+        },
+        {
+          "actionType": "click",
+          "id": "unknown-click-1",
+          "elements": [
+            {
+              "type": "button",
+              "selector": ".submit-button"
+            }
+          ]
+        },
+        {
+          "actionType": "expectation",
+          "id": "unknown-expect-2",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Request submitted"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/androidTest/resources/fake-broker-scan-unknown-action.json
+++ b/pir/pir-impl/src/androidTest/resources/fake-broker-scan-unknown-action.json
@@ -1,0 +1,115 @@
+{
+  "name": "FakeBrokerScanUnknownAction",
+  "url": "fake-broker-scan-unknown-action.com",
+  "version": "0.7.0",
+  "addedDatetime": 1692572400000,
+  "optOutUrl": "https://fake-broker-scan-unknown-action.com/optout",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "unknown-nav-scan-1",
+          "url": "https://www.fake-broker-scan-unknown-action.com/${firstName}-${lastName}/${state|stateFull}/${city}"
+        },
+        {
+          "actionType": "unknownFutureAction",
+          "id": "unknown-action-scan-1",
+          "someField": "someValue"
+        },
+        {
+          "actionType": "extract",
+          "id": "unknown-extract-1",
+          "selector": "div[role='listitem']",
+          "noResultsSelector": ".no_results_container",
+          "profile": {
+            "name": {
+              "selector": "h3",
+              "beforeText": ","
+            },
+            "age": {
+              "selector": "h3",
+              "afterText": ","
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(text(), 'Reside')]",
+              "afterText": "Resides in"
+            },
+            "profileUrl": {
+              "selector": "a",
+              "identifierType": "path",
+              "identifier": "https://www.fake-broker-scan-unknown-action.com/${firstName}-${lastName}/${state|stateFull}/${city|hyphenated}/${id}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "formOptOut",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "unknown-nav-optout-1",
+          "url": "https://www.fake-broker-unknown-action.com/optout"
+        },
+        {
+          "actionType": "expectation",
+          "id": "unknown-expect-1",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#optout-form",
+              "parent": ".optout_container"
+            }
+          ]
+        },
+        {
+          "actionType": "fillForm",
+          "id": "unknown-fill-1",
+          "selector": ".optout_container",
+          "elements": [
+            {
+              "type": "email",
+              "selector": ".//input[@name='email']"
+            },
+            {
+              "type": "profileUrl",
+              "selector": ".//input[@name='url']"
+            }
+          ]
+        },
+        {
+          "actionType": "click",
+          "id": "unknown-click-1",
+          "elements": [
+            {
+              "type": "button",
+              "selector": ".submit-button"
+            }
+          ]
+        },
+        {
+          "actionType": "expectation",
+          "id": "unknown-expect-2",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Request submitted"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1212509220972152?focus=true

### Description
Adds two e2e tests for checking behavior with unsupported actions in the scan and opt out steps.

### Steps to test this PR
(Optional) Run tests in `PirEndToEndTest`

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two e2e tests and fixtures to verify graceful handling of unknown actions in scan and opt-out steps, plus minor test infra refactors.
> 
> - **Tests (PirEndToEndTest.kt)**
>   - Add `testScanGracefullyHandlesUnknownActions` to assert scan step with unknown action is parsed as NOT_EXECUTED and does not push actions.
>   - Add `testOptOutGracefullyHandlesUnknownActions` to assert valid scan works but opt-out with unknown action remains NOT_EXECUTED and pushes no opt-out actions.
>   - Introduce constants for `"FakeBrokerScanUnknownAction"` and `"FakeBrokerOptOutUnknownAction"`.
>   - Refactor DB setup: extract `insertBrokerIntoDb(...)`; add loaders `loadBrokerWithScanUnknownAction()` and `loadBrokerWithOptOutUnknownAction()`.
> - **Fakes**
>   - `FakePirMessagingInterface`: generate unique `identifier`/`profileUrl` for `extract` responses based on action ID.
> - **Test resources**
>   - Add `resources/fake-broker-scan-unknown-action.json` and `resources/fake-broker-optout-unknown-action.json` to model unknown actions in respective steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d0bb07f493138f1d983e2459461e1352aafa828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->