### PR TITLE
Change default value for vpnReminderNotification Toggle

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -281,7 +281,7 @@ interface PrivacyProFeature {
     /**
      * When enabled, a VPN reminder notification will be scheduled for day 2 of the free trial.
      */
-    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun vpnReminderNotification(): Toggle
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212891764495747?focus=true

### Description
Change the default value for the Day-2 VPN notification Toggle

### Steps to test this PR _(Optional)_

- [ ] Follow same steps as in https://github.com/duckduckgo/Android/pull/7500 and check notification doesn't appear

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the Day-2 VPN reminder by default for free trial users.
> 
> - Changes `PrivacyProFeature.vpnReminderNotification` default from `TRUE` to `FALSE`, preventing automatic scheduling of the day-2 reminder unless remotely enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ff09527d60483644aa449fd33463d27e56d06a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->