### PR TITLE
Add feature flag for "What's new" entry in settings

### DIFF
--- a/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
+++ b/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
@@ -30,4 +30,7 @@ interface SettingsPageFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun embeddedSettingsWebView(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun whatsNewEnabled(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1212857042764818?focus=true

### Description
Added a new toggle `whatsNewEnabled()` to the `SettingsPageFeature` interface with a default value of `FALSE`. This toggle will control whether the "What's New" feature is enabled in the settings page.

### Steps to test this PR

_What's New Feature Toggle_
- [ ] Verify that the feature is displayed in feature toggles section in settings 

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new feature flag to gate the "What's New" item in settings.
> 
> - Adds `whatsNewEnabled()` (default `FALSE`) to `SettingsPageFeature` interface in `settings-api`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a15d4157482d24818bed0598c426cbb766c59bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->