### PR TITLE
Fix: The custom tabs pixel validation

### DIFF
--- a/PixelDefinitions/pixels/custom_tabs.json5
+++ b/PixelDefinitions/pixels/custom_tabs.json5
@@ -4,7 +4,7 @@
         "description": "When a user clicks the 'address bar' part of the custom tab, the pixel is fired.",
         "owners": ["0nko"],
         "triggers": ["other"],
-        "suffixes": [["form_factor"], ["first_daily_count", "form_factor"]],
+        "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion", "atb"],
         "expires": "2026-01-05"
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1212406760963050?focus=true

### Description

This PR fixes the custom tabs pixel validation JSON, because it failed the live validation.

### Steps to test this PR

QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `first_daily_count` with `daily_count_short` in `m_custom_tabs_address_bar_clicked` pixel suffixes (`PixelDefinitions/pixels/custom_tabs.json5`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f33e55f2156ab31d501a16986ea007e105faf8d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->