### PR TITLE
Revert #7459: Ensure fresh purchase token for plan switch

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
@@ -97,14 +97,10 @@ interface PlayBillingManager {
     )
 
     /**
-     * Returns the most recent purchase token from active purchases via
-     * queryPurchasesAsync, which is preferred over purchase history for obtaining
-     * active purchase tokens.
-     *
-     * Ensures the billing client is connected and fetches updated purchase data
-     * from Google Play prior to returning the token.
+     * Gets the current purchase token from active purchases (queryPurchasesAsync)
+     * This is the preferred method over purchase history for getting current tokens
      */
-    suspend fun getLatestPurchaseToken(): String?
+    fun getLatestPurchaseToken(): String?
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -387,13 +383,7 @@ class RealPlayBillingManager @Inject constructor(
         }
     }
 
-    override suspend fun getLatestPurchaseToken(): String? = withContext(dispatcherProvider.io()) {
-        if (!billingClient.ready) {
-            connect()
-        }
-        logcat { "Billing: Refreshing purchases before getting token" }
-        loadPurchases()
-
+    override fun getLatestPurchaseToken(): String? {
         val activePurchases = purchases.filter { purchase: Purchase ->
             purchase.products.contains(BASIC_SUBSCRIPTION) &&
                 purchase.purchaseState == Purchase.PurchaseState.PURCHASED
@@ -401,7 +391,14 @@ class RealPlayBillingManager @Inject constructor(
 
         val latestPurchase = activePurchases.maxByOrNull { it.purchaseTime }
 
-        return@withContext latestPurchase?.purchaseToken
+        return if (latestPurchase != null) {
+            val tokenPreview = latestPurchase.purchaseToken.take(10) + "..."
+            logcat { "Billing: Latest active purchase token preview: $tokenPreview" }
+            latestPurchase.purchaseToken
+        } else {
+            logcat { "Billing: No active purchase token found" }
+            null
+        }
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
@@ -373,97 +373,6 @@ class RealPlayBillingManagerTest {
             assertEquals(PurchaseState.Failure("BILLING_UNAVAILABLE"), awaitItem())
         }
     }
-
-    @Test
-    fun `when getLatestPurchaseToken called and client not connected then connects first`() = runTest {
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-
-        // Simulate disconnection
-        billingClientAdapter.connected = false
-        billingClientAdapter.methodInvocations.clear()
-
-        subject.getLatestPurchaseToken()
-
-        billingClientAdapter.verifyConnectInvoked()
-    }
-
-    @Test
-    fun `when getLatestPurchaseToken called then always queries purchases`() = runTest {
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-        billingClientAdapter.methodInvocations.clear()
-
-        subject.getLatestPurchaseToken()
-
-        billingClientAdapter.verifyQueryPurchasesInvoked()
-    }
-
-    @Test
-    fun `when getLatestPurchaseToken called with active purchases then returns latest token`() = runTest {
-        val mockPurchase: Purchase = mock {
-            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
-            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
-            whenever(it.purchaseTime).thenReturn(1000L)
-            whenever(it.purchaseToken).thenReturn("test_purchase_token")
-        }
-        billingClientAdapter.activePurchases = listOf(mockPurchase)
-
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-
-        val result = subject.getLatestPurchaseToken()
-
-        assertEquals("test_purchase_token", result)
-    }
-
-    @Test
-    fun `when getLatestPurchaseToken called with no active purchases then returns null`() = runTest {
-        billingClientAdapter.activePurchases = emptyList()
-
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-
-        val result = subject.getLatestPurchaseToken()
-
-        assertEquals(null, result)
-    }
-
-    @Test
-    fun `when getLatestPurchaseToken called with pending purchase then returns null`() = runTest {
-        val pendingPurchase: Purchase = mock {
-            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
-            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PENDING)
-            whenever(it.purchaseTime).thenReturn(1000L)
-            whenever(it.purchaseToken).thenReturn("pending_token")
-        }
-        billingClientAdapter.activePurchases = listOf(pendingPurchase)
-
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-
-        val result = subject.getLatestPurchaseToken()
-
-        assertEquals(null, result)
-    }
-
-    @Test
-    fun `when getLatestPurchaseToken called with non-subscription purchase then returns null`() = runTest {
-        val otherProductPurchase: Purchase = mock {
-            whenever(it.products).thenReturn(listOf("other_product"))
-            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
-            whenever(it.purchaseTime).thenReturn(1000L)
-            whenever(it.purchaseToken).thenReturn("other_token")
-        }
-        billingClientAdapter.activePurchases = listOf(otherProductPurchase)
-
-        processLifecycleOwner.currentState = RESUMED
-        runCurrent()
-
-        val result = subject.getLatestPurchaseToken()
-
-        assertEquals(null, result)
-    }
 }
 
 class FakeBillingClientAdapter : BillingClientAdapter {
@@ -585,11 +494,6 @@ class FakeBillingClientAdapter : BillingClientAdapter {
 
     fun verifyGetSubscriptionPurchaseHistoryInvoked(times: Int = 1) {
         val invocations = methodInvocations.filterIsInstance<GetSubscriptionsPurchaseHistory>()
-        assertEquals(times, invocations.count())
-    }
-
-    fun verifyQueryPurchasesInvoked(times: Int = 1) {
-        val invocations = methodInvocations.filterIsInstance<QueryPurchases>()
         assertEquals(times, invocations.count())
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212772159665034?focus=true

### Description
Reverts duckduckgo/Android#7459. In 5.261.0 there was 100% switch success, so I'll monitor for another release if the problem has been fixed in a previous PR

### Steps to test this PR
- [ ] N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the prior behavior that refreshed purchases when retrieving the current purchase token.
> 
> - Change `getLatestPurchaseToken` from `suspend` to synchronous; remove client connect/`loadPurchases` calls and add token preview logging
> - Update KDoc to reflect using active purchases cache (`queryPurchasesAsync`) for current tokens
> - Remove unit tests asserting connection/query on token retrieval and delete `verifyQueryPurchasesInvoked` from the fake billing client
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67cf0c93f43542f07f206e763473d0363eb1a228. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->