### PR TITLE
Fix opening external apps via non-http deeplinks

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2898,7 +2898,14 @@ class BrowserTabFragment :
                         object : StackedAlertDialogBuilder.EventListener() {
                             override fun onButtonClicked(position: Int) {
                                 when (LaunchInExternalAppOptions.getOptionFromPosition(position)) {
-                                    LaunchInExternalAppOptions.OPEN -> onClick()
+                                    LaunchInExternalAppOptions.OPEN -> {
+                                        runCatching {
+                                            onClick()
+                                        }.onFailure { exception ->
+                                            logcat(ERROR) { "Failed to launch external app: ${exception.asLog()}" }
+                                            showToast(R.string.unableToOpenLink)
+                                        }
+                                    }
                                     LaunchInExternalAppOptions.CLOSE_TAB -> {
                                         launch {
                                             viewModel.closeCurrentTab()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1212793886724830?focus=true

### Description
Fixes issue with opening external non-http deeplinks for apps that require permission.

### Steps to test this PR
Could not reproduce, so no steps

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness when opening external apps via non-http deeplinks.
> 
> - In `BrowserTabFragment`, when `OPEN` is chosen in the "Launch in external app" dialog, wrap `onClick()` in `runCatching`; on failure, log the error and show `unableToOpenLink` toast
> - Reduces silent failures for apps requiring permissions or unavailable handlers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9160fdd40e4a63ea1711ad23527ae5d359118b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->