### PR TITLE
Use shared instance of PublicSuffixDatabase

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickManager.kt
@@ -37,8 +37,6 @@ class DuckDuckGoAdClickManager @Inject constructor(
     private val adClickCollector: AdClickCollector,
 ) : AdClickManager {
 
-    private val publicSuffixDatabase = PublicSuffixDatabase()
-
     override fun detectAdClick(url: String?, isMainFrame: Boolean) {
         if (url == null) return
         if (!isMainFrame) return
@@ -132,7 +130,7 @@ class DuckDuckGoAdClickManager @Inject constructor(
     private fun toTldPlusOne(url: String): String? {
         val urlAdDomain = UriString.host(url)
         if (urlAdDomain.isNullOrEmpty()) return urlAdDomain
-        return kotlin.runCatching { publicSuffixDatabase.getEffectiveTldPlusOne(urlAdDomain) }.getOrNull()
+        return kotlin.runCatching { PublicSuffixDatabase.get().getEffectiveTldPlusOne(urlAdDomain) }.getOrNull()
     }
 
     private fun adClicked(detectedAdDomain: String?) {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
@@ -45,7 +45,6 @@ private fun htmlDrawable(
 private const val HTTPS_PREFIX = "https://"
 private const val WWW_PREFIX = "www."
 private const val WWW_SUFFIX = "/"
-private val publicSuffixDatabase = PublicSuffixDatabase()
 
 fun String.websiteFromGeoLocationsApiOrigin(): String {
     val uri = Uri.parse(this)
@@ -60,7 +59,7 @@ fun String.asLocationPermissionOrigin(): String {
 }
 
 fun String.toTldPlusOne(): String? {
-    return runCatching { publicSuffixDatabase.getEffectiveTldPlusOne(this) }.getOrNull()
+    return runCatching { PublicSuffixDatabase.get().getEffectiveTldPlusOne(this) }.getOrNull()
 }
 
 /**

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/RequestDataViewStateMapper.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/RequestDataViewStateMapper.kt
@@ -48,7 +48,6 @@ interface RequestDataViewStateMapper {
 @ContributesBinding(AppScope::class)
 class AppSiteRequestDataViewStateMapper @Inject constructor() : RequestDataViewStateMapper {
 
-    private val publicSuffixDatabase = PublicSuffixDatabase()
     private val allowedCategories = listOf(
         "Analytics",
         "Advertising",
@@ -123,6 +122,6 @@ class AppSiteRequestDataViewStateMapper @Inject constructor() : RequestDataViewS
     private fun toTldPlusOne(url: String): String? {
         val urlAdDomain = UriString.host(url)
         if (urlAdDomain.isNullOrEmpty()) return urlAdDomain
-        return kotlin.runCatching { publicSuffixDatabase.getEffectiveTldPlusOne(urlAdDomain) }.getOrNull()
+        return kotlin.runCatching { PublicSuffixDatabase.get().getEffectiveTldPlusOne(urlAdDomain) }.getOrNull()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1212567455556396?focus=true

### Description

This PR makes the app use the existing PublicSuffixDatabase singleton instead of creating additional instances of the class.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts the shared `PublicSuffixDatabase.get()` singleton for eTLD+1 resolution to avoid creating per-class instances.
> 
> - `DuckDuckGoAdClickManager`: `toTldPlusOne` now uses `PublicSuffixDatabase.get()`; removed local database field
> - `StringExtensions.toTldPlusOne`: switched to `PublicSuffixDatabase.get()`
> - `RequestDataViewStateMapper.toTldPlusOne`: switched to `PublicSuffixDatabase.get()`; removed local database field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57fae4d0e0bfdf7c0394778ca235f15ea7dffd9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->