### PR TITLE
Fix crash when creating shortcuts with custom app icon

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/shortcut/ShortcutBuilder.kt
@@ -19,17 +19,14 @@ package com.duckduckgo.app.browser.shortcut
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.commands.Command
-import com.duckduckgo.app.icon.api.AppIcon
 import java.util.UUID
 import javax.inject.Inject
 
@@ -52,12 +49,6 @@ class ShortcutBuilder @Inject constructor() {
         return ShortcutInfoCompat.Builder(context, UUID.randomUUID().toString())
             .setShortLabel(homeShortcut.title)
             .setIntent(intent)
-            .apply {
-                val enabledAlias = context.getEnabledAlias()
-                if (enabledAlias != null) {
-                    setActivity(enabledAlias)
-                }
-            }
             .setIcon(icon)
             .build()
     }
@@ -81,18 +72,6 @@ class ShortcutBuilder @Inject constructor() {
         val pendingIntent = buildPendingIntent(context, homeShortcut.url, homeShortcut.title)
 
         ShortcutManagerCompat.requestPinShortcut(context, shortcutInfo, pendingIntent?.intentSender)
-    }
-
-    private fun Context.getEnabledAlias(): ComponentName? {
-        for (alias in AppIcon.entries) {
-            val component = ComponentName(this, alias.componentName)
-            val state = packageManager.getComponentEnabledSetting(component)
-
-            if (state == PackageManager.COMPONENT_ENABLED_STATE_ENABLED || state == PackageManager.COMPONENT_ENABLED_STATE_DEFAULT) {
-                return component
-            }
-        }
-        return null
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1212744634442746?focus=true

### Description
Simplified the shortcut creation process by removing the code that sets the activity component based on the enabled app icon alias. This change removes the dependency on `AppIcon` and eliminates the need to check for enabled components through the package manager.

The activity component will be set only when the app icon changes. When the shortcut is creted the system automatically sets the icon. 

### Steps to test this PR

_Shortcut Creation_
- [x] Create a home screen shortcut for a website
- [x] Verify the shortcut is created successfully
- [x] Change the app icon in the appearance settings 
- [x] The shortcut should be persisted and the app icon of the shortcut should be updated 

### UI changes

[Screen_recording_20260112_182254.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8e8958dc-4f1a-45ae-84f3-a85dc49ad50a.mp4" />](https://app.graphite.com/user-attachments/video/8e8958dc-4f1a-45ae-84f3-a85dc49ad50a.mp4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines pinned shortcut creation and removes fragile app-icon alias handling.
> 
> - Deletes `getEnabledAlias` and `setActivity(...)` usage; no longer queries `PackageManager` or depends on `AppIcon`
> - Cleans up unused imports (`ComponentName`, `PackageManager`, `AppIcon`) and alias resolution code
> - Keeps shortcut payload the same (`ACTION_VIEW`, extras, icon fallback) and requests pin via `ShortcutManagerCompat`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 489943273ce18ffcf6cf3dec96f2528c22152de9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->