### PR TITLE
PIR: Clean-up pixels

### DIFF
--- a/PixelDefinitions/pixels/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/personal_information_removal.json5
@@ -1130,5 +1130,426 @@
                 "type": "string"
             }
         ]
+    },
+    "m_dbp_foreground-run_started": {
+        "description": "Fired when pir run is started in the foreground",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_foreground-run_completed": {
+        "description": "Fired when pir run is completed in the foreground",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "totalTimeInMillis",
+                "description": "Total time in ms the foreground run took to complete",
+                "type": "string"
+            },
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_scheduled-run_scheduled": {
+        "description": "Fired when the pir scheduled runs are scheduled",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_dbp_scheduled-run_started": {
+        "description": "Fired when the pir scheduled run is started",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_scheduled-run_completed": {
+        "description": "Fired when the pir scheduled run is completed",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "totalTimeInMillis",
+                "description": "Total time in ms the scheduled run took to complete",
+                "type": "string"
+            },
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_cpu-usage": {
+        "description": "Fired when the CPU Usage threshold has been reached while executing PIR related work.",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "cpuUsage",
+                "description": "Average CPU usage percent",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation-link_client-received": {
+        "description": "Fired when the client persists a confirmation link provided by the backend",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "link_age_ms",
+                "description": "Time from when the link is received on BE till it's retrieved on the client (in milliseconds)",
+                "type": "number"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation-link_backend-status_error": {
+        "description": "Fired when the backend returns an unknown/error status while polling email data",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "status",
+                "description": "Backend item status",
+                "type": "string",
+                "enum": ["unknown", "error"]
+            },
+            {
+                "key": "error_code",
+                "description": "Backend item error code",
+                "type": "string",
+                "enum": ["server_error", "extraction_error", "request_error"]
+            }
+        ]
+    },
+    "m_dbp_optout_stage_submit-awaiting-email-confirmation": {
+        "description": "Fired when the opt-out form is submitted and the operation is awaiting email confirmation",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "attempt_id",
+                "description": "Client-generated ID of the attempt",
+                "type": "string"
+            },
+            {
+                "key": "action_id",
+                "description": "Predefined identifier of the broker action executed in this stage",
+                "type": "string"
+            },
+            {
+                "key": "duration",
+                "description": "Stage duration in milliseconds",
+                "type": "string"
+            },
+            {
+                "key": "tries",
+                "description": "Number of tries it took to complete the stage",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_attempt-start": {
+        "description": "Fired when an email confirmation attempt is starting",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "attempt_number",
+                "description": "Confirmation attempt ordinal (1..3)",
+                "type": "number"
+            },
+            {
+                "key": "attempt_id",
+                "description": "Client-generated ID of the attempt",
+                "type": "string"
+            },
+            {
+                "key": "action_id",
+                "description": "Predefined identifier of the broker action executed in this stage",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_attempt-success": {
+        "description": "Fired when an email confirmation attempt succeeds",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "attempt_number",
+                "description": "Confirmation attempt ordinal (1..3)",
+                "type": "number"
+            },
+            {
+                "key": "duration",
+                "description": "Stage duration in milliseconds",
+                "type": "string"
+            },
+            {
+                "key": "attempt_id",
+                "description": "Client-generated ID of the attempt",
+                "type": "string"
+            },
+            {
+                "key": "action_id",
+                "description": "Predefined identifier of the broker action executed in this stage",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_attempt-failure": {
+        "description": "Fired when an email confirmation attempt fails (non-final).",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "attempt_number",
+                "description": "Confirmation attempt ordinal (1..3)",
+                "type": "number"
+            },
+            {
+                "key": "duration",
+                "description": "Stage duration in milliseconds",
+                "type": "string"
+            },
+            {
+                "key": "attempt_id",
+                "description": "Client-generated ID of the attempt",
+                "type": "string"
+            },
+            {
+                "key": "action_id",
+                "description": "Predefined identifier of the broker action executed in this stage",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_max-retries-exceeded": {
+        "description": "Fired when the email confirmation job hits the maximum number of retries (final failure).",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            },
+            {
+                "key": "attempt_id",
+                "description": "Client-generated ID of the attempt",
+                "type": "string"
+            },
+            {
+                "key": "action_id",
+                "description": "Predefined identifier of the broker action executed in this stage",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_job-success": {
+        "description": "Fired when the email confirmation job finishes successfully (after any number of attempts).",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker",
+                "type": "string"
+            },
+            {
+                "key": "broker_version",
+                "description": "The version of the broker JSON file",
+                "type": "string"
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_started": {
+        "description": "Android specific pixel which is fired when the email confirmation job starts",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_email-confirmation_completed": {
+        "description": "Android specific pixel which is fired when the email confirmation job completes",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "totalTimeInMillis",
+                "description": "Total time in ms the run took to complete",
+                "type": "string"
+            },
+            {
+                "key": "totalFetchAttempts",
+                "description": "Total number of email confirmation links attempted to be fetched",
+                "type": "number"
+            },
+            {
+                "key": "totalEmailConfirmationJobs",
+                "description": "Total number of email confirmation opt-outs to be resumed",
+                "type": "number"
+            },
+            {
+                "key": "man",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "batteryOptimizations",
+                "description": "If device has battery optimizations enabled for the app",
+                "enum": ["false", "true"]
+            }
+        ]
+    },
+    "m_dbp_secure-storage_unavailable": {
+        "description": "Android specific pixel which is fired when we detect that the secure storage is unavailable",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -494,20 +494,17 @@ class PirEndToEndTest {
         println("==========STEP 6: Verify all scan and opt-out pixels fired ==========")
         // Scan pixels
         assertPixelsWereFired(
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_STARTED,
-            PirPixel.PIR_INTERNAL_SCAN_STATS,
+            PirPixel.PIR_FOREGROUND_RUN_STARTED,
             PirPixel.PIR_SCAN_STARTED,
             PirPixel.PIR_SCAN_STAGE,
             PirPixel.PIR_SCAN_STAGE_RESULT_MATCHES,
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_COMPLETED,
+            PirPixel.PIR_FOREGROUND_RUN_COMPLETED,
             PirPixel.PIR_INITIAL_SCAN_DURATION,
         )
 
         // Opt-out pixels
         assertPixelsWereFired(
-            PirPixel.PIR_INTERNAL_SCAN_STATS,
             PirPixel.PIR_OPTOUT_STAGE_START,
-            PirPixel.PIR_INTERNAL_BROKER_OPT_OUT_STARTED,
             PirPixel.PIR_OPTOUT_STAGE_FILLFORM,
             PirPixel.PIR_OPTOUT_STAGE_CAPTCHA_PARSE,
             PirPixel.PIR_OPTOUT_STAGE_CAPTCHA_SEND,
@@ -563,6 +560,7 @@ class PirEndToEndTest {
             PirPixel.PIR_EMAIL_CONFIRMATION_LINK_RECEIVED,
             PirPixel.PIR_EMAIL_CONFIRMATION_ATTEMPT_START,
             PirPixel.PIR_EMAIL_CONFIRMATION_ATTEMPT_SUCCESS,
+            PirPixel.PIR_OPTOUT_SUBMIT_SUCCESS,
             PirPixel.PIR_EMAIL_CONFIRMATION_JOB_SUCCESS,
             PirPixel.PIR_EMAIL_CONFIRMATION_RUN_COMPLETED,
         )
@@ -616,12 +614,11 @@ class PirEndToEndTest {
 
         // Verify confirmation scan pixels fired
         assertPixelsWereFired(
-            PirPixel.PIR_INTERNAL_SCHEDULED_SCAN_STARTED,
-            PirPixel.PIR_INTERNAL_SCAN_STATS,
+            PirPixel.PIR_SCHEDULED_RUN_STARTED,
             PirPixel.PIR_SCAN_STARTED,
             PirPixel.PIR_SCAN_STAGE,
             PirPixel.PIR_SCAN_STAGE_RESULT_MATCHES,
-            PirPixel.PIR_INTERNAL_SCHEDULED_SCAN_COMPLETED,
+            PirPixel.PIR_SCHEDULED_RUN_COMPLETED,
         )
     }
 
@@ -687,8 +684,8 @@ class PirEndToEndTest {
 
         // Verify scan completion pixels were fired (indicating graceful completion)
         assertPixelsWereFired(
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_STARTED,
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_COMPLETED,
+            PirPixel.PIR_FOREGROUND_RUN_STARTED,
+            PirPixel.PIR_FOREGROUND_RUN_COMPLETED,
         )
     }
 
@@ -778,8 +775,8 @@ class PirEndToEndTest {
 
         // Verify scan completion pixels were fired (indicating graceful completion)
         assertPixelsWereFired(
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_STARTED,
-            PirPixel.PIR_INTERNAL_MANUAL_SCAN_COMPLETED,
+            PirPixel.PIR_FOREGROUND_RUN_STARTED,
+            PirPixel.PIR_FOREGROUND_RUN_COMPLETED,
         )
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
@@ -131,10 +131,12 @@ interface PirRunStateHandler {
 
         data class BrokerRecordEmailConfirmationCompleted(
             override val broker: Broker,
-            val extractedProfileId: Long,
+            val extractedProfile: ExtractedProfile,
             val isSuccess: Boolean,
             val lastActionId: String,
             val totalTimeMillis: Long,
+            val emailPattern: String,
+            val attemptId: String,
         ) : PirRunState(broker)
 
         data class BrokerRecordOptOutStarted(
@@ -509,9 +511,10 @@ class RealPirRunStateHandler @Inject constructor(
     }
 
     private suspend fun handleBrokerRecordEmailConfirmationCompleted(pirRunState: BrokerRecordEmailConfirmationCompleted) {
+        val extractedProfileId = pirRunState.extractedProfile.dbId
         if (pirRunState.isSuccess) {
             // The job we pass to the engine could have outdated info so we just re-fetch it
-            val updatedRecord = pirSchedulingRepository.getEmailConfirmationJob(pirRunState.extractedProfileId)
+            val updatedRecord = pirSchedulingRepository.getEmailConfirmationJob(extractedProfileId)
 
             if (updatedRecord != null) {
                 pixelSender.reportEmailConfirmationAttemptSuccess(
@@ -522,14 +525,26 @@ class RealPirRunStateHandler @Inject constructor(
                     attemptId = updatedRecord.emailData.attemptId,
                     durationMs = pirRunState.totalTimeMillis,
                 )
+                emitAndLogBrokerOptOutSubmitted(
+                    brokerUrl = pirRunState.broker.url,
+                    brokerName = pirRunState.broker.name,
+                    brokerParent = pirRunState.broker.parent.orEmpty(),
+                    attemptId = pirRunState.attemptId,
+                    attemptCount = updatedRecord.jobAttemptData.jobAttemptCount,
+                    emailPattern = pirRunState.emailPattern,
+                    extractedProfile = pirRunState.extractedProfile,
+                    startTimeInMillis = currentTimeProvider.currentTimeMillis() - pirRunState.totalTimeMillis,
+                    endTimeInMillis = currentTimeProvider.currentTimeMillis(),
+                )
             }
 
-            jobRecordUpdater.recordEmailConfirmationCompleted(pirRunState.extractedProfileId)
+            jobRecordUpdater.recordEmailConfirmationCompleted(extractedProfileId)
 
             pixelSender.reportEmailConfirmationJobSuccess(
                 brokerUrl = pirRunState.broker.url,
                 brokerVersion = pirRunState.broker.version,
             )
+
             eventsRepository.saveEmailConfirmationLog(
                 eventTimeInMillis = currentTimeProvider.currentTimeMillis(),
                 type = EMAIL_CONFIRMATION_SUCCESS,
@@ -537,7 +552,7 @@ class RealPirRunStateHandler @Inject constructor(
             )
         } else {
             val updatedRecord = jobRecordUpdater.recordEmailConfirmationFailed(
-                pirRunState.extractedProfileId,
+                extractedProfileId,
                 pirRunState.lastActionId,
             )
 
@@ -658,29 +673,48 @@ class RealPirRunStateHandler @Inject constructor(
             parentUrl = state.broker.parent.orEmpty(),
             attemptId = state.attemptId,
         )
-
-        pixelSender.reportOptOutStarted(
-            brokerName = state.broker.name,
-        )
     }
 
     private suspend fun handleBrokerRecordOptOutSubmitted(state: BrokerRecordOptOutSubmitted) {
         val optOutJobRecord = updateOptOutRecord(true, state.extractedProfile.dbId) ?: return
-
-        pixelSender.reportOptOutSubmitted(
+        emitAndLogBrokerOptOutSubmitted(
             brokerUrl = state.broker.url,
-            parent = state.broker.parent.orEmpty(),
-            attemptId = state.attemptId,
-            durationMs = state.endTimeInMillis - state.startTimeInMillis,
-            optOutAttemptCount = optOutJobRecord.attemptCount,
-            emailPattern = state.emailPattern,
-        )
-
-        eventsRepository.saveOptOutCompleted(
             brokerName = state.broker.name,
+            brokerParent = state.broker.parent.orEmpty(),
+            attemptId = state.attemptId,
+            attemptCount = optOutJobRecord.attemptCount,
+            emailPattern = state.emailPattern.orEmpty(),
             extractedProfile = state.extractedProfile,
             startTimeInMillis = state.startTimeInMillis,
             endTimeInMillis = state.endTimeInMillis,
+        )
+    }
+
+    private suspend fun emitAndLogBrokerOptOutSubmitted(
+        brokerUrl: String,
+        brokerName: String,
+        brokerParent: String,
+        attemptId: String,
+        attemptCount: Int,
+        emailPattern: String,
+        extractedProfile: ExtractedProfile,
+        startTimeInMillis: Long,
+        endTimeInMillis: Long,
+    ) {
+        pixelSender.reportOptOutSubmitted(
+            brokerUrl = brokerUrl,
+            parent = brokerParent,
+            attemptId = attemptId,
+            durationMs = endTimeInMillis - startTimeInMillis,
+            optOutAttemptCount = attemptCount,
+            emailPattern = emailPattern,
+        )
+
+        eventsRepository.saveOptOutCompleted(
+            brokerName = brokerName,
+            extractedProfile = extractedProfile,
+            startTimeInMillis = startTimeInMillis,
+            endTimeInMillis = endTimeInMillis,
             isSubmitSuccess = true,
         )
     }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
@@ -199,7 +199,9 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                             currentOptOutStep.step.actions.getLastActionForFailure(state.currentActionIndex)
                         }.id,
                         totalTimeMillis = totalTimeMillis,
-                        extractedProfileId = currentBrokerStep.emailConfirmationJob.extractedProfileId,
+                        extractedProfile = currentOptOutStep.profileToOptOut,
+                        attemptId = state.attemptId,
+                        emailPattern = state.generatedEmailData?.pattern.orEmpty(),
                     ),
                 )
             }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
@@ -26,90 +26,75 @@ enum class PirPixel(
     private val types: Set<PixelType>,
     private val withSuffix: Boolean = true,
 ) {
-    PIR_INTERNAL_MANUAL_SCAN_STARTED(
-        baseName = "pir_internal_manual-scan_started",
+    PIR_FOREGROUND_RUN_STARTED(
+        baseName = "m_dbp_foreground-run_started",
         type = Count,
     ),
 
-    PIR_INTERNAL_MANUAL_SCAN_COMPLETED(
-        baseName = "pir_internal_manual-scan_completed",
+    PIR_FOREGROUND_RUN_COMPLETED(
+        baseName = "m_dbp_foreground-run_completed",
         type = Count,
     ),
 
-    PIR_INTERNAL_SCHEDULED_SCAN_SCHEDULED(
-        baseName = "pir_internal_scheduled-scan_scheduled",
+    PIR_SCHEDULED_RUN_SCHEDULED(
+        baseName = "m_dbp_scheduled-run_scheduled",
         type = Count,
     ),
 
-    PIR_INTERNAL_SCHEDULED_SCAN_STARTED(
-        baseName = "pir_internal_scheduled-scan_started",
+    PIR_SCHEDULED_RUN_STARTED(
+        baseName = "m_dbp_scheduled-run_started",
         type = Count,
     ),
 
-    PIR_INTERNAL_SCHEDULED_SCAN_COMPLETED(
-        baseName = "pir_internal_scheduled-scan_completed",
+    PIR_SCHEDULED_RUN_COMPLETED(
+        baseName = "m_dbp_scheduled-run_completed",
         type = Count,
     ),
 
-    PIR_INTERNAL_SCAN_STATS(
-        baseName = "pir_internal_scan-stats",
-        type = Count,
-    ),
-
-    PIR_INTERNAL_OPT_OUT_STATS(
-        baseName = "pir_internal_opt-out-stats",
-        type = Count,
-    ),
-
-    PIR_INTERNAL_BROKER_OPT_OUT_STARTED(
-        baseName = "pir_internal_opt-out_started",
-        type = Count,
-    ),
-
-    PIR_INTERNAL_CPU_USAGE(
-        baseName = "pir_internal_cpu_usage",
+    PIR_CPU_USAGE(
+        baseName = "m_dbp_cpu-usage",
         type = Count,
     ),
 
     PIR_EMAIL_CONFIRMATION_LINK_RECEIVED(
-        baseName = "pir_email-confirmation-link_client-received",
+        baseName = "m_dbp_email-confirmation-link_client-received",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_LINK_BE_ERROR(
-        baseName = "pir_email-confirmation-link_backend-status_error",
+        baseName = "m_dbp_email-confirmation-link_backend-status_error",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_ATTEMPT_START(
-        baseName = "pir_email-confirmation_attempt-start",
+        baseName = "m_dbp_email-confirmation_attempt-start",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_ATTEMPT_SUCCESS(
-        baseName = "pir_email-confirmation_attempt-success",
+        baseName = "m_dbp_email-confirmation_attempt-success",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_ATTEMPT_FAILED(
-        baseName = "pir_email-confirmation_attempt-failure",
+        baseName = "m_dbp_email-confirmation_attempt-failure",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_MAX_RETRIES_EXCEEDED(
-        baseName = "pir_email-confirmation_max-retries-exceeded",
+        baseName = "m_dbp_email-confirmation_max-retries-exceeded",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_JOB_SUCCESS(
-        baseName = "pir_email-confirmation_job-success",
+        baseName = "m_dbp_email-confirmation_job-success",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_RUN_STARTED(
-        baseName = "pir_email-confirmation_started",
+        baseName = "m_dbp_email-confirmation_started",
         type = Count,
     ),
     PIR_EMAIL_CONFIRMATION_RUN_COMPLETED(
-        baseName = "pir_email-confirmation_completed",
+        baseName = "m_dbp_email-confirmation_completed",
         type = Count,
     ),
 
     PIR_INTERNAL_SECURE_STORAGE_UNAVAILABLE(
-        baseName = "pir_internal_secure-storage_unavailable",
+        baseName = "m_dbp_secure-storage_unavailable",
         types = setOf(Count, Daily()),
     ),
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -40,12 +40,11 @@ class PirPixelInterceptor @Inject constructor(
         val request = chain.request().newBuilder()
         val pixel = chain.request().url.pathSegments.last()
 
-        val url = if (pixel.startsWith(PIXEL_PREFIX) && !EXCEPTIONS.any { exception -> pixel.startsWith(exception) }) {
+        val url = if (ALLOWLIST.any { prefix -> pixel.startsWith(prefix) }) {
             chain.request().url.newBuilder()
                 .addQueryParameter(
                     KEY_METADATA,
                     JSONObject()
-                        .put("os", appBuildConfig.sdkInt)
                         .put("batteryOptimizations", (!isIgnoringBatteryOptimizations()).toString())
                         .put("man", appBuildConfig.manufacturer)
                         .toString().toByteArray().run {
@@ -73,7 +72,13 @@ class PirPixelInterceptor @Inject constructor(
 
     companion object {
         private const val KEY_METADATA = "metadata"
-        private const val PIXEL_PREFIX = "pir_internal"
-        private val EXCEPTIONS = emptyList<String>()
+        private val ALLOWLIST = listOf(
+            "m_dbp_foreground-run_started",
+            "m_dbp_foreground-run_completed",
+            "m_dbp_scheduled-run_started",
+            "m_dbp_scheduled-run_completed",
+            "m_dbp_email-confirmation_started",
+            "m_dbp_email-confirmation_completed",
+        )
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -93,16 +93,12 @@ class RealPirJobsRunner @Inject constructor(
 
         if (profileQueries.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No profile queries available. Completing run." }
-            pixelSender.reportScanStats(0)
-            pixelSender.reportOptOutStats(0)
             emitCompletedPixel(executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
 
         if (activeBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active brokers available. Completing run." }
-            pixelSender.reportScanStats(0)
-            pixelSender.reportOptOutStats(0)
             emitCompletedPixel(executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
@@ -123,7 +119,6 @@ class RealPirJobsRunner @Inject constructor(
 
         if (activeFormOptOutBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active parent brokers available for optout. Completing run." }
-            pixelSender.reportOptOutStats(0)
             emitCompletedPixel(executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
@@ -208,7 +203,6 @@ class RealPirJobsRunner @Inject constructor(
                     RunType.SCHEDULED
                 }
 
-                pixelSender.reportScanStats(it.size)
                 if (it.isNotEmpty()) {
                     logcat { "PIR-JOB-RUNNER: Executing scan for ${it.size} eligible scan jobs." }
                     pirScan.executeScanForJobs(it, context, runType)
@@ -253,7 +247,6 @@ class RealPirJobsRunner @Inject constructor(
             .filter {
                 activeFormOptOutBrokers.contains(it.brokerName)
             }.also {
-                pixelSender.reportOptOutStats(it.size)
                 if (it.isNotEmpty()) {
                     logcat { "PIR-JOB-RUNNER: Executing opt-outs for ${it.size} eligible optout jobs." }
                     pirOptOut.executeOptOutForJobs(it, context)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
@@ -563,6 +563,7 @@ class BrokerStepCompletedEventHandlerTest {
                 currentStage = PirStage.OTHER,
                 stageStartMs = testStageStartMs,
             ),
+            attemptId = "attempt-123",
         )
         val event = BrokerStepCompleted(
             needsEmailConfirmation = false,
@@ -577,7 +578,9 @@ class BrokerStepCompletedEventHandlerTest {
         assertEquals(true, capturedState.firstValue.isSuccess)
         assertEquals("action-2", capturedState.firstValue.lastActionId)
         assertEquals(testCurrentTimeInMillis - testBrokerStartTime, capturedState.firstValue.totalTimeMillis)
-        assertEquals(456L, capturedState.firstValue.extractedProfileId)
+        assertEquals(testExtractedProfile, capturedState.firstValue.extractedProfile)
+        assertEquals("", capturedState.firstValue.emailPattern)
+        assertEquals("attempt-123", capturedState.firstValue.attemptId)
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
@@ -63,9 +63,9 @@ class PirPixelInterceptorTest {
     }
 
     @Test
-    fun whenInterceptPirInternalPixelThenAddsMetadataParameter() = runTest {
+    fun whenInterceptAllowListedPixelThenAddsMetadataParameter() = runTest {
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_scan_started")
+            .url("https://example.com/m_dbp_foreground-run_started")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -99,9 +99,9 @@ class PirPixelInterceptorTest {
     }
 
     @Test
-    fun whenInterceptPirInternalPixelThenMetadataContainsCorrectFields() = runTest {
+    fun whenInterceptPirAllowListedPixelThenMetadataContainsCorrectFields() = runTest {
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test_pixel")
+            .url("https://example.com/m_dbp_foreground-run_completed")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -120,17 +120,16 @@ class PirPixelInterceptorTest {
         val decodedJson = String(decodedBytes)
         val jsonObject = JSONObject(decodedJson)
 
-        assertEquals(30, jsonObject.getInt("os"))
         assertEquals("false", jsonObject.getString("batteryOptimizations"))
         assertEquals("TestManufacturer", jsonObject.getString("man"))
     }
 
     @Test
-    fun whenInterceptPirInternalPixelWithBatteryOptimizationsDisabledThenMetadataShowsTrue() = runTest {
+    fun whenInterceptPirAllowlistedPixelWithBatteryOptimizationsDisabledThenMetadataShowsTrue() = runTest {
         whenever(mockPowerManager.isIgnoringBatteryOptimizations(any())).thenReturn(false)
 
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test_pixel")
+            .url("https://example.com/m_dbp_foreground-run_started")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -152,9 +151,9 @@ class PirPixelInterceptorTest {
     }
 
     @Test
-    fun whenInterceptPirInternalPixelThenPreservesOtherQueryParameters() = runTest {
+    fun whenInterceptPirAllowListedPixelThenPreservesOtherQueryParameters() = runTest {
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test_pixel?existing=param&another=value")
+            .url("https://example.com/m_dbp_foreground-run_started?existing=param&another=value")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -171,9 +170,9 @@ class PirPixelInterceptorTest {
     }
 
     @Test
-    fun whenInterceptPirInternalPixelThenMetadataIsBase64Encoded() = runTest {
+    fun whenInterceptPirAllowListedThenMetadataIsBase64Encoded() = runTest {
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test")
+            .url("https://example.com/m_dbp_foreground-run_started")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -215,7 +214,7 @@ class PirPixelInterceptorTest {
         whenever(mockPowerManager.isIgnoringBatteryOptimizations(any())).thenThrow(RuntimeException("Test exception"))
 
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test")
+            .url("https://example.com/m_dbp_foreground-run_started")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
@@ -242,7 +241,7 @@ class PirPixelInterceptorTest {
         whenever(mockContext.packageName).thenReturn(null)
 
         val request = Request.Builder()
-            .url("https://example.com/pir_internal_test")
+            .url("https://example.com/m_dbp_foreground-run_started")
             .build()
 
         whenever(mockChain.request()).thenReturn(request)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -116,22 +116,6 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportOptOutStartedThenFiresPixelWithBrokerName() = runTest {
-        testee.reportOptOutStarted("test-broker")
-
-        val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
-            pixelName = any(),
-            parameters = paramsCaptor.capture(),
-            encodedParameters = any(),
-            type = any(),
-        )
-
-        assert(paramsCaptor.firstValue.containsKey("brokerName"))
-        assert(paramsCaptor.firstValue["brokerName"] == "test-broker")
-    }
-
-    @Test
     fun whenReportOptOutSubmittedThenFiresPixelWithAllParameters() = runTest {
         testee.reportOptOutSubmitted(
             brokerUrl = "https://broker.com",
@@ -216,36 +200,6 @@ class RealPirPixelSenderTest {
         assert(params["pattern"] == "pattern-xyz")
         assert(params["action_id"] == "action-1")
         assert(params["action_type"] == "fillform")
-    }
-
-    @Test
-    fun whenReportScanStatsThenFiresPixelWithTotalScanCount() = runTest {
-        testee.reportScanStats(25)
-
-        val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
-            pixelName = any(),
-            parameters = paramsCaptor.capture(),
-            encodedParameters = any(),
-            type = any(),
-        )
-
-        assert(paramsCaptor.firstValue["totalScanToRun"] == "25")
-    }
-
-    @Test
-    fun whenReportOptOutStatsThenFiresPixelWithTotalOptOutCount() = runTest {
-        testee.reportOptOutStats(15)
-
-        val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
-            pixelName = any(),
-            parameters = paramsCaptor.capture(),
-            encodedParameters = any(),
-            type = any(),
-        )
-
-        assert(paramsCaptor.firstValue["totalOptOutToRun"] == "15")
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -156,8 +156,6 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportScanStats(0)
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPixelSender).reportManualScanCompleted(any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
@@ -265,8 +263,6 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportScanStats(0)
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPixelSender).reportManualScanCompleted(any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
@@ -319,8 +315,6 @@ class RealPirJobsRunnerTest {
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
         verify(mockPixelSender).reportManualScanCompleted(any())
-        verify(mockPixelSender).reportScanStats(1)
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -369,8 +363,6 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPixelSender).reportManualScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any())
-        verify(mockPixelSender).reportScanStats(1)
-        verify(mockPixelSender).reportOptOutStats(0)
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
         verify(mockPirScan).executeScanForJobs(
@@ -421,8 +413,6 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPixelSender).reportScheduledScanStarted()
         verify(mockPixelSender).reportScheduledScanCompleted(any())
-        verify(mockPixelSender).reportScanStats(1)
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -546,7 +536,6 @@ class RealPirJobsRunnerTest {
         verify(mockPirScan).stop()
         verify(mockPixelSender).reportManualScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any())
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
                 OptOutJobRecord(
@@ -695,7 +684,6 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPixelSender).reportManualScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any())
-        verify(mockPixelSender).reportOptOutStats(0)
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 
@@ -730,7 +718,6 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportOptOutStats(1)
         verify(mockPirOptOut).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 
@@ -760,7 +747,6 @@ class RealPirJobsRunnerTest {
             testee.runEligibleJobs(mockContext, MANUAL)
 
             // Then
-            verify(mockPixelSender).reportOptOutStats(0)
             verify(mockPirOptOut, never()).executeOptOutForJobs(
                 listOf(testOptOutJobRecord),
                 mockContext,
@@ -839,7 +825,6 @@ class RealPirJobsRunnerTest {
         )
         verify(mockEligibleOptOutJobProvider).getAllEligibleOptOutJobs(testCurrentTime)
         verify(mockPirRepository).getBrokersForOptOut(true)
-        verify(mockPixelSender).reportOptOutStats(1)
         verify(mockPirOptOut).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212698127516421?focus=true 

### Description
See attached task description

### Steps to test this PR
Testing should be done on the last stacked PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes PIR telemetry and aligns it with the `m_dbp_*` pixel schema.
> 
> - Replace legacy `pir_internal_*` pixels with `m_dbp_*` equivalents (foreground/scheduled run start/completed, CPU usage, email confirmation, dashboard opened); remove `scan-stats`, `opt-out-stats`, and `opt-out_started` pixels
> - Add new `m_dbp_initial_scan_duration` pixel and emit it after manual scans; extend `PirPixel` and `RealPirPixelSender`
> - Update `PirPixelInterceptor` to use an allowlist for adding `metadata` and drop `os`; keep `batteryOptimizations` and `man`
> - Refactor `PirRunStateHandler`: carry `extractedProfile` in email confirmation completion, emit `optout_submit-success` upon successful confirmation via shared `emitAndLogBrokerOptOutSubmitted`, and remove separate opt-out-start signal
> - Adjust `PirJobsRunner` to no longer emit scan/opt-out counts and to emit initial-scan duration for manual runs
> - Update integration/unit tests to new pixel names, sequences, interceptor behavior, and handler contracts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a03fb735214aea3a3bff023ab76f388cb99a91f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->