### PR TITLE
Update content scope scripts to version 12.17.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -451,7 +451,12 @@
     });
     output.featureSettings = parseFeatureSettings(data, enabledFeatures);
     output.bundledConfig = data;
+    output.messagingContextName = output.messagingContextName || "contentScopeScripts";
     return output;
+  }
+  function getLoadArgs(processedConfig) {
+    const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
+    return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
   function computeEnabledFeatures(data, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data.features);
@@ -539,7 +544,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "duckAiDataClearing", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -550,6 +555,7 @@
       "messageBridge",
       "favicon"
     ],
+    "apple-ai-clear": ["duckAiDataClearing"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -3166,7 +3172,8 @@
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
        *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
-       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       *   messagingContextName: string,
+       *   currentCohorts?: Array<{feature: string, cohort: string, subfeature: string}>,
        * } | null}
        */
       __privateAdd(this, _args);
@@ -3661,9 +3668,9 @@
      * @return {MessagingContext}
      */
     _createMessagingContext() {
-      const contextName = this.injectName === "apple-isolated" ? "contentScopeScriptsIsolated" : "contentScopeScripts";
+      if (!this.args) throw new Error("messaging requires args to be set");
       return new MessagingContext({
-        context: contextName,
+        context: this.args.messagingContextName,
         env: this.isDebug ? "development" : "production",
         featureName: this.name
       });
@@ -6178,7 +6185,7 @@
     }
     try {
       const messagingContext = new MessagingContext({
-        context: "contentScopeScripts",
+        context: processedConfig.messagingContextName,
         env: processedConfig.debug ? "development" : "production",
         featureName: "messaging"
       });
@@ -6210,13 +6217,7 @@
       debug: processedConfig.debug
     });
     sendInitialPingAndUpdate(processedConfig.messagingConfig, processedConfig);
-    load({
-      platform: processedConfig.platform,
-      site: processedConfig.site,
-      bundledConfig: processedConfig.bundledConfig,
-      messagingConfig: processedConfig.messagingConfig,
-      messageSecret: processedConfig.messageSecret
-    });
+    load(getLoadArgs(processedConfig));
     init(processedConfig);
   }
   initCode();

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1957,7 +1957,12 @@
     });
     output.featureSettings = parseFeatureSettings(data2, enabledFeatures);
     output.bundledConfig = data2;
+    output.messagingContextName = output.messagingContextName || "contentScopeScripts";
     return output;
+  }
+  function getLoadArgs(processedConfig) {
+    const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
+    return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
   function computeEnabledFeatures(data2, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data2.features);
@@ -2074,7 +2079,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "duckAiDataClearing", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -2085,6 +2090,7 @@
       "messageBridge",
       "favicon"
     ],
+    "apple-ai-clear": ["duckAiDataClearing"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -4731,7 +4737,8 @@
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
        *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
-       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       *   messagingContextName: string,
+       *   currentCohorts?: Array<{feature: string, cohort: string, subfeature: string}>,
        * } | null}
        */
       __privateAdd(this, _args);
@@ -5226,9 +5233,9 @@
      * @return {MessagingContext}
      */
     _createMessagingContext() {
-      const contextName = this.injectName === "apple-isolated" ? "contentScopeScriptsIsolated" : "contentScopeScripts";
+      if (!this.args) throw new Error("messaging requires args to be set");
       return new MessagingContext({
-        context: contextName,
+        context: this.args.messagingContextName,
         env: this.isDebug ? "development" : "production",
         featureName: this.name
       });
@@ -9759,7 +9766,7 @@
     }
     try {
       const messagingContext = new MessagingContext({
-        context: "contentScopeScripts",
+        context: processedConfig.messagingContextName,
         env: processedConfig.debug ? "development" : "production",
         featureName: "messaging"
       });
@@ -9791,13 +9798,7 @@
       debug: processedConfig.debug
     });
     sendInitialPingAndUpdate(processedConfig.messagingConfig, processedConfig);
-    load({
-      platform: processedConfig.platform,
-      site: processedConfig.site,
-      bundledConfig: processedConfig.bundledConfig,
-      messagingConfig: processedConfig.messagingConfig,
-      messageSecret: processedConfig.messageSecret
-    });
+    load(getLoadArgs(processedConfig));
     init(processedConfig);
   }
   initCode();

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1957,7 +1957,12 @@
     });
     output.featureSettings = parseFeatureSettings(data2, enabledFeatures);
     output.bundledConfig = data2;
+    output.messagingContextName = output.messagingContextName || "contentScopeScripts";
     return output;
+  }
+  function getLoadArgs(processedConfig) {
+    const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
+    return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
   function computeEnabledFeatures(data2, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data2.features);
@@ -2046,7 +2051,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "duckAiDataClearing", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -2057,6 +2062,7 @@
       "messageBridge",
       "favicon"
     ],
+    "apple-ai-clear": ["duckAiDataClearing"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -4700,7 +4706,8 @@
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
        *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
-       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       *   messagingContextName: string,
+       *   currentCohorts?: Array<{feature: string, cohort: string, subfeature: string}>,
        * } | null}
        */
       __privateAdd(this, _args);
@@ -5195,9 +5202,9 @@
      * @return {MessagingContext}
      */
     _createMessagingContext() {
-      const contextName = this.injectName === "apple-isolated" ? "contentScopeScriptsIsolated" : "contentScopeScripts";
+      if (!this.args) throw new Error("messaging requires args to be set");
       return new MessagingContext({
-        context: contextName,
+        context: this.args.messagingContextName,
         env: this.isDebug ? "development" : "production",
         featureName: this.name
       });
@@ -9153,13 +9160,7 @@
       target: globalThis,
       debug: processedConfig.debug
     });
-    load({
-      platform: processedConfig.platform,
-      site: processedConfig.site,
-      bundledConfig: processedConfig.bundledConfig,
-      messagingConfig: processedConfig.messagingConfig,
-      messageSecret: processedConfig.messageSecret
-    });
+    load(getLoadArgs(processedConfig));
     init(processedConfig);
   }
   initCode();

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1290,7 +1290,12 @@
     });
     output.featureSettings = parseFeatureSettings(data, enabledFeatures);
     output.bundledConfig = data;
+    output.messagingContextName = output.messagingContextName || "contentScopeScripts";
     return output;
+  }
+  function getLoadArgs(processedConfig) {
+    const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
+    return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
   function computeEnabledFeatures(data, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data.features);
@@ -1379,7 +1384,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "duckAiDataClearing", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -1390,6 +1395,7 @@
       "messageBridge",
       "favicon"
     ],
+    "apple-ai-clear": ["duckAiDataClearing"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -4562,7 +4568,8 @@
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
        *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
-       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       *   messagingContextName: string,
+       *   currentCohorts?: Array<{feature: string, cohort: string, subfeature: string}>,
        * } | null}
        */
       __privateAdd(this, _args);
@@ -5057,9 +5064,9 @@
      * @return {MessagingContext}
      */
     _createMessagingContext() {
-      const contextName = this.injectName === "apple-isolated" ? "contentScopeScriptsIsolated" : "contentScopeScripts";
+      if (!this.args) throw new Error("messaging requires args to be set");
       return new MessagingContext({
-        context: contextName,
+        context: this.args.messagingContextName,
         env: this.isDebug ? "development" : "production",
         featureName: this.name
       });
@@ -10387,13 +10394,7 @@
       target: globalThis,
       debug: processedConfig.debug
     });
-    load({
-      platform: processedConfig.platform,
-      site: processedConfig.site,
-      bundledConfig: processedConfig.bundledConfig,
-      messagingConfig: processedConfig.messagingConfig,
-      messageSecret: processedConfig.messageSecret
-    });
+    load(getLoadArgs(processedConfig));
     init(processedConfig);
   }
   initCode();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.16.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.17.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#fe9e36ee732bff99f04ed94e8e201ff2355f6d8a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#90c67aa4d128c6417da952d38b9b16b424ed945f",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.0.tgz",
-      "integrity": "sha512-mxape1ivliSPgpzESMVipdC9UZNfuEvypoiJBW0wR+AxMCgJY8Zh5M/1UBXe+y9TvNkvJCU2T/zsF9y2R3pHXA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.1.tgz",
+      "integrity": "sha512-uPmJ0TOWvI8LTx2tBU5SFTHjUV0ZStqLS/Jq1c2PdAq1c4ToeyCo9uE7pTyN9SaRg9lckUZonMtkm94vH1rz8w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.13.0",
-        "@ghostery/adblocker-extended-selectors": "^2.13.0",
+        "@ghostery/adblocker-content": "^2.13.1",
+        "@ghostery/adblocker-extended-selectors": "^2.13.1",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.0.tgz",
-      "integrity": "sha512-6WZrVReCZtF0XvR2T2jK9QAccneFe+HLKhjogRa0ud+Ys7rGwwRZYLOUy3MlVEhJLTeLfA9FLc+bt4K6QovXSQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.1.tgz",
+      "integrity": "sha512-fzHCwAQnAgO91kqIt8qugQxXv1n8lyyfHdSz7Wd+4JkipmGE8HjtzBfVBXtEo+sAM0aOFyZbg2NDQdpUuoYvaQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.13.0"
+        "@ghostery/adblocker-extended-selectors": "^2.13.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.0.tgz",
-      "integrity": "sha512-YfBQHF9fiBt8CKWb727b/T4qLrYEWXS4E8GSPS8OqeBEvRh6f09oHGZJ0lW3F6sPbEwVjHr2JuLoFJDUciX6bA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.1.tgz",
+      "integrity": "sha512-Qmfp7p9nQGTPLL9EpXJ5ZBdgwTDW44b2Va6xhpa3OcU0X3/fpAUHE0cLqj3fYATfQm0qYj97mWqtnpqV4K3Mvw==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.16.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.17.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run