### PR TITLE
Update content scope scripts to version 12.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.21.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.22.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5adda7bff2887c764178755bc511f0317cafd0f1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#cb3431f467bab6b0cec2abd180766f17f6c8e905",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.3.tgz",
-      "integrity": "sha512-ut/oogz9HFKKC0MGGH7NqTHv61dxhobXgCYx1GqDwYLDJpbC5vwEKEUNXAFK6SHV5Cu6DqjV68R4NkXaYC4V9g==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.4.tgz",
+      "integrity": "sha512-rI7MbS+F2ckIr/2brV+QHMyl55W7F1vazAFiJYHcOBi6i4ClI47Ep95HakwB2qM95gv9igQDTE1zFisV2YKgGg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.13.3",
-        "@ghostery/adblocker-extended-selectors": "^2.13.3",
+        "@ghostery/adblocker-content": "^2.13.4",
+        "@ghostery/adblocker-extended-selectors": "^2.13.4",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.3.tgz",
-      "integrity": "sha512-XOVpkfBlobXv/iWieJj5YnR7oLLA66yK3L9n9/c9OIP4/m6B/x+LSgsAy20mlNlytVkUsYJZVObdmRBCnZl6yQ==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.4.tgz",
+      "integrity": "sha512-VPa4dyHqTyMWxut/wCYYlHdVRsQ2ZXXezTv31WiRhUC86LFKz8rL/Jnj1baHXlRrO5Ndhpll1/e/J/Tzwu6mqg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.13.3"
+        "@ghostery/adblocker-extended-selectors": "^2.13.4"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.3.tgz",
-      "integrity": "sha512-7TZKtvJ8ywIbnzueDc8bK55AqYq0Z7asNZWTKZJ7uxI5fPpctxukQVSDo2av56OdYEbBQemowEOh/6i0PMKkSg==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.4.tgz",
+      "integrity": "sha512-nDNK72R9Ly+AOBsd3f0SAxtF3FELx7ogOPCDD2MVJtv3qYZG76fHUmUoCGRmN2oHlPPNUQJ+vI4Rm/LRM1B5XQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.21.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.22.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1212821215378534/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency versions; no source changes.
> 
> - Upgrades `@duckduckgo/content-scope-scripts` from `12.21.0` to `12.22.0` in `package.json` and lockfile (new commit `cb3431f...`)
> - Lockfile refresh bumps `@ghostery/adblocker*` packages to `2.13.4`
> - Dependency-only update; no app code modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d8d81a4b639e324b5c292d56a49b6610868965e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->