### PR TITLE
Create pixel definition for exception retrieving harmony preferences

### DIFF
--- a/PixelDefinitions/pixels/autofill.json5
+++ b/PixelDefinitions/pixels/autofill.json5
@@ -4,6 +4,6 @@
         "owners": ["CrisBarreiro"],
         "triggers": ["exception"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "atb"]
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212876203729027?focus=true

### Description
Create pixel definition for exception retrieving harmony preferences #7533


### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new pixel definition for tracking Autofill Harmony preference retrieval failures.
> 
> - Introduces `pixels/autofill.json5` with `autofill_harmony_preferences_retrieval_failed`
> - Configures `owners`, `triggers: ["exception"]`, `suffixes: ["form_factor"]`, and `parameters: ["appVersion"]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7462986ee68329d8c085d7c85091f803750a1510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->