### PR TITLE
PIR: Fix opt out 24h stats pixel scheduling

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOut24HourSubmissionSuccessRateReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/OptOut24HourSubmissionSuccessRateReporter.kt
@@ -44,11 +44,13 @@ class RealOptOut24HourSubmissionSuccessRateReporter @Inject constructor(
     override suspend fun attemptFirePixel() {
         withContext(dispatcherProvider.io()) {
             logcat { "PIR-CUSTOM-STATS: Attempt to fire 24hour submission pixels" }
-            val startDate = pirRepository.getCustomStatsPixelsLastSentMs()
+            val lastSentMs = pirRepository.getCustomStatsPixelsLastSentMs()
             val now = currentTimeProvider.currentTimeMillis()
 
-            if (!shouldFirePixel(startDate, now)) return@withContext
+            if (!shouldFirePixel(lastSentMs, now)) return@withContext
             logcat { "PIR-CUSTOM-STATS: Should fire pixel - 24hrs passed since last send" }
+            // previous endDate was (lastSentMs - 24h) so that should be our new startDate
+            val startDate = if (lastSentMs == 0L) 0L else lastSentMs - TimeUnit.HOURS.toMillis(24)
             val endDate = now - TimeUnit.HOURS.toMillis(24)
             val activeBrokers = pirRepository.getAllActiveBrokerObjects()
             val hasUserProfiles = pirRepository.getAllUserProfileQueries().isNotEmpty()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212678721759386?focus=true

### Description
Fixes the start and end date calculations for the opt out 24h submission success rate pixel.

### Steps to test this PR
See https://app.asana.com/1/137249556945/task/1212709715647988?focus=true for testing instructions.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the 24h submission success-rate calculation and validates behavior with expanded tests.
> 
> - Derives `startDate` from `lastSentMs - 24h` (or `0L` on first run) and sets `endDate = now - 24h`; maintains 24h gating via `shouldFirePixel`
> - Continues to send per-broker pixels only when brokers, profiles, and job records exist; updates `customStatsPixelsLastSentMs` after firing
> - Updates existing test to verify correct date range and adds scenarios for exactly/25h/48h elapsed, consecutive runs, mixed/null success rates, and broker-without-records
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b7829650de2afac9436f62e5935c13c0c4763c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->