### PR TITLE
Add nativeCrashReportsFullWebViewVersion RC flag

### DIFF
--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
@@ -51,6 +51,9 @@ interface NativeCrashFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun nativeCrashHandlingSecondaryProcess(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun nativeCrashReportsFullWebViewVersion(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
@@ -58,7 +58,13 @@ class NativeCrashInit @Inject constructor(
     private val isCustomTab: Boolean by lazy { customTabDetector.isCustomTab() }
     private val processName: String by lazy { if (isMainProcess) "main" else "vpn" }
 
-    private val webViewVersion: String by lazy { webViewVersionProvider.getFullVersion() }
+    private val webViewVersion: String by lazy {
+        if (nativeCrashFeature.nativeCrashReportsFullWebViewVersion().isEnabled()) {
+            webViewVersionProvider.getFullVersion()
+        } else {
+            webViewVersionProvider.getMajorVersion()
+        }
+    }
 
     private val webViewPackage: String by lazy { webViewVersionProvider.getPackageName() }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1212768277485475?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a remote-config toggle to control WebView version granularity in native crash reports.
> 
> - Adds `nativeCrashReportsFullWebViewVersion` (default `false`) to `NativeCrashFeature`
> - `NativeCrashInit` now sets `webViewVersion` via the toggle: uses `getFullVersion()` when enabled, otherwise `getMajorVersion()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b173cc449ced0642df93bcf667beb967769bb48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->