### PR TITLE
Update content scope scripts to version 12.24.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -5985,6 +5985,35 @@
     };
   }
 
+  // src/detectors/detections/adwall-detection.js
+  function runAdwallDetection(config = {}) {
+    const results = [];
+    for (const [detectorId, detectorConfig] of Object.entries(config)) {
+      if (detectorConfig?.state !== "enabled") {
+        continue;
+      }
+      const detected = detectAdwall(detectorConfig);
+      if (detected) {
+        results.push({
+          detected: true,
+          detectorId
+        });
+      }
+    }
+    return {
+      detected: results.length > 0,
+      type: "adwallDetection",
+      results
+    };
+  }
+  function detectAdwall(patternConfig) {
+    const { textPatterns, textSources } = patternConfig;
+    if (checkTextPatterns(textPatterns, textSources)) {
+      return true;
+    }
+    return false;
+  }
+
   // src/features/breakage-reporting.js
   var BreakageReporting = class extends ContentFeature {
     init() {
@@ -6009,7 +6038,8 @@
         if (detectorSettings) {
           result.detectorData = {
             botDetection: runBotDetection(detectorSettings.botDetection),
-            fraudDetection: runFraudDetection(detectorSettings.fraudDetection)
+            fraudDetection: runFraudDetection(detectorSettings.fraudDetection),
+            adwallDetection: runAdwallDetection(detectorSettings.adwallDetection)
           };
         }
         if (isExpandedPerformanceMetricsEnabled) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7835,6 +7835,36 @@
     };
   }
 
+  // src/detectors/detections/adwall-detection.js
+  init_define_import_meta_trackerLookup();
+  function runAdwallDetection(config = {}) {
+    const results = [];
+    for (const [detectorId, detectorConfig] of Object.entries(config)) {
+      if (detectorConfig?.state !== "enabled") {
+        continue;
+      }
+      const detected = detectAdwall(detectorConfig);
+      if (detected) {
+        results.push({
+          detected: true,
+          detectorId
+        });
+      }
+    }
+    return {
+      detected: results.length > 0,
+      type: "adwallDetection",
+      results
+    };
+  }
+  function detectAdwall(patternConfig) {
+    const { textPatterns, textSources } = patternConfig;
+    if (checkTextPatterns(textPatterns, textSources)) {
+      return true;
+    }
+    return false;
+  }
+
   // src/features/web-interference-detection.js
   var WebInterferenceDetection = class extends ContentFeature {
     init() {
@@ -7850,6 +7880,9 @@
         }
         if (types.includes("fraudDetection")) {
           results.fraudDetection = runFraudDetection(settings?.fraudDetection);
+        }
+        if (types.includes("adwallDetection")) {
+          results.adwallDetection = runAdwallDetection(settings?.adwallDetection);
         }
         return results;
       });
@@ -7977,7 +8010,8 @@
         if (detectorSettings) {
           result.detectorData = {
             botDetection: runBotDetection(detectorSettings.botDetection),
-            fraudDetection: runFraudDetection(detectorSettings.fraudDetection)
+            fraudDetection: runFraudDetection(detectorSettings.fraudDetection),
+            adwallDetection: runAdwallDetection(detectorSettings.adwallDetection)
           };
         }
         if (isExpandedPerformanceMetricsEnabled) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.49.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.49.0.tgz",
-      "integrity": "sha512-4ivl6UunTn1fwdG5Z/I4elur3Ii5mJksI9e14aG9uLLQVE7npf7jLNJFIaaYqEbEggt8tm7J9ASue/0vOl5pIw==",
+      "version": "14.50.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.50.0.tgz",
+      "integrity": "sha512-7Z3lp5NpKWmcOfdWytRBY52LEAH668YSvxLDqapz7wBDYtFWk494m58+viYGnnCzp49WttF7ewbmRhkDhAS0SQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#cb3431f467bab6b0cec2abd180766f17f6c8e905",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a8de801488a17a86a209a6b3ff7e339f6a2ed1f7",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
-      "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1212811804421348/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces adwall detection and updates dependencies.
> 
> - Adds `runAdwallDetection`/`detectAdwall` and integrates `adwallDetection` into `webInterferenceDetection` and breakage report `detectorData`
> - Bumps `@duckduckgo/content-scope-scripts` to `12.24.0` (with rebuilt Android bundles) and updates lockfile deps (`@duckduckgo/autoconsent`, `@types/node`, `terser`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c99d760c107aba9db528e445a90ec0c88d641be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->