### PR TITLE
Update content scope scripts to version 12.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.17.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.18.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.44.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.44.0.tgz",
-      "integrity": "sha512-gqBbdFxjPh3ai0OWJVabezlhncFuqeLz+MCef61MDO9nHoAuBFz8p/vj2dTlX5/98BwCpqC02IH9h3cpiitYRg==",
+      "version": "14.46.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.46.0.tgz",
+      "integrity": "sha512-tzDs47m1Xfnv3m3bHWpT/irtNPZPBnJEbJXTkPorqAckm+7K2bWk7xK2x7zUOnMB0Rorg6xl+HH8GF7ktgTW/A==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#90c67aa4d128c6417da952d38b9b16b424ed945f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0045d5040130720ae672fc9a8a10b93765219ff9",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.1.tgz",
-      "integrity": "sha512-uPmJ0TOWvI8LTx2tBU5SFTHjUV0ZStqLS/Jq1c2PdAq1c4ToeyCo9uE7pTyN9SaRg9lckUZonMtkm94vH1rz8w==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.2.tgz",
+      "integrity": "sha512-OZ3lG665ZTijchjclqFfW1I6BVE7pesu5tNWR7UZueSgWgHjCinw8cT1NEWmUocjQpBYBYl+rLaV0+HY7kGQAg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.13.1",
-        "@ghostery/adblocker-extended-selectors": "^2.13.1",
+        "@ghostery/adblocker-content": "^2.13.2",
+        "@ghostery/adblocker-extended-selectors": "^2.13.2",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.1.tgz",
-      "integrity": "sha512-fzHCwAQnAgO91kqIt8qugQxXv1n8lyyfHdSz7Wd+4JkipmGE8HjtzBfVBXtEo+sAM0aOFyZbg2NDQdpUuoYvaQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.2.tgz",
+      "integrity": "sha512-noCmPF7vdzScClz1fEcN05a53x/114WpxISRbTAjDrAMYxHeWkG+NdytGLqauEPL68fDunr70vgoyR1YnY1AkA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.13.1"
+        "@ghostery/adblocker-extended-selectors": "^2.13.2"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.1.tgz",
-      "integrity": "sha512-Qmfp7p9nQGTPLL9EpXJ5ZBdgwTDW44b2Va6xhpa3OcU0X3/fpAUHE0cLqj3fYATfQm0qYj97mWqtnpqV4K3Mvw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.2.tgz",
+      "integrity": "sha512-5djmtmtCD+xCeKjOPDz5W369wTOZMj8wdl1KLRGcBIGOdD8p2QaX+BjXoDiQ2TCj1V24k68IlrPIbIFwXYbEsA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.17.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.18.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update**
> 
> - Bumps `@duckduckgo/content-scope-scripts` to `12.18.0` in `package.json`
> - Refreshes `package-lock.json`, updating resolved commits and versions (e.g., `@duckduckgo/autoconsent` `14.46.0`, Ghostery adblocker packages to `2.13.2`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1754b4645a77a2959735c72c645ff246c43b1d99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->