### PR TITLE
Add verified install/updated pixel

### DIFF
--- a/PixelDefinitions/pixels/verified_install.json5
+++ b/PixelDefinitions/pixels/verified_install.json5
@@ -1,0 +1,31 @@
+// Verified install pixels - only fire for verified Play Store installs
+{
+    "verified_app_install": {
+        "description": "Fires once ever on first app open for verified Play Store installs",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "returning_user",
+                "type": "string",
+                "description": "Whether the user was detected as a returning user on first install",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
+    "verified_app_update": {
+        "description": "Fires once for every subsequent app update for verified Play Store installs",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "returning_user",
+                "type": "string",
+                "description": "Whether they were originally detected as a returning user on first install",
+                "enum": ["true", "false"]
+            }
+        ]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -159,6 +159,8 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             RemoteMessagingPixelName.REMOTE_MESSAGE_IMAGE_LOAD_SUCCESS.pixelName to PixelParameter.removeAtb(),
             RemoteMessagingPixelName.REMOTE_MESSAGE_IMAGE_LOAD_FAILED.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_HARMONY_PREFERENCES_RETRIEVAL_FAILED.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.APP_INSTALL_VERIFIED_INSTALL.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.APP_UPDATE_VERIFIED_INSTALL.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/install/VerifiedInstallDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/install/VerifiedInstallDataStore.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.install
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+interface VerifiedInstallDataStore {
+    suspend fun getLastInstalledVersion(): Int?
+    suspend fun setLastInstalledVersion(version: Int?)
+}
+
+@ContributesBinding(scope = AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class VerifiedInstallDataStoreImpl @Inject constructor(
+    private val context: Context,
+) : VerifiedInstallDataStore {
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "verified_install_preferences",
+    )
+
+    override suspend fun getLastInstalledVersion(): Int? {
+        return context.dataStore.data.map { preferences ->
+            preferences[LAST_INSTALLED_VERSION]
+        }.firstOrNull()
+    }
+
+    override suspend fun setLastInstalledVersion(version: Int?) {
+        context.dataStore.edit { preferences ->
+            if (version == null) {
+                preferences.remove(LAST_INSTALLED_VERSION)
+            } else {
+                preferences[LAST_INSTALLED_VERSION] = version
+            }
+        }
+    }
+
+    companion object {
+        private val LAST_INSTALLED_VERSION = intPreferencesKey("last_installed_version")
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/install/VerifiedInstallPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/install/VerifiedInstallPixelSender.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.install
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import logcat.asLog
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class VerifiedInstallPixelSender @Inject constructor(
+    private val isVerifiedPlayStoreInstall: IsVerifiedPlayStoreInstall,
+    private val appBuildConfig: AppBuildConfig,
+    private val pixel: Pixel,
+    private val verifiedInstallDataStore: VerifiedInstallDataStore,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : AtbLifecyclePlugin {
+
+    // cache this in memory since it can't change at runtime
+    private var cachedIsVerifiedInstall: Boolean? = null
+
+    override fun onAppAtbInitialized() {
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (!isFeatureEnabled()) {
+                logcat(LogPriority.VERBOSE) { "Verified-install: feature is disabled so nothing to do in onAppAtbInitialized" }
+                return@launch
+            }
+            if (!isVerifiedInstall()) {
+                logcat(LogPriority.VERBOSE) { "Verified-install: not a verified install so nothing to do in onAppAtbInitialized" }
+                return@launch
+            }
+
+            fireInstallPixelIfNewInstall()
+        }
+    }
+
+    override fun onAppRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (!isFeatureEnabled()) {
+                logcat(LogPriority.VERBOSE) { "Verified-install: feature is disabled so nothing to do in onAppRetentionAtbRefreshed" }
+                return@launch
+            }
+            if (!isVerifiedInstall()) {
+                logcat(LogPriority.VERBOSE) { "Verified-install: not a verified install so nothing to do in onAppRetentionAtbRefreshed" }
+                return@launch
+            }
+
+            fireUpdatePixelIfNewVersion()
+        }
+    }
+
+    private fun isFeatureEnabled(): Boolean = androidBrowserConfigFeature.sendVerifiedInstallPixels().isEnabled()
+
+    private fun isVerifiedInstall(): Boolean {
+        cachedIsVerifiedInstall?.let { return it }
+
+        return runCatching { isVerifiedPlayStoreInstall() }
+            .getOrElse { e ->
+                logcat(LogPriority.WARN) { "Verified-install: exception checking verified install status: ${e.asLog()}" }
+                false
+            }
+            .also { cachedIsVerifiedInstall = it }
+    }
+
+    private suspend fun fireInstallPixelIfNewInstall() {
+        val lastVersion = verifiedInstallDataStore.getLastInstalledVersion()
+        if (lastVersion != null) {
+            logcat(LogPriority.VERBOSE) { "Verified-install: not a new install, skipping install pixel" }
+            return
+        }
+
+        val currentVersion = appBuildConfig.versionCode
+        val returningUser = appBuildConfig.isAppReinstall()
+        val params = mapOf(RETURNING_USER_KEY to returningUser.toString())
+
+        logcat { "Verified-install: new install on version $currentVersion, returning user: $returningUser" }
+        pixel.fire(AppPixelName.APP_INSTALL_VERIFIED_INSTALL, params, type = Pixel.PixelType.Unique())
+        verifiedInstallDataStore.setLastInstalledVersion(currentVersion)
+    }
+
+    private suspend fun fireUpdatePixelIfNewVersion() {
+        val currentVersion = appBuildConfig.versionCode
+        val lastVersion = verifiedInstallDataStore.getLastInstalledVersion()
+
+        if (lastVersion == null) {
+            // Existing user before this feature was added - store the version for future updates
+            logcat(LogPriority.VERBOSE) { "Verified-install: no stored version, storing version $currentVersion for future updates" }
+            verifiedInstallDataStore.setLastInstalledVersion(currentVersion)
+            return
+        }
+
+        if (lastVersion == currentVersion) {
+            logcat(LogPriority.VERBOSE) { "Verified-install: no version change, skipping update pixel" }
+            return
+        }
+
+        val returningUser = appBuildConfig.isAppReinstall()
+        val params = mapOf(RETURNING_USER_KEY to returningUser.toString())
+
+        logcat { "Verified-install: app update. now=$currentVersion, previous=$lastVersion, returning user: $returningUser" }
+        pixel.fire(AppPixelName.APP_UPDATE_VERIFIED_INSTALL, params, type = Count)
+        verifiedInstallDataStore.setLastInstalledVersion(currentVersion)
+    }
+
+    private companion object {
+        private const val RETURNING_USER_KEY = "returning_user"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -24,6 +24,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     PROCESS_CREATED_VPN("m_process_created_vpn"),
 
     APP_LAUNCH_VERIFIED_INSTALL("m_app_launched_on_verified_play_store_install"),
+    APP_INSTALL_VERIFIED_INSTALL("verified_app_install"),
+    APP_UPDATE_VERIFIED_INSTALL("verified_app_update"),
 
     FORGET_ALL_PRESSED_BROWSING("mf_bp"),
     FORGET_ALL_PRESSED_TABSWITCHING("mf_tp"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -266,4 +266,13 @@ interface AndroidBrowserConfigFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun experimentalBrowsingMenu(): Toggle
+
+    /**
+     * Controls whether verified install/update pixels are sent.
+     * @return `true` when the remote config has the global "sendVerifiedInstallPixels" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `true`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun sendVerifiedInstallPixels(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/install/VerifiedInstallPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/install/VerifiedInstallPixelSenderTest.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.install
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class VerifiedInstallPixelSenderTest {
+
+    @get:Rule
+    @Suppress("unused")
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val isVerifiedPlayStoreInstall: IsVerifiedPlayStoreInstall = mock()
+
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    private val pixel: Pixel = mock()
+
+    private val verifiedInstallDataStore: VerifiedInstallDataStore = mock()
+
+    private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val paramsCaptor = argumentCaptor<Map<String, String>>()
+
+    private lateinit var testee: VerifiedInstallPixelSender
+
+    @Before
+    fun setUp() {
+        configureFeatureFlag(enabled = true)
+
+        testee = VerifiedInstallPixelSender(
+            isVerifiedPlayStoreInstall = isVerifiedPlayStoreInstall,
+            appBuildConfig = appBuildConfig,
+            pixel = pixel,
+            verifiedInstallDataStore = verifiedInstallDataStore,
+            androidBrowserConfigFeature = androidBrowserConfigFeature,
+            appCoroutineScope = coroutineRule.testScope,
+            dispatchers = coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun `install - when feature flag disabled then no pixel is fired`() = runTest {
+        configureFeatureFlag(enabled = false)
+        configureAsNewVerifiedInstall()
+
+        testee.onAppAtbInitialized()
+
+        verifyNoVerifiedInstallPixelsFired()
+    }
+
+    @Test
+    fun `install - when not verified install then no pixel is fired`() = runTest {
+        configureAsNotVerifiedInstall()
+
+        testee.onAppAtbInitialized()
+
+        verifyNoVerifiedInstallPixelsFired()
+    }
+
+    @Test
+    fun `install - when verified install and no stored version then install pixel is fired`() = runTest {
+        configureAsNewVerifiedInstall()
+
+        testee.onAppAtbInitialized()
+
+        verifyInstallPixelFired(returningUser = false)
+        verify(verifiedInstallDataStore).setLastInstalledVersion(123)
+    }
+
+    @Test
+    fun `install - when verified install with returning user then install pixel is fired with returning user true`() = runTest {
+        configureAsNewVerifiedInstall(returningUser = true)
+
+        testee.onAppAtbInitialized()
+
+        verifyInstallPixelFired(returningUser = true)
+        verify(verifiedInstallDataStore).setLastInstalledVersion(123)
+    }
+
+    @Test
+    fun `install - when already has stored version then no pixel is fired`() = runTest {
+        configureAsExistingVerifiedInstall(lastVersion = 123, currentVersion = 123)
+
+        testee.onAppAtbInitialized()
+
+        verifyNoVerifiedInstallPixelsFired()
+    }
+
+    @Test
+    fun `update - when feature flag disabled then no pixel is fired`() = runTest {
+        configureFeatureFlag(enabled = false)
+        configureAsExistingVerifiedInstall(lastVersion = 123, currentVersion = 124)
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyNoVerifiedInstallPixelsFired()
+    }
+
+    @Test
+    fun `update - when not verified install then no pixel is fired`() = runTest {
+        configureAsNotVerifiedInstall()
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyNoVerifiedInstallPixelsFired()
+    }
+
+    @Test
+    fun `update - when same version then no pixel is fired`() = runTest {
+        configureAsExistingVerifiedInstall(lastVersion = 123, currentVersion = 123)
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyNoVerifiedInstallPixelsFired()
+        verify(verifiedInstallDataStore, never()).setLastInstalledVersion(any())
+    }
+
+    @Test
+    fun `update - when no stored version then stores current version without firing pixel`() = runTest {
+        configureAsExistingUserWithNoStoredVersion(currentVersion = 124)
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyNoVerifiedInstallPixelsFired()
+        verify(verifiedInstallDataStore).setLastInstalledVersion(124)
+    }
+
+    @Test
+    fun `update - when different version then update pixel is fired`() = runTest {
+        configureAsExistingVerifiedInstall(lastVersion = 123, currentVersion = 124)
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyUpdatePixelFired(returningUser = false)
+        verify(verifiedInstallDataStore).setLastInstalledVersion(124)
+    }
+
+    @Test
+    fun `update - when different version with returning user then update pixel is fired with returning user true`() = runTest {
+        configureAsExistingVerifiedInstall(lastVersion = 123, currentVersion = 124, returningUser = true)
+
+        testee.onAppRetentionAtbRefreshed("old", "new")
+
+        verifyUpdatePixelFired(returningUser = true)
+        verify(verifiedInstallDataStore).setLastInstalledVersion(124)
+    }
+
+    private fun verifyInstallPixelFired(returningUser: Boolean) {
+        verify(pixel).fire(
+            eq(AppPixelName.APP_INSTALL_VERIFIED_INSTALL),
+            paramsCaptor.capture(),
+            eq(emptyMap()),
+            eq(Pixel.PixelType.Unique()),
+        )
+
+        val params = paramsCaptor.firstValue
+        assert(params["returning_user"] == returningUser.toString())
+    }
+
+    private fun verifyUpdatePixelFired(returningUser: Boolean) {
+        verify(pixel).fire(
+            eq(AppPixelName.APP_UPDATE_VERIFIED_INSTALL),
+            paramsCaptor.capture(),
+            eq(emptyMap()),
+            eq(Pixel.PixelType.Count),
+        )
+
+        val params = paramsCaptor.firstValue
+        assert(params["returning_user"] == returningUser.toString())
+    }
+
+    private fun verifyNoVerifiedInstallPixelsFired() {
+        verifyNoInteractions(pixel)
+    }
+
+    private fun configureFeatureFlag(enabled: Boolean) {
+        androidBrowserConfigFeature.sendVerifiedInstallPixels().setRawStoredState(Toggle.State(enable = enabled))
+    }
+
+    private fun configureAsNotVerifiedInstall() {
+        whenever(isVerifiedPlayStoreInstall()).thenReturn(false)
+    }
+
+    private suspend fun configureAsNewVerifiedInstall(returningUser: Boolean = false) {
+        whenever(isVerifiedPlayStoreInstall()).thenReturn(true)
+        whenever(appBuildConfig.versionCode).thenReturn(123)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(returningUser)
+        whenever(verifiedInstallDataStore.getLastInstalledVersion()).thenReturn(null)
+    }
+
+    private suspend fun configureAsExistingVerifiedInstall(
+        lastVersion: Int,
+        currentVersion: Int,
+        returningUser: Boolean = false,
+    ) {
+        whenever(isVerifiedPlayStoreInstall()).thenReturn(true)
+        whenever(appBuildConfig.versionCode).thenReturn(currentVersion)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(returningUser)
+        whenever(verifiedInstallDataStore.getLastInstalledVersion()).thenReturn(lastVersion)
+    }
+
+    private suspend fun configureAsExistingUserWithNoStoredVersion(currentVersion: Int) {
+        whenever(isVerifiedPlayStoreInstall()).thenReturn(true)
+        whenever(appBuildConfig.versionCode).thenReturn(currentVersion)
+        whenever(verifiedInstallDataStore.getLastInstalledVersion()).thenReturn(null)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1212849844285253?focus=true 

### Description
Adds pixels for `verified` installs/updates, similar to what exists for `verified app launches` (i.e., using the same requirements for what is considered `verified` or not)

### Steps to test this PR

Locat filter: `package:mine message~:"Pixel interceptor:.*verified_app_install|Pixel interceptor:.*verified_app_update|Verified-install|Initialized ATB"`

### Not a verified install
- [x] Fresh install `internalDebug` and launch app
- [x] Verify in the logs you see ```Verified-install: not a verified install so nothing to do in onAppAtbInitialized```
- [ ] [Optionally] you might see ```Verified-install: not a verified install so nothing to do in onAppRetentionAtbRefreshed``` (you might need to accept/dismiss the notification permission prompt for this to show up, or it might not show up at all here depending on your device)


### Simulate verified install
- [x] Install `Patch 1` (see below) to simulate a verified install on an older app version
- [x] Fresh install `internalDebug` and launch app 
- [x] Verify in the logs that you see `Verified-install: new install on version 52600000`
- [x] Verify in the logs that you see `verified_app_install` pixel with the correct `appVersion`
- [x] Kill the app and restart it. Verify you see `Verified-install: no version change`

### Simulate verified update
- [x] Open `version.properties` and update to `VERSION=5.262.0`
- [x] Install and open the app
- [x] Verify in the logs that you see `Verified-install: app update. now=52620000, previous=52600000`
- [x] Verify in the logs that see you `verified_app_update` with the correct `appVersion`
- [x] Kill the app and restart it. Verify you see `Verified-install: no version change`

### Feature flag disabled
- [x] Apply `Patch 2` (see below) to disable the feature flag. Keep the changed `IsVerifiedPlayStoreInstallImpl` from the previous patch.
- [x] Fresh install and open the app
- [x] Verify in the logs: `Verified-install: feature is disabled so nothing to do in onAppAtbInitialized`
- [ ] [Optionally] you might see ```Verified-install: not a verified install so nothing to do in onAppRetentionAtbRefreshed``` (you might need to accept/dismiss the notification permission prompt for this to show up, or it might not show up at all here depending on your device)


### Existing user (installed before this feature)
Overview to do this:   
1. Install from develop with a fake older version (e.g., 5.260.0)
2. Then install from the PR branch with a newer version (e.g., 5.261.0)
3. Then update the version again to test the upgrade (e.g., 5.262.0)

- [x] Checkout `develop` branch, apply `Patch 1`, and fresh install `internalDebug`
- [x] Open the app and wait for ATB to be initialized (look for `Initialized ATB` in the logs)
- [x] Checkout this PR branch, keeping changes from `Patch 1`
- [x] Update `version.properties` to `5.261.0`. Install `internalDebug` over the existing install, and open the app
- [x] Verify in logs: `Verified-install: no stored version, storing version 52610000 for future updates` and no pixels
- [x] Update `version.properties` to `5.262.0`. Install `internalDebug` over the existing install, and open the app
- [x] Verify in logs: `Verified-install: app update. now=52620000, previous=52610000` and update pixel fires



### Patches

**Patch 1: Simulating a verified install**
```
Index: app/version/version.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/app/version/version.properties b/app/version/version.properties
--- a/app/version/version.properties	(revision Staged)
+++ b/app/version/version.properties	(date 1768825141534)
@@ -1,1 +1,1 @@
-VERSION=5.262.0
\ No newline at end of file
+VERSION=5.260.0
\ No newline at end of file
Index: verified-installation/verified-installation-impl/src/main/java/com/duckduckgo/verifiedinstallation/IsVerifiedPlayStoreInstallImpl.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/verified-installation/verified-installation-impl/src/main/java/com/duckduckgo/verifiedinstallation/IsVerifiedPlayStoreInstallImpl.kt b/verified-installation/verified-installation-impl/src/main/java/com/duckduckgo/verifiedinstallation/IsVerifiedPlayStoreInstallImpl.kt
--- a/verified-installation/verified-installation-impl/src/main/java/com/duckduckgo/verifiedinstallation/IsVerifiedPlayStoreInstallImpl.kt	(revision Staged)
+++ b/verified-installation/verified-installation-impl/src/main/java/com/duckduckgo/verifiedinstallation/IsVerifiedPlayStoreInstallImpl.kt	(date 1768825141540)
@@ -43,6 +43,6 @@
     }
 
     override fun invoke(): Boolean {
-        return isVerifiedInstall
+        return true
     }
 }
```



**Patch 2: Disable feature flag**
```
Index: app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(revision Staged)
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(date 1768826311562)
@@ -264,6 +264,6 @@
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun sendVerifiedInstallPixels(): Toggle
 }
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Play Store–verified install/update telemetry gated by remote config.
> 
> - New pixels `verified_app_install` (Unique) and `verified_app_update` (Count) with `returning_user` param
> - `VerifiedInstallPixelSender` (AtbLifecyclePlugin) fires on first app open and on version changes only for verified installs; caches verification and logs; uses `AppBuildConfig.isAppReinstall()`
> - `VerifiedInstallDataStore` (DataStore) persists `last_installed_version` to detect new installs vs updates
> - Remote toggle `sendVerifiedInstallPixels()` added to `AndroidBrowserConfigFeature` (default true)
> - `PixelParamRemovalInterceptor` updated to strip ATB for the new pixels
> - Comprehensive unit tests for sender behavior and feature flagging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c367077fdac965e148b76ce18ce94a02c5cd6f7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->