### PR TITLE
Fix param name on sync attributed metric

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetric.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetric.kt
@@ -78,7 +78,7 @@ class SyncDevicesAttributeMetric @Inject constructor(
     override suspend fun getMetricParameters(): Map<String, String> {
         val connectedDevices = connectedDevicesObserver.observeConnectedDevicesCount().value
         val params = mutableMapOf(
-            "device_count" to getBucketValue(connectedDevices).toString(),
+            "number_of_devices" to getBucketValue(connectedDevices).toString(),
             "version" to bucketConfig.await().version.toString(),
         )
         return params

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetricTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/metrics/SyncDevicesAttributeMetricTest.kt
@@ -125,7 +125,7 @@ class SyncDevicesAttributeMetricTest {
         deviceCountExpectedBuckets.forEach { (devices, bucket) ->
             connectedDevicesFlow.emit(devices)
 
-            val realbucket = testee.getMetricParameters()["device_count"]
+            val realbucket = testee.getMetricParameters()["number_of_devices"]
 
             assertEquals(
                 "For $devices devices, should return bucket $bucket",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212751623640137?focus=true 

### Description
Update param name to match specs

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the sync devices attributed metric parameter name with spec.
> 
> - Renames `getMetricParameters` key from `device_count` to `number_of_devices` in `SyncDevicesAttributeMetric`
> - Updates tests to assert the new `number_of_devices` key
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72a06e9ab76bc82346b24d19e11ba2d8c01bbe1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->