### PR TITLE
Fix physical back button behaviour while omnibar is focused

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1000,7 +1000,9 @@ class BrowserTabFragment :
                         logcat { "BrowserTabFragment: Keyboard shown (GlobalLayout)" }
                     } else {
                         logcat { "BrowserTabFragment: Keyboard hidden (GlobalLayout)" }
-                        binding.focusDummy.requestFocus()
+                        if (omnibar.omnibarTextInput.isFocused) {
+                            binding.focusDummy.requestFocus()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1000,7 +1000,7 @@ class BrowserTabFragment :
                         logcat { "BrowserTabFragment: Keyboard shown (GlobalLayout)" }
                     } else {
                         logcat { "BrowserTabFragment: Keyboard hidden (GlobalLayout)" }
-                        if (omnibar.omnibarTextInput.isFocused) {
+                        if (getOmnibar()?.omnibarTextInput?.isFocused == true) {
                             binding.focusDummy.requestFocus()
                         }
                     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -170,12 +170,12 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 if (previouslyVisible != isKeyboardCurrentlyVisible) {
                     if (isKeyboardCurrentlyVisible) {
                         logcat { "inputScreenLauncher: Keyboard shown (GlobalLayout)" }
+                        keyboardHiddenByCommand = false
                     } else {
                         logcat { "inputScreenLauncher: Keyboard hidden (GlobalLayout)" }
                         if (!keyboardHiddenByCommand) {
                             preserveDraftTextAndExit()
                         }
-                        keyboardHiddenByCommand = false
                         inputModeWidget.clearInputFocus()
                     }
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -172,6 +172,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                     } else {
                         logcat { "inputScreenLauncher: Keyboard hidden (GlobalLayout)" }
                         inputModeWidget.clearInputFocus()
+                        exitInputScreen()
                     }
                 }
             }


### PR DESCRIPTION
Task/Issue URL: 
[[Bug] Clicking back button while search bar while keyboard is open unexpected behaviour](https://github.com/duckduckgo/Android/issues/7461)

### Description
If the searchbar is focused if I click the phisical back button or perform the back gesture, the behaviour is not the same as if I click on the back button of the omnibar.

The omnibar back button is having the expected behaviour.

### Steps to test this PR
Just navigate any website. 
Focus on the omnibar
Click back button


### UI changes
| Before  | After |
| ------ | ----- |
https://github.com/user-attachments/assets/6bbe2bc3-ec51-4f71-8640-a614a78489c0|https://github.com/user-attachments/assets/1c63831c-96d5-4f8b-8113-14b65a72b164 https://github.com/user-attachments/assets/f041c6d1-b184-45fb-bb07-3e2300e13154|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves back/keyboard handling to make physical back/gestures behave like the omnibar back.
> 
> - BrowserTabFragment: Add `OnGlobalLayoutListener` to detect keyboard visibility; when keyboard hides and `omnibar` is focused, shift focus to `focusDummy`. Manage listener lifecycle.
> - InputScreenFragment: Track `keyboardHiddenByCommand` to distinguish programmatic hides; on keyboard hide (not by command), preserve draft via `CANCELED_DRAFT_PARAM` and exit. Route system back to the same preserve-and-exit path; set flag when handling `HideKeyboard` command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f5a0cb7326220cb10644c584ae1005a0bdad6e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->