### PR TITLE
Enable gradle configuration caching in CI

### DIFF
--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble the project
         run: ./gradlew assembleInternalRelease -Pforce-default-variant

--- a/.github/workflows/build-ad-hoc.yml
+++ b/.github/workflows/build-ad-hoc.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble APK
         env:

--- a/.github/workflows/build-benchmark-nightly.yml
+++ b/.github/workflows/build-benchmark-nightly.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-read-only: true
 
       - name: Install SDKMAN

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble the project
         env:

--- a/.github/workflows/build-fdroid-apk.yml
+++ b/.github/workflows/build-fdroid-apk.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble F-Droid release apk
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run Code Formatting Checks
         run: ./gradlew spotlessCheck
@@ -60,6 +62,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -98,6 +102,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Lint
         run: ./gradlew lint
@@ -146,6 +152,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -x lint

--- a/.github/workflows/design-system-composable-pr-test.yml
+++ b/.github/workflows/design-system-composable-pr-test.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Execute Gradle build
         run: ./gradlew dokkaHtmlMultiModule --no-configuration-cache # Dokka 1.8.20 is not compatible with configuration cache. 2.x is.

--- a/.github/workflows/duckplayer.yml
+++ b/.github/workflows/duckplayer.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble APK which does not require auth to use Autofill
         run: ./gradlew assemblePlayRelease -Pautofill-disable-auth-requirement -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble release APK
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -93,6 +95,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/input-screen-e2e-tests.yml
+++ b/.github/workflows/input-screen-e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run Code Formatting Checks
         run: ./gradlew spotlessCheck
@@ -51,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
         run: ./gradlew jvm_tests
@@ -89,6 +93,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Lint
         run: ./gradlew lint
@@ -137,6 +143,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/omnibar-nightly-e2e-tests.yml
+++ b/.github/workflows/omnibar-nightly-e2e-tests.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble the project
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
         run: ./gradlew androidTestsBuild

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble release APK
         run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Set up ruby env
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Set up JDK version
         uses: actions/setup-java@v4

--- a/.github/workflows/security-e2e-tests.yml
+++ b/.github/workflows/security-e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/security-internal-e2e-tests.yml
+++ b/.github/workflows/security-internal-e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble internal release APK
         run: ./gradlew assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212708850241524?focus=true 

### Description
Enables gradle configuration caching in CI by:
- adding an encryption key (to GitHub Secrets as key=`GRADLE_ENCRYPTION_KEY`)
- adding `cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }` to build scripts

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables encrypted Gradle caching in GitHub Actions by updating Gradle setup steps across the workflow suite.
> 
> - Adds `with: cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}` to `gradle/actions/setup-gradle@v5` in CI (`ci.yml`), nightly (`nightly.yml`), ad-hoc/build workflows, E2E test workflows (e.g., `end-to-end-robintest.yml`, `privacy.yml`, `duckplayer.yml`, feature-specific E2E), docs generation (`docs.yml`), and release workflows (`release_upload_*`, `release_tests.yml`)
> - Retains existing options (e.g., `cache-read-only: true` where present) while adding the encryption key
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aab40c33e5373af1651a977f2ba72bd36deed70e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->