### PR TITLE
Improve error handling for syncing duck chats

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/DecryptWithSyncMasterKeyHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/DecryptWithSyncMasterKeyHandler.kt
@@ -51,7 +51,7 @@ class DecryptWithSyncMasterKeyHandler @Inject constructor(
             ) {
                 if (jsMessage.id.isNullOrEmpty()) return
 
-                logcat(LogPriority.WARN) { "DuckChat-Sync: ${jsMessage.method} called" }
+                logcat { "DuckChat-Sync: ${jsMessage.method} called" }
 
                 val responder = SyncJsResponder(jsMessaging, jsMessage, featureName)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandler.kt
@@ -51,7 +51,7 @@ class EncryptWithSyncMasterKeyHandler @Inject constructor(
             ) {
                 if (jsMessage.id.isNullOrEmpty()) return
 
-                logcat(LogPriority.WARN) { "DuckChat-Sync: ${jsMessage.method} called" }
+                logcat { "DuckChat-Sync: ${jsMessage.method} called" }
 
                 val responder = SyncJsResponder(jsMessaging, jsMessage, featureName)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/SetUpSyncHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/SetUpSyncHandler.kt
@@ -32,7 +32,6 @@ import com.duckduckgo.sync.api.DeviceSyncState
 import com.duckduckgo.sync.api.DeviceSyncState.SyncAccountState.SignedIn
 import com.duckduckgo.sync.api.SyncActivityWithEmptyParams
 import com.squareup.anvil.annotations.ContributesMultibinding
-import logcat.LogPriority
 import logcat.logcat
 import javax.inject.Inject
 
@@ -51,7 +50,7 @@ class SetUpSyncHandler @Inject constructor(
             ) {
                 if (jsMessage.id.isNullOrEmpty()) return
 
-                logcat(LogPriority.WARN) { "DuckChat-Sync: ${jsMessage.method} called" }
+                logcat { "DuckChat-Sync: ${jsMessage.method} called" }
 
                 val responder = SyncJsResponder(jsMessaging, jsMessage, featureName)
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptor.kt
@@ -51,7 +51,7 @@ class SyncInvalidTokenInterceptor @Inject constructor(
         val response = chain.proceed(chain.request())
 
         val method = chain.request().method
-        if (response.code == API_CODE.INVALID_LOGIN_CREDENTIALS.code && (method == "PATCH" || method == "GET")) {
+        if (response.code == API_CODE.INVALID_LOGIN_CREDENTIALS.code && method in METHODS_TRIGGERING_LOGGED_OUT_NOTIFICATION) {
             logcat { "Sync-Engine: User logged out, invalid token detected." }
             notificationManager.checkPermissionAndNotify(
                 context,
@@ -66,5 +66,6 @@ class SyncInvalidTokenInterceptor @Inject constructor(
 
     companion object {
         internal const val SYNC_USER_LOGGED_OUT_NOTIFICATION_ID = 8451
+        private val METHODS_TRIGGERING_LOGGED_OUT_NOTIFICATION = listOf("GET", "PATCH", "DELETE", "POST")
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetSyncStatusHandler.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetSyncStatusHandler.kt
@@ -46,7 +46,7 @@ class GetSyncStatusHandler @Inject constructor(
             ) {
                 if (jsMessage.id.isNullOrEmpty()) return
 
-                logcat(LogPriority.WARN) { "DuckChat-Sync: ${jsMessage.method} called" }
+                logcat { "DuckChat-Sync: ${jsMessage.method} called" }
 
                 val jsonPayload = runCatching {
                     val syncAvailable = deviceSyncState.isFeatureEnabled()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -176,6 +176,7 @@ class RealSyncPixels @Inject constructor(
             SyncAccountOperation.DELETE_ACCOUNT -> fireDeleteAccountErrorPixel(result)
             SyncAccountOperation.USER_SIGNED_IN -> fireAlreadySignedInErrorPixel(result)
             SyncAccountOperation.CREATE_PDF -> fireSaveRecoveryPdfErrorPixel(result)
+            SyncAccountOperation.RESCOPE_TOKEN -> fireRescopeTokenErrorPixel(result)
             SyncAccountOperation.GENERIC -> fireSyncAccountErrorPixel(result)
         }
     }
@@ -249,6 +250,10 @@ class RealSyncPixels @Inject constructor(
 
     private fun fireSaveRecoveryPdfErrorPixel(result: Error) {
         result.fireAddingErrorAsParams(SyncPixelName.SYNC_CREATE_PDF_FAILURE)
+    }
+
+    private fun fireRescopeTokenErrorPixel(result: Error) {
+        result.fireAddingErrorAsParams(SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE)
     }
 
     private fun Error.fireAddingErrorAsParams(pixelName: SyncPixelName) {
@@ -413,6 +418,7 @@ enum class SyncAccountOperation {
     DELETE_ACCOUNT,
     USER_SIGNED_IN,
     CREATE_PDF,
+    RESCOPE_TOKEN,
 }
 
 // https://app.asana.com/0/72649045549333/1205649300615861
@@ -432,6 +438,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_DELETE_ACCOUNT_FAILURE("m_delete_account_error"),
     SYNC_USER_SIGNED_IN_FAILURE("m_login_existing_account_error"),
     SYNC_CREATE_PDF_FAILURE("m_sync_create_recovery_pdf_error"),
+    SYNC_RESCOPE_TOKEN_FAILURE("m_sync_rescope_token_error"),
     SYNC_PATCH_COMPRESS_FAILED("m_sync_patch_compression_failed"),
     SYNC_TOO_MANY_REQUESTS_DAILY("m_sync_%s_too_many_requests_daily"),
     SYNC_OBJECT_LIMIT_EXCEEDED_DAILY("m_sync_%s_object_limit_exceeded_daily"),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncInvalidTokenInterceptorTest.kt
@@ -94,6 +94,44 @@ class SyncInvalidTokenInterceptorTest {
         assertNull(notificationManager.activeNotifications.find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID })
     }
 
+    @Test
+    fun whenInterceptingSyncResponseInvalidTokenWhenDELETEThenNotifyUser() {
+        val chain = givenDeleteRequest(SYNC_PROD_ENVIRONMENT_URL, INVALID_LOGIN_CREDENTIALS.code)
+
+        invalidTokenInterceptor.intercept(chain)
+
+        notificationManager.activeNotifications
+            .find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID } ?: fail("Notification not found")
+    }
+
+    @Test
+    fun whenInterceptingNonSyncDeleteRequestThenDoNotNotifyUser() {
+        val chain = givenDeleteRequest("https://www.example.com", INVALID_LOGIN_CREDENTIALS.code)
+
+        invalidTokenInterceptor.intercept(chain)
+
+        assertNull(notificationManager.activeNotifications.find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID })
+    }
+
+    @Test
+    fun whenInterceptingSyncResponseInvalidTokenWhenPOSTThenNotifyUser() {
+        val chain = givenPostRequest(SYNC_PROD_ENVIRONMENT_URL, INVALID_LOGIN_CREDENTIALS.code)
+
+        invalidTokenInterceptor.intercept(chain)
+
+        notificationManager.activeNotifications
+            .find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID } ?: fail("Notification not found")
+    }
+
+    @Test
+    fun whenInterceptingNonSyncPostRequestThenDoNotNotifyUser() {
+        val chain = givenPostRequest("https://www.example.com", INVALID_LOGIN_CREDENTIALS.code)
+
+        invalidTokenInterceptor.intercept(chain)
+
+        assertNull(notificationManager.activeNotifications.find { it.id == SYNC_USER_LOGGED_OUT_NOTIFICATION_ID })
+    }
+
     private fun givenGetRequest(
         url: String,
         expectedResponseCode: Int? = null,
@@ -109,6 +147,24 @@ class SyncInvalidTokenInterceptorTest {
     ): Chain {
         return object : FakeChain(url, expectedResponseCode) {
             override fun request() = Request.Builder().url(url).method("PATCH", "".toRequestBody()).build()
+        }
+    }
+
+    private fun givenDeleteRequest(
+        url: String,
+        expectedResponseCode: Int? = null,
+    ): Chain {
+        return object : FakeChain(url, expectedResponseCode) {
+            override fun request() = Request.Builder().url(url).method("DELETE", null).build()
+        }
+    }
+
+    private fun givenPostRequest(
+        url: String,
+        expectedResponseCode: Int? = null,
+    ): Chain {
+        return object : FakeChain(url, expectedResponseCode) {
+            override fun request() = Request.Builder().url(url).method("POST", "".toRequestBody()).build()
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -148,6 +148,21 @@ class RealSyncPixelsTest {
         verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
 
+    @Test
+    fun whenFireSyncAccountErrorPixelForRescopeTokenThenPixelSent() {
+        val error = Error(code = 401, reason = "unauthorized")
+
+        testee.fireSyncAccountErrorPixel(error, SyncAccountOperation.RESCOPE_TOKEN)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE,
+            mapOf(
+                SyncPixelParameters.ERROR_CODE to "401",
+                SyncPixelParameters.ERROR_REASON to "unauthorized",
+            ),
+        )
+    }
+
     private fun givenSomeDailyStats(): DailyStats {
         val date = DatabaseDateFormatter.getUtcIsoLocalDate()
         val dailyStats = DailyStats("1", date, emptyMap())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212290253282722?focus=true

### Description
Improves error handling around duck ai chat syncing.

Patches are provided to test out different error scenarios that would be hard to reach naturally. ([Patches for testing](https://app.asana.com/1/137249556945/task/1212862949858349?focus=true))

### Steps to test this PR

**Pre-requisite setup**
1. Use `internal` build type
2. Use two devices/emulators. Set them up to sync with each other.
3. Authenticate for internal duck chat features
4. Enable duck.ai chat fire button clearing - `App Settings > Data Clearing > Clear Duck.ai Chats` [**ENABLE**]

**Logcat filter:** `package:mine message~:"DuckChat-Sync:|Sync-service: DEBUG|Pixel sent: m_sync_rescope|Pixel sent: m_sync_ai_chats_too_many_requests_daily|Pixel ignored: m_sync_ai_chats_too_many_requests_daily|Sync-Engine: User logged out"`

#### Test 1 - Rescope token error

**Steps:**
1. Apply patch (from repo root): `git apply <path-to>/force_rescope_401.patch`. Build and install the app
2. Open Duck.ai and start/continue a chat (this might trigger a rescope token call from JS). if it doesn't (if you don't see the 401 error in the logs) then kill the app and re-open duck chat
4. Verify `m_sync_rescope_token_error` is in logcat, and verify you see a notification that syncing has been paused

**Cleanup:** `git checkout sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt`


#### Test 2 - 
Delete AI Chats Error (429 - Too Many Requests)

**Steps:**
1. Apply patch (from repo root): `git apply <path-to>/force_delete_429.patch`
2. Build and install the app
3. Re-establish sync between the two devices
4. Create a chat, then clear chat history using the **native** fire button
5. The app will restart. Wait for sync to run

**Expected Result:**
- Pixel `m_sync_ai_chats_too_many_requests_daily` fired (daily pixel)
- Logcat shows: `DuckChat-Sync: failed to inform sync of of deleted duck ai chats`
- No crash, deletion timestamp preserved for retry on next sync

**Cleanup:** `git checkout sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt`


#### Test 3 - Delete AI Chats Error (418 - Too Many Requests variant)

**Purpose:** Verify 418 is handled same as 429.

**Steps:**
1. Apply patch (from repo root): `git apply <path-to>/force_delete_418.patch`
2. Build and install the app. Launch. Wait for sync to run.
3. (it'll still be trying to send the deletion from the last step so you don't have to repeat anything in the app)

**Expected Result:**
- `Pixel ignored: m_sync_ai_chats_too_many_requests_daily` in logs (it would have sent, but it sent in the last test)
- No crash, deletion will retry on next sync

**Cleanup:** `git checkout sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt`


#### Test 4: 401 Notification via Interceptor

**Steps:**
1. Apply patch (from repo root): `git apply <path-to>/force_delete_401.patch`
2. Build and install the app. Launch. Wait for sync to run.
3. (it'll still be trying to send the deletion from the last step so you don't have to repeat anything in the app)

**Expected Result:**
- "Sync is Paused" notification appears
- Logcat shows: `Sync-Engine: User logged out, invalid token detected.`

**Cleanup:** `git checkout sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens sync error handling and telemetry for Duck AI chats.
> 
> - **Invalid token handling:** `SyncInvalidTokenInterceptor` now triggers the "Sync is Paused" notification on 401 for `GET`, `PATCH`, `DELETE`, and `POST` (was only `GET`/`PATCH`), with new tests covering DELETE/POST and non-sync URLs.
> - **Rescope token telemetry:** Adds `SYNC_RESCOPE_TOKEN_FAILURE` pixel and wires it via `SyncPixels.fireSyncAccountErrorPixel` using `SyncAccountOperation.RESCOPE_TOKEN`.
> - **JS bridge handler:** `GetScopedSyncAuthTokenHandler` now fires the rescope token error pixel on failures and returns structured success/error payloads; includes domain/method metadata and tests for success, error, and exception paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec27199dc1e3ea3ab75c29a06c5ce1597ea8a3e3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->