### PR TITLE
Adjust top margin to 16dp for remote message with illustration

### DIFF
--- a/android-design-system/design-system/src/main/res/layout/view_remote_message_cta.xml
+++ b/android-design-system/design-system/src/main/res/layout/view_remote_message_cta.xml
@@ -45,7 +45,7 @@
             android:id="@+id/topIllustrationAnimated"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
-            android:layout_marginTop="@dimen/keyline_2"
+            android:layout_marginTop="@dimen/keyline_4"
             app:layout_constraintHeight_max="96dp"
             android:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212514266292946?focus=true

### Description

Adjust top margin to 16dp for remote message with illustration

### Steps to test this PR

- [x] Open the application
- [x] Go to settings screen
- [x] Scroll to "Android Design System Preview" and tap
- [x] Go to "Messaging" tab
- [x] Check message with top illustration and check that the space is bigger than before

### UI changes
| Before  | After |
| ------ | ----- |
<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/a57d63ba-1217-42d3-9f78-fc92de0b944d" /> | <img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/91b3b9d3-29e8-44aa-b91f-a8baff1bf3ac" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase the top margin for `topIllustration` and `topIllustrationAnimated` in `view_remote_message_cta.xml` from `@dimen/keyline_2` to `@dimen/keyline_4` (16dp).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b875b5e738d72a4461de0421e2f30e229cf9578b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->