### PR TITLE
Pixel definition for new free trial pixels

### DIFF
--- a/PixelDefinitions/pixels/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/subscription_pixels.json5
@@ -3,14 +3,14 @@
         "description": "Fired when a user starts a free trial. Used to measure total count of trialists independent of whether they complete the trial.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
-        "suffixes": ["unique", "form_factor"],
+        "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
     "subscription_free_trial_vpn_activation": {
         "description": "Fired when a user activates VPN while on a free trial. Used to measure how many trialists activate VPN and compare with wide event data.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
-        "suffixes": ["unique", "form_factor"],
+        "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212929097662561?focus=true

### Description
Pixel definition for pixels added in https://github.com/duckduckgo/Android/pull/7535

### Steps to test this PR

N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new subscription free trial telemetry definitions.
> 
> - Introduces `subscription_free_trial_start` and `subscription_free_trial_vpn_activation` pixels in `subscription_pixels.json5`
> - `vpn_activation` includes `activation_day` param with enum values to distinguish activation timing
> - No code/UI changes; extends pixel schema only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab16387e3b55e4b8bca1f9508abcf0b91a670e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->