### PR TITLE
Add onboarding brand design update feature toggles

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboardingbranddesignupdate
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Feature toggles for the onboarding brand design updates.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "onboardingBrandDesignUpdate",
+)
+interface OnboardingBrandDesignUpdateToggles {
+
+    /**
+     * Main toggle for the onboarding brand design update feature.
+     * Default value: false (disabled).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    /**
+     * Toggle for the brand design update variant.
+     * Default value: false (disabled).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun brandDesignUpdate(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1212699261164255?focus=true

### Description

Add new remote feature toggle for the onboarding brand design updates. The feature includes two toggles:
- `self()`: Main toggle for the entire feature (default: OFF)
- `brandDesignUpdate()`: Toggle for the brand design update variant (default: OFF)

### Steps to test this PR

Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new remote feature toggle interface for onboarding brand design updates.
> 
> - Introduces `OnboardingBrandDesignUpdateToggles` contributed via `@ContributesRemoteFeature` (`featureName = "onboardingBrandDesignUpdate"`, `AppScope`)
> - Defines `self()` and `brandDesignUpdate()` toggles, both defaulting to `false` (OFF)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4470b1cd5c1a80f93820b61857aaca0e8e8d6f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->