### PR TITLE
Move nightly checks to use the larger GHA runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   code_formatting:
     name: Code Formatting
-    runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
+    runs-on: android-large-runner
 
     steps:
       - name: Checkout repository
@@ -35,7 +35,7 @@ jobs:
 
   unit_tests:
     name: Unit tests
-    runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
+    runs-on: android-large-runner
 
     steps:
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
+    runs-on: android-large-runner
 
     steps:
       - name: Checkout repository
@@ -105,7 +105,7 @@ jobs:
           path: lint-report.zip
 
   android_tests:
-    runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
+    runs-on: android-large-runner
     name: Android CI checks
 
     steps:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1212657520126346?focus=true 

### Description
Switches runner to use the larger `android-large-runner` for the checks performed in the `nightly.yml` workflow.

### Steps to test this PR
- [ ] Make sure this passes: https://github.com/duckduckgo/Android/actions/runs/20712941910

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Nightly CI jobs to a larger runner to improve capacity; workflow logic remains the same.
> 
> - Update `runs-on` to `android-large-runner` for `code_formatting`, `unit_tests`, `lint`, and `android_tests`
> - Keep `create_task_when_failed` on `ubuntu-24.04`; no step changes elsewhere
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae443c88b6abd0d57c8b02997247b25825c42ce6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->