### PR TITLE
Maestro: pass binary id to reporter

### DIFF
--- a/.github/workflows/e2e-nightly-omnibar.yml
+++ b/.github/workflows/e2e-nightly-omnibar.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: Assemble the project
+        run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint
+
       - name: Move APK to new folder
         if: always()
         run: find . -name "*.apk"  -exec mv '{}' apk/playRelease.apk \;
@@ -62,7 +65,7 @@ jobs:
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           maestro_test_name: omnibar_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ae7284eae2131da6d8add95c9e1057293d7cbb22
+          maestro_app_file: apk/playRelease.apk
           maestro_include_tags: omnibarTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1212838282644671?focus=true

### Description
This PR adds the ability to use a binary id when launching tests in Maestro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables running Maestro Cloud with a pre-uploaded app binary ID and makes the APK path optional.
> 
> - Adds `maestro_app_binary_id` input and marks `maestro_app_file` as optional
> - Updates `Run Maestro Cloud` step to pass `app-binary-id` when provided, otherwise use `app-file`
> - Exposes `maestro_app_binary_id` in action outputs mapped to `MAESTRO_CLOUD_APP_BINARY_ID`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1608eb684b48bb991ab1bb5ec1862b46bf864bc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212838282644675