### PR TITLE
Fix gradle caching in CI

### DIFF
--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble the project
         run: ./gradlew assembleInternalRelease -Pforce-default-variant

--- a/.github/workflows/build-ad-hoc.yml
+++ b/.github/workflows/build-ad-hoc.yml
@@ -79,7 +79,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble APK
         env:

--- a/.github/workflows/build-benchmark-nightly.yml
+++ b/.github/workflows/build-benchmark-nightly.yml
@@ -36,7 +36,7 @@ jobs:
           java-version-file: .github/.java-version
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: true
 

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -52,7 +52,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble the project
         env:

--- a/.github/workflows/build-fdroid-apk.yml
+++ b/.github/workflows/build-fdroid-apk.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble F-Droid release apk
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run Code Formatting Checks
         run: ./gradlew spotlessCheck
@@ -59,7 +59,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -97,7 +97,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Lint
         run: ./gradlew lint
@@ -145,7 +145,7 @@ jobs:
         run: echo "$FLANK" > flank.json
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -x lint

--- a/.github/workflows/design-system-composable-pr-test.yml
+++ b/.github/workflows/design-system-composable-pr-test.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Execute Gradle build
         run: ./gradlew dokkaHtmlMultiModule --no-configuration-cache # Dokka 1.8.20 is not compatible with configuration cache. 2.x is.

--- a/.github/workflows/duckplayer.yml
+++ b/.github/workflows/duckplayer.yml
@@ -55,7 +55,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble APK which does not require auth to use Autofill
         run: ./gradlew assemblePlayRelease -Pautofill-disable-auth-requirement -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble release APK
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "$FLANK" > flank.json
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -92,7 +92,7 @@ jobs:
         run: echo "$FLANK" > flank.json
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/input-screen-e2e-tests.yml
+++ b/.github/workflows/input-screen-e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run Code Formatting Checks
         run: ./gradlew spotlessCheck
@@ -50,7 +50,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -88,7 +88,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Lint
         run: ./gradlew lint
@@ -136,7 +136,7 @@ jobs:
         run: echo "$FLANK" > flank.json
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/omnibar-nightly-e2e-tests.yml
+++ b/.github/workflows/omnibar-nightly-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -48,7 +48,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "$FLANK" > flank.json
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -54,7 +54,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble release APK
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Set up ruby env
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Set up JDK version
         uses: actions/setup-java@v4

--- a/.github/workflows/security-e2e-tests.yml
+++ b/.github/workflows/security-e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/security-internal-e2e-tests.yml
+++ b/.github/workflows/security-internal-e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -52,7 +52,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1212707493088882?focus=true 

### Description
Fixes gradle caching. Currently we're getting a `400` error code back when trying to retrieve gradle cache. After some investigation, it's all down to an outdated action. Updating to `v5` of `setup-gradle` makes everything work and much faster.

### Steps to test this PR

- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades GitHub Actions to use `gradle/actions/setup-gradle@v5` across CI, test, E2E, docs, and release workflows to align on the latest Gradle setup action.
> 
> - Replaces older `@v3`/`@v4` references with `@v5` in multiple workflows (build, lint/unit, Android tests, nightly, E2E/maestro flows, F-Droid, docs, ad-hoc builds, and release pipelines)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ed3e5884f6d92f5b6424f55fa76219b8d831526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->