### PR TITLE
Experimental browsing menu: new feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -247,4 +247,14 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun moreGranularDataClearingOptions(): Toggle
+
+    /**
+     * Controls the experimental browsing menu in appearance settings.
+     * @return `true` when the remote config has the global "experimentalBrowsingMenu" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.InternalAlwaysEnabled
+    fun experimentalBrowsingMenu(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1212689092503451?focus=true

### Description

This PR just adds a new feature flag that will be used in other linked PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new remote-config toggle for the experimental browsing menu in appearance settings.
> 
> - Adds `experimentalBrowsingMenu` to `AndroidBrowserConfigFeature` with `DefaultFeatureValue.FALSE` and `@Toggle.InternalAlwaysEnabled`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34b83ce9b7fd9d27921ac337a78cd6002a247c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->