### PR TITLE
Reduce max active tabs to 15

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 
 interface TabManager {
     companion object {
-        const val MAX_ACTIVE_TABS = 20
+        const val MAX_ACTIVE_TABS = 15
     }
 
     fun registerCallbacks(onTabsUpdated: (List<TabModel>) -> Unit)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1212715799570745?focus=true

### Description
Reduced the maximum number of active tabs from 20 to 15 in the TabManager interface.

As an attempt to fix the crash https://app.asana.com/1/137249556945/project/1211724162604201/task/1212315408122893?focus=true, we can try reducing the number of active tabs to 15. From the stacktrace it looks like the crash occurs when we are trying to save the instance state. Looking in the app, the only place where more data is saved which could lead to an increased Bundle size it in the BrowserActivity. There we are getting the instance state of all the fragments in the adapter used for the swiping tabs and saving it. Having more fragments leads to a larger bundle, as we need to persist the state for each fragment. 

### Steps to test this PR

_Tab Management_
- [x] Open more than 15 tabs and verify the oldest tabs are properly closed (when going to an older tab the webview should be reloaded, when going to a new tab the webpage should not load again)

### UI changes
No UI changes visible to the user, as this is an internal limit change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the active tab limit across the app by updating `TabManager.MAX_ACTIVE_TABS` from 20 to 15.
> 
> - Single change in `DefaultTabManager.kt`: `MAX_ACTIVE_TABS` constant reduced to 15
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e422d75f89163f5ddd41fabfba56b91d5fde7d71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->