### PR TITLE
Add exempted domains to RealMediaPlayback

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.mediaplayback
 
 import androidx.core.net.toUri
+import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomain
 import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackRepository
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.di.scopes.AppScope
@@ -35,6 +36,7 @@ class RealMediaPlayback @Inject constructor(
 
     override fun doesMediaPlaybackRequireUserGestureForUrl(url: String): Boolean {
         val uri = url.toUri()
+        if (mediaPlaybackRepository.exemptedDomains.any { sameOrSubdomain(uri, it) }) return false
         return mediaPlaybackFeature.self().isEnabled() && mediaPlaybackRepository.exceptions.none { it.domain == uri.baseHost }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/RealMediaPlaybackTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/RealMediaPlaybackTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackRepository
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.FeatureException
+import com.duckduckgo.feature.toggles.api.Toggle
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CopyOnWriteArrayList
+
+@RunWith(AndroidJUnit4::class)
+class RealMediaPlaybackTest {
+
+    private lateinit var mediaPlaybackFeature: MediaPlaybackFeature
+    private lateinit var mediaPlaybackRepository: FakeMediaPlaybackRepository
+    private lateinit var realMediaPlayback: RealMediaPlayback
+
+    @Before
+    fun before() {
+        mediaPlaybackFeature = FakeFeatureToggleFactory.create(MediaPlaybackFeature::class.java)
+        mediaPlaybackRepository = FakeMediaPlaybackRepository()
+        realMediaPlayback = RealMediaPlayback(mediaPlaybackFeature, mediaPlaybackRepository)
+    }
+
+    @Test
+    fun `when url is exempted domain then return false`() {
+        mediaPlaybackRepository.setExemptedDomains(listOf("duckduckgo.com"))
+
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://duckduckgo.com"))
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://www.duckduckgo.com"))
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://subdomain.duckduckgo.com"))
+    }
+
+    @Test
+    fun `when feature is enabled and url not in exceptions then return true`() {
+        mediaPlaybackFeature.self().setRawStoredState(Toggle.State(enable = true, exceptions = emptyList()))
+        mediaPlaybackRepository.setExceptions(listOf(FeatureException("foo.com", "reason")))
+
+        assertTrue(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://example.com"))
+    }
+
+    @Test
+    fun `when feature is enabled and url in exceptions then return false`() {
+        mediaPlaybackFeature.self().setRawStoredState(Toggle.State(enable = true, exceptions = emptyList()))
+        mediaPlaybackRepository.setExceptions(listOf(FeatureException("example.com", "reason")))
+
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://example.com"))
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://example.com/path?query=value"))
+    }
+
+    @Test
+    fun `when feature is disabled then return false`() {
+        mediaPlaybackFeature.self().setRawStoredState(Toggle.State(enable = false, exceptions = emptyList()))
+        mediaPlaybackRepository.setExceptions(emptyList())
+
+        assertFalse(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://example.com"))
+    }
+
+    @Test
+    fun `when domain is in exceptions and is subdomain then return true`() {
+        mediaPlaybackFeature.self().setRawStoredState(Toggle.State(enable = true, exceptions = emptyList()))
+        mediaPlaybackRepository.setExceptions(listOf(FeatureException("example.com", "reason")))
+
+        assertTrue(realMediaPlayback.doesMediaPlaybackRequireUserGestureForUrl("https://subdomain.example.com"))
+    }
+
+    private class FakeMediaPlaybackRepository : MediaPlaybackRepository {
+        private val _exceptions = CopyOnWriteArrayList<FeatureException>()
+        private val _exemptedDomains = CopyOnWriteArrayList<String>()
+
+        override val exceptions: CopyOnWriteArrayList<FeatureException>
+            get() = _exceptions
+
+        override val exemptedDomains: CopyOnWriteArrayList<String>
+            get() = _exemptedDomains
+
+        fun setExceptions(exceptions: List<FeatureException>) {
+            _exceptions.clear()
+            _exceptions.addAll(exceptions)
+        }
+
+        fun setExemptedDomains(domains: List<String>) {
+            _exemptedDomains.clear()
+            _exemptedDomains.addAll(domains)
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1212710755908366?focus=true

### Description

- Updates `RealMediaPlayback` to match against exempted domains and return `false`, which in turn sets `mediaPlaybackRequiresUserGesture` to `false` for that domain on the WebView.

### Steps to test this PR

- [ ] Testing steps in task


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements domain-based exemptions so media playback won’t require a user gesture on specified domains.
> 
> - Updates `RealMediaPlayback` to return `false` when URL matches any `exemptedDomains` via `sameOrSubdomain`
> - Extends `MediaPlaybackRepository` to load and expose `exemptedDomains` from feature `settings` JSON (Moshi), refresh on `onPrivacyConfigDownloaded`, and log parse failures
> - Adds tests for exempted domain behavior and repository settings parsing/updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a4ed449c30e357f46d17b70ab78fdc6ecea32c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->