### PR TITLE
Update reference tests to version 1766162897

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.16.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -85,17 +85,17 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#78c9439b5c2f88503a5e2c4e95506c89ea8c9f00",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#c2b49fe7ce4a75404c6a79e4dd1053710a9869ee",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.0.tgz",
-      "integrity": "sha512-mxape1ivliSPgpzESMVipdC9UZNfuEvypoiJBW0wR+AxMCgJY8Zh5M/1UBXe+y9TvNkvJCU2T/zsF9y2R3pHXA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.1.tgz",
+      "integrity": "sha512-uPmJ0TOWvI8LTx2tBU5SFTHjUV0ZStqLS/Jq1c2PdAq1c4ToeyCo9uE7pTyN9SaRg9lckUZonMtkm94vH1rz8w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.13.0",
-        "@ghostery/adblocker-extended-selectors": "^2.13.0",
+        "@ghostery/adblocker-content": "^2.13.1",
+        "@ghostery/adblocker-extended-selectors": "^2.13.1",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.0.tgz",
-      "integrity": "sha512-6WZrVReCZtF0XvR2T2jK9QAccneFe+HLKhjogRa0ud+Ys7rGwwRZYLOUy3MlVEhJLTeLfA9FLc+bt4K6QovXSQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.1.tgz",
+      "integrity": "sha512-fzHCwAQnAgO91kqIt8qugQxXv1n8lyyfHdSz7Wd+4JkipmGE8HjtzBfVBXtEo+sAM0aOFyZbg2NDQdpUuoYvaQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.13.0"
+        "@ghostery/adblocker-extended-selectors": "^2.13.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.0.tgz",
-      "integrity": "sha512-YfBQHF9fiBt8CKWb727b/T4qLrYEWXS4E8GSPS8OqeBEvRh6f09oHGZJ0lW3F6sPbEwVjHr2JuLoFJDUciX6bA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.1.tgz",
+      "integrity": "sha512-Qmfp7p9nQGTPLL9EpXJ5ZBdgwTDW44b2Va6xhpa3OcU0X3/fpAUHE0cLqj3fYATfQm0qYj97mWqtnpqV4K3Mvw==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.16.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1764159068"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1212497179479373/f 

 ----- 
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates @duckduckgo/privacy-reference-tests to revision 1766162897 (lockfile updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74865a1c76381641990bc77e1899faf0dd94a56b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->