### PR TITLE
Make release-upload-internal only take release tags into account

### DIFF
--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -58,7 +58,6 @@ jobs:
         id: check_for_changes
         uses: ./.github/actions/check-for-changes-since-tag
         with:
-           github_token: ${{ secrets.GT_DAXMOBILE }}
            tag: ${{ steps.get_latest_tag.outputs.latest_tag }}
 
       - name: Notify if no changes


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212746279260659?focus=true

### Description
Update release-upload-internal so that only release tags are taken into account to determine next release tag number

### Steps to test this PR
_Feature 1_
- [ ] Create a tag using `git tag -a "test-tag" -m "Create test tag"`
- [ ] Run `git for-each-ref --sort=taggerdate --format='%(refname:short)' refs/tags | grep -E "^[0-9]+\.[0-9]+\.[0-9]+(\.?[0-9]*-internal)?$" | tail -n 1`
- [ ] Check output is a release tag, not `test-tag`
- [ ] Create a tag using  tag using `git tag -a "6.0.0" -m "Create test release tag"`
- [ ] Run `git for-each-ref --sort=taggerdate --format='%(refname:short)' refs/tags | grep -E "^[0-9]+\.[0-9]+\.[0-9]+(\.?[0-9]*-internal)?$" | tail -n 1`
- [ ] Check output is `6.0.0`
- [ ] Create a tag using  tag using `git tag -a "6.0.0.1-internal" -m "Create test nightly tag"`
- [ ] Run `git for-each-ref --sort=taggerdate --format='%(refname:short)' refs/tags | grep -E "^[0-9]+\.[0-9]+\.[0-9]+(\.?[0-9]*-internal)?$" | tail -n 1`
- [ ] Check output is `6.0.0.1-internal`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrows the internal release workflow to only consider release/nightly tags when determining the latest tag.
> 
> - Updates `Get latest release tag` step to filter tags via regex `^[0-9]+\.[0-9]+\.[0-9]+(\.?[0-9]*-internal)?$` before selecting the newest
> - Renames step from `Get latest tag` to `Get latest release tag`
> - Removes `github_token` input from `check-for-changes-since-tag` action
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4da844b0e1421ac2c17e8786a24c69bc80fcf6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->