### PR TITLE
Use adaptive icons for app shortcuts

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -123,7 +123,7 @@ class AppShortcutCreator @Inject constructor(
     private fun buildNewTabShortcut(context: Context): ShortcutInfo {
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_NEW_TAB)
             .setShortLabel(context.getString(R.string.newTabMenuItem))
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_new_tab))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_new_tab_adaptive))
             .setIntent(
                 Intent(context, BrowserActivity::class.java).also {
                     it.action = Intent.ACTION_VIEW
@@ -136,7 +136,7 @@ class AppShortcutCreator @Inject constructor(
     private fun buildClearDataShortcut(context: Context): ShortcutInfo {
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_CLEAR_DATA)
             .setShortLabel(context.getString(R.string.fireMenu))
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_fire))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_fire_adaptive))
             .setIntent(
                 Intent(context, BrowserActivity::class.java).also {
                     it.action = Intent.ACTION_VIEW
@@ -159,7 +159,7 @@ class AppShortcutCreator @Inject constructor(
 
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_SHOW_BOOKMARKS)
             .setShortLabel(context.getString(com.duckduckgo.saved.sites.impl.R.string.bookmarksActivityTitle))
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_bookmarks))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_bookmarks_adaptive))
             .setIntents(stackBuilder.intents)
             .build().toShortcutInfo()
     }
@@ -171,7 +171,7 @@ class AppShortcutCreator @Inject constructor(
 
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_DUCK_AI)
             .setShortLabel(context.getString(com.duckduckgo.duckchat.impl.R.string.duck_chat_title))
-            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_duck_ai))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_duck_ai_adaptive))
             .setIntents(stackBuilder.intents)
             .build().toShortcutInfo()
     }

--- a/app/src/main/res/drawable-anydpi/ic_app_shortcut_bookmarks_adaptive.xml
+++ b/app/src/main/res/drawable-anydpi/ic_app_shortcut_bookmarks_adaptive.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/white"/>
+    <foreground android:drawable="@drawable/ic_app_shortcut_bookmarks"/>
+</adaptive-icon>

--- a/app/src/main/res/drawable-anydpi/ic_app_shortcut_duck_ai_adaptive.xml
+++ b/app/src/main/res/drawable-anydpi/ic_app_shortcut_duck_ai_adaptive.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/white"/>
+    <foreground android:drawable="@drawable/ic_app_shortcut_duck_ai"/>
+</adaptive-icon>

--- a/app/src/main/res/drawable-anydpi/ic_app_shortcut_fire_adaptive.xml
+++ b/app/src/main/res/drawable-anydpi/ic_app_shortcut_fire_adaptive.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/white"/>
+    <foreground android:drawable="@drawable/ic_app_shortcut_fire"/>
+</adaptive-icon>

--- a/app/src/main/res/drawable-anydpi/ic_app_shortcut_new_tab_adaptive.xml
+++ b/app/src/main/res/drawable-anydpi/ic_app_shortcut_new_tab_adaptive.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/white"/>
+    <foreground android:drawable="@drawable/ic_app_shortcut_new_tab"/>
+</adaptive-icon>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212975986536996?focus=true

### Description

- Uses adaptive icons so that app shortcuts are the correct size.

### Steps to test this PR

- [ ] Fresh install (Issue visible on Pixel, API 36)
- [ ] Long press the the app icon
- [ ] Verify that the app shortcut icons are the correct size

### UI changes
<img width="2364" height="1463" alt="combined" src="https://github.com/user-attachments/assets/0fbf720d-aced-4dee-9614-e655287a82ae" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates app shortcuts to use adaptive icons for consistent appearance across launchers.
> 
> - In `AppShortcutCreator`, replace icon references for `new tab`, `clear data`, `bookmarks`, and `Duck AI` shortcuts with their `*_adaptive` drawables
> - Add four adaptive icon resources in `res/drawable-anydpi` that set a white background and use existing foreground assets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af9fed762a6335d083ecf5f5ed08d63bc951688b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->