### PR TITLE
Remove Input Screen ViewTreeObserver

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -89,6 +89,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
     }
 
     private var bottomBlurView: BottomBlurView? = null
+    private var bottomBlurLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
 
     private fun configureBottomBlur() {
         if (VERSION.SDK_INT >= 33 && inputScreenConfigResolver.useTopBar()) {
@@ -106,6 +107,11 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
                     }
                 },
             )
+
+            bottomBlurLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+                bottomBlurView?.invalidate()
+            }
+            binding.root.viewTreeObserver.addOnGlobalLayoutListener(bottomBlurLayoutListener)
         }
     }
 
@@ -174,7 +180,6 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         viewModel.autoCompleteSuggestionResults
             .onEach {
                 autoCompleteSuggestionsAdapter.updateData(it.query, it.suggestions)
-                bottomBlurView?.invalidate()
             }.launchIn(lifecycleScope)
 
         viewModel.searchTabCommand.observe(viewLifecycleOwner) {
@@ -249,6 +254,12 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
     }
 
     override fun onDestroyView() {
+        bottomBlurLayoutListener?.let { listener ->
+            if (binding.root.viewTreeObserver.isAlive) {
+                binding.root.viewTreeObserver.removeOnGlobalLayoutListener(listener)
+            }
+        }
+        bottomBlurLayoutListener = null
         bottomBlurView = null
         super.onDestroyView()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1212705755390361?focus=true

### Description

- Fixes a perf issue with the Samsung keyboard when deleting characters in Search Mode.

### Steps to test this PR

- [x] Go to the Input Screen
- [x] Type in a search query
- [x] Verify that the bottom blur updates correctly


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors bottom blur updates in `SearchTabFragment` for the autocomplete list.
> 
> - Replace `ViewTreeObserver.OnPreDrawListener` with `RecyclerView.OnScrollListener` and a root `OnGlobalLayoutListener` to invalidate `BottomBlurView` during scroll/layout
> - Store `bottomBlurView` and layout listener as members; remove the global layout listener in `onDestroyView` to prevent leaks
> - Minor: add `RecyclerView` import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ce76a2ef2b9c052511b835f280ac27a357e453. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->