### PR TITLE
Update content scope scripts to version 12.36.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -517,7 +517,7 @@
 
   // src/features.js
   var baseFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "fingerprintingAudio",
       "fingerprintingBattery",
@@ -535,7 +535,7 @@
     ]
   );
   var otherFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "clickToLoad",
       "cookie",
@@ -572,7 +572,7 @@
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
+    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -600,6 +600,7 @@
       "webCompat",
       "pageContext",
       "duckAiDataClearing",
+      "performanceMetrics",
       "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
@@ -3576,9 +3577,25 @@
   _args = new WeakMap();
 
   // src/content-feature.js
-  var _messaging, _isDebugFlagSet, _importConfig;
+  var CallFeatureMethodError = class extends Error {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+      super(message);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = new.target.name;
+    }
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features;
   var ContentFeature = class extends ConfigFeature {
-    constructor(featureName, importConfig, args) {
+    /**
+     * @param {string} featureName
+     * @param {*} importConfig
+     * @param {Partial<FeatureMap>} features
+     * @param {*} args
+     */
+    constructor(featureName, importConfig, features, args) {
       super(featureName, args);
       /** @type {import('./utils.js').RemoteConfig | undefined} */
       /** @type {import('../../messaging').Messaging} */
@@ -3603,8 +3620,25 @@
       __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
+      /**
+       * @type {Partial<FeatureMap>}
+       */
+      __privateAdd(this, _features);
+      /**
+       * @template {string} K
+       * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
+       */
+      /**
+       * Methods that are exposed for inter-feature communication.
+       *
+       * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
+       *
+       * @type {ExposeMethods<any> | undefined}
+       */
+      __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
       this.monitor = new PerformanceMonitor();
+      __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
     }
     get isDebug() {
@@ -3682,6 +3716,48 @@
      */
     get documentOriginIsTracker() {
       return isTrackerOrigin(this.trackerLookup);
+    }
+    /**
+     * Declares which methods may be called on the feature instance from other features.
+     *
+     * @template {keyof typeof this} K
+     * @param {K[]} methods
+     * @returns {ExposeMethods<K>}
+     */
+    _declareExposedMethods(methods) {
+      for (const method of methods) {
+        if (typeof this[method] !== "function") {
+          throw new Error(`'${method.toString()}' is not a method of feature '${this.name}'`);
+        }
+      }
+      return methods;
+    }
+    /**
+     * Run an exposed method of another feature.
+     *
+     * `args` are the arguments to pass to the feature method.
+     *
+     * @template {keyof FeatureMap} FeatureName
+     * @template {FeatureMap[FeatureName]} Feature
+     * @template {keyof Feature & (Feature['_exposedMethods'] extends ExposeMethods<infer K> ? K : never)} MethodName
+     * @param {FeatureName} featureName
+     * @param {MethodName} methodName
+     * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
+     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     */
+    callFeatureMethod(featureName, methodName, ...args) {
+      const feature = __privateGet(this, _features)[featureName];
+      if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
+      if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
+        return new CallFeatureMethodError(`'${methodName}' is not exposed by feature '${featureName}'`);
+      const method = (
+        /** @type {Feature} */
+        feature[methodName]
+      );
+      if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
+      if (!(method instanceof Function))
+        return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      return method.call(feature, ...args);
     }
     /**
      * @deprecated as we should make this internal to the class and not used externally
@@ -3881,6 +3957,7 @@
   _messaging = new WeakMap();
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
+  _features = new WeakMap();
 
   // src/features/api-manipulation.js
   var ApiManipulation = class extends ContentFeature {
@@ -6100,7 +6177,7 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
+    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
       const navigations = /* @__PURE__ */ new WeakMap();
       globalThis.navigation.addEventListener("navigate", (event) => {
@@ -6140,7 +6217,7 @@
   // src/content-scope-features.js
   var initArgs = null;
   var updates = [];
-  var features = [];
+  var _features2 = {};
   var alwaysInitFeatures = /* @__PURE__ */ new Set(["cookie"]);
   var performanceMonitor = new PerformanceMonitor();
   var isHTMLDocument = document instanceof HTMLDocument || document instanceof XMLDocument && document.createElement("div") instanceof HTMLDivElement;
@@ -6158,15 +6235,19 @@
     for (const featureName of bundledFeatureNames) {
       if (featuresToLoad.includes(featureName)) {
         const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-        const featureInstance = new ContentFeature2(featureName, importConfig, args);
+        const featureInstance = new ContentFeature2(featureName, importConfig, _features2, args);
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           continue;
         }
         featureInstance.callLoad();
-        features.push({ featureName, featureInstance });
+        _features2[featureName] = featureInstance;
       }
     }
     mark.end();
+  }
+  async function getFeatures() {
+    await Promise.all(Object.entries(_features2));
+    return _features2;
   }
   async function init(args) {
     const mark = performanceMonitor.mark("init");
@@ -6176,17 +6257,20 @@
     }
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           return;
         }
         featureInstance.callInit(args);
-        if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
+        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
           registerForURLChanges((navigationType) => {
             featureInstance.recomputeSiteObject();
-            featureInstance?.urlChanged(navigationType);
+            if (hasUrlChangedMethod) {
+              featureInstance.urlChanged(navigationType);
+            }
           });
         }
       }
@@ -6204,8 +6288,8 @@
     if (!isHTMLDocument) {
       return;
     }
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance }) => {
+    const features = await getFeatures();
+    Object.values(features).forEach((featureInstance) => {
       if (featureInstance && featureInstance.listenForConfigUpdates) {
         if (typeof featureInstance.setArgs === "function") {
           featureInstance.setArgs(updatedArgs);
@@ -6220,8 +6304,8 @@
     return args.platform.name === "extension" && alwaysInitFeatures.has(featureName);
   }
   async function updateFeaturesInner(args) {
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -65,7 +65,7 @@
        * Steven Levithan (c) 2007-2017 MIT License
        */
       var REGEX_DATA = "xregexp";
-      var features2 = {
+      var features = {
         astral: false,
         natives: false
       };
@@ -301,7 +301,7 @@
         return result;
       }
       function setAstral(on) {
-        features2.astral = on;
+        features.astral = on;
       }
       function setNatives(on) {
         RegExp.prototype.exec = (on ? fixed : nativ).exec;
@@ -309,7 +309,7 @@
         String.prototype.match = (on ? fixed : nativ).match;
         String.prototype.replace = (on ? fixed : nativ).replace;
         String.prototype.split = (on ? fixed : nativ).split;
-        features2.natives = on;
+        features.natives = on;
       }
       function toObject(value) {
         if (value == null) {
@@ -480,15 +480,15 @@
       };
       XRegExp.install = function(options) {
         options = prepareOptions(options);
-        if (!features2.astral && options.astral) {
+        if (!features.astral && options.astral) {
           setAstral(true);
         }
-        if (!features2.natives && options.natives) {
+        if (!features.natives && options.natives) {
           setNatives(true);
         }
       };
       XRegExp.isInstalled = function(feature) {
-        return !!features2[feature];
+        return !!features[feature];
       };
       XRegExp.isRegExp = function(value) {
         return toString.call(value) === "[object RegExp]";
@@ -572,10 +572,10 @@
       };
       XRegExp.uninstall = function(options) {
         options = prepareOptions(options);
-        if (features2.astral && options.astral) {
+        if (features.astral && options.astral) {
           setAstral(false);
         }
-        if (features2.natives && options.natives) {
+        if (features.natives && options.natives) {
           setNatives(false);
         }
       };
@@ -2052,7 +2052,7 @@
   // src/features.js
   init_define_import_meta_trackerLookup();
   var baseFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "fingerprintingAudio",
       "fingerprintingBattery",
@@ -2070,7 +2070,7 @@
     ]
   );
   var otherFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "clickToLoad",
       "cookie",
@@ -2107,7 +2107,7 @@
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
+    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -2135,6 +2135,7 @@
       "webCompat",
       "pageContext",
       "duckAiDataClearing",
+      "performanceMetrics",
       "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
@@ -5141,9 +5142,25 @@
   _args = new WeakMap();
 
   // src/content-feature.js
-  var _messaging, _isDebugFlagSet, _importConfig;
+  var CallFeatureMethodError = class extends Error {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+      super(message);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = new.target.name;
+    }
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features;
   var ContentFeature = class extends ConfigFeature {
-    constructor(featureName, importConfig, args) {
+    /**
+     * @param {string} featureName
+     * @param {*} importConfig
+     * @param {Partial<FeatureMap>} features
+     * @param {*} args
+     */
+    constructor(featureName, importConfig, features, args) {
       super(featureName, args);
       /** @type {import('./utils.js').RemoteConfig | undefined} */
       /** @type {import('../../messaging').Messaging} */
@@ -5168,8 +5185,25 @@
       __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
+      /**
+       * @type {Partial<FeatureMap>}
+       */
+      __privateAdd(this, _features);
+      /**
+       * @template {string} K
+       * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
+       */
+      /**
+       * Methods that are exposed for inter-feature communication.
+       *
+       * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
+       *
+       * @type {ExposeMethods<any> | undefined}
+       */
+      __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
       this.monitor = new PerformanceMonitor();
+      __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
     }
     get isDebug() {
@@ -5247,6 +5281,48 @@
      */
     get documentOriginIsTracker() {
       return isTrackerOrigin(this.trackerLookup);
+    }
+    /**
+     * Declares which methods may be called on the feature instance from other features.
+     *
+     * @template {keyof typeof this} K
+     * @param {K[]} methods
+     * @returns {ExposeMethods<K>}
+     */
+    _declareExposedMethods(methods) {
+      for (const method of methods) {
+        if (typeof this[method] !== "function") {
+          throw new Error(`'${method.toString()}' is not a method of feature '${this.name}'`);
+        }
+      }
+      return methods;
+    }
+    /**
+     * Run an exposed method of another feature.
+     *
+     * `args` are the arguments to pass to the feature method.
+     *
+     * @template {keyof FeatureMap} FeatureName
+     * @template {FeatureMap[FeatureName]} Feature
+     * @template {keyof Feature & (Feature['_exposedMethods'] extends ExposeMethods<infer K> ? K : never)} MethodName
+     * @param {FeatureName} featureName
+     * @param {MethodName} methodName
+     * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
+     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     */
+    callFeatureMethod(featureName, methodName, ...args) {
+      const feature = __privateGet(this, _features)[featureName];
+      if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
+      if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
+        return new CallFeatureMethodError(`'${methodName}' is not exposed by feature '${featureName}'`);
+      const method = (
+        /** @type {Feature} */
+        feature[methodName]
+      );
+      if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
+      if (!(method instanceof Function))
+        return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      return method.call(feature, ...args);
     }
     /**
      * @deprecated as we should make this internal to the class and not used externally
@@ -5446,6 +5522,7 @@
   _messaging = new WeakMap();
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
+  _features = new WeakMap();
 
   // src/features/broker-protection/execute.js
   init_define_import_meta_trackerLookup();
@@ -9651,7 +9728,7 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
+    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
       const navigations = /* @__PURE__ */ new WeakMap();
       globalThis.navigation.addEventListener("navigate", (event) => {
@@ -9691,7 +9768,7 @@
   // src/content-scope-features.js
   var initArgs = null;
   var updates = [];
-  var features = [];
+  var _features2 = {};
   var alwaysInitFeatures = /* @__PURE__ */ new Set(["cookie"]);
   var performanceMonitor = new PerformanceMonitor();
   var isHTMLDocument = document instanceof HTMLDocument || document instanceof XMLDocument && document.createElement("div") instanceof HTMLDivElement;
@@ -9709,15 +9786,19 @@
     for (const featureName of bundledFeatureNames) {
       if (featuresToLoad.includes(featureName)) {
         const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-        const featureInstance = new ContentFeature2(featureName, importConfig, args);
+        const featureInstance = new ContentFeature2(featureName, importConfig, _features2, args);
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           continue;
         }
         featureInstance.callLoad();
-        features.push({ featureName, featureInstance });
+        _features2[featureName] = featureInstance;
       }
     }
     mark.end();
+  }
+  async function getFeatures() {
+    await Promise.all(Object.entries(_features2));
+    return _features2;
   }
   async function init(args) {
     const mark = performanceMonitor.mark("init");
@@ -9727,17 +9808,20 @@
     }
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           return;
         }
         featureInstance.callInit(args);
-        if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
+        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
           registerForURLChanges((navigationType) => {
             featureInstance.recomputeSiteObject();
-            featureInstance?.urlChanged(navigationType);
+            if (hasUrlChangedMethod) {
+              featureInstance.urlChanged(navigationType);
+            }
           });
         }
       }
@@ -9755,8 +9839,8 @@
     if (!isHTMLDocument) {
       return;
     }
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance }) => {
+    const features = await getFeatures();
+    Object.values(features).forEach((featureInstance) => {
       if (featureInstance && featureInstance.listenForConfigUpdates) {
         if (typeof featureInstance.setArgs === "function") {
           featureInstance.setArgs(updatedArgs);
@@ -9771,8 +9855,8 @@
     return args.platform.name === "extension" && alwaysInitFeatures.has(featureName);
   }
   async function updateFeaturesInner(args) {
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -65,7 +65,7 @@
        * Steven Levithan (c) 2007-2017 MIT License
        */
       var REGEX_DATA = "xregexp";
-      var features2 = {
+      var features = {
         astral: false,
         natives: false
       };
@@ -301,7 +301,7 @@
         return result;
       }
       function setAstral(on) {
-        features2.astral = on;
+        features.astral = on;
       }
       function setNatives(on) {
         RegExp.prototype.exec = (on ? fixed : nativ).exec;
@@ -309,7 +309,7 @@
         String.prototype.match = (on ? fixed : nativ).match;
         String.prototype.replace = (on ? fixed : nativ).replace;
         String.prototype.split = (on ? fixed : nativ).split;
-        features2.natives = on;
+        features.natives = on;
       }
       function toObject(value) {
         if (value == null) {
@@ -480,15 +480,15 @@
       };
       XRegExp.install = function(options) {
         options = prepareOptions(options);
-        if (!features2.astral && options.astral) {
+        if (!features.astral && options.astral) {
           setAstral(true);
         }
-        if (!features2.natives && options.natives) {
+        if (!features.natives && options.natives) {
           setNatives(true);
         }
       };
       XRegExp.isInstalled = function(feature) {
-        return !!features2[feature];
+        return !!features[feature];
       };
       XRegExp.isRegExp = function(value) {
         return toString.call(value) === "[object RegExp]";
@@ -572,10 +572,10 @@
       };
       XRegExp.uninstall = function(options) {
         options = prepareOptions(options);
-        if (features2.astral && options.astral) {
+        if (features.astral && options.astral) {
           setAstral(false);
         }
-        if (features2.natives && options.natives) {
+        if (features.natives && options.natives) {
           setNatives(false);
         }
       };
@@ -2024,7 +2024,7 @@
   // src/features.js
   init_define_import_meta_trackerLookup();
   var baseFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "fingerprintingAudio",
       "fingerprintingBattery",
@@ -2042,7 +2042,7 @@
     ]
   );
   var otherFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "clickToLoad",
       "cookie",
@@ -2079,7 +2079,7 @@
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
+    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -2107,6 +2107,7 @@
       "webCompat",
       "pageContext",
       "duckAiDataClearing",
+      "performanceMetrics",
       "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
@@ -5110,9 +5111,25 @@
   _args = new WeakMap();
 
   // src/content-feature.js
-  var _messaging, _isDebugFlagSet, _importConfig;
+  var CallFeatureMethodError = class extends Error {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+      super(message);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = new.target.name;
+    }
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features;
   var ContentFeature = class extends ConfigFeature {
-    constructor(featureName, importConfig, args) {
+    /**
+     * @param {string} featureName
+     * @param {*} importConfig
+     * @param {Partial<FeatureMap>} features
+     * @param {*} args
+     */
+    constructor(featureName, importConfig, features, args) {
       super(featureName, args);
       /** @type {import('./utils.js').RemoteConfig | undefined} */
       /** @type {import('../../messaging').Messaging} */
@@ -5137,8 +5154,25 @@
       __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
+      /**
+       * @type {Partial<FeatureMap>}
+       */
+      __privateAdd(this, _features);
+      /**
+       * @template {string} K
+       * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
+       */
+      /**
+       * Methods that are exposed for inter-feature communication.
+       *
+       * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
+       *
+       * @type {ExposeMethods<any> | undefined}
+       */
+      __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
       this.monitor = new PerformanceMonitor();
+      __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
     }
     get isDebug() {
@@ -5216,6 +5250,48 @@
      */
     get documentOriginIsTracker() {
       return isTrackerOrigin(this.trackerLookup);
+    }
+    /**
+     * Declares which methods may be called on the feature instance from other features.
+     *
+     * @template {keyof typeof this} K
+     * @param {K[]} methods
+     * @returns {ExposeMethods<K>}
+     */
+    _declareExposedMethods(methods) {
+      for (const method of methods) {
+        if (typeof this[method] !== "function") {
+          throw new Error(`'${method.toString()}' is not a method of feature '${this.name}'`);
+        }
+      }
+      return methods;
+    }
+    /**
+     * Run an exposed method of another feature.
+     *
+     * `args` are the arguments to pass to the feature method.
+     *
+     * @template {keyof FeatureMap} FeatureName
+     * @template {FeatureMap[FeatureName]} Feature
+     * @template {keyof Feature & (Feature['_exposedMethods'] extends ExposeMethods<infer K> ? K : never)} MethodName
+     * @param {FeatureName} featureName
+     * @param {MethodName} methodName
+     * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
+     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     */
+    callFeatureMethod(featureName, methodName, ...args) {
+      const feature = __privateGet(this, _features)[featureName];
+      if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
+      if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
+        return new CallFeatureMethodError(`'${methodName}' is not exposed by feature '${featureName}'`);
+      const method = (
+        /** @type {Feature} */
+        feature[methodName]
+      );
+      if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
+      if (!(method instanceof Function))
+        return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      return method.call(feature, ...args);
     }
     /**
      * @deprecated as we should make this internal to the class and not used externally
@@ -5415,6 +5491,7 @@
   _messaging = new WeakMap();
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
+  _features = new WeakMap();
 
   // src/features/broker-protection/execute.js
   init_define_import_meta_trackerLookup();
@@ -9051,7 +9128,7 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
+    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
       const navigations = /* @__PURE__ */ new WeakMap();
       globalThis.navigation.addEventListener("navigate", (event) => {
@@ -9091,7 +9168,7 @@
   // src/content-scope-features.js
   var initArgs = null;
   var updates = [];
-  var features = [];
+  var _features2 = {};
   var alwaysInitFeatures = /* @__PURE__ */ new Set(["cookie"]);
   var performanceMonitor = new PerformanceMonitor();
   var isHTMLDocument = document instanceof HTMLDocument || document instanceof XMLDocument && document.createElement("div") instanceof HTMLDivElement;
@@ -9109,15 +9186,19 @@
     for (const featureName of bundledFeatureNames) {
       if (featuresToLoad.includes(featureName)) {
         const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-        const featureInstance = new ContentFeature2(featureName, importConfig, args);
+        const featureInstance = new ContentFeature2(featureName, importConfig, _features2, args);
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           continue;
         }
         featureInstance.callLoad();
-        features.push({ featureName, featureInstance });
+        _features2[featureName] = featureInstance;
       }
     }
     mark.end();
+  }
+  async function getFeatures() {
+    await Promise.all(Object.entries(_features2));
+    return _features2;
   }
   async function init(args) {
     const mark = performanceMonitor.mark("init");
@@ -9127,17 +9208,20 @@
     }
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           return;
         }
         featureInstance.callInit(args);
-        if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
+        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
           registerForURLChanges((navigationType) => {
             featureInstance.recomputeSiteObject();
-            featureInstance?.urlChanged(navigationType);
+            if (hasUrlChangedMethod) {
+              featureInstance.urlChanged(navigationType);
+            }
           });
         }
       }
@@ -9155,8 +9239,8 @@
     return args.platform.name === "extension" && alwaysInitFeatures.has(featureName);
   }
   async function updateFeaturesInner(args) {
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance]) => {
       if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1353,11 +1353,20 @@
       createCustomEvent("sendMessageProxy" + messageSecret, { detail: JSON.stringify({ messageType, options }) })
     );
   }
+  function isDuckAi() {
+    const tabUrl = getTabUrl();
+    const domains = ["duckduckgo.com", "duck.ai", "duck.co"];
+    if (tabUrl?.hostname && domains.some((domain) => matchHostname(tabUrl?.hostname, domain))) {
+      const url = new URL(tabUrl?.href);
+      return url.searchParams.has("duckai") || url.searchParams.get("ia") === "chat";
+    }
+    return false;
+  }
 
   // src/features.js
   init_define_import_meta_trackerLookup();
   var baseFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "fingerprintingAudio",
       "fingerprintingBattery",
@@ -1375,7 +1384,7 @@
     ]
   );
   var otherFeatures = (
-    /** @type {const} */
+    /** @type {FeatureName[]} */
     [
       "clickToLoad",
       "cookie",
@@ -1412,7 +1421,7 @@
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge"],
+    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -1440,6 +1449,7 @@
       "webCompat",
       "pageContext",
       "duckAiDataClearing",
+      "performanceMetrics",
       "duckAiChatHistory"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
@@ -4972,9 +4982,25 @@
   _args = new WeakMap();
 
   // src/content-feature.js
-  var _messaging, _isDebugFlagSet, _importConfig;
+  var CallFeatureMethodError = class extends Error {
+    /**
+     * @param {string} message
+     */
+    constructor(message) {
+      super(message);
+      Object.setPrototypeOf(this, new.target.prototype);
+      this.name = new.target.name;
+    }
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features;
   var ContentFeature = class extends ConfigFeature {
-    constructor(featureName, importConfig, args) {
+    /**
+     * @param {string} featureName
+     * @param {*} importConfig
+     * @param {Partial<FeatureMap>} features
+     * @param {*} args
+     */
+    constructor(featureName, importConfig, features, args) {
       super(featureName, args);
       /** @type {import('./utils.js').RemoteConfig | undefined} */
       /** @type {import('../../messaging').Messaging} */
@@ -4999,8 +5025,25 @@
       __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
+      /**
+       * @type {Partial<FeatureMap>}
+       */
+      __privateAdd(this, _features);
+      /**
+       * @template {string} K
+       * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
+       */
+      /**
+       * Methods that are exposed for inter-feature communication.
+       *
+       * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
+       *
+       * @type {ExposeMethods<any> | undefined}
+       */
+      __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
       this.monitor = new PerformanceMonitor();
+      __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
     }
     get isDebug() {
@@ -5078,6 +5121,48 @@
      */
     get documentOriginIsTracker() {
       return isTrackerOrigin(this.trackerLookup);
+    }
+    /**
+     * Declares which methods may be called on the feature instance from other features.
+     *
+     * @template {keyof typeof this} K
+     * @param {K[]} methods
+     * @returns {ExposeMethods<K>}
+     */
+    _declareExposedMethods(methods) {
+      for (const method of methods) {
+        if (typeof this[method] !== "function") {
+          throw new Error(`'${method.toString()}' is not a method of feature '${this.name}'`);
+        }
+      }
+      return methods;
+    }
+    /**
+     * Run an exposed method of another feature.
+     *
+     * `args` are the arguments to pass to the feature method.
+     *
+     * @template {keyof FeatureMap} FeatureName
+     * @template {FeatureMap[FeatureName]} Feature
+     * @template {keyof Feature & (Feature['_exposedMethods'] extends ExposeMethods<infer K> ? K : never)} MethodName
+     * @param {FeatureName} featureName
+     * @param {MethodName} methodName
+     * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
+     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     */
+    callFeatureMethod(featureName, methodName, ...args) {
+      const feature = __privateGet(this, _features)[featureName];
+      if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
+      if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
+        return new CallFeatureMethodError(`'${methodName}' is not exposed by feature '${featureName}'`);
+      const method = (
+        /** @type {Feature} */
+        feature[methodName]
+      );
+      if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
+      if (!(method instanceof Function))
+        return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      return method.call(feature, ...args);
     }
     /**
      * @deprecated as we should make this internal to the class and not used externally
@@ -5277,6 +5362,7 @@
   _messaging = new WeakMap();
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
+  _features = new WeakMap();
 
   // src/features/fingerprinting-audio.js
   var FingerprintingAudio = class extends ContentFeature {
@@ -10282,6 +10368,567 @@
   };
   var message_bridge_default = MessageBridge;
 
+  // src/features/page-context.js
+  init_define_import_meta_trackerLookup();
+
+  // src/features/favicon.js
+  init_define_import_meta_trackerLookup();
+  function getFaviconList() {
+    const selectors = [
+      "link[href][rel='favicon']",
+      "link[href][rel*='icon']",
+      "link[href][rel='apple-touch-icon']",
+      "link[href][rel='apple-touch-icon-precomposed']"
+    ];
+    const elements = document.head.querySelectorAll(selectors.join(","));
+    return Array.from(elements).map((link) => {
+      const href = link.href || "";
+      const rel = link.getAttribute("rel") || "";
+      return { href, rel };
+    });
+  }
+
+  // src/features/page-context.js
+  var MSG_PAGE_CONTEXT_RESPONSE = "collectionResult";
+  function checkNodeIsVisible(node) {
+    try {
+      const style = window.getComputedStyle(node);
+      if (style.display === "none" || style.visibility === "hidden" || parseFloat(style.opacity) === 0) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+  function collapseWhitespace(str) {
+    return typeof str === "string" ? str.replace(/\s+/g, " ") : "";
+  }
+  function isHtmlElement(node) {
+    return node.nodeType === Node.ELEMENT_NODE;
+  }
+  function getSameOriginIframeDocument(iframe) {
+    const src = iframe.src;
+    if (iframe.hasAttribute("sandbox") && !iframe.sandbox.contains("allow-scripts")) {
+      return null;
+    }
+    if (src && src !== "about:blank" && src !== "") {
+      try {
+        const iframeUrl = new URL(src, window.location.href);
+        if (iframeUrl.origin !== window.location.origin) {
+          return null;
+        }
+      } catch (e) {
+        return null;
+      }
+    }
+    try {
+      const doc = iframe.contentDocument;
+      if (doc && doc.documentElement) {
+        return doc;
+      }
+    } catch (e) {
+      return null;
+    }
+    return null;
+  }
+  function domToMarkdownChildren(childNodes, settings, depth = 0) {
+    if (depth > settings.maxDepth) {
+      return "";
+    }
+    let children = "";
+    for (const childNode of childNodes) {
+      const childContent = domToMarkdown(childNode, settings, depth + 1);
+      children += childContent;
+      if (children.length > settings.maxLength) {
+        children = children.substring(0, settings.maxLength) + "...";
+        break;
+      }
+    }
+    return children;
+  }
+  function domToMarkdown(node, settings, depth = 0) {
+    if (depth > settings.maxDepth) {
+      return "";
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      return collapseWhitespace(node.textContent);
+    }
+    if (!isHtmlElement(node)) {
+      return "";
+    }
+    if (!checkNodeIsVisible(node) || settings.excludeSelectors && node.matches(settings.excludeSelectors)) {
+      return "";
+    }
+    const tag = node.tagName.toLowerCase();
+    let children = domToMarkdownChildren(node.childNodes, settings, depth + 1);
+    if (node.shadowRoot) {
+      children += domToMarkdownChildren(node.shadowRoot.childNodes, settings, depth + 1);
+    }
+    switch (tag) {
+      case "strong":
+      case "b":
+        return `**${children}**`;
+      case "em":
+      case "i":
+        return `*${children}*`;
+      case "h1":
+        return `
+# ${children}
+`;
+      case "h2":
+        return `
+## ${children}
+`;
+      case "h3":
+        return `
+### ${children}
+`;
+      case "p":
+        return `${children}
+`;
+      case "br":
+        return `
+`;
+      case "img":
+        return `
+![${getAttributeOrBlank(node, "alt")}](${getAttributeOrBlank(node, "src")})
+`;
+      case "ul":
+      case "ol":
+        return `
+${children}
+`;
+      case "li":
+        return `
+- ${collapseAndTrim(children)}
+`;
+      case "a":
+        return getLinkText(node, children, settings);
+      case "iframe": {
+        if (!settings.includeIframes) {
+          return children;
+        }
+        const iframeDoc = getSameOriginIframeDocument(
+          /** @type {HTMLIFrameElement} */
+          node
+        );
+        if (iframeDoc && iframeDoc.body) {
+          const iframeContent = domToMarkdown(iframeDoc.body, settings, depth + 1);
+          return iframeContent ? `
+
+--- Iframe Content ---
+${iframeContent}
+--- End Iframe ---
+
+` : children;
+        }
+        return children;
+      }
+      default:
+        return children;
+    }
+  }
+  function getAttributeOrBlank(node, attr) {
+    const attrValue = node.getAttribute(attr) ?? "";
+    return attrValue.trim();
+  }
+  function collapseAndTrim(str) {
+    return collapseWhitespace(str).trim();
+  }
+  function getLinkText(node, children, settings) {
+    const href = node.getAttribute("href");
+    const trimmedContent = collapseAndTrim(children);
+    if (settings.trimBlankLinks && trimmedContent.length === 0) {
+      return "";
+    }
+    return href ? `[${trimmedContent}](${href})` : collapseWhitespace(children);
+  }
+  var _cachedContent, _cachedTimestamp, _delayedRecheckTimer, _activeCapture;
+  var PageContext = class extends ContentFeature {
+    constructor() {
+      super(...arguments);
+      /** @type {any} */
+      __privateAdd(this, _cachedContent);
+      __privateAdd(this, _cachedTimestamp, 0);
+      /** @type {MutationObserver | null} */
+      __publicField(this, "mutationObserver", null);
+      __publicField(this, "lastSentContent", null);
+      /** @type {ReturnType<typeof setTimeout> | null} */
+      __privateAdd(this, _delayedRecheckTimer, null);
+      __publicField(this, "recheckCount", 0);
+      __publicField(this, "recheckLimit", 0);
+      /** @type {boolean} */
+      __privateAdd(this, _activeCapture, true);
+    }
+    get shouldListenForUrlChanges() {
+      return __privateGet(this, _activeCapture) && this.getFeatureSettingEnabled("subscribeToUrlChange", "enabled");
+    }
+    get shouldActivate() {
+      if (isBeingFramed() || isDuckAi()) {
+        return false;
+      }
+      const tabUrl = getTabUrl();
+      if (tabUrl?.protocol === "duck:") {
+        return false;
+      }
+      return true;
+    }
+    init() {
+      this.recheckLimit = this.getFeatureSetting("recheckLimit") || 5;
+      if (!this.shouldActivate) {
+        return;
+      }
+      __privateSet(this, _activeCapture, !this.getFeatureSettingEnabled("activeCaptureOnFirstMessage", "disabled"));
+      this.setupListeners();
+    }
+    resetRecheckCount() {
+      this.recheckCount = 0;
+    }
+    /**
+     * Sets up all listeners. When activeCaptureOnFirstMessage is enabled,
+     * active capture listeners are deferred until the first collect message.
+     */
+    setupListeners() {
+      if (this.getFeatureSettingEnabled("subscribeToCollect", "enabled")) {
+        this.messaging.subscribe("collect", () => {
+          this.invalidateCache();
+          this.handleContentCollectionRequest();
+          if (!__privateGet(this, _activeCapture)) {
+            __privateSet(this, _activeCapture, true);
+            this.log.info("First native message received, activating capture");
+            this.setupActiveCaptureListeners();
+          }
+        });
+      }
+      if (__privateGet(this, _activeCapture)) {
+        this.setupActiveCaptureListeners();
+      } else {
+        this.log.info("Active capture gated behind first native message");
+      }
+    }
+    /**
+     * Sets up listeners that actively capture page content.
+     * These are the listeners that can be gated behind the first native message.
+     */
+    setupActiveCaptureListeners() {
+      this.log.info("Setting up active capture listeners");
+      this.observeContentChanges();
+      if (this.getFeatureSettingEnabled("subscribeToLoad", "enabled")) {
+        window.addEventListener("load", () => {
+          this.handleContentCollectionRequest();
+        });
+      }
+      if (this.getFeatureSettingEnabled("subscribeToHashChange", "enabled")) {
+        window.addEventListener("hashchange", () => {
+          this.handleContentCollectionRequest();
+        });
+      }
+      if (this.getFeatureSettingEnabled("subscribeToPageShow", "enabled")) {
+        window.addEventListener("pageshow", () => {
+          this.handleContentCollectionRequest();
+        });
+      }
+      if (this.getFeatureSettingEnabled("subscribeToVisibilityChange", "enabled")) {
+        window.addEventListener("visibilitychange", () => {
+          if (document.visibilityState === "hidden") {
+            return;
+          }
+          this.handleContentCollectionRequest();
+        });
+      }
+      if (this.getFeatureSettingEnabled("collectOnInit", "enabled")) {
+        if (document.body) {
+          this.setup();
+        } else {
+          window.addEventListener(
+            "DOMContentLoaded",
+            () => {
+              this.setup();
+            },
+            { once: true }
+          );
+        }
+      }
+    }
+    /**
+     * @param {NavigationType} _navigationType
+     */
+    urlChanged(_navigationType) {
+      if (!this.shouldListenForUrlChanges || !this.shouldActivate) {
+        return;
+      }
+      this.handleContentCollectionRequest();
+    }
+    setup() {
+      this.handleContentCollectionRequest();
+      this.startObserving();
+    }
+    get cachedContent() {
+      if (!__privateGet(this, _cachedContent) || this.isCacheExpired()) {
+        if (__privateGet(this, _cachedContent)) {
+          this.invalidateCache();
+        }
+        return void 0;
+      }
+      return __privateGet(this, _cachedContent);
+    }
+    invalidateCache() {
+      this.log.info("Invalidating cache");
+      __privateSet(this, _cachedContent, void 0);
+      __privateSet(this, _cachedTimestamp, 0);
+      this.stopObserving();
+    }
+    /**
+     * Clear all pending timers
+     */
+    clearTimers() {
+      if (__privateGet(this, _delayedRecheckTimer)) {
+        clearTimeout(__privateGet(this, _delayedRecheckTimer));
+        __privateSet(this, _delayedRecheckTimer, null);
+      }
+    }
+    set cachedContent(content) {
+      if (content === void 0) {
+        this.invalidateCache();
+        return;
+      }
+      __privateSet(
+        this,
+        _cachedContent,
+        /** @type {any} */
+        content
+      );
+      __privateSet(this, _cachedTimestamp, Date.now());
+      this.startObserving();
+    }
+    isCacheExpired() {
+      const cacheExpiration = this.getFeatureSetting("cacheExpiration") || 3e4;
+      return Date.now() - __privateGet(this, _cachedTimestamp) > cacheExpiration;
+    }
+    observeContentChanges() {
+      if (window.MutationObserver && this.getFeatureSettingEnabled("observeMutations", "enabled")) {
+        this.mutationObserver = new MutationObserver((_mutations) => {
+          this.log.info("MutationObserver", _mutations);
+          this.cachedContent = void 0;
+          this.scheduleDelayedRecheck();
+        });
+        this.startObserving();
+      }
+    }
+    /**
+     * Schedule a delayed recheck after navigation events
+     */
+    scheduleDelayedRecheck() {
+      this.clearTimers();
+      if (this.recheckLimit > 0 && this.recheckCount >= this.recheckLimit) {
+        return;
+      }
+      const delayMs = this.getFeatureSetting("navigationRecheckDelayMs") || 1500;
+      this.log.info("Scheduling delayed recheck", { delayMs });
+      __privateSet(this, _delayedRecheckTimer, setTimeout(() => {
+        this.log.info("Performing delayed recheck after navigation");
+        this.recheckCount++;
+        this.invalidateCache();
+        this.handleContentCollectionRequest(false);
+      }, delayMs));
+    }
+    startObserving() {
+      this.log.info("Starting observing", this.mutationObserver, __privateGet(this, _cachedContent));
+      if (this.mutationObserver && __privateGet(this, _cachedContent) && !this.isObserving && document.body) {
+        this.isObserving = true;
+        this.mutationObserver.observe(document.body, {
+          childList: true,
+          subtree: true,
+          characterData: true
+        });
+      }
+    }
+    stopObserving() {
+      if (this.mutationObserver) {
+        this.mutationObserver.disconnect();
+        this.isObserving = false;
+      }
+    }
+    handleContentCollectionRequest(resetRecheckCount = true) {
+      this.log.info("Handling content collection request");
+      if (resetRecheckCount) {
+        this.resetRecheckCount();
+      }
+      try {
+        const content = this.collectPageContent();
+        this.sendContentResponse(content);
+      } catch (error) {
+        this.sendErrorResponse(error);
+      }
+    }
+    collectPageContent() {
+      if (this.cachedContent) {
+        this.log.info("Returning cached content", this.cachedContent);
+        return this.cachedContent;
+      }
+      const mainContent = this.getMainContent();
+      const truncated = mainContent.endsWith("...");
+      const content = {
+        favicon: getFaviconList(),
+        title: this.getPageTitle(),
+        content: mainContent,
+        truncated,
+        fullContentLength: this.fullContentLength,
+        // Include full content length before truncation
+        timestamp: Date.now(),
+        url: window.location.href
+      };
+      if (this.getFeatureSettingEnabled("includeMetaDescription", "disabled")) {
+        content.metaDescription = this.getMetaDescription();
+      }
+      if (this.getFeatureSettingEnabled("includeHeadings", "disabled")) {
+        content.headings = this.getHeadings();
+      }
+      if (this.getFeatureSettingEnabled("includeLinks", "disabled")) {
+        content.links = this.getLinks();
+      }
+      if (this.getFeatureSettingEnabled("includeImages", "disabled")) {
+        content.images = this.getImages();
+      }
+      if (content.content.length > 0) {
+        this.cachedContent = content;
+      }
+      return content;
+    }
+    getPageTitle() {
+      const title = document.title || "";
+      const maxTitleLength = this.getFeatureSetting("maxTitleLength") || 100;
+      if (title.length > maxTitleLength) {
+        return title.substring(0, maxTitleLength).trim() + "...";
+      }
+      return title;
+    }
+    getMetaDescription() {
+      const metaDesc = document.querySelector('meta[name="description"]');
+      return metaDesc ? metaDesc.getAttribute("content") || "" : "";
+    }
+    getMainContent() {
+      const maxLength = this.getFeatureSetting("maxContentLength") || 9500;
+      const upperLimit = this.getFeatureSetting("upperLimit") || 5e5;
+      const maxDepth = this.getFeatureSetting("maxDepth") || 5e3;
+      let excludeSelectors = this.getFeatureSetting("excludeSelectors") || [".ad", ".sidebar", ".footer", ".nav", ".header"];
+      const excludedInertElements = this.getFeatureSetting("excludedInertElements") || [
+        "img",
+        // Note we're currently disabling images which we're handling in domToMarkdown (this can be per-site enabled in the config if needed).
+        "script",
+        "style",
+        "link",
+        "meta",
+        "noscript",
+        "svg",
+        "canvas"
+      ];
+      excludeSelectors = excludeSelectors.concat(excludedInertElements);
+      const excludeSelectorsString = excludeSelectors.join(",");
+      let content = "";
+      const mainContentSelector = this.getFeatureSetting("mainContentSelector") || "main, article, .content, .main, #content, #main";
+      let mainContent = document.querySelector(mainContentSelector);
+      const mainContentLength = this.getFeatureSetting("mainContentLength") || 100;
+      if (mainContent && mainContent.innerHTML.trim().length <= mainContentLength) {
+        mainContent = null;
+      }
+      let contentRoot = mainContent || document.body;
+      const extractContent = (root) => {
+        this.log.info("Getting content", root);
+        const result = domToMarkdown(root, {
+          maxLength: upperLimit,
+          maxDepth,
+          includeIframes: this.getFeatureSettingEnabled("includeIframes", "enabled"),
+          excludeSelectors: excludeSelectorsString,
+          trimBlankLinks: this.getFeatureSettingEnabled("trimBlankLinks", "enabled")
+        }).trim();
+        this.log.info("Content markdown", result, root);
+        return result;
+      };
+      if (contentRoot) {
+        content += extractContent(contentRoot);
+      }
+      if (content.length === 0 && contentRoot !== document.body && this.getFeatureSettingEnabled("bodyFallback", "enabled")) {
+        contentRoot = document.body;
+        content += extractContent(contentRoot);
+      }
+      this.fullContentLength = content.length;
+      if (content.length > maxLength) {
+        this.log.info("Truncating content", {
+          content,
+          contentLength: content.length,
+          maxLength
+        });
+        content = content.substring(0, maxLength) + "...";
+      }
+      return content;
+    }
+    getHeadings() {
+      const headings = [];
+      const headingSelector = this.getFeatureSetting("headingSelector") || "h1, h2, h3, h4, h5, h6";
+      const headingElements = document.querySelectorAll(headingSelector);
+      headingElements.forEach((heading) => {
+        const level = parseInt(heading.tagName.charAt(1));
+        const text2 = heading.textContent?.trim();
+        if (text2) {
+          headings.push({ level, text: text2 });
+        }
+      });
+      return headings;
+    }
+    getLinks() {
+      const links = [];
+      const linkSelector = this.getFeatureSetting("linkSelector") || "a[href]";
+      const linkElements = document.querySelectorAll(linkSelector);
+      linkElements.forEach((link) => {
+        const text2 = link.textContent?.trim();
+        const href = link.getAttribute("href");
+        if (text2 && href && text2.length > 0) {
+          links.push({ text: text2, href });
+        }
+      });
+      return links;
+    }
+    getImages() {
+      const images = [];
+      const imgSelector = this.getFeatureSetting("imgSelector") || "img";
+      const imgElements = document.querySelectorAll(imgSelector);
+      imgElements.forEach((img) => {
+        const alt = img.getAttribute("alt") || "";
+        const src = img.getAttribute("src") || "";
+        if (src) {
+          images.push({ alt, src });
+        }
+      });
+      return images;
+    }
+    sendContentResponse(content) {
+      if (this.lastSentContent && this.lastSentContent === content) {
+        this.log.info("Content already sent");
+        return;
+      }
+      this.lastSentContent = content;
+      this.log.info("Sending content response", content);
+      this.messaging.notify(MSG_PAGE_CONTEXT_RESPONSE, {
+        // TODO: This is a hack to get the data to the browser. We should probably not be paying this cost.
+        serializedPageData: JSON.stringify(content)
+      });
+    }
+    sendErrorResponse(error) {
+      this.log.error("Error sending content response", error);
+      this.messaging.notify(MSG_PAGE_CONTEXT_RESPONSE, {
+        success: false,
+        error: error.message || "Unknown error occurred",
+        timestamp: Date.now()
+      });
+    }
+  };
+  _cachedContent = new WeakMap();
+  _cachedTimestamp = new WeakMap();
+  _delayedRecheckTimer = new WeakMap();
+  _activeCapture = new WeakMap();
+
   // ddg:platformFeatures:ddg:platformFeatures
   var ddg_platformFeatures_default = {
     ddg_feature_fingerprintingAudio: FingerprintingAudio,
@@ -10301,7 +10948,8 @@
     ddg_feature_webInterferenceDetection: WebInterferenceDetection,
     ddg_feature_breakageReporting: BreakageReporting,
     ddg_feature_duckPlayer: DuckPlayerFeature,
-    ddg_feature_messageBridge: message_bridge_default
+    ddg_feature_messageBridge: message_bridge_default,
+    ddg_feature_pageContext: PageContext
   };
 
   // src/url-change.js
@@ -10319,7 +10967,7 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
+    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
       const navigations = /* @__PURE__ */ new WeakMap();
       globalThis.navigation.addEventListener("navigate", (event) => {
@@ -10359,7 +11007,7 @@
   // src/content-scope-features.js
   var initArgs = null;
   var updates = [];
-  var features = [];
+  var _features2 = {};
   var alwaysInitFeatures = /* @__PURE__ */ new Set(["cookie"]);
   var performanceMonitor = new PerformanceMonitor();
   var isHTMLDocument = document instanceof HTMLDocument || document instanceof XMLDocument && document.createElement("div") instanceof HTMLDivElement;
@@ -10377,15 +11025,19 @@
     for (const featureName of bundledFeatureNames) {
       if (featuresToLoad.includes(featureName)) {
         const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-        const featureInstance2 = new ContentFeature2(featureName, importConfig, args);
+        const featureInstance2 = new ContentFeature2(featureName, importConfig, _features2, args);
         if (!featureInstance2.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           continue;
         }
         featureInstance2.callLoad();
-        features.push({ featureName, featureInstance: featureInstance2 });
+        _features2[featureName] = featureInstance2;
       }
     }
     mark.end();
+  }
+  async function getFeatures() {
+    await Promise.all(Object.entries(_features2));
+    return _features2;
   }
   async function init(args) {
     const mark = performanceMonitor.mark("init");
@@ -10395,17 +11047,20 @@
     }
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance: featureInstance2, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance2]) => {
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         if (!featureInstance2.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           return;
         }
         featureInstance2.callInit(args);
-        if (featureInstance2.listenForUrlChanges || featureInstance2.urlChanged) {
+        const hasUrlChangedMethod = "urlChanged" in featureInstance2 && typeof featureInstance2.urlChanged === "function";
+        if (featureInstance2.listenForUrlChanges || hasUrlChangedMethod) {
           registerForURLChanges((navigationType) => {
             featureInstance2.recomputeSiteObject();
-            featureInstance2?.urlChanged(navigationType);
+            if (hasUrlChangedMethod) {
+              featureInstance2.urlChanged(navigationType);
+            }
           });
         }
       }
@@ -10423,8 +11078,8 @@
     return args.platform.name === "extension" && alwaysInitFeatures.has(featureName);
   }
   async function updateFeaturesInner(args) {
-    const resolvedFeatures = await Promise.all(features);
-    resolvedFeatures.forEach(({ featureInstance: featureInstance2, featureName }) => {
+    const features = await getFeatures();
+    Object.entries(features).forEach(([featureName, featureInstance2]) => {
       if (!isFeatureBroken(initArgs, featureName) && featureInstance2.listenForUpdateChanges) {
         featureInstance2.update(args);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.31.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.36.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#647406e99129be6828fb4e2db0fe47d22e8065e9",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3a6321e5a884e37dfc40dc368b84324c237c5094",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
-      "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.5.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.31.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.36.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1212949016898816/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency to `@duckduckgo/content-scope-scripts#12.36.0` and integrates new runtime features/refactors.
> 
> - **Enable `pageContext` on Android**: adds DOM-to-markdown page content capture with favicon collection, mutation/URL/hash/page visibility listeners, caching, and safeguards (e.g., Duck AI and framing checks)
> - **Add `performanceMetrics` to android-adsjs bundle**
> - **Refactor feature system**: `ContentFeature` now accepts a features map for inter-feature method calls (`callFeatureMethod`) with explicit exposed-method declarations; features are stored/accessed via a shared map instead of an array
> - **Improve URL change handling**: safer `urlChanged` detection, updated constructor usages, and centralized registration; supports config updates for Android builds
> - **Minor build/type tweaks**: JSDoc type annotations, internal variable renames (e.g., XRegExp `features`), and helper `isDuckAi` to gate collection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c819642a170ecc2e6e0b31bbd632bc22c13ec64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->