### PR TITLE
Revert Input Screen return button behavior

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -80,6 +80,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelFactory
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelProviderFactory
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchLauncher
@@ -347,6 +348,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 hideAutoCompleteIfOnChatTab(state)
                 previousSearchMode = state.searchMode
                 updateButtonVisibility(state)
+                inputScreenButtons.setNewLineButtonVisible(state.newLineButtonVisible)
             }.launchIn(lifecycleScope)
 
         viewModel.visibilityState
@@ -560,6 +562,10 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             // todo remove round-tripping through the input mode widget - actions should go directly to the view model
             inputModeWidget.submitMessage()
             viewModel.onSendButtonClicked()
+        }
+        inputScreenButtons.onNewLineClick = {
+            inputModeWidget.printNewLine()
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_RETURN_PRESSED)
         }
         inputScreenButtons.onVoiceClick = {
             voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.fromValue(inputModeWidget.getSelectedTabPosition()))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -23,9 +23,10 @@ data class InputScreenVisibilityState(
     val bottomFadeVisible: Boolean = false,
     val showChatLogo: Boolean = true,
     val showSearchLogo: Boolean = true,
+    val newLineButtonVisible: Boolean = false,
     val mainButtonsVisible: Boolean = false,
     val searchMode: Boolean = false,
     val fullScreenMode: Boolean = false,
 ) {
-    val actionButtonsContainerVisible: Boolean = submitButtonVisible || voiceInputButtonVisible
+    val actionButtonsContainerVisible: Boolean = submitButtonVisible || voiceInputButtonVisible || newLineButtonVisible
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -344,12 +344,11 @@ class InputModeWidget @JvmOverloads constructor(
                 maxLines = if (canExpand) MAX_LINES else 1
             } else {
                 hint = context.getString(R.string.input_screen_chat_hint)
-                imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_NONE
+                imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO
                 setRawInputType(
                     InputType.TYPE_CLASS_TEXT or
                         InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or
-                        InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
-                        InputType.TYPE_TEXT_FLAG_MULTI_LINE,
+                        InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
                 )
                 val chatMin = if (bottomButtonsMode) 1 else CHAT_MIN_LINES
                 minLines = chatMin
@@ -428,6 +427,15 @@ class InputModeWidget @JvmOverloads constructor(
             )
         }
         view.isVisible = visible
+    }
+
+    fun printNewLine() {
+        val currentText = inputField.text.toString()
+        val selectionStart = inputField.selectionStart
+        val selectionEnd = inputField.selectionEnd
+        val newText = currentText.substring(0, selectionStart) + "\n" + currentText.substring(selectionEnd)
+        text = newText
+        inputField.setSelection(selectionStart + 1)
     }
 
     fun selectAllText() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -45,6 +45,12 @@ class InputScreenButtons @JvmOverloads constructor(
             binding.actionSend.setOnClickListener { value?.invoke() }
         }
 
+    var onNewLineClick: (() -> Unit)? = null
+        set(value) {
+            field = value
+            binding.actionNewLine.setOnClickListener { value?.invoke() }
+        }
+
     var onVoiceClick: (() -> Unit)? = null
         set(value) {
             field = value
@@ -69,6 +75,10 @@ class InputScreenButtons @JvmOverloads constructor(
         binding.actionSend.isVisible = visible
     }
 
+    fun setNewLineButtonVisible(visible: Boolean) {
+        binding.actionNewLine.isVisible = visible
+    }
+
     fun setVoiceButtonVisible(visible: Boolean) {
         binding.actionVoice.isVisible = visible
     }
@@ -80,6 +90,10 @@ class InputScreenButtons @JvmOverloads constructor(
             width = buttonSizePx
             height = buttonSizePx
         }
+        binding.actionNewLine.updateLayoutParams {
+            width = buttonSizePx
+            height = buttonSizePx
+        }
         binding.actionVoice.updateLayoutParams {
             width = buttonSizePx
             height = buttonSizePx
@@ -87,15 +101,18 @@ class InputScreenButtons @JvmOverloads constructor(
 
         // add shadows via elevation and add padding to the container to avoid clipping
         val elevation = 6f.toPx(context)
+        binding.actionNewLine.elevation = elevation
         binding.actionVoice.elevation = elevation
         binding.actionSend.elevation = elevation
         val padding = elevation.times(2).roundToInt()
         binding.root.setPadding(padding)
 
-        // add circular background and click ripple to voice button
+        // add circular background and click ripple to all remaining buttons
         val backgroundRes = R.drawable.background_input_screen_button
+        binding.actionNewLine.setBackgroundResource(backgroundRes)
         binding.actionVoice.setBackgroundResource(backgroundRes)
         val circularRippleDrawable = ContextCompat.getDrawable(context, CommonR.drawable.selectable_circular_ripple)
+        binding.actionNewLine.foreground = circularRippleDrawable
         binding.actionVoice.foreground = circularRippleDrawable
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -154,6 +154,7 @@ class InputScreenViewModel @AssistedInject constructor(
                 bottomFadeVisible = false,
                 showChatLogo = true,
                 showSearchLogo = true,
+                newLineButtonVisible = false,
                 mainButtonsVisible = false,
                 searchMode = true,
                 fullScreenMode = duckAiFeatureState.showFullScreenMode.value,
@@ -396,6 +397,7 @@ class InputScreenViewModel @AssistedInject constructor(
         _visibilityState.update {
             it.copy(
                 showChatLogo = true,
+                newLineButtonVisible = query.isNotBlank(),
             )
         }
     }
@@ -470,7 +472,7 @@ class InputScreenViewModel @AssistedInject constructor(
                 it.copy(icon = SubmitButtonIcon.SEND)
             }
             _visibilityState.update {
-                it.copy(searchMode = false, mainButtonsVisible = false)
+                it.copy(newLineButtonVisible = true, searchMode = false, mainButtonsVisible = false)
             }
         }
         if (userSelectedMode == SEARCH) {
@@ -486,7 +488,7 @@ class InputScreenViewModel @AssistedInject constructor(
         userSelectedMode = SEARCH
         viewModelScope.launch {
             _visibilityState.update {
-                it.copy(mainButtonsVisible = canShowMainButtons())
+                it.copy(newLineButtonVisible = false, mainButtonsVisible = canShowMainButtons())
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_screen_buttons.xml
@@ -34,6 +34,19 @@
         android:visibility="gone" />
 
     <ImageView
+        android:id="@+id/actionNewLine"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="8dp"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_enter_24"
+        android:visibility="visible" />
+
+    <ImageView
         android:id="@+id/actionSend"
         android:layout_marginTop="6dp"
         android:layout_marginBottom="8dp"
@@ -46,7 +59,7 @@
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:src="@drawable/ic_find_search_24"
-        android:visibility="invisible"
+        android:visibility="gone"
         app:tint="?attr/daxColorWhite" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1212864806121264?focus=true

### Description

- Adds the return button back to Duck.ai tab and sets the keyboard action to submit.

### Steps to test this PR

- [ ] Open in the Input Screen
- [ ] Go to Duck.ai tab and type something
- [ ] Verify that the return button works as expected
- [ ] Repeat above steps with bottom address bar enabled

### UI changes
| Top address bar  | Bottom address bar |
| ------ | ----- |
<img width="1280" height="2856" alt="Screenshot_20260120_130726" src="https://github.com/user-attachments/assets/b3002224-05bf-4394-a956-edbcf5093988" />|<img width="1280" height="2856" alt="Screenshot_20260120_130700" src="https://github.com/user-attachments/assets/de52bec1-c19d-4c13-afab-de0bef3429be" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an explicit multiline entry control and ties it into visibility/state and telemetry.
> 
> - Adds `actionNewLine` button to `view_input_screen_buttons.xml` and `InputScreenButtons`, with floating styling, click handler, and visibility control
> - Extends `InputScreenVisibilityState` with `newLineButtonVisible` and includes it in `actionButtonsContainerVisible`; `InputScreenViewModel` sets it (true in chat, based on text) and clears it in search
> - Wires `onNewLineClick` in `InputScreenFragment` to `InputModeWidget.printNewLine()` and fires `DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_RETURN_PRESSED`
> - Implements `printNewLine()` in `InputModeWidget` and changes chat `imeOptions` to `IME_ACTION_GO`
> - Updates button container visibility logic to account for the new button; minor visibility tweaks (e.g., send button default to `gone`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d58c8400f1dc2e58d4a480d1b42d322fbcf97d19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->