### PR TITLE
PDF won't download or load on homedepot.ca

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4129,6 +4129,7 @@ class BrowserTabFragment :
                 contentDisposition = contentDisposition,
                 mimeType = mimeType,
                 subfolder = Environment.DIRECTORY_DOWNLOADS,
+                userAgent = userAgentProvider.userAgent(),
             )
 
         if (hasWriteStoragePermission()) {
@@ -4146,6 +4147,7 @@ class BrowserTabFragment :
             PendingFileDownload(
                 url = url,
                 subfolder = Environment.DIRECTORY_DOWNLOADS,
+                userAgent = userAgentProvider.userAgent(),
             )
 
         if (hasWriteStoragePermission()) {

--- a/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
+++ b/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
@@ -37,5 +37,6 @@ interface FileDownloader {
         val directory: File = Environment.getExternalStoragePublicDirectory(subfolder),
         val isUrlCompressed: Boolean = false,
         val fileName: String? = null,
+        val userAgent: String? = null,
     ) : Serializable
 }

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':downloads-store')
     implementation project(path: ':data-store-api')
+    implementation project(':user-agent-api')
 
     implementation AndroidX.core.ktx
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
@@ -36,6 +36,7 @@ interface DownloadFileService {
     @GET
     fun downloadFile(
         @Header("Cookie") cookie: String?,
+        @Header("User-Agent") userAgent: String?,
         @Url urlString: String,
     ): Call<ResponseBody>
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
@@ -30,7 +30,10 @@ import retrofit2.http.Url
 interface DownloadFileService {
 
     @HEAD
-    fun getFileDetails(@Url urlString: String): Call<Void>?
+    fun getFileDetails(
+        @Header("User-Agent") userAgent: String?,
+        @Url urlString: String,
+    ): Call<Void>?
 
     @Streaming
     @GET

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName.DOWNLOAD_REQUEST_CANCELLED_BY_USER
 import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName.DOWNLOAD_REQUEST_RETRIED
 import com.duckduckgo.downloads.store.DownloadStatus.STARTED
+import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,7 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
+    private val userAgentProvider: UserAgentProvider,
 ) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -95,6 +97,7 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
             PendingFileDownload(
                 url = url,
                 subfolder = Environment.DIRECTORY_DOWNLOADS,
+                userAgent = userAgentProvider.userAgent(),
             ).run {
                 logcat { "Retrying download for $url" }
                 coroutineScope.launch(dispatcherProvider.io()) {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
@@ -67,6 +67,7 @@ private const val CONTENT_DISPOSITION = "CONTENT_DISPOSITION"
 private const val MIME_TYPE = "MIME_TYPE"
 private const val SUBFOLDER = "SUBFOLDER"
 private const val DIRECTORY = "DIRECTORY"
+private const val USER_AGENT = "USER_AGENT"
 
 @VisibleForTesting
 internal const val IS_URL_COMPRESSED = "IS_URL_COMPRESSED"
@@ -82,6 +83,7 @@ fun FileDownloader.PendingFileDownload.toInputData(): Data {
         .putString(SUBFOLDER, subfolder)
         .putString(DIRECTORY, directory.absolutePath)
         .putBoolean(IS_URL_COMPRESSED, urlTooLarge)
+        .putString(USER_AGENT, userAgent)
         .build()
 }
 
@@ -95,6 +97,7 @@ fun Data.toPendingFileDownload(): FileDownloader.PendingFileDownload {
         subfolder = getString(SUBFOLDER)!!,
         directory = File(getString(DIRECTORY)!!),
         isUrlCompressed = false,
+        userAgent = getString(USER_AGENT),
     )
 }
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/NetworkFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/NetworkFileDownloader.kt
@@ -46,7 +46,7 @@ class NetworkFileDownloader @Inject constructor(
         logcat { "Make a HEAD request for ${pendingDownload.url} as there are no values for Content-Disposition or Content-Type." }
 
         runCatching {
-            fileService.getFileDetails(pendingDownload.url)?.execute()?.let { response ->
+            fileService.getFileDetails(pendingDownload.userAgent, pendingDownload.url)?.execute()?.let { response ->
                 var updatedPendingDownload = pendingDownload.copy()
 
                 if (response.isSuccessful) {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
@@ -53,6 +53,7 @@ class UrlFileDownloader @Inject constructor(
         val call = downloadFileService.downloadFile(
             urlString = url,
             cookie = cookieManagerWrapper.getCookie(url).handleNull(),
+            userAgent = pendingFileDownload.userAgent,
         )
         val downloadId = Random.nextLong()
         urlFileDownloadCallManager.add(downloadId, call)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
@@ -27,16 +27,19 @@ import com.duckduckgo.downloads.store.DownloadStatus.STARTED
 import logcat.asLog
 import logcat.logcat
 import okhttp3.ResponseBody
+import okhttp3.internal.http2.StreamResetException
 import okio.Buffer
 import okio.sink
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.math.exp
 import kotlin.math.floor
 import kotlin.random.Random
 
 class UrlFileDownloader @Inject constructor(
     private val downloadFileService: DownloadFileService,
+    @Named("http1Fallback") private val downloadFileServiceHttp1: DownloadFileService,
     private val urlFileDownloadCallManager: UrlFileDownloadCallManager,
     private val cookieManagerWrapper: CookieManagerWrapper,
     private val fileDownloadFeature: FileDownloadFeature,
@@ -50,13 +53,7 @@ class UrlFileDownloader @Inject constructor(
     ) {
         val url = pendingFileDownload.url
         val directory = pendingFileDownload.directory
-        val call = downloadFileService.downloadFile(
-            urlString = url,
-            cookie = cookieManagerWrapper.getCookie(url).handleNull(),
-            userAgent = pendingFileDownload.userAgent,
-        )
         val downloadId = Random.nextLong()
-        urlFileDownloadCallManager.add(downloadId, call)
 
         logcat { "Starting download $fileName / $url" }
         downloadCallback.onStart(
@@ -68,45 +65,120 @@ class UrlFileDownloader @Inject constructor(
                 filePath = directory.path + File.separatorChar + fileName,
                 createdAt = DatabaseDateFormatter.timestamp(),
             ),
-
         )
 
-        runCatching {
-            val response = call.execute()
+        val result = executeDownload(
+            service = downloadFileService,
+            pendingFileDownload = pendingFileDownload,
+            fileName = fileName,
+            directory = directory,
+            downloadId = downloadId,
+            downloadCallback = downloadCallback,
+        )
 
-            if (response.isSuccessful) {
-                response.body()?.let {
-                    if (writeStreamingResponseBodyToDisk(downloadId, fileName, directory, it, downloadCallback)) {
+        when (result) {
+            is DownloadResult.Success -> {
+                val file = directory.getOrCreate(fileName)
+                // for file length we don't use body.contentLength() as it is not reliable. Eg. when downloading image from DDG search
+                // as the link is a re-direct, contentLength() will be -1
+                downloadCallback.onSuccess(downloadId, file.length(), file, pendingFileDownload.mimeType)
+            }
+            is DownloadResult.Cancelled -> {
+                logcat { "Download $fileName cancelled" }
+                downloadCallback.onCancel(downloadId)
+                directory.getOrCreate(fileName).delete()
+            }
+            is DownloadResult.StreamResetError -> {
+                logcat { "HTTP/2 stream reset error, retrying with HTTP/1.1 for $fileName" }
+                directory.getOrCreate(fileName).delete()
+
+                val retryResult = executeDownload(
+                    service = downloadFileServiceHttp1,
+                    pendingFileDownload = pendingFileDownload,
+                    fileName = fileName,
+                    directory = directory,
+                    downloadId = downloadId,
+                    downloadCallback = downloadCallback,
+                )
+
+                when (retryResult) {
+                    is DownloadResult.Success -> {
                         val file = directory.getOrCreate(fileName)
-                        // for file length we don't use body.contentLength() as it is not reliable. Eg. when downloading image from DDG search
-                        // as the link is a re-direct, contentLength() will be -1
                         downloadCallback.onSuccess(downloadId, file.length(), file, pendingFileDownload.mimeType)
-                    } else {
-                        if (call.isCanceled) {
-                            logcat { "Download $fileName cancelled" }
-                            downloadCallback.onCancel(downloadId)
-                        } else {
-                            logcat { "Download $fileName failed" }
-                            downloadCallback.onError(url = url, downloadId = downloadId, reason = Other)
-                        }
-                        // clean up
+                    }
+                    is DownloadResult.Cancelled -> {
+                        logcat { "Download $fileName cancelled during HTTP/1.1 retry" }
+                        downloadCallback.onCancel(downloadId)
+                        directory.getOrCreate(fileName).delete()
+                    }
+                    else -> {
+                        logcat { "Download $fileName failed during HTTP/1.1 retry" }
+                        downloadCallback.onError(url = url, downloadId = downloadId, reason = ConnectionRefused)
                         directory.getOrCreate(fileName).delete()
                     }
                 }
+            }
+            is DownloadResult.Error -> {
+                logcat { "Download $fileName failed: ${result.reason}" }
+                downloadCallback.onError(url = url, downloadId = downloadId, reason = result.reason)
+                directory.getOrCreate(fileName).delete()
+            }
+        }
+    }
+
+    private fun executeDownload(
+        service: DownloadFileService,
+        pendingFileDownload: FileDownloader.PendingFileDownload,
+        fileName: String,
+        directory: File,
+        downloadId: Long,
+        downloadCallback: DownloadCallback,
+    ): DownloadResult {
+        val url = pendingFileDownload.url
+        val call = service.downloadFile(
+            urlString = url,
+            cookie = cookieManagerWrapper.getCookie(url).handleNull(),
+            userAgent = pendingFileDownload.userAgent,
+        )
+        urlFileDownloadCallManager.add(downloadId, call)
+
+        return try {
+            val response = call.execute()
+
+            if (response.isSuccessful) {
+                response.body()?.let { body ->
+                    if (writeStreamingResponseBodyToDisk(downloadId, fileName, directory, body, downloadCallback)) {
+                        DownloadResult.Success
+                    } else {
+                        if (call.isCanceled) {
+                            DownloadResult.Cancelled
+                        } else {
+                            DownloadResult.Error(Other)
+                        }
+                    }
+                } ?: DownloadResult.Error(Other)
             } else {
                 logcat { "Failed to download $fileName / ${response.errorBody()?.string()}" }
-                downloadCallback.onError(url = url, downloadId = downloadId, reason = ConnectionRefused)
+                DownloadResult.Error(ConnectionRefused)
             }
-        }.onFailure {
-            logcat { "Failed to download $fileName: ${it.asLog()}" }
+        } catch (e: StreamResetException) {
+            logcat { "StreamResetException during download $fileName: ${e.asLog()}" }
+            DownloadResult.StreamResetError(e)
+        } catch (t: Throwable) {
+            logcat { "Failed to download $fileName: ${t.asLog()}" }
             if (call.isCanceled) {
-                downloadCallback.onCancel(downloadId)
+                DownloadResult.Cancelled
             } else {
-                downloadCallback.onError(url = url, downloadId = downloadId, reason = ConnectionRefused)
+                DownloadResult.Error(ConnectionRefused)
             }
-            // clean up
-            directory.getOrCreate(fileName).delete()
         }
+    }
+
+    private sealed class DownloadResult {
+        data object Success : DownloadResult()
+        data object Cancelled : DownloadResult()
+        data class StreamResetError(val exception: StreamResetException) : DownloadResult()
+        data class Error(val reason: com.duckduckgo.downloads.api.DownloadFailReason) : DownloadResult()
     }
 
     private fun writeStreamingResponseBodyToDisk(

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/di/DownloadsModule.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/di/DownloadsModule.kt
@@ -16,14 +16,18 @@
 
 package com.duckduckgo.downloads.impl.di
 
+import android.annotation.SuppressLint
 import com.duckduckgo.data.store.api.DatabaseProvider
 import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.downloads.impl.DownloadFileService
 import com.duckduckgo.downloads.store.DownloadsDatabase
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
+import retrofit2.Retrofit
+import javax.inject.Named
 
 @Module
 @ContributesTo(AppScope::class)
@@ -39,5 +43,19 @@ class DownloadsModule {
                 fallbackToDestructiveMigration = true,
             ),
         )
+    }
+
+    /**
+     * Provides a fallback DownloadFileService that uses HTTP/1.1 only.
+     * Used when HTTP/2 fails with StreamResetException on certain servers.
+     */
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @Named("http1Fallback")
+    @SuppressLint("NoRetrofitCreateMethodCallDetector")
+    fun provideDownloadFileServiceHttp1Fallback(
+        @Named("downloadsHttp1") retrofit: Retrofit,
+    ): DownloadFileService {
+        return retrofit.create(DownloadFileService::class.java)
     }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
@@ -52,7 +52,7 @@ class UrlFileDownloaderTest {
     @Before
     fun setup() {
         realFileDownloadManager = RealUrlFileDownloadCallManager()
-        whenever(downloadFileService.downloadFile(anyOrNull(), anyString())).thenReturn(call)
+        whenever(downloadFileService.downloadFile(anyOrNull(), anyOrNull(), anyString())).thenReturn(call)
 
         urlFileDownloader = UrlFileDownloader(
             downloadFileService,
@@ -186,7 +186,7 @@ class UrlFileDownloaderTest {
         val pendingFileDownload = buildPendingDownload("https://example.com/file.txt")
         urlFileDownloader.downloadFile(pendingFileDownload, "file.txt", mock<DownloadCallback>())
 
-        verify(downloadFileService).downloadFile(cookie = eq(null), urlString = any())
+        verify(downloadFileService).downloadFile(cookie = eq(null), userAgent = anyOrNull(), urlString = any())
     }
 
     @Test
@@ -196,7 +196,7 @@ class UrlFileDownloaderTest {
         val pendingFileDownload = buildPendingDownload("https://example.com/file.txt")
         urlFileDownloader.downloadFile(pendingFileDownload, "file.txt", mock<DownloadCallback>())
 
-        verify(downloadFileService).downloadFile(cookie = eq(""), urlString = any())
+        verify(downloadFileService).downloadFile(cookie = eq(""), userAgent = anyOrNull(), urlString = any())
     }
 
     @Test
@@ -213,7 +213,7 @@ class UrlFileDownloaderTest {
         val pendingFileDownload = buildPendingDownload("https://example.com/file.txt")
         urlFileDownloader.downloadFile(pendingFileDownload, "file.txt", mock<DownloadCallback>())
 
-        verify(downloadFileService).downloadFile(cookie = eq("session=abc123; token=xyz"), urlString = any())
+        verify(downloadFileService).downloadFile(cookie = eq("session=abc123; token=xyz"), userAgent = anyOrNull(), urlString = any())
     }
 
     @Test
@@ -230,7 +230,7 @@ class UrlFileDownloaderTest {
         val pendingFileDownload = buildPendingDownload("https://example.com/file.txt")
         urlFileDownloader.downloadFile(pendingFileDownload, "file.txt", mock<DownloadCallback>())
 
-        verify(downloadFileService).downloadFile(cookie = eq("session=abc123; token=xyz"), urlString = any())
+        verify(downloadFileService).downloadFile(cookie = eq("session=abc123; token=xyz"), userAgent = anyOrNull(), urlString = any())
     }
 
     private fun buildPendingDownload(

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
@@ -42,6 +42,7 @@ class UrlFileDownloaderTest {
     val coroutineRule = CoroutineTestRule()
 
     private val downloadFileService: DownloadFileService = mock()
+    private val downloadFileServiceHttp1: DownloadFileService = mock()
     private val call: Call<ResponseBody> = mock()
     private lateinit var realFileDownloadManager: RealUrlFileDownloadCallManager
 
@@ -53,9 +54,11 @@ class UrlFileDownloaderTest {
     fun setup() {
         realFileDownloadManager = RealUrlFileDownloadCallManager()
         whenever(downloadFileService.downloadFile(anyOrNull(), anyOrNull(), anyString())).thenReturn(call)
+        whenever(downloadFileServiceHttp1.downloadFile(anyOrNull(), anyOrNull(), anyString())).thenReturn(call)
 
         urlFileDownloader = UrlFileDownloader(
             downloadFileService,
+            downloadFileServiceHttp1,
             realFileDownloadManager,
             FakeCookieManagerWrapper(),
             fileDownloadFeature = fileDownloadFeature,
@@ -205,6 +208,7 @@ class UrlFileDownloaderTest {
 
         val urlFileDownloader = UrlFileDownloader(
             downloadFileService,
+            downloadFileServiceHttp1,
             realFileDownloadManager,
             FakeCookieManagerWrapper("session=abc123; token=xyz"),
             fileDownloadFeature = fileDownloadFeature,
@@ -222,6 +226,7 @@ class UrlFileDownloaderTest {
 
         val urlFileDownloader = UrlFileDownloader(
             downloadFileService,
+            downloadFileServiceHttp1,
             realFileDownloadManager,
             FakeCookieManagerWrapper("session=abc123; token=xyz"),
             fileDownloadFeature = fileDownloadFeature,

--- a/duckchat/duckchat-impl/build.gradle
+++ b/duckchat/duckchat-impl/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(':navigation-api')
     implementation project(':sync-api')
     implementation project(':data-store-api')
+    implementation project(':user-agent-api')
 
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -92,6 +92,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
@@ -173,6 +174,9 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
 
     @Inject
     lateinit var browserAndInputScreenTransitionProvider: BrowserAndInputScreenTransitionProvider
+
+    @Inject
+    lateinit var userAgentProvider: UserAgentProvider
 
     private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
@@ -626,6 +630,7 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
             fileName = "duck.ai_${System.currentTimeMillis()}",
+            userAgent = userAgentProvider.userAgent(),
         )
 
         if (hasWriteStoragePermission()) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -396,6 +396,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             contentDisposition = contentDisposition,
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
+            userAgent = userAgent.userAgent(),
         )
 
         if (hasWriteStoragePermission()) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211134676219652?focus=true

### Description

Added User-Agent header to file downloads to ensure proper handling by servers. This PR:
- Adds a `userAgent` parameter to the `PendingFileDownload` class
- Passes the User-Agent from the browser to download requests in BrowserTabFragment, DuckChatWebViewFragment, and SubscriptionsWebViewActivity
- Updates the download service to include the User-Agent header in requests

### Steps to test this PR

_File Downloads_
- [ ] Download a file from a website that checks User-Agent headers
- [ ] Verify the download starts and completes successfully
- [ ] Test downloads from BrowserTabFragment
- [ ] Test downloads from DuckChat
- [ ] Test downloads from Subscriptions screen
- [ ] Test retrying a failed download to ensure User-Agent is preserved

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures servers receive a proper `User-Agent` during downloads and adds a resilient fallback when HTTP/2 breaks.
> 
> - Adds `userAgent` to `PendingFileDownload` and threads it through workers (`FileDownloadWorker`), receivers, and callers (`BrowserTabFragment`, DuckChat, Subscriptions)
> - Updates `DownloadFileService` to send `User-Agent` for both `HEAD` and streaming `GET`
> - Refines `ApiRequestInterceptor` to skip adding `User-Agent` if already present and to use WebView UA for re-query pixels
> - Introduces HTTP/1.1-only OkHttp/Retrofit (`@Named("downloadsHttp1")`) and DI wiring; provides `@Named("http1Fallback")` `DownloadFileService`
> - Enhances `UrlFileDownloader` to include UA, handle `StreamResetException`, and retry via HTTP/1.1 client; cleans up on cancel/failure
> - Adds required module deps and updates tests to reflect new headers and fallback path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4cba0511fbf9ff769dd29166a990d141ec7dc5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->