### PR TITLE
Fix the welcome page returning to the starting state 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -114,6 +114,11 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
                 is SetAddressBarPositionOptions -> setAddressBarPositionOptions(it.defaultOption)
             }
         }.launchIn(lifecycleScope)
+
+        viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).onEach { state ->
+            // This will fire immediately with the current state upon rotation
+            state?.let { configureDaxCta(it) }
+        }.launchIn(lifecycleScope)
     }
 
     private fun setAddressBarPositionOptions(defaultOption: Boolean) {


### PR DESCRIPTION
Fixed an issue where the Welcome flow would reset to the beginning and re-play the onboarding whenever the device was rotated (configuration change).

#### Task/Issue URL: [Issue 7431](https://github.com/duckduckgo/Android/issues/7431)

### Changes:

ViewModel Refactor: Migrated the WelcomePageViewModel to use StateFlow (viewState) alongside the existing Command Channel. This ensures the current onboarding step (PreOnboardingDialogType) is persisted across lifecycle changes.

Fragment Update: Updated WelcomePage to observe the new viewState. The UI now automatically restores the correct dialog (e.g., "Choose Your Browser") immediately upon recreation.

### Steps to Test
- Launch the app on a fresh install.
- Progress to the "Choose Your Browser" or "Comparison Chart" step.
- Rotate the device 90°.
- Verify: The app remains on the current step and does not reset to the start.
- Verify: The hiker/typing animation does not play again after the rotation.

### No UI changes

### Result (Pixel 8): 

Rotated            |  Normal
:-------------------------:|:-------------------------:
<img width="2513" height="1187" alt="Screenshot_20260103_192323" src="https://github.com/user-attachments/assets/581c76a1-efee-4e01-bcd0-6ac1bfd48522" /> | <img width="1187" height="2513" alt="Screenshot_20260103_192234" src="https://github.com/user-attachments/assets/d8f1d1cf-b6d4-44a9-b9de-a397db56a8cc" />


<b>Obs.: The skip button becomes unaligned</b>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Welcome/onboarding flow resumes at the correct step after configuration changes.
> 
> - Introduces `viewState: StateFlow<PreOnboardingDialogType?>` in `WelcomePageViewModel` and `emitStateCommand(...)` to update state alongside command emissions
> - `WelcomePage` now observes `viewModel.viewState` and re-applies `configureDaxCta(state)` on recreation
> - Guards `loadDaxDialog()` to avoid re-initializing when a state already exists
> - Replaces direct `_commands.send(...)` with `emitStateCommand(...)` for key transitions (e.g., `COMPARISON_CHART`, `ADDRESS_BAR_POSITION`, `INPUT_SCREEN`, `SKIP_ONBOARDING_OPTION`) to keep UI state in sync
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 079ced6790ead21ea72fb71e459aa6ed0295f5c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->