### PR TITLE
Enable SERP settings sync feature for internal users

### DIFF
--- a/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SerpSettingsFeature.kt
+++ b/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SerpSettingsFeature.kt
@@ -24,6 +24,6 @@ interface SerpSettingsFeature {
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun storeSerpSettings(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1212901795000404?focus=true

### Description

Now we are happy rolling out SERP setting sync, turn it on for internal users.

### Steps to test this PR

Optionally: [Testing Steps](https://app.asana.com/1/137249556945/project/1207908166761516/task/1212517945831187?focus=true)

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables SERP settings sync for internal users.
> 
> - Changes `SerpSettingsFeature.storeSerpSettings` default from `FALSE` to `INTERNAL`, activating the feature for internal builds/users
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf12fe4a7ca5494baf37617e90fe1d1a7be4ba00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->