### PR TITLE
Use guava-android instead of guava-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ subprojects {
             // Use Guava (which already bundles ListenableFuture) everywhere a bare listenablefuture is requested.
             // Note: refreshVersions placeholders ("_") are not resolved in substitutions, so pin the version explicitly.
             substitute(module("com.google.guava:listenablefuture"))
-                    .using(module("com.google.guava:guava:33.4.0-jre"))
+                    .using(module("com.google.guava:guava:33.4.0-android"))
                     .because("Use guava’s bundled ListenableFuture to avoid duplicate classes")
         }
     }

--- a/versions.properties
+++ b/versions.properties
@@ -98,7 +98,7 @@ version.com.github.bumptech.glide..glide=4.16.0
 
 version.com.github.bumptech.glide..okhttp3-integration=4.16.0
 
-version.com.google.guava..guava=33.4.0-jre
+version.com.google.guava..guava=33.4.0-android
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1212706655936576?focus=true

### Description
Use guava-android instead of guava-hre
### Steps to test this PR
CI passes and smoke tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the project to the Android variant of Guava.
> 
> - Update `versions.properties` to `com.google.guava:guava:33.4.0-android`
> - Change `build.gradle` dependency substitution for `com.google.guava:listenablefuture` to use `guava:33.4.0-android`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6735f3f2b412aae7a3d84248a3032c18b20dc52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->