### PR TITLE
Fix onboarding dialog not being refreshed when trackers animation does not play

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4681,9 +4681,9 @@ class BrowserTabFragment :
                         createTrackersAnimation()
                     }
                 } else {
-                    lifecycleScope.launch {
-                        if (addressBarTrackersAnimationManager.isFeatureEnabled()) {
-                            if (viewState.progress == MAX_PROGRESS) {
+                    if (viewState.progress == MAX_PROGRESS) {
+                        lifecycleScope.launch {
+                            if (addressBarTrackersAnimationManager.isFeatureEnabled()) {
                                 viewModel.refreshCta()
                             }
                         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212922439831537?focus=true

### Description

- The onboarding dialog refresh was previously tied to creating the trackers animation (in 2020, I believe!), probably so the trackers animation would have a chance to start before the dialog appeared.
- With the reduced frequency, we don't call that function, so the dialog doesn't get a chance to refresh if we're on the same site.
- The fix was to changed the code so that even when we don't run the trackers animation, we still call the onboarding dialog refresh function.

### Steps to test this PR

Prerequisite: `addressBarTrackersAnimation` should be on (on by default for internal users)

_Maestro Test_
- [ ] Run onboarding_dismiss_all_dialogs.yaml
- [ ] Tests pass

_Contextual Onboarding_

This issue does **not** affect pre-onboarding (before landing in the browser) so do not be concerned with that part. 

- [x] Test contextual onboarding happy path (i.e. search for suggested sites, agree to things)
- [x] Onboarding should complete successfully and you should see all CTAs
- [x] Clear data
- [x] Test contextual onboarding dismiss path similar to Maestro (i.e. close onboarding dialogs instead of pressing buttons)
- [x] Onboarding should complete successfully and you should see all CTAs
- [x] Clear data
- [x] Test contextual onboarding new tab path. Every time a dialog shows, open tab switcher, click new tab
- [x] Onboarding should complete successfully and you should see all CTAs

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures onboarding CTA refreshes even when trackers animation doesn’t run.
> 
> - In `BrowserTabFragment.kt` (`renderLoadingIndicator`), when `progress == MAX_PROGRESS` and `trackersAnimationEnabled` is false, launch a coroutine that checks `addressBarTrackersAnimationManager.isFeatureEnabled()` and then calls `viewModel.refreshCta()`.
> - Keeps existing behavior when the animation is enabled (still calls `createTrackersAnimation()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d53c7221dc1484a92cdf1ebc41d6a4697a473782. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->