### PR TITLE
PIR: Hide deprecated extracted profiles from in progress tab

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardInitialScanStateProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardInitialScanStateProvider.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus.Status.COMPLETED
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus.Status.IN_PROGRESS
+import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus.Status.NOT_STARTED
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
 import com.squareup.anvil.annotations.ContributesBinding
@@ -110,6 +111,6 @@ class RealPirDashboardInitialScanStateProvider @Inject constructor(
     }
 
     override suspend fun getScanResults(): List<DashboardExtractedProfileResult> {
-        return getAllExtractedProfileResults()
+        return getAllExtractedProfileResults(includeResultsForDeprecatedProfileQueries = false)
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardMaintenanceScanDataProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardMaintenanceScanDataProvider.kt
@@ -94,13 +94,13 @@ class RealPirDashboardMaintenanceScanDataProvider @Inject constructor(
     private val pirSchedulingRepository: PirSchedulingRepository,
 ) : PirDashboardStateProvider(currentTimeProvider, pirRepository, pirSchedulingRepository), PirDashboardMaintenanceScanDataProvider {
     override suspend fun getInProgressOptOuts(): List<DashboardExtractedProfileResult> = withContext(dispatcherProvider.io()) {
-        return@withContext getAllExtractedProfileResults().filter {
+        return@withContext getAllExtractedProfileResults(includeResultsForDeprecatedProfileQueries = false).filter {
             it.optOutRemovedDateInMillis == null || it.optOutRemovedDateInMillis == 0L
         }
     }
 
     override suspend fun getRemovedOptOuts(): List<DashboardRemovedExtractedProfileResult> = withContext(dispatcherProvider.io()) {
-        val allRemovedExtractedProfiles = getAllExtractedProfileResults().filter {
+        val allRemovedExtractedProfiles = getAllExtractedProfileResults(includeResultsForDeprecatedProfileQueries = true).filter {
             it.optOutRemovedDateInMillis != null && it.optOutRemovedDateInMillis != 0L
         }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardStateProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardStateProvider.kt
@@ -33,9 +33,10 @@ abstract class PirDashboardStateProvider(
     private val pirRepository: PirRepository,
     private val pirSchedulingRepository: PirSchedulingRepository,
 ) {
-    suspend fun getAllExtractedProfileResults(): List<DashboardExtractedProfileResult> {
+    suspend fun getAllExtractedProfileResults(includeResultsForDeprecatedProfileQueries: Boolean): List<DashboardExtractedProfileResult> {
+        val nonDeprecatedProfileQueries = pirRepository.getValidUserProfileQueries().map { it.id }.toSet()
         val extractedProfiles = pirRepository.getAllExtractedProfiles().filter {
-            !it.deprecated
+            !it.deprecated && (includeResultsForDeprecatedProfileQueries || it.profileQueryId in nonDeprecatedProfileQueries)
         }
         val extractedProfilesFromBrokers = getAllExtractedProfileResultForBrokers(extractedProfiles)
         val extractedProfilesFromMirrorSites = extractedProfilesFromBrokers.getMirrorSites(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212150118866240?focus=true

### Description
When the user changes their profile, the dashboard still shows In Progress records belonging to the old profile. These records will remain stuck as we no longer opt out for them.

The already removed records should still be visible.

### Steps to test this PR

- [x] Run a full scan with a user profile until the dashboard shows In Progress records and the scan is finished
- [x] Update the user profile by changing a name or address
- [x] The initial scan should pick up again, the dashboard should not show In Progress records for the old profile
- [x] After the scan is finished the dashboard should show In Progress records only for the new profile.
- [x] Completed tab can still show records removed for the old profile if any

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out extracted profiles linked to deprecated profile queries from initial/maintenance in-progress results while still including them in removed opt-outs; updates plumbing and tests.
> 
> - **Backend**
>   - **Filtering logic**: `PirDashboardStateProvider.getAllExtractedProfileResults(includeResultsForDeprecatedProfileQueries)` now filters by non-deprecated `ProfileQuery` IDs from `pirRepository.getValidUserProfileQueries()`.
>   - **Initial scan**: `RealPirDashboardInitialScanStateProvider.getScanResults` calls the new API with `includeResultsForDeprecatedProfileQueries = false`.
>   - **Maintenance scan**:
>     - `getInProgressOptOuts` excludes deprecated-profile-query results.
>     - `getRemovedOptOuts` includes deprecated-profile-query results (passes `true`).
> - **Tests**
>   - Extend test helpers to set `profileQueryId` and create `ProfileQuery` objects.
>   - Add/adjust unit tests to verify filtering for in-progress vs. removed results and mirror-site behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07692b3074bea3c1ab8587075f61b0405f43cdec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->