### PR TITLE
Rework DaxText Composable contract

### DIFF
--- a/android-design-system/design-system-internal/lint-baseline.xml
+++ b/android-design-system/design-system-internal/lint-baseline.xml
@@ -1803,7 +1803,7 @@
 
     <issue
         id="InvalidDaxTextColorUsage"
-        message="Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.&#xA;&#xA;Examples:&#xA;• DuckDuckGoTheme.textColors.primary&#xA;• DuckDuckGoTheme.textColors.secondary&#xA;&#xA;For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR."
+        message="Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.&#xA;&#xA;Examples:&#xA;• DuckDuckGoTheme.colors.text.primary&#xA;• DuckDuckGoTheme.colors.text.secondary&#xA;&#xA;For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR."
         errorLine1="                color = DuckDuckGoTheme.colors.destructive,"
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/palette/ColorPaletteFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/palette/ColorPaletteFragment.kt
@@ -151,7 +151,7 @@ class ColorPaletteFragment : Fragment() {
             DaxColorAttributeListItem(
                 text = "Primary Text",
                 dotColors = DaxColorDotColors(
-                    fillColor = DuckDuckGoTheme.textColors.primary,
+                    fillColor = DuckDuckGoTheme.colors.text.primary,
                     strokeColor = DuckDuckGoTheme.colors.backgrounds.backgroundInverted,
                 ),
             )
@@ -162,7 +162,7 @@ class ColorPaletteFragment : Fragment() {
             DaxColorAttributeListItem(
                 text = "Secondary Text",
                 dotColors = DaxColorDotColors(
-                    fillColor = DuckDuckGoTheme.textColors.secondary,
+                    fillColor = DuckDuckGoTheme.colors.text.secondary,
                     strokeColor = DuckDuckGoTheme.colors.backgrounds.backgroundInverted,
                 ),
             )
@@ -173,7 +173,7 @@ class ColorPaletteFragment : Fragment() {
             DaxColorAttributeListItem(
                 text = "Text Disabled",
                 dotColors = DaxColorDotColors(
-                    fillColor = DuckDuckGoTheme.textColors.disabled,
+                    fillColor = DuckDuckGoTheme.colors.text.disabled,
                     strokeColor = DuckDuckGoTheme.colors.backgrounds.backgroundInverted,
                 ),
             )

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/sheets/DaxActionBottomSheetDialog.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/sheets/DaxActionBottomSheetDialog.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,9 +40,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.text.DaxText
-import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.asTextStyle
 import com.duckduckgo.mobile.android.R
 
 /**
@@ -110,11 +107,10 @@ private fun DaxActionTitleBottomSheetDialog(
     contentColor: Color = DaxActionBottomSheetDefaults.contentColor,
     style: TextStyle = DaxActionBottomSheetDefaults.style,
 ) {
-    val daxStyle = remember(style) { DuckDuckGoTextStyle(style) }
     DaxText(
         text = text,
         color = contentColor,
-        style = daxStyle,
+        style = style,
         modifier = modifier
             .padding(DaxActionBottomSheetDefaults.sheetActionTitleContentPadding),
     )
@@ -123,7 +119,7 @@ private fun DaxActionTitleBottomSheetDialog(
 object DaxActionBottomSheetDefaults {
     internal val style: TextStyle
         @Composable
-        get() = DuckDuckGoTheme.typography.body1.asTextStyle
+        get() = DuckDuckGoTheme.typography.body1
 
     internal val contentColor: Color
         @Composable

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
@@ -16,24 +16,26 @@
 
 package com.duckduckgo.common.ui.compose.text
 
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.asTextStyle
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.common.ui.compose.tools.PreviewBoxInverted
 
 /**
  * Base text component for the DuckDuckGo design system.
  *
- * @param color The text color. Should use colors from [DuckDuckGoTheme.textColors] for consistency
- * with the design system (e.g., [DuckDuckGoTheme.textColors.primary], [DuckDuckGoTheme.textColors.secondary]).
+ * @param color The text color. Should use colors from [DuckDuckGoTheme.colors.text] for consistency
+ * with the design system (e.g., [DuckDuckGoTheme.colors.text.primary], [DuckDuckGoTheme.colors.text.secondary]).
  * A lint rule will warn if arbitrary colors are used.
  *
  * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211634956773768
@@ -43,16 +45,17 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBoxInverted
 fun DaxText(
     text: String,
     modifier: Modifier = Modifier,
-    style: DuckDuckGoTextStyle = DuckDuckGoTheme.typography.body1,
-    color: Color = DuckDuckGoTheme.textColors.primary,
+    color: Color = Color.Unspecified,
+    style: TextStyle = LocalTextStyle.current,
     textAlign: TextAlign? = null,
     overflow: TextOverflow = TextOverflow.Ellipsis,
     maxLines: Int = Int.MAX_VALUE,
 ) {
+    val textColor = color.takeOrElse { style.color.takeOrElse { LocalContentColor.current } }
     Text(
         text = text,
-        color = color,
-        style = style.asTextStyle,
+        color = textColor,
+        style = style,
         textAlign = textAlign,
         overflow = overflow,
         maxLines = maxLines,
@@ -170,7 +173,7 @@ private fun DaxTextColorPrimaryPreview() {
     PreviewBox {
         DaxText(
             text = "Primary Color",
-            color = DuckDuckGoTheme.textColors.primary,
+            color = DuckDuckGoTheme.colors.text.primary,
         )
     }
 }
@@ -181,7 +184,7 @@ private fun DaxTextColorPrimaryInvertedPreview() {
     PreviewBoxInverted {
         DaxText(
             text = "Primary Inverted",
-            color = DuckDuckGoTheme.textColors.primaryInverted,
+            color = DuckDuckGoTheme.colors.text.primaryInverted,
         )
     }
 }
@@ -192,7 +195,7 @@ private fun DaxTextColorSecondaryPreview() {
     PreviewBox {
         DaxText(
             text = "Secondary Color",
-            color = DuckDuckGoTheme.textColors.secondary,
+            color = DuckDuckGoTheme.colors.text.secondary,
         )
     }
 }
@@ -203,7 +206,7 @@ private fun DaxTextColorSecondaryInvertedPreview() {
     PreviewBoxInverted {
         DaxText(
             text = "Secondary Inverted",
-            color = DuckDuckGoTheme.textColors.secondaryInverted,
+            color = DuckDuckGoTheme.colors.text.secondaryInverted,
         )
     }
 }
@@ -214,7 +217,7 @@ private fun DaxTextColorTertiaryPreview() {
     PreviewBox {
         DaxText(
             text = "Tertiary Color",
-            color = DuckDuckGoTheme.textColors.tertiary,
+            color = DuckDuckGoTheme.colors.text.tertiary,
         )
     }
 }
@@ -225,7 +228,7 @@ private fun DaxTextColorDisabledPreview() {
     PreviewBox {
         DaxText(
             text = "Disabled Color",
-            color = DuckDuckGoTheme.textColors.disabled,
+            color = DuckDuckGoTheme.colors.text.disabled,
         )
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/textfield/DaxSecureTextField.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/textfield/DaxSecureTextField.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
 import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.asTextStyle
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -174,11 +173,11 @@ internal fun DaxSecureTextField(
     // override is needed as TextField uses MaterialTheme.typography internally for animating the label text style
     MaterialTheme(
         typography = Typography(
-            bodySmall = DuckDuckGoTheme.typography.caption.asTextStyle.copy(
+            bodySmall = DuckDuckGoTheme.typography.caption.copy(
                 fontFamily = FontFamily.Default,
                 color = DuckDuckGoTheme.colors.text.secondary,
             ),
-            bodyLarge = DuckDuckGoTheme.typography.body1.asTextStyle.copy(
+            bodyLarge = DuckDuckGoTheme.typography.body1.copy(
                 fontFamily = FontFamily.Default,
                 color = DuckDuckGoTheme.colors.text.secondary,
             ),
@@ -221,8 +220,8 @@ internal fun DaxSecureTextField(
                     ),
                 enabled = inputMode == DaxTextFieldInputMode.Editable || inputMode == DaxTextFieldInputMode.ReadOnly,
                 readOnly = inputMode == DaxTextFieldInputMode.ReadOnly || inputMode == DaxTextFieldInputMode.Disabled,
-                textStyle = DuckDuckGoTheme.typography.body1.asTextStyle.copy(
-                    color = DuckDuckGoTheme.textColors.primary,
+                textStyle = DuckDuckGoTheme.typography.body1.copy(
+                    color = DuckDuckGoTheme.colors.text.primary,
                 ),
                 cursorBrush = SolidColor(daxTextFieldColors.cursorColor),
                 keyboardOptions = keyboardOptions,
@@ -260,7 +259,7 @@ internal fun DaxSecureTextField(
                             DaxText(
                                 text = error,
                                 style = DuckDuckGoTheme.typography.caption,
-                                color = DuckDuckGoTheme.textColors.destructive,
+                                color = DuckDuckGoTheme.colors.text.destructive,
                             )
                         }
                     } else {

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/textfield/DaxTextField.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/textfield/DaxTextField.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.theme.Transparent
-import com.duckduckgo.common.ui.compose.theme.asTextStyle
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -96,13 +95,13 @@ fun DaxTextField(
     // override is needed as TextField uses MaterialTheme.typography internally for animating the label text style
     MaterialTheme(
         typography = Typography(
-            bodySmall = DuckDuckGoTheme.typography.caption.asTextStyle.copy(
+            bodySmall = DuckDuckGoTheme.typography.caption.copy(
                 fontFamily = FontFamily.Default,
-                color = DuckDuckGoTheme.textColors.secondary,
+                color = DuckDuckGoTheme.colors.text.secondary,
             ),
-            bodyLarge = DuckDuckGoTheme.typography.body1.asTextStyle.copy(
+            bodyLarge = DuckDuckGoTheme.typography.body1.copy(
                 fontFamily = FontFamily.Default,
-                color = DuckDuckGoTheme.textColors.secondary,
+                color = DuckDuckGoTheme.colors.text.secondary,
             ),
         ),
     ) {
@@ -142,7 +141,7 @@ fun DaxTextField(
                     null
                 },
                 labelPosition = TextFieldLabelPosition.Attached(),
-                textStyle = DuckDuckGoTheme.typography.body1.asTextStyle,
+                textStyle = DuckDuckGoTheme.typography.body1,
                 trailingIcon = trailingIcon?.let {
                     {
                         DaxTextFieldTrailingIconScope.it()
@@ -155,7 +154,7 @@ fun DaxTextField(
                         DaxText(
                             text = error,
                             style = DuckDuckGoTheme.typography.caption,
-                            color = DuckDuckGoTheme.textColors.destructive,
+                            color = DuckDuckGoTheme.colors.text.destructive,
                         )
                     }
                 } else {
@@ -246,7 +245,7 @@ object DaxTextFieldTrailingIconScope {
             Icon(
                 painter = painter,
                 contentDescription = contentDescription,
-                tint = DuckDuckGoTheme.iconColors.primary,
+                tint = DuckDuckGoTheme.colors.icons.primary,
             )
         }
     }
@@ -301,10 +300,10 @@ enum class DaxTextFieldInputMode {
 
 @Composable
 internal fun daxTextFieldColors(): TextFieldColors = OutlinedTextFieldDefaults.colors(
-    focusedTextColor = DuckDuckGoTheme.textColors.primary,
-    unfocusedTextColor = DuckDuckGoTheme.textColors.primary,
-    disabledTextColor = DuckDuckGoTheme.textColors.primary,
-    errorTextColor = DuckDuckGoTheme.textColors.primary,
+    focusedTextColor = DuckDuckGoTheme.colors.text.primary,
+    unfocusedTextColor = DuckDuckGoTheme.colors.text.primary,
+    disabledTextColor = DuckDuckGoTheme.colors.text.primary,
+    errorTextColor = DuckDuckGoTheme.colors.text.primary,
     focusedContainerColor = Transparent,
     unfocusedContainerColor = Transparent,
     disabledContainerColor = Transparent,
@@ -312,41 +311,41 @@ internal fun daxTextFieldColors(): TextFieldColors = OutlinedTextFieldDefaults.c
     focusedBorderColor = DuckDuckGoTheme.colors.brand.accentBlue,
     unfocusedBorderColor = DuckDuckGoTheme.colors.textField.borders,
     disabledBorderColor = DuckDuckGoTheme.colors.textField.borders,
-    errorBorderColor = DuckDuckGoTheme.textColors.destructive,
+    errorBorderColor = DuckDuckGoTheme.colors.text.destructive,
     focusedLabelColor = DuckDuckGoTheme.colors.brand.accentBlue,
-    unfocusedLabelColor = DuckDuckGoTheme.textColors.secondary,
-    disabledLabelColor = DuckDuckGoTheme.textColors.secondary,
-    errorLabelColor = DuckDuckGoTheme.textColors.destructive,
-    focusedTrailingIconColor = DuckDuckGoTheme.iconColors.primary,
-    unfocusedTrailingIconColor = DuckDuckGoTheme.iconColors.primary,
-    disabledTrailingIconColor = DuckDuckGoTheme.iconColors.primary,
-    errorTrailingIconColor = DuckDuckGoTheme.textColors.destructive,
-    focusedSupportingTextColor = DuckDuckGoTheme.textColors.destructive,
-    unfocusedSupportingTextColor = DuckDuckGoTheme.textColors.destructive,
-    disabledSupportingTextColor = DuckDuckGoTheme.textColors.destructive,
-    errorSupportingTextColor = DuckDuckGoTheme.textColors.destructive,
+    unfocusedLabelColor = DuckDuckGoTheme.colors.text.secondary,
+    disabledLabelColor = DuckDuckGoTheme.colors.text.secondary,
+    errorLabelColor = DuckDuckGoTheme.colors.text.destructive,
+    focusedTrailingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    unfocusedTrailingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    disabledTrailingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    errorTrailingIconColor = DuckDuckGoTheme.colors.text.destructive,
+    focusedSupportingTextColor = DuckDuckGoTheme.colors.text.destructive,
+    unfocusedSupportingTextColor = DuckDuckGoTheme.colors.text.destructive,
+    disabledSupportingTextColor = DuckDuckGoTheme.colors.text.destructive,
+    errorSupportingTextColor = DuckDuckGoTheme.colors.text.destructive,
     cursorColor = DuckDuckGoTheme.colors.brand.accentBlue,
-    errorCursorColor = DuckDuckGoTheme.textColors.primary,
+    errorCursorColor = DuckDuckGoTheme.colors.text.primary,
     selectionColors = TextSelectionColors(
         handleColor = DuckDuckGoTheme.colors.brand.accentBlue,
         backgroundColor = DuckDuckGoTheme.colors.brand.accentBlue.copy(alpha = DaxTextFieldDefaults.ALPHA_DISABLED),
     ),
-    focusedLeadingIconColor = DuckDuckGoTheme.iconColors.primary,
-    unfocusedLeadingIconColor = DuckDuckGoTheme.iconColors.primary,
-    disabledLeadingIconColor = DuckDuckGoTheme.iconColors.primary,
-    errorLeadingIconColor = DuckDuckGoTheme.textColors.destructive,
-    focusedPrefixColor = DuckDuckGoTheme.textColors.secondary,
-    unfocusedPrefixColor = DuckDuckGoTheme.textColors.secondary,
-    disabledPrefixColor = DuckDuckGoTheme.textColors.secondary,
-    errorPrefixColor = DuckDuckGoTheme.textColors.secondary,
-    focusedSuffixColor = DuckDuckGoTheme.textColors.secondary,
-    unfocusedSuffixColor = DuckDuckGoTheme.textColors.secondary,
-    disabledSuffixColor = DuckDuckGoTheme.textColors.secondary,
-    errorSuffixColor = DuckDuckGoTheme.textColors.secondary,
-    focusedPlaceholderColor = DuckDuckGoTheme.textColors.secondary,
-    unfocusedPlaceholderColor = DuckDuckGoTheme.textColors.secondary,
-    disabledPlaceholderColor = DuckDuckGoTheme.textColors.secondary,
-    errorPlaceholderColor = DuckDuckGoTheme.textColors.secondary,
+    focusedLeadingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    unfocusedLeadingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    disabledLeadingIconColor = DuckDuckGoTheme.colors.icons.primary,
+    errorLeadingIconColor = DuckDuckGoTheme.colors.text.destructive,
+    focusedPrefixColor = DuckDuckGoTheme.colors.text.secondary,
+    unfocusedPrefixColor = DuckDuckGoTheme.colors.text.secondary,
+    disabledPrefixColor = DuckDuckGoTheme.colors.text.secondary,
+    errorPrefixColor = DuckDuckGoTheme.colors.text.secondary,
+    focusedSuffixColor = DuckDuckGoTheme.colors.text.secondary,
+    unfocusedSuffixColor = DuckDuckGoTheme.colors.text.secondary,
+    disabledSuffixColor = DuckDuckGoTheme.colors.text.secondary,
+    errorSuffixColor = DuckDuckGoTheme.colors.text.secondary,
+    focusedPlaceholderColor = DuckDuckGoTheme.colors.text.secondary,
+    unfocusedPlaceholderColor = DuckDuckGoTheme.colors.text.secondary,
+    disabledPlaceholderColor = DuckDuckGoTheme.colors.text.secondary,
+    errorPlaceholderColor = DuckDuckGoTheme.colors.text.secondary,
 )
 
 @PreviewLightDark

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.common.ui.compose.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Shapes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -35,16 +37,6 @@ object DuckDuckGoTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalDuckDuckGoColors.current
-
-    val textColors: DuckDuckGoTextColors
-        @Composable
-        @ReadOnlyComposable
-        get() = colors.text
-
-    val iconColors: DuckDuckGoIconsColors
-        @Composable
-        @ReadOnlyComposable
-        get() = colors.icons
 
     val shapes
         @Composable
@@ -188,7 +180,17 @@ fun DuckDuckGoTheme(
             colorScheme = debugColors(),
             typography = debugTypography(),
             shapes = debugShapes,
-            content = content,
+            content = {
+                ProvideTextStyle(
+                    LocalDuckDuckGoTypography.current.body1,
+                    content = {
+                        CompositionLocalProvider(
+                            LocalContentColor provides colors.text.primary,
+                            content = content,
+                        )
+                    },
+                )
+            },
         )
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Typography.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Typography.kt
@@ -39,110 +39,78 @@ private val RobotoMono = FontFamily(
 @Immutable
 data class DuckDuckGoTypography(
 
-    val title: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 32.sp,
-                lineHeight = 36.sp,
-                fontWeight = FontWeight.Bold,
-            ),
-        ),
-
-    val h1: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 24.sp,
-                lineHeight = 30.sp,
-                fontWeight = FontWeight.Bold,
-            ),
-        ),
-
-    val h2: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 20.sp,
-                lineHeight = 24.sp,
-                letterSpacing = 0.3.sp,
-                fontWeight = FontWeight.Medium,
-            ),
-        ),
-
-    val h3: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 16.sp,
-                lineHeight = 21.sp,
-                fontWeight = FontWeight.Medium,
-            ),
-        ),
-
-    val h4: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 14.sp,
-                lineHeight = 20.sp,
-                letterSpacing = 0.3.sp,
-                fontWeight = FontWeight.Medium,
-            ),
-        ),
-
-    val h5: DuckDuckGoTextStyle =
-        DuckDuckGoTextStyle(
-            TextStyle(
-                fontSize = 13.sp,
-                lineHeight = 16.sp,
-                fontWeight = FontWeight.Medium,
-            ),
-        ),
-
-    val body1: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        TextStyle(
-            fontSize = 16.sp,
-            lineHeight = 20.sp,
-        ),
+    val title: TextStyle = TextStyle(
+        fontSize = 32.sp,
+        lineHeight = 36.sp,
+        fontWeight = FontWeight.Bold,
     ),
 
-    val body1Bold: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        body1.textStyle.copy(
-            fontWeight = FontWeight.Bold,
-        ),
+    val h1: TextStyle = TextStyle(
+        fontSize = 24.sp,
+        lineHeight = 30.sp,
+        fontWeight = FontWeight.Bold,
     ),
 
-    val body1Mono: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        body1.textStyle.copy(
-            fontFamily = RobotoMono,
-        ),
+    val h2: TextStyle = TextStyle(
+        fontSize = 20.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.3.sp,
+        fontWeight = FontWeight.Medium,
     ),
 
-    val body2: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        TextStyle(
-            fontSize = 14.sp,
-            lineHeight = 18.sp,
-            letterSpacing = 0.2.sp,
-        ),
+    val h3: TextStyle = TextStyle(
+        fontSize = 16.sp,
+        lineHeight = 21.sp,
+        fontWeight = FontWeight.Medium,
     ),
 
-    val body2Bold: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        body2.textStyle.copy(
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 0.3.sp,
-        ),
+    val h4: TextStyle = TextStyle(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.3.sp,
+        fontWeight = FontWeight.Medium,
     ),
 
-    val button: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        TextStyle(
-            fontSize = 15.sp,
-            lineHeight = 20.sp,
-            fontWeight = FontWeight.Bold,
-        ),
+    val h5: TextStyle = TextStyle(
+        fontSize = 13.sp,
+        lineHeight = 16.sp,
+        fontWeight = FontWeight.Medium,
     ),
 
-    val caption: DuckDuckGoTextStyle = DuckDuckGoTextStyle(
-        TextStyle(
-            fontSize = 12.sp,
-            lineHeight = 16.sp,
-            letterSpacing = 0.2.sp,
-        ),
+    val body1: TextStyle = TextStyle(
+        fontSize = 16.sp,
+        lineHeight = 20.sp,
+    ),
+
+    val body1Bold: TextStyle = body1.copy(
+        fontWeight = FontWeight.Bold,
+    ),
+
+    val body1Mono: TextStyle = body1.copy(
+        fontFamily = RobotoMono,
+    ),
+
+    val body2: TextStyle = TextStyle(
+        fontSize = 14.sp,
+        lineHeight = 18.sp,
+        letterSpacing = 0.2.sp,
+    ),
+
+    val body2Bold: TextStyle = body2.copy(
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.3.sp,
+    ),
+
+    val button: TextStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 20.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+
+    val caption: TextStyle = TextStyle(
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.2.sp,
     ),
 )
 
@@ -152,13 +120,3 @@ val Typography = DuckDuckGoTypography()
 val LocalDuckDuckGoTypography = staticCompositionLocalOf<DuckDuckGoTypography> {
     error("No DuckDuckGoTypography provided")
 }
-
-@JvmInline
-@Immutable
-value class DuckDuckGoTextStyle internal constructor(
-    internal val textStyle: TextStyle,
-)
-
-// Internal extension to extract TextStyle - only accessible within the design system
-internal val DuckDuckGoTextStyle.asTextStyle: TextStyle
-    get() = textStyle

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxTextColorUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxTextColorUsageDetector.kt
@@ -53,7 +53,7 @@ class DaxTextColorUsageDetector : Detector(), SourceCodeScanner {
                 parameterName == "color"
             } ?: return // No color parameter provided, using default is fine
 
-            // Check if the color argument comes from DuckDuckGoTheme.textColors
+            // Check if the color argument comes from DuckDuckGoTheme.colors.text
             val isFromTextColors = isFromDuckDuckGoTextColors(colorArgument)
 
             if (!isFromTextColors) {
@@ -64,13 +64,13 @@ class DaxTextColorUsageDetector : Detector(), SourceCodeScanner {
         private fun isFromDuckDuckGoTextColors(argument: org.jetbrains.uast.UExpression): Boolean {
             val source = argument.sourcePsi?.text ?: return false
 
-            // Check if the source contains DuckDuckGoTheme.textColors or theme.textColors
+            // Check if the source contains DuckDuckGoTheme.colors.text or theme.colors.text
             // This covers cases like:
-            // - DuckDuckGoTheme.textColors.primary
-            // - theme.textColors.secondary
-            return source.contains("DuckDuckGoTheme.textColors") ||
-                   source.contains("theme.textColors") ||
-                   source.contains(".textColors.")
+            // - DuckDuckGoTheme.colors.text.primary
+            // - theme.colors.text.secondary
+            return source.contains("DuckDuckGoTheme.colors.text") ||
+                   source.contains("theme.colors.text") ||
+                   source.contains(".colors.text")
         }
 
         private fun reportInvalidColorUsage(colorArgument: org.jetbrains.uast.UExpression) {
@@ -86,13 +86,13 @@ class DaxTextColorUsageDetector : Detector(), SourceCodeScanner {
         val INVALID_DAX_TEXT_COLOR_USAGE = Issue
             .create(
                 id = "InvalidDaxTextColorUsage",
-                briefDescription = "DaxText color parameter should use DuckDuckGoTheme.textColors",
+                briefDescription = "DaxText color parameter should use DuckDuckGoTheme.colors.text colors",
                 explanation = """
-                    Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.
+                    Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.
 
                     Examples:
-                    • DuckDuckGoTheme.textColors.primary
-                    • DuckDuckGoTheme.textColors.secondary
+                    • DuckDuckGoTheme.colors.text.primary
+                    • DuckDuckGoTheme.colors.text.secondary
 
                     For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR.
                 """.trimIndent(),

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxTextColorUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxTextColorUsageDetectorTest.kt
@@ -54,6 +54,10 @@ class DaxTextColorUsageDetectorTest {
         import androidx.compose.runtime.Composable
         import androidx.compose.ui.graphics.Color
 
+        data class DuckDuckGoColors(
+            val text: DuckDuckGoTextColors
+        )
+
         data class DuckDuckGoTextColors(
             val primary: Color,
             val secondary: Color,
@@ -61,12 +65,14 @@ class DaxTextColorUsageDetectorTest {
         )
 
         object DuckDuckGoTheme {
-            val textColors: DuckDuckGoTextColors
+            val colors: DuckDuckGoColors
                 @Composable
-                get() = DuckDuckGoTextColors(
-                    primary = Color(0xFF000000),
-                    secondary = Color(0xFF666666),
-                    tertiary = Color(0xFF999999)
+                get() = DuckDuckGoColors(
+                    text = DuckDuckGoTextColors(
+                        primary = Color(0xFF000000),
+                        secondary = Color(0xFF666666),
+                        tertiary = Color(0xFF999999)
+                    )
                 )
         }
         """.trimIndent()
@@ -85,7 +91,7 @@ class DaxTextColorUsageDetectorTest {
         fun DaxText(
             text: String,
             modifier: Modifier = Modifier,
-            color: Color = DuckDuckGoTheme.textColors.primary
+            color: Color = DuckDuckGoTheme.colors.text.primary
         ) {
             // Implementation
         }
@@ -108,7 +114,7 @@ class DaxTextColorUsageDetectorTest {
                     fun TestScreen() {
                         DaxText(
                             text = "Hello",
-                            color = DuckDuckGoTheme.textColors.primary
+                            color = DuckDuckGoTheme.colors.text.primary
                         )
                     }
                     """.trimIndent()
@@ -141,7 +147,7 @@ class DaxTextColorUsageDetectorTest {
                         val theme = DuckDuckGoTheme
                         DaxText(
                             text = "Hello",
-                            color = theme.textColors.secondary
+                            color = theme.colors.text.secondary
                         )
                     }
                     """.trimIndent()
@@ -214,11 +220,11 @@ class DaxTextColorUsageDetectorTest {
             .run()
             .expect(
                 """
-                src/com/example/test/test.kt:11: Warning: Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.
+                src/com/example/test/test.kt:11: Warning: Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.
 
                 Examples:
-                • DuckDuckGoTheme.textColors.primary
-                • DuckDuckGoTheme.textColors.secondary
+                • DuckDuckGoTheme.colors.text.primary
+                • DuckDuckGoTheme.colors.text.secondary
 
                 For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR. [InvalidDaxTextColorUsage]
                         color = Color.Red
@@ -258,11 +264,11 @@ class DaxTextColorUsageDetectorTest {
             .run()
             .expect(
                 """
-                src/com/example/test/test.kt:11: Warning: Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.
+                src/com/example/test/test.kt:11: Warning: Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.
 
                 Examples:
-                • DuckDuckGoTheme.textColors.primary
-                • DuckDuckGoTheme.textColors.secondary
+                • DuckDuckGoTheme.colors.text.primary
+                • DuckDuckGoTheme.colors.text.secondary
 
                 For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR. [InvalidDaxTextColorUsage]
                         color = Color(0xFF123456)
@@ -289,7 +295,7 @@ class DaxTextColorUsageDetectorTest {
                     fun TestScreen() {
                         DaxText(
                             text = "Valid",
-                            color = DuckDuckGoTheme.textColors.primary
+                            color = DuckDuckGoTheme.colors.text.primary
                         )
 
                         DaxText(
@@ -299,7 +305,7 @@ class DaxTextColorUsageDetectorTest {
 
                         DaxText(
                             text = "Also Valid",
-                            color = DuckDuckGoTheme.textColors.secondary
+                            color = DuckDuckGoTheme.colors.text.secondary
                         )
 
                         DaxText(
@@ -319,20 +325,20 @@ class DaxTextColorUsageDetectorTest {
             .run()
             .expect(
                 """
-                src/com/example/test/test.kt:17: Warning: Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.
+                src/com/example/test/test.kt:17: Warning: Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.
 
                 Examples:
-                • DuckDuckGoTheme.textColors.primary
-                • DuckDuckGoTheme.textColors.secondary
+                • DuckDuckGoTheme.colors.text.primary
+                • DuckDuckGoTheme.colors.text.secondary
 
                 For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR. [InvalidDaxTextColorUsage]
                         color = Color.Blue
                                 ~~~~~~~~~~
-                src/com/example/test/test.kt:27: Warning: Use DuckDuckGoTheme.textColors instead of arbitrary Color values to maintain design system consistency and theme support.
+                src/com/example/test/test.kt:27: Warning: Use DuckDuckGoTheme.colors.text instead of arbitrary Color values to maintain design system consistency and theme support.
 
                 Examples:
-                • DuckDuckGoTheme.textColors.primary
-                • DuckDuckGoTheme.textColors.secondary
+                • DuckDuckGoTheme.colors.text.primary
+                • DuckDuckGoTheme.colors.text.secondary
 
                 For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR. [InvalidDaxTextColorUsage]
                         color = Color(0xFFFF0000)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202857801505092/task/1212532766386636?focus=true

### Description

Suggest a new contract for the `DaxText` component that:
* Supports usage of Compose locals (e.g., colors and typography inherited from parent components).
* Is correctly wired into the theme to preserve and enforce DuckDuckGo theming rules.

**Note:** an important open question is whether we should use `DaxText` instead of the `Text` component directly, since both are aware of our semantics and configured by our theming composable.

**Why it is important?**

For now, the api slot feature is limited with the actual implementation where we want to pre-configured local content color applied to child components:

```
@Composable
fun PrimaryButton(
  ...,
  content: @Composable () -> Unit
) {
  Button(...) {
    // In the content API slot, I want to pre-configure a specific typography and color for
    // a potential text, icon or both but with the actual DaxText api contract, it is
    // impossible to be aware about the standard LocalContentColor or LocalTextStyle locals.
    content()
  }
}
```

### Steps to test this PR

- [ ] Open the application
- [ ] Go to the settings
- [ ] Scroll to "Android Design System Preview" and tap
- [ ] Go to "Typography" tab
- [ ] Check there is no difference between XML and Compose


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the design-system `DaxText` API/behavior and theme defaults (LocalContentColor/TextStyle), which can subtly alter text styling across many Compose components.
> 
> **Overview**
> **Reworks `DaxText` to better support Compose locals.** `DaxText` now takes a plain `TextStyle` and uses `Color.Unspecified` by default, resolving its final color via `LocalTextStyle`/`LocalContentColor` fallbacks instead of forcing theme-provided defaults.
> 
> **Simplifies theme/typography APIs and updates call sites.** Theme aliases `DuckDuckGoTheme.textColors`/`iconColors` and the `DuckDuckGoTextStyle` wrapper are removed; typography is now exposed as `TextStyle` directly, `DuckDuckGoTheme` provides default `ProvideTextStyle` + `LocalContentColor`, and components (bottom sheet, text fields, internal palette preview) are updated to use `DuckDuckGoTheme.colors.text`/`.icons` and direct typography styles.
> 
> **Aligns lint guidance with the new color API.** The `InvalidDaxTextColorUsage` lint rule, tests, and baseline messaging are updated to enforce `DuckDuckGoTheme.colors.text.*` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52e0392c9637df6858a91cd55d87eae7314e11af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->