### PR TITLE
Update content scope scripts to version 12.30.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -543,6 +543,7 @@
       "duckPlayer",
       "duckPlayerNative",
       "duckAiDataClearing",
+      "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
       "webInterferenceDetection",
@@ -570,6 +571,7 @@
       "favicon"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
+    "apple-ai-history": ["duckAiChatHistory"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -597,7 +599,8 @@
       "messageBridge",
       "webCompat",
       "pageContext",
-      "duckAiDataClearing"
+      "duckAiDataClearing",
+      "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2078,6 +2078,7 @@
       "duckPlayer",
       "duckPlayerNative",
       "duckAiDataClearing",
+      "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
       "webInterferenceDetection",
@@ -2105,6 +2106,7 @@
       "favicon"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
+    "apple-ai-history": ["duckAiChatHistory"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -2132,7 +2134,8 @@
       "messageBridge",
       "webCompat",
       "pageContext",
-      "duckAiDataClearing"
+      "duckAiDataClearing",
+      "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2050,6 +2050,7 @@
       "duckPlayer",
       "duckPlayerNative",
       "duckAiDataClearing",
+      "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
       "webInterferenceDetection",
@@ -2077,6 +2078,7 @@
       "favicon"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
+    "apple-ai-history": ["duckAiChatHistory"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -2104,7 +2106,8 @@
       "messageBridge",
       "webCompat",
       "pageContext",
-      "duckAiDataClearing"
+      "duckAiDataClearing",
+      "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1383,6 +1383,7 @@
       "duckPlayer",
       "duckPlayerNative",
       "duckAiDataClearing",
+      "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
       "webInterferenceDetection",
@@ -1410,6 +1411,7 @@
       "favicon"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
+    "apple-ai-history": ["duckAiChatHistory"],
     android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
@@ -1437,7 +1439,8 @@
       "messageBridge",
       "webCompat",
       "pageContext",
-      "duckAiDataClearing"
+      "duckAiDataClearing",
+      "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.26.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.30.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#be81e16327f61e024f13810bb683420f62d5cd3e",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d6674948bfd8017e21c016da497b6066feed3c46",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.26.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.30.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates to `@duckduckgo/content-scope-scripts#12.30.0` and regenerates bundled scripts.
> 
> - Adds `duckAiChatHistory` to feature sets in generated Android builds (`adsjsContentScope.js`, `autofillImport.js`, `brokerProtection.js`, `contentScope.js`)
> - Introduces `apple-ai-history` config mapping to `duckAiChatHistory` and includes it in the `android-adsjs` features list
> - Bumps dependency refs in `package.json` and `package-lock.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69bf2dbe2824e3e7a48eb88e1dbe2959e5f7c969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->