### PR TITLE
Update wide event POST payload to use Boolean value for app.dev_mode param

### DIFF
--- a/PixelDefinitions/params_dictionary.json
+++ b/PixelDefinitions/params_dictionary.json
@@ -34,9 +34,8 @@
     },
     "widePixelDevMode": {
         "key": "app.dev_mode",
-        "type": "string",
-        "description": "Whether the app is a development build. This is `true` for development builds and `false` for production/internal builds.",
-        "enum": ["true", "false"]
+        "type": "boolean",
+        "description": "Whether the app is a development build. This is `true` for development builds and `false` for production/internal builds."
     },
     "widePixelPlatform": {
         "key": "global.platform",

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSender.kt
@@ -56,7 +56,7 @@ class ApiWideEventSender @Inject constructor(
                 name = APP_NAME,
                 version = appBuildConfig.versionName,
                 formFactor = deviceInfo.formFactor().description,
-                devMode = appBuildConfig.isDebug.toString(),
+                devMode = appBuildConfig.isDebug,
             ),
             feature = FeatureSection(
                 name = event.name,

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/api/WideEventRequest.kt
@@ -35,7 +35,7 @@ data class AppSection(
     @field:Json(name = "name") val name: String,
     @field:Json(name = "version") val version: String,
     @field:Json(name = "form_factor") val formFactor: String,
-    @field:Json(name = "dev_mode") val devMode: String,
+    @field:Json(name = "dev_mode") val devMode: Boolean,
 )
 
 data class FeatureSection(

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/ApiWideEventSenderTest.kt
@@ -89,7 +89,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = eventName,
@@ -129,7 +129,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = "feature-event",
@@ -164,7 +164,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = "simple-event",
@@ -199,7 +199,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "true",
+                devMode = true,
             ),
             feature = FeatureSection(
                 name = "debug-event",
@@ -234,7 +234,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "tablet",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = "tablet-event",
@@ -267,7 +267,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = "unknown-event",
@@ -305,7 +305,7 @@ class ApiWideEventSenderTest {
                 name = "DuckDuckGo Android",
                 version = "5.123.0",
                 formFactor = "phone",
-                devMode = "false",
+                devMode = false,
             ),
             feature = FeatureSection(
                 name = "filtered-event",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1212760961590594?focus=true

### Description

### Steps to test this PR

- [x] Do something that triggers sending a wide event (e.g. purchase or restore subscription)
- [x] Inspect network request to improving.duckduckgo.com/e and confirm app.dev_mode param is encoded as boolean, not string.

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates wide event payload to encode `app.dev_mode` as a boolean.
> 
> - Changes `widePixelDevMode` type to `boolean` in `params_dictionary.json`
> - Updates `AppSection.devMode` (String → Boolean) in `WideEventRequest`
> - Sends `devMode = appBuildConfig.isDebug` in `ApiWideEventSender`
> - Adjusts unit tests to expect boolean `devMode`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9375d32d586bb7c6cb4bcabfa9f8398a394b259f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->