### PR TITLE
Fix wide pixel definition

### DIFF
--- a/PixelDefinitions/pixels/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/wide_free_trial_conversion.json5
@@ -24,14 +24,14 @@
                 "key": "feature.data.ext.free_trial_plan",
                 "description": "The base plan ID of the free trial product activated",
                 "enum": [
-                    "ddg-privacy.pro.monthly.renews.us",
-                    "ddg.privacy.pro.monthly.renews.row",
-                    "ddg.privacy.pro.yearly.renews.us",
-                    "ddg.privacy.pro.yearly.renews.row",
-                    "ddg-privacy.pro.sandbox.monthly.renews.us",
-                    "ddg.privacy.pro.sandbox.monthly.renews.row",
-                    "ddg.privacy.pro.sandbox.yearly.renews.us",
-                    "ddg.privacy.pro.sandbox.yearly.renews.row"
+                    "ddg-privacy-pro-monthly-renews-us",
+                    "ddg-privacy-pro-monthly-renews-row",
+                    "ddg-privacy-pro-yearly-renews-us",
+                    "ddg-privacy-pro-yearly-renews-row",
+                    "ddg-privacy-pro-sandbox-monthly-renews-us",
+                    "ddg-privacy-pro-sandbox-monthly-renews-row",
+                    "ddg-privacy-pro-sandbox-yearly-renews-us",
+                    "ddg-privacy-pro-sandbox-yearly-renews-row"
                 ]
             },
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212731197391579?focus=true

### Description
Fix definitions to match live pixels

### Steps to test this PR
N/A

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns plan ID enums with live pixel naming for the free trial conversion wide pixel.
> 
> - Updates `feature.data.ext.free_trial_plan` enum in `PixelDefinitions/pixels/wide_free_trial_conversion.json5` from dotted IDs (e.g., `ddg.privacy.pro...`) to hyphenated IDs (e.g., `ddg-privacy-pro-...`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abfa062e18b5d18fd7d9a305313e65350e245bd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->