### PR TITLE
Update content scope scripts to version 12.26.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -442,7 +442,7 @@
         output.platform.version = version;
       }
     }
-    const enabledFeatures = computeEnabledFeatures(data, topLevelHostname, preferences.platform?.version, platformSpecificFeatures2);
+    const enabledFeatures = computeEnabledFeatures(data, topLevelHostname, preferences.platform, platformSpecificFeatures2);
     const isBroken = isUnprotectedDomain(topLevelHostname, data.unprotectedTemporary);
     output.site = Object.assign(site, {
       isBroken,
@@ -458,19 +458,33 @@
     const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
     return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
-  function computeEnabledFeatures(data, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
+  function isStateEnabled(state, platform) {
+    switch (state) {
+      case "enabled":
+        return true;
+      case "disabled":
+        return false;
+      case "internal":
+        return platform?.internal === true;
+      case "preview":
+        return platform?.preview === true;
+      default:
+        return false;
+    }
+  }
+  function computeEnabledFeatures(data, topLevelHostname, platform, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data.features);
     const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures2.filter(
       (featureName) => !remoteFeatureNames.includes(featureName)
     );
     const enabledFeatures = remoteFeatureNames.filter((featureName) => {
       const feature = data.features[featureName];
-      if (feature.minSupportedVersion && platformVersion) {
-        if (!isSupportedVersion(feature.minSupportedVersion, platformVersion)) {
+      if (feature.minSupportedVersion && platform?.version) {
+        if (!isSupportedVersion(feature.minSupportedVersion, platform.version)) {
           return false;
         }
       }
-      return feature.state === "enabled" && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
+      return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
   }
@@ -3182,7 +3196,7 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform.version);
+        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
         __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
       }
     }
@@ -3443,18 +3457,21 @@
      *   }
      * }
      * ```
+     * State values can be: 'enabled', 'disabled', 'internal', or 'preview'.
+     * 'internal' and 'preview' are enabled based on platform flags.
      * This also supports domain overrides as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @param {'enabled' | 'disabled'} [defaultState]
+     * @param {import('./utils.js').FeatureState} [defaultState]
      * @param {string} [featureName]
      * @returns {boolean}
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
+      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return result.state === "enabled";
+        return isStateEnabled(result.state, platform);
       }
-      return result === "enabled";
+      return isStateEnabled(result, platform);
     }
     /**
      * Return a specific setting from the feature settings

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1948,7 +1948,7 @@
         output.platform.version = version;
       }
     }
-    const enabledFeatures = computeEnabledFeatures(data2, topLevelHostname, preferences.platform?.version, platformSpecificFeatures2);
+    const enabledFeatures = computeEnabledFeatures(data2, topLevelHostname, preferences.platform, platformSpecificFeatures2);
     const isBroken = isUnprotectedDomain(topLevelHostname, data2.unprotectedTemporary);
     output.site = Object.assign(site, {
       isBroken,
@@ -1964,19 +1964,33 @@
     const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
     return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
-  function computeEnabledFeatures(data2, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
+  function isStateEnabled(state, platform) {
+    switch (state) {
+      case "enabled":
+        return true;
+      case "disabled":
+        return false;
+      case "internal":
+        return platform?.internal === true;
+      case "preview":
+        return platform?.preview === true;
+      default:
+        return false;
+    }
+  }
+  function computeEnabledFeatures(data2, topLevelHostname, platform, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data2.features);
     const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures2.filter(
       (featureName) => !remoteFeatureNames.includes(featureName)
     );
     const enabledFeatures = remoteFeatureNames.filter((featureName) => {
       const feature = data2.features[featureName];
-      if (feature.minSupportedVersion && platformVersion) {
-        if (!isSupportedVersion(feature.minSupportedVersion, platformVersion)) {
+      if (feature.minSupportedVersion && platform?.version) {
+        if (!isSupportedVersion(feature.minSupportedVersion, platform.version)) {
           return false;
         }
       }
-      return feature.state === "enabled" && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
+      return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
   }
@@ -4747,7 +4761,7 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform.version);
+        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
         __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
       }
     }
@@ -5008,18 +5022,21 @@
      *   }
      * }
      * ```
+     * State values can be: 'enabled', 'disabled', 'internal', or 'preview'.
+     * 'internal' and 'preview' are enabled based on platform flags.
      * This also supports domain overrides as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @param {'enabled' | 'disabled'} [defaultState]
+     * @param {import('./utils.js').FeatureState} [defaultState]
      * @param {string} [featureName]
      * @returns {boolean}
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
+      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return result.state === "enabled";
+        return isStateEnabled(result.state, platform);
       }
-      return result === "enabled";
+      return isStateEnabled(result, platform);
     }
     /**
      * Return a specific setting from the feature settings

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1948,7 +1948,7 @@
         output.platform.version = version;
       }
     }
-    const enabledFeatures = computeEnabledFeatures(data2, topLevelHostname, preferences.platform?.version, platformSpecificFeatures2);
+    const enabledFeatures = computeEnabledFeatures(data2, topLevelHostname, preferences.platform, platformSpecificFeatures2);
     const isBroken = isUnprotectedDomain(topLevelHostname, data2.unprotectedTemporary);
     output.site = Object.assign(site, {
       isBroken,
@@ -1964,19 +1964,33 @@
     const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
     return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
-  function computeEnabledFeatures(data2, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
+  function isStateEnabled(state, platform) {
+    switch (state) {
+      case "enabled":
+        return true;
+      case "disabled":
+        return false;
+      case "internal":
+        return platform?.internal === true;
+      case "preview":
+        return platform?.preview === true;
+      default:
+        return false;
+    }
+  }
+  function computeEnabledFeatures(data2, topLevelHostname, platform, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data2.features);
     const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures2.filter(
       (featureName) => !remoteFeatureNames.includes(featureName)
     );
     const enabledFeatures = remoteFeatureNames.filter((featureName) => {
       const feature = data2.features[featureName];
-      if (feature.minSupportedVersion && platformVersion) {
-        if (!isSupportedVersion(feature.minSupportedVersion, platformVersion)) {
+      if (feature.minSupportedVersion && platform?.version) {
+        if (!isSupportedVersion(feature.minSupportedVersion, platform.version)) {
           return false;
         }
       }
-      return feature.state === "enabled" && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
+      return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
   }
@@ -4716,7 +4730,7 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform.version);
+        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
         __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
       }
     }
@@ -4977,18 +4991,21 @@
      *   }
      * }
      * ```
+     * State values can be: 'enabled', 'disabled', 'internal', or 'preview'.
+     * 'internal' and 'preview' are enabled based on platform flags.
      * This also supports domain overrides as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @param {'enabled' | 'disabled'} [defaultState]
+     * @param {import('./utils.js').FeatureState} [defaultState]
      * @param {string} [featureName]
      * @returns {boolean}
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
+      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return result.state === "enabled";
+        return isStateEnabled(result.state, platform);
       }
-      return result === "enabled";
+      return isStateEnabled(result, platform);
     }
     /**
      * Return a specific setting from the feature settings

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1281,7 +1281,7 @@
         output.platform.version = version;
       }
     }
-    const enabledFeatures = computeEnabledFeatures(data, topLevelHostname, preferences.platform?.version, platformSpecificFeatures2);
+    const enabledFeatures = computeEnabledFeatures(data, topLevelHostname, preferences.platform, platformSpecificFeatures2);
     const isBroken = isUnprotectedDomain(topLevelHostname, data.unprotectedTemporary);
     output.site = Object.assign(site, {
       isBroken,
@@ -1297,19 +1297,33 @@
     const { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts } = processedConfig;
     return { platform, site, bundledConfig, messagingConfig, messageSecret: messageSecret2, messagingContextName, currentCohorts };
   }
-  function computeEnabledFeatures(data, topLevelHostname, platformVersion, platformSpecificFeatures2 = []) {
+  function isStateEnabled(state, platform) {
+    switch (state) {
+      case "enabled":
+        return true;
+      case "disabled":
+        return false;
+      case "internal":
+        return platform?.internal === true;
+      case "preview":
+        return platform?.preview === true;
+      default:
+        return false;
+    }
+  }
+  function computeEnabledFeatures(data, topLevelHostname, platform, platformSpecificFeatures2 = []) {
     const remoteFeatureNames = Object.keys(data.features);
     const platformSpecificFeaturesNotInRemoteConfig = platformSpecificFeatures2.filter(
       (featureName) => !remoteFeatureNames.includes(featureName)
     );
     const enabledFeatures = remoteFeatureNames.filter((featureName) => {
       const feature = data.features[featureName];
-      if (feature.minSupportedVersion && platformVersion) {
-        if (!isSupportedVersion(feature.minSupportedVersion, platformVersion)) {
+      if (feature.minSupportedVersion && platform?.version) {
+        if (!isSupportedVersion(feature.minSupportedVersion, platform.version)) {
           return false;
         }
       }
-      return feature.state === "enabled" && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
+      return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
   }
@@ -4578,7 +4592,7 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform.version);
+        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
         __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
       }
     }
@@ -4839,18 +4853,21 @@
      *   }
      * }
      * ```
+     * State values can be: 'enabled', 'disabled', 'internal', or 'preview'.
+     * 'internal' and 'preview' are enabled based on platform flags.
      * This also supports domain overrides as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @param {'enabled' | 'disabled'} [defaultState]
+     * @param {import('./utils.js').FeatureState} [defaultState]
      * @param {string} [featureName]
      * @returns {boolean}
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
+      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return result.state === "enabled";
+        return isStateEnabled(result.state, platform);
       }
-      return result === "enabled";
+      return isStateEnabled(result, platform);
     }
     /**
      * Return a specific setting from the feature settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.24.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.26.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.50.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.50.0.tgz",
-      "integrity": "sha512-7Z3lp5NpKWmcOfdWytRBY52LEAH668YSvxLDqapz7wBDYtFWk494m58+viYGnnCzp49WttF7ewbmRhkDhAS0SQ==",
+      "version": "14.50.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.50.1.tgz",
+      "integrity": "sha512-YZEfo6lmnscMuISlE+Zt8WLjsiQG7AUtZyHwT0XlVY2Brw7vZIlNsJKFyHZFM48FreTpLe8+cLGjicHm5VPZmA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a8de801488a17a86a209a6b3ff7e339f6a2ed1f7",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#be81e16327f61e024f13810bb683420f62d5cd3e",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.24.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.26.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1212844837964817?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run