### PR TITLE
Tag LGC from nightly-orchestrator

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -59,7 +59,7 @@ jobs:
 
   tag_lgc_when_successful:
     name: Tag last good commit when successful
-    runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
+    runs-on: android-large-runner
     needs: [ resolve-commit, call-end-to-end, call-privacy, call-update-content-scope, call-update-ref-tests]
     if: ${{ success() }}
     steps:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1212502548756445?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] https://github.com/duckduckgo/Android/actions/runs/21174660155 completes successfully and creates LGC tag
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates tagging of the last good commit after successful nightly runs.
> 
> - Adds `tag_lgc_when_successful` job in `nightly-orchestrator.yml` that depends on nightly/e2e/privacy/content-scope/ref-tests and runs only on success
> - Checks out the resolved commit, configures git with `GT_DAXMOBILE`, and creates/pushes `LGC-<timestamp>` tag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df0b17fdc2eabf37a904faac746fea2c2050b5d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->