### PR TITLE
Open Duck.ai in fullscreen mode from app shortcut

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -621,8 +621,22 @@ open class BrowserActivity : DuckDuckGoActivity() {
             if (duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value) {
                 externalIntentProcessingState.onIntentRequestToOpenDuckAi()
             }
-            val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)
-            viewModel.openDuckChat(intent.getStringExtra(DUCK_CHAT_URL), duckChatSessionActive, withTransition = duckAiShouldAnimate)
+
+            if (duckAiFeatureState.showFullScreenMode.value) {
+                val url = intent.getStringExtra(DUCK_CHAT_URL) ?: duckChat.getDuckChatUrl("", false)
+                if (currentTab != null) {
+                    currentTab?.submitQuery(url)
+                } else {
+                    if (swipingTabsFeature.isEnabled) {
+                        launchNewTab(query = url, skipHome = true)
+                    } else {
+                        lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, skipHome = true) }
+                    }
+                }
+            } else {
+                val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)
+                viewModel.openDuckChat(intent.getStringExtra(DUCK_CHAT_URL), duckChatSessionActive, withTransition = duckAiShouldAnimate)
+            }
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212890792841243?focus=true

### Description

- Opens Duck.ai in a tab when opening from the app shortcut and fullscreen mode is enabled.

### Steps to test this PR

- [ ] Long press on the app icon and tap Duck.ai
- [ ] Verify Duck.ai is opened in fullscreen mode
- [ ] Go Feature Flag Inventory and disable “fullscreenMode”
- [ ] Kill the app
- [ ] Long press on the app icon and tap Duck.ai
- [ ] Verify that Duck.ai is opened in the standalone WebView

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables full-screen Duck.ai launch via intents when the feature flag is on, routing the chat URL into the main browser tab flow instead of the embedded Duck Chat view.
> 
> - In `BrowserActivity`, `OPEN_DUCK_CHAT` handling now checks `duckAiFeatureState.showFullScreenMode`; if enabled, resolves a Duck.ai URL (from intent or `duckChat.getDuckChatUrl`) and either `submitQuery` on the current tab or opens a new tab (supports swiping-tabs and non-swiping paths)
> - Falls back to previous behavior (`viewModel.openDuckChat(...)`) when full-screen mode is disabled
> - Maintains existing signals to `externalIntentProcessingState` and animation behavior via `duckAiShouldAnimate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2fe2bb5186a5b59f42a850f49e33145b948cf3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->