### PR TITLE
Fix showDuckChatContextualSheet

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -299,6 +299,8 @@ import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenBrowserButtonsConfig
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment
+import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment.Companion.KEY_DUCK_AI_CONTEXTUAL_RESULT
+import com.duckduckgo.duckchat.impl.ui.DuckChatContextualFragment.Companion.KEY_DUCK_AI_URL
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -3286,43 +3288,43 @@ class BrowserTabFragment :
     }
 
     private fun showDuckChatContextualSheet() {
-        // duckAiContextualFragment?.let { fragment ->
-        //     val transaction = childFragmentManager.beginTransaction()
-        //     transaction.show(fragment)
-        //     transaction.commit()
-        // } ?: run {
-        //     val fragment = DuckChatContextualFragment()
-        //     duckAiContextualFragment = fragment
-        //     val transaction = childFragmentManager.beginTransaction()
-        //     transaction.replace(binding.duckAiFragmentContainer.id, fragment)
-        //     transaction.commit()
-        // }
-        //
-        // childFragmentManager.setFragmentResultListener(KEY_DUCK_AI_CONTEXTUAL_RESULT, viewLifecycleOwner) { _, bundle ->
-        //     val contextualChatUrl = bundle.getString(KEY_DUCK_AI_URL)
-        //     contextualChatUrl?.let {
-        //         webView?.loadUrl(contextualChatUrl)
-        //         removeDuckChatContextualSheet()
-        //     }
-        // }
-        //
-        // binding.duckAiFragmentContainer.show()
-        //
-        // val bottomSheetBehavior = BottomSheetBehavior.from(binding.duckAiFragmentContainer)
-        // bottomSheetBehavior.state = duckAiContextualBehaviourState
-        //
-        // bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
-        //     override fun onStateChanged(bottomSheet: View, newState: Int) {
-        //         if (newState == BottomSheetBehavior.STATE_HIDDEN) {
-        //             binding.duckAiFragmentContainer.gone()
-        //             hideKeyboard()
-        //         }
-        //         if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED || newState == BottomSheetBehavior.STATE_EXPANDED) {
-        //             duckAiContextualBehaviourState = newState
-        //         }
-        //     }
-        //     override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-        // })
+        duckAiContextualFragment?.let { fragment ->
+            val transaction = childFragmentManager.beginTransaction()
+            transaction.show(fragment)
+            transaction.commit()
+        } ?: run {
+            val fragment = DuckChatContextualFragment()
+            duckAiContextualFragment = fragment
+            val transaction = childFragmentManager.beginTransaction()
+            transaction.replace(binding.duckAiContextualFragmentContainer.id, fragment)
+            transaction.commit()
+        }
+
+        childFragmentManager.setFragmentResultListener(KEY_DUCK_AI_CONTEXTUAL_RESULT, viewLifecycleOwner) { _, bundle ->
+            val contextualChatUrl = bundle.getString(KEY_DUCK_AI_URL)
+            contextualChatUrl?.let {
+                webView?.loadUrl(contextualChatUrl)
+                removeDuckChatContextualSheet()
+            }
+        }
+
+        binding.duckAiContextualFragmentContainer.show()
+
+        val bottomSheetBehavior = BottomSheetBehavior.from(binding.duckAiContextualFragmentContainer)
+        bottomSheetBehavior.state = duckAiContextualBehaviourState
+
+        bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) {
+                if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+                    binding.duckAiContextualFragmentContainer.gone()
+                    hideKeyboard()
+                }
+                if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED || newState == BottomSheetBehavior.STATE_EXPANDED) {
+                    duckAiContextualBehaviourState = newState
+                }
+            }
+            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+        })
     }
 
     private fun removeDuckChatContextualSheet() {

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -142,15 +142,15 @@
 
     </RelativeLayout>
 
-<!--    <FrameLayout-->
-<!--        android:id="@+id/duckAiFragmentContainer"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="match_parent"-->
-<!--        android:elevation="12dp"-->
-<!--        app:behavior_hideable="true"-->
-<!--        app:behavior_skipCollapsed="true"-->
-<!--        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"-->
-<!--        android:visibility="gone" />-->
+    <FrameLayout
+        android:id="@+id/duckAiContextualFragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:elevation="12dp"
+        app:behavior_hideable="true"
+        app:behavior_skipCollapsed="true"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        android:visibility="gone" />
 
     <com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
         android:id="@+id/navigationBar"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1212924236320011?focus=true

### Description

- Uncomments and renames `@+id/duckAiFragmentContainer` to `@+id/duckAiContextualFragmentContainer` in order to fix an ID collision.

### Steps to test this PR

- [ ] Go to Feature Flag Inventory and enable `contextualMode`
- [ ] Visit a site
- [ ] Tap on the Duck.ai omnibar icon
- [ ] Verify that the contextual sheet is shown
- [ ] Go to Feature Flag Inventory and disable `fullscreenMode`
- [ ] Kill the app
- [ ] Open a new tab and tap on the Duck.ai omnibar icon
- [ ] Verify that standalone Duck.ai is opened (not blank)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the Duck AI contextual chat bottom sheet in the browser tab and wires it to navigate based on user selection.
> 
> - Implements `showDuckChatContextualSheet` to create/show `DuckChatContextualFragment`, listen for `KEY_DUCK_AI_CONTEXTUAL_RESULT`, and load the returned `KEY_DUCK_AI_URL` into the WebView
> - Adds `duckAiContextualFragmentContainer` to `fragment_browser_tab.xml` and uses it for `BottomSheetBehavior` (including state restore and hide handling)
> - Imports result key constants from `DuckChatContextualFragment`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f0b7668e701e176d43dcab386b08d3e96fab606. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->