### PR TITLE
Duck.ai: Ensure Duck.ai is visible on Resume

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -983,9 +983,18 @@ class BrowserTabFragment :
 
     private fun resumeWebView() {
         logcat { "Resuming webview: $tabId" }
+
+        if (omnibar.viewMode == ViewMode.DuckAI) {
+            logcat { "Duck.ai: resume in Duck.ai mode" }
+            appCoroutineScope.launch(dispatchers.main()) {
+                delay(100)
+                webView?.onResume()
+                webView?.requestFocus()
+            }
+        }
+
         webView?.let { webView ->
             if (webView.isShown) {
-                webView.ensureVisible()
                 webView.onResume()
             } else if (swipingTabsFeature.isEnabled) {
                 // Sometimes a tab is brought back from the background but the WebView is not shown yet due to
@@ -1007,10 +1016,6 @@ class BrowserTabFragment :
         postDelayed(100) {
             if (swipingTabsFeature.isEnabled) {
                 wiggle()
-            }
-            if (omnibar.viewMode == ViewMode.DuckAI) {
-                wiggle()
-                requestLayout()
             }
         }
 
@@ -4019,11 +4024,13 @@ class BrowserTabFragment :
     }
 
     private fun resetWebView() {
+        logcat { "Duck.ai: resetWebView" }
         destroyWebView()
         configureWebView()
     }
 
     override fun onDestroy() {
+        logcat { "Duck.ai: onDestroy" }
         dismissAppLinkSnackBar()
         supervisorJob.cancel()
         if (::popupMenu.isInitialized) popupMenu.dismiss()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -938,7 +938,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onViewResumed() {
-        logcat { "Duck.ai: onViewResumed" }
         if (currentGlobalLayoutState() is Invalidated && currentBrowserViewState().browserShowing) {
             showErrorWithAction()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1212674626961681?focus=true

### Description
This PR ensures that resuming Duck.ai after a tab change properly shows the site

### Steps to test this PR

_Steps_
- [x] Load duck.ai in one tab
- [x] Load a second tab (do a search/visit a website)
- [x] Switch back to the first tab (via the tab switcher - don't swipe)
- [x] Verify Duck.ai is visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves DuckAI visibility when returning to a tab.
> 
> - Update `resumeWebView` to detect `DuckAI` view mode and perform a short delayed `onResume()` + `requestFocus()` on the `WebView`
> - Remove `ensureVisible()` call when the `WebView` is already shown; keep resume-on-post for ViewPager delays
> - Simplify `ensureVisible()` by dropping DuckAI-specific wiggle/requestLayout logic
> - Add debug logs in `resetWebView` and `onDestroy`; remove a redundant log in `ViewModel.onViewResumed`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69c180568c29d6829409ea99066e0652ce4ccbd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->