### PR TITLE
Fix pixel definition for free-trial-conversion wide event

### DIFF
--- a/PixelDefinitions/pixels/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/wide_free_trial_conversion.json5
@@ -24,10 +24,14 @@
                 "key": "feature.data.ext.free_trial_plan",
                 "description": "The base plan ID of the free trial product activated",
                 "enum": [
-                    "ddg-privacy-pro-monthly-renews-us",
-                    "ddg-privacy-pro-monthly-renews-row",
-                    "ddg-privacy-pro-yearly-renews-us",
-                    "ddg-privacy-pro-yearly-renews-row",
+                    "ddg-privacy.pro.monthly.renews.us",
+                    "ddg.privacy.pro.monthly.renews.row",
+                    "ddg.privacy.pro.yearly.renews.us",
+                    "ddg.privacy.pro.yearly.renews.row",
+                    "ddg-privacy.pro.sandbox.monthly.renews.us",
+                    "ddg.privacy.pro.sandbox.monthly.renews.row",
+                    "ddg.privacy.pro.sandbox.yearly.renews.us",
+                    "ddg.privacy.pro.sandbox.yearly.renews.row"
                 ]
             },
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212540712304974?focus=true

### Description
Fix pixel definition for free trial conversion wide event pixels

### Steps to test this PR
N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the `wide_free-trial-conversion` pixel to fix a plan ID, add sandbox plan enums, and rename activation step keys.
> 
> - **Pixels**
>   - `PixelDefinitions/pixels/wide_free_trial_conversion.json5`
>     - Fix plan ID in `feature.data.ext.free_trial_plan` enum: `ddg.privacy.pro.monthly.renews.us` -> `ddg-privacy.pro.monthly.renews.us`.
>     - Add sandbox plan IDs to `feature.data.ext.free_trial_plan` enum.
>     - Rename activation step keys: `feature.data.ext.step.vpn_activated_d1.success` -> `feature.data.ext.step.vpn_activated_d1`, and `feature.data.ext.step.vpn_activated_d2_to_d7.success` -> `feature.data.ext.step.vpn_activated_d2_to_d7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4bbf94a5973e7d75fb635a8034ed3d13723a5cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->