### PR TITLE
PIR: Fix duplicated brokers in  the next up scan section

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardMaintenanceScanDataProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardMaintenanceScanDataProvider.kt
@@ -123,6 +123,7 @@ class RealPirDashboardMaintenanceScanDataProvider @Inject constructor(
                 it.lastScanDateInMillis in startDate..endDate
             },
             getDateMillis = { it.lastScanDateInMillis },
+            keepEarliest = false,
         )
 
         return DashboardScanDetails(
@@ -146,6 +147,7 @@ class RealPirDashboardMaintenanceScanDataProvider @Inject constructor(
                 val schedulingConfig = schedulingConfigMap[it.brokerName] ?: return@getBrokerMatches 0L
                 it.getNextRunMillis(schedulingConfig, nextRunFromOptOutDataMap[it.brokerName], startDate, endDate)
             },
+            keepEarliest = true,
         )
 
         return DashboardScanDetails(
@@ -230,6 +232,7 @@ class RealPirDashboardMaintenanceScanDataProvider @Inject constructor(
     private suspend fun getBrokerMatches(
         scanFilter: (ScanJobRecord) -> Boolean,
         getDateMillis: (ScanJobRecord) -> Long,
+        keepEarliest: Boolean,
     ): List<DashboardBrokerMatch> {
         val activeBrokerMap = pirRepository.getAllActiveBrokerObjects().associateBy { it.name }
         // Only consider active brokers and ignore removed ones
@@ -255,9 +258,13 @@ class RealPirDashboardMaintenanceScanDataProvider @Inject constructor(
         }
 
         val mirrorValidScanJobs = validScansJobs.getMirrorSites()
-        return (validScansJobs + mirrorValidScanJobs)
-            .sortedBy { it.dateInMillis }
-            .distinctBy { it.broker.name }
+        val combined = validScansJobs + mirrorValidScanJobs
+        val sorted = if (keepEarliest) {
+            combined.sortedBy { it.dateInMillis }
+        } else {
+            combined.sortedByDescending { it.dateInMillis }
+        }
+        return sorted.distinctBy { it.broker.name }
     }
 
     private suspend fun List<DashboardBrokerMatch>.getMirrorSites(): List<DashboardBrokerMatch> {

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirDashboardMaintenanceScanDataProviderTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirDashboardMaintenanceScanDataProviderTest.kt
@@ -255,9 +255,9 @@ class RealPirDashboardMaintenanceScanDataProviderTest {
         // Then
         assertEquals(2, result.brokerMatches.size) // Only scans within 8 days
         assertEquals(
-            currentTime - TimeUnit.DAYS.toMillis(5),
+            currentTime - TimeUnit.DAYS.toMillis(2),
             result.dateInMillis,
-        ) // Earliest scan within range
+        ) // Most recent scan within range
 
         val broker1Match = result.brokerMatches.find { it.broker.name == "broker1" }!!
         assertEquals(currentTime - TimeUnit.DAYS.toMillis(2), broker1Match.dateInMillis)
@@ -295,8 +295,10 @@ class RealPirDashboardMaintenanceScanDataProviderTest {
             val result = testee.getLastScanDetails()
 
             // Then - Returns only ONE broker match per broker, regardless of how many profile queries exist
+            // and keeps the most recent (latest) scan date for getLastScanDetails
             assertEquals(1, result.brokerMatches.size)
             assertEquals("broker1", result.brokerMatches[0].broker.name)
+            assertEquals(currentTime - TimeUnit.DAYS.toMillis(2), result.brokerMatches[0].dateInMillis)
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1212221190455658?focus=true

### Description
Fixes duplicated broker names in the "Next up" section of the "Scan Schedule" bottom sheet. This happens with multiple profile queries when same brokers are scanned multiple times.

### Steps to test this PR
- [x] Complete an initial scan for a profile
- [x] Add a second name to the profile and finish the scan again
- [x] Click on the "Recent scans" card and verify there are no duplicated broker names in the "Next Up" section

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures dashboard scan lists show one entry per broker and correct ordering.
> 
> - Adds `keepEarliest` to `getBrokerMatches`, sorts ascending for "Next up" and descending for "Recent", then `distinctBy { broker.name }` to dedupe multiple profile queries
> - `getLastScanDetails` now selects the most recent scan per broker; `getNextScanDetails` keeps the earliest upcoming per broker
> - Updates tests and adds coverage for deduping across multiple profile queries and corrected date expectations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49fe32b04fbc56365c62c1dcbac8f9d6c4cb53fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->