### PR TITLE
Update Compose BOM to 2026.01.00

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version.androidx.arch.core=2.2.0
 
 version.androidx.browser=1.8.0
 
-version.androidx.compose=2025.10.00
+version.androidx.compose=2026.01.00
 
 # Cannot update past 1.5.14 because we need Kotlin 2.x
 version.androidx.compose.compiler=1.5.14


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1212936284568435?focus=true

### Description

Updates the Compose BOM from `2025.10.00` to `2026.01.00`.

This bumps core Compose libraries (animation, foundation, material, runtime, ui) from **1.9.4 → 1.10.1**. Material3 and adaptive libraries remain unchanged.

**Notable changes in this release:**
- **Performance:** Pausable composition in lazy prefetch now enabled by default, reducing jank during heavy scrolling
- **New `retain` API:** Persists non-serializable values (media players, flows, bitmaps) across configuration changes
- **New v2 test APIs:** `StandardTestDispatcher`-based test functions for better production parity

### Steps to test this PR

_Build & Tests_
- [x] Project builds successfully

_Smoke test_
- [x] ADS screen composables

### UI changes

N/A - no visual changes expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit aa3f1936f94b2b61d498008e3061b5ec8c568305. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->