### PR TITLE
Update internal release job to have gradle caching enabled with a new timeslot

### DIFF
--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -2,7 +2,7 @@ name: Release to Internal and Firebase
 
 on:
   schedule:
-    - cron: '0 2 * * *' # run at 3 AM UTC
+    - cron: '15 2 * * *' # run at 2:15 AM UTC
   workflow_call:
   workflow_dispatch:
 
@@ -29,6 +29,9 @@ jobs:
         with:
           java-version-file: .github/.java-version
           distribution: 'adopt'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Set up ruby env
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1212629934314787?focus=true 

### Description
Enables gradle caching, and slightly staggers the time the job runs.

### Steps to test this PR
- [ ] Sense-check the changes; will run an internal release once we merge this to test properly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves the internal release workflow timing and build performance.
> 
> - Changes cron schedule to `15 2 * * *` (02:15 UTC)
> - Adds `gradle/actions/setup-gradle@v3` to enable Gradle caching
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d232e15583dba484a3ac0d316f09d0ded680c8e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->