### PR TITLE
Add step to dismiss RMF card

### DIFF
--- a/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
+++ b/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
@@ -69,18 +69,17 @@ appId: com.duckduckgo.mobile.android
     childOf:
       id: "omnibarTextInput"
 
+# verify that favorites are shown when opening the Input Screen from a web page and autocomplete is suppressed
+- tapOn:
+    id: "omnibarTextInput"
+- assertNotVisible:
+    id: "autoCompleteSuggestionsList"
 # dismiss RMF card if it appears
 - tapOn:
     id: "close"
     childOf:
       id: "remoteMessage"
     optional: true
-
-# verify that favorites are shown when opening the Input Screen from a web page and autocomplete is suppressed
-- tapOn:
-    id: "omnibarTextInput"
-- assertNotVisible:
-    id: "autoCompleteSuggestionsList"
 - assertVisible:
     text: "reddit at DuckDuckGo"
     childOf:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212752835004489?focus=true

### Description
Fixes test for "Input Screen Search Mode test (bottom config)" maestro test that fails on CI due to an RMF card being visible. We now dismiss the card before performing validation on next steps.

### Steps to test this PR
QA optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the Maestro "Input Screen Search Mode" flow by handling an intermittent RMF card overlay.
> 
> - In `input_screen/shared/input_screen_search_mode_flow.yaml`, add an optional `tapOn` for `id: "close"` within `remoteMessage` to dismiss the RMF card before asserting favorites, preventing false failures when the card appears
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bafca6e00d3388bf8db04e7b6105b56cb550db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->