### PR TITLE
Fix blank screen when accessing Duck.ai via overflow on new tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -297,8 +297,6 @@ import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment
-import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment.Companion.KEY_DUCK_AI_CONTEXTUAL_RESULT
-import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment.Companion.KEY_DUCK_AI_URL
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -3134,43 +3132,43 @@ class BrowserTabFragment :
     }
 
     private fun showDuckChatContextualSheet() {
-        duckAiContextualFragment?.let { fragment ->
-            val transaction = childFragmentManager.beginTransaction()
-            transaction.show(fragment)
-            transaction.commit()
-        } ?: run {
-            val fragment = DuckChatContextualFragment()
-            duckAiContextualFragment = fragment
-            val transaction = childFragmentManager.beginTransaction()
-            transaction.replace(binding.duckAiFragmentContainer.id, fragment)
-            transaction.commit()
-        }
-
-        childFragmentManager.setFragmentResultListener(KEY_DUCK_AI_CONTEXTUAL_RESULT, viewLifecycleOwner) { _, bundle ->
-            val contextualChatUrl = bundle.getString(KEY_DUCK_AI_URL)
-            contextualChatUrl?.let {
-                webView?.loadUrl(contextualChatUrl)
-                removeDuckChatContextualSheet()
-            }
-        }
-
-        binding.duckAiFragmentContainer.show()
-
-        val bottomSheetBehavior = BottomSheetBehavior.from(binding.duckAiFragmentContainer)
-        bottomSheetBehavior.state = duckAiContextualBehaviourState
-
-        bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
-            override fun onStateChanged(bottomSheet: View, newState: Int) {
-                if (newState == BottomSheetBehavior.STATE_HIDDEN) {
-                    binding.duckAiFragmentContainer.gone()
-                    hideKeyboard()
-                }
-                if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED || newState == BottomSheetBehavior.STATE_EXPANDED) {
-                    duckAiContextualBehaviourState = newState
-                }
-            }
-            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-        })
+        // duckAiContextualFragment?.let { fragment ->
+        //     val transaction = childFragmentManager.beginTransaction()
+        //     transaction.show(fragment)
+        //     transaction.commit()
+        // } ?: run {
+        //     val fragment = DuckChatContextualFragment()
+        //     duckAiContextualFragment = fragment
+        //     val transaction = childFragmentManager.beginTransaction()
+        //     transaction.replace(binding.duckAiFragmentContainer.id, fragment)
+        //     transaction.commit()
+        // }
+        //
+        // childFragmentManager.setFragmentResultListener(KEY_DUCK_AI_CONTEXTUAL_RESULT, viewLifecycleOwner) { _, bundle ->
+        //     val contextualChatUrl = bundle.getString(KEY_DUCK_AI_URL)
+        //     contextualChatUrl?.let {
+        //         webView?.loadUrl(contextualChatUrl)
+        //         removeDuckChatContextualSheet()
+        //     }
+        // }
+        //
+        // binding.duckAiFragmentContainer.show()
+        //
+        // val bottomSheetBehavior = BottomSheetBehavior.from(binding.duckAiFragmentContainer)
+        // bottomSheetBehavior.state = duckAiContextualBehaviourState
+        //
+        // bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+        //     override fun onStateChanged(bottomSheet: View, newState: Int) {
+        //         if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+        //             binding.duckAiFragmentContainer.gone()
+        //             hideKeyboard()
+        //         }
+        //         if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED || newState == BottomSheetBehavior.STATE_EXPANDED) {
+        //             duckAiContextualBehaviourState = newState
+        //         }
+        //     }
+        //     override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+        // })
     }
 
     private fun removeDuckChatContextualSheet() {

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -142,15 +142,15 @@
 
     </RelativeLayout>
 
-    <FrameLayout
-        android:id="@+id/duckAiFragmentContainer"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:elevation="12dp"
-        app:behavior_hideable="true"
-        app:behavior_skipCollapsed="true"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-        android:visibility="gone" />
+<!--    <FrameLayout-->
+<!--        android:id="@+id/duckAiFragmentContainer"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent"-->
+<!--        android:elevation="12dp"-->
+<!--        app:behavior_hideable="true"-->
+<!--        app:behavior_skipCollapsed="true"-->
+<!--        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"-->
+<!--        android:visibility="gone" />-->
 
     <com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
         android:id="@+id/navigationBar"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212890700101835?focus=true

### Description

- Respects the full screen setting when opening Duck.ai from the overflow menu > “Duck.ai” on new tab.
- Fixes blank standalone Duck.ai when the full screen setting is disabled.

### Steps to test this PR

- [ ] Go to new tab > overflow menu > “Duck.ai"
- [ ] Verify that full screen Duck.ai is opened
- [ ] Go to Feature Flag Inventory and disable “fullscreenMode"
- [ ] Kill the app
- [ ] Go to new tab > overflow menu > “Duck.ai"
- [ ] Verify that standalone Duck.ai is opened


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Duck.ai launch behavior from the overflow menu and removes unused contextual UI.
> 
> - When tapping `Duck.ai` in the menu, checks `duckAiFeatureState.showFullScreenMode`; opens full-screen via `viewModel.openNewDuckChat(...)` or falls back to `viewModel.onDuckChatMenuClicked()`
> - Disables the Duck.ai contextual bottom sheet by commenting out `showDuckChatContextualSheet` logic and the `duckAiFragmentContainer` `FrameLayout` in `fragment_browser_tab.xml`
> - Cleans up now-unused imports/constants for Duck.ai contextual result handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e599e9d9a1d1dad647978ddf7de70886e1503a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->