### PR TITLE
Migrate autofill SharedPreferences to Harmony

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/di/SecureStorageModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/di/SecureStorageModule.kt
@@ -18,12 +18,14 @@ package com.duckduckgo.autofill.impl.securestorage.di
 
 import android.content.Context
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.impl.securestorage.DerivedKeySecretFactory
 import com.duckduckgo.autofill.impl.securestorage.RealDerivedKeySecretFactory
 import com.duckduckgo.autofill.store.RealSecureStorageKeyRepository
 import com.duckduckgo.autofill.store.SecureStorageKeyRepository
 import com.duckduckgo.autofill.store.keys.RealSecureStorageKeyStore
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -42,9 +44,11 @@ object SecureStorageModule {
         context: Context,
         @AppCoroutineScope coroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        autofillFeature: AutofillFeature,
+        sharedPreferencesProvider: SharedPreferencesProvider,
     ): SecureStorageKeyRepository =
         RealSecureStorageKeyRepository(
-            RealSecureStorageKeyStore(context, coroutineScope, dispatcherProvider),
+            RealSecureStorageKeyStore(context, coroutineScope, dispatcherProvider, autofillFeature, sharedPreferencesProvider),
         )
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -21,7 +21,9 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -30,7 +32,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
-import java.lang.Exception
 
 /**
  * This class provides a way to access and store key related data
@@ -56,9 +57,12 @@ class RealSecureStorageKeyStore constructor(
     private val context: Context,
     private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val autofillFeature: AutofillFeature,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : SecureStorageKeyStore {
 
     private val mutex: Mutex = Mutex()
+    private val harmonyMutex: Mutex = Mutex()
     private val encryptedPreferencesDeferred: Deferred<SharedPreferences?> by lazy {
         coroutineScope.async(dispatcherProvider.io()) {
             try {
@@ -79,8 +83,28 @@ class RealSecureStorageKeyStore constructor(
         }
     }
 
+    private val harmonyPreferencesDeferred: Deferred<SharedPreferences?> by lazy {
+        coroutineScope.async(dispatcherProvider.io()) {
+            try {
+                harmonyMutex.withLock {
+                    if (autofillFeature.useHarmony().isEnabled()) {
+                        sharedPreferencesProvider.getMigratedEncryptedSharedPreferences(FILENAME)
+                    } else {
+                        null
+                    }
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
     private suspend fun getEncryptedPreferences(): SharedPreferences? {
         return encryptedPreferencesDeferred.await()
+    }
+
+    private suspend fun getHarmonyEncryptedPreferences(): SharedPreferences? {
+        return harmonyPreferencesDeferred.await()
     }
 
     override suspend fun updateKey(
@@ -95,12 +119,27 @@ class RealSecureStorageKeyStore constructor(
                     putString(keyName, keyValue.toByteString().base64())
                 }
             }
+
+            if (autofillFeature.useHarmony().isEnabled()) {
+                getHarmonyEncryptedPreferences()?.edit(commit = true) {
+                    if (keyValue == null) {
+                        remove(keyName)
+                    } else {
+                        putString(keyName, keyValue.toByteString().base64())
+                    }
+                }
+            }
         }
     }
 
     override suspend fun getKey(keyName: String): ByteArray? {
         return withContext(dispatcherProvider.io()) {
-            return@withContext getEncryptedPreferences()?.getString(keyName, null)?.run {
+            val preferences = if (autofillFeature.useHarmony().isEnabled()) {
+                getHarmonyEncryptedPreferences()
+            } else {
+                getEncryptedPreferences()
+            }
+            return@withContext preferences?.getString(keyName, null)?.run {
                 this.decodeBase64()?.toByteArray()
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1212732771705204?focus=true

### Description
* Migrate autofill sharedPreferences to Harmony
* Provide a fallback in case we need to get back to not using Harmony

### Steps to test this PR

_Feature 1_
- [x] Clean install the app
- [x] Create a new password
- [x] Enable `useHarmony` RC flag, kill and reopen the app
- [x] Go to passwords and check the item you've created previously is still there and readable
- [x] Create a new password again
- [x] Disable `useHarmony` RC flag, kill and reopen the app
- [x] Go to passwords and check both items are still there and readable

_Feature 2_
- [x] Clean install the app
- [x] Enable `useHarmony` RC flag, kill and reopen the app
- [x] Create a new password
- [x] Disable `useHarmony` RC flag, kill and reopen the app
- [x] Go to passwords and check the item you've created previously is still there and readable

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Harmony-backed encrypted storage for autofill keys behind a feature flag, with dual-write and selective read to enable migration/fallback.
> 
> - `RealSecureStorageKeyStore` now conditionally uses Harmony (`SharedPreferencesProvider.getMigratedEncryptedSharedPreferences`) when `AutofillFeature.useHarmony()` is enabled, reading from Harmony and writing to both Harmony and legacy `EncryptedSharedPreferences`
> - Introduces a separate mutex for Harmony prefs initialization; preserves legacy prefs and `canUseEncryption` check
> - DI updated to inject `AutofillFeature` and `SharedPreferencesProvider` into the secure storage components
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab3815b825ba49698ea427f74f5e0bb46292252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->