### PR TITLE
Upgrade AndroidX Core to 1.16.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -48,7 +48,7 @@ version.androidx.localbroadcastmanager=1.1.0
 
 version.androidx.recyclerview=1.3.2
 
-version.androidx.core=1.13.1
+version.androidx.core=1.16.0
 
 version.androidx.fragment=1.8.6
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212901794978421?focus=true

### Description
Upgrade AndroidX Core from 1.13.1 to 1.16.0. No breaking changes affect this codebase.

We can't update to the latest version, 1.17.0:

> Core library has been updated to target Kotlin 2.0 language level and requires the Kotlin Gradle Plugin 2.0.0 or newer.

### Steps to test this PR

_Verification_
- [x] Build completes successfully
- [x] Unit tests pass
- [x] App launches and basic functionality works

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency upgrade**
> 
> - Updates `version.androidx.core` in `versions.properties` from `1.13.1` to `1.16.0`
> 
> *No code changes or UI impact; verify build/tests and basic app launch.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 813f755a4667485561f11f2e477e46ed082e5f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->