### PR TITLE
Remove mattermost integration from release_tests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -65,16 +65,6 @@ jobs:
         if: always()
         run: find . -name "*.apk"  -exec mv '{}' apk/release.apk \;
 
-      - name: Notify Mattermost of Maestro tests
-        id: send-mm-tests-started
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
-          mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
-          mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: ${{env.emoji_info}} Release ${{ github.event.inputs.app-version }}. Running Maestro tests for tag ${{ github.event.inputs.test-tag }} https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
-          action: 'send-mattermost-message'
-
       - name: Maestro tests flows
         id: release-tests
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
@@ -106,47 +96,6 @@ jobs:
           echo "Release Tests Step Conclusion: ${{ steps.release-tests.conclusion }}" # From Maestro action itself
           echo "Analyzed Flow Summary Status: ${{ steps.analyze-flow-results.outputs.flow_summary_status }}" # From analyzer action
           printf "Analyzed Flow Summary Message:\n%s\n" "${{ steps.analyze-flow-results.outputs.flow_summary_message }}"
-
-      - name: Notify Mattermost - Maestro Tests ALL SUCCEEDED
-        # Condition 1: Our script says success
-        # Condition 2: The Maestro action itself also reported overall success
-        if: always() && steps.analyze-flow-results.outputs.flow_summary_status == 'success' && steps.release-tests.conclusion == 'success'
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          action: 'send-mattermost-message'
-          mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
-          mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
-          mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: |
-            ${{env.emoji_success}} Release ${{ github.event.inputs.app-version }}: Tests for tag ${{ github.event.inputs.test-tag }} PASSED successfully.
-            Console: ${{ steps.release-tests.outputs.MAESTRO_CLOUD_CONSOLE_URL }}
-
-      - name: Notify Mattermost - Maestro Tests FAILURES or ISSUES DETECTED
-        # Condition: Our script detected 'failure' OR the Maestro action itself reported failure
-        if: always() && (steps.analyze-flow-results.outputs.flow_summary_status == 'failure' || steps.release-tests.conclusion == 'failure')
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          action: 'send-mattermost-message'
-          mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
-          mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
-          mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: |
-            ${{env.emoji_failure}} Release ${{ github.event.inputs.app-version }}: Tests for tag ${{ github.event.inputs.test-tag }} FAILED or encountered issues.          
-            Console: ${{ steps.release-tests.outputs.MAESTRO_CLOUD_CONSOLE_URL }}
-
-      - name: Notify Mattermost - Maestro Tests CANCELED Flows Present (Informational or Warning)
-        # Condition: Our script detected 'canceled_present' AND no critical 'failure' was found
-        # AND Maestro action itself didn't mark the whole run as a 'failure'
-        if: always() && steps.analyze-flow-results.outputs.flow_summary_status == 'canceled_present' && steps.release-tests.conclusion != 'failure'
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          action: 'send-mattermost-message'
-          mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
-          mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
-          mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: |
-            :warning: Release ${{ github.event.inputs.app-version }}: Some tests for tag ${{ github.event.inputs.test-tag }} were CANCELED. Please review.          
-            Console: ${{ steps.release-tests.outputs.MAESTRO_CLOUD_CONSOLE_URL }}
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1212975179537573?focus=true 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Mattermost notification steps from the release E2E Maestro workflow while retaining build, test, result analysis, and Asana failure task creation.
> 
> - Deleted Mattermost message on test start and post-run notifications for success, failure, and canceled flows in `release_tests.yml`
> - No changes to APK build, Maestro test execution, analyzer step, or failure handling (Asana task creation)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa471dfce4f5d78ea051a3a4a478f947f3acec70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->