### PR TITLE
Fix: Fire dialog null binding access cases

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/LegacyFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/LegacyFireDialog.kt
@@ -104,7 +104,7 @@ class LegacyFireDialog : BottomSheetDialogFragment(), FireDialog {
 
     private val accelerateAnimatorUpdateListener = object : ValueAnimator.AnimatorUpdateListener {
         override fun onAnimationUpdate(animation: ValueAnimator) {
-            binding.fireAnimationView.let {
+            _binding?.fireAnimationView?.let {
                 it.speed += ANIMATION_SPEED_INCREMENT
                 if (it.speed > ANIMATION_MAX_SPEED) {
                     it.removeUpdateListener(this)
@@ -301,13 +301,12 @@ class LegacyFireDialog : BottomSheetDialogFragment(), FireDialog {
 
     @Synchronized
     private fun onFireDialogClearAllEvent(event: FireDialogClearAllEvent) {
-        if (!canRestart) {
+        if (!canRestart && _binding != null) {
             canRestart = true
             if (event is FireDialogClearAllEvent.ClearAllDataFinished) {
                 binding.fireAnimationView.addAnimatorUpdateListener(accelerateAnimatorUpdateListener)
             }
         } else {
-            // Both clearing and animation are done, now restart
             clearDataAction.killAndRestartProcess(notifyDataCleared = false, enableTransitionAnimation = false)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212674866476209?focus=true

### Description

This PR fixes 2 potential instances when the binding might be null.

If the dialog's view is destroyed while the coroutine is still running on the IO dispatcher, when the coroutine completes and calls onFireDialogClearAllEvent, _binding is already null, causing the NPE.

### Steps to test this PR

QA-optional since the issue's a race condition that's not easy to reproduce.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents null-binding access in `LegacyFireDialog` during async/animation callbacks to avoid race-condition crashes.
> 
> - Use `_binding?.fireAnimationView?.let { ... }` in the animator update to safely adjust animation speed
> - Gate `onFireDialogClearAllEvent` logic with `_binding != null` before touching views; otherwise proceed to restart
> - Mitigates NPE when the dialog view is destroyed while background work completes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad9d4dc353a7e2f3c0fa9aa1af916cbd5ed25c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->