### PR TITLE
Add a 1.5 second delay before showing the what's new modal

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import logcat.logcat
 import javax.inject.Inject
 
 interface RemoteMessageModalSurfaceEvaluator
@@ -79,9 +78,7 @@ class RemoteMessageModalSurfaceEvaluatorImpl @Inject constructor(
                 return@withContext ModalEvaluator.EvaluationResult.Skipped
             }
 
-            val message = remoteMessagingRepository.message().also {
-                logcat(tag = "RadoiuC") { "Remote message: $it" }
-            }
+            val message = remoteMessagingRepository.message()
                 ?: return@withContext ModalEvaluator.EvaluationResult.Skipped
 
             if (message.surfaces.contains(Surface.MODAL)) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212974313804263?focus=true

### Description
Added a delay of 1.5 seconds before displaying remote message modals to improve user experience.

### Steps to test this PR

_Remote Message Modal Display_
Setup the “What’s new” message to be displayed and check there is a small delay before the modal is shown after the app is resumed. 

### UI changes
Modal should appear with a 1.5 second delay after the app is resumed, and not immediately. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a short defer before displaying remote message modals to smooth app resume UX.
> 
> - Inserts `delay(MODAL_DISPLAY_DELAY)` (1.5s) in `RemoteMessageModalSurfaceEvaluatorImpl.evaluate` before launching the modal activity
> - Adds `MODAL_DISPLAY_DELAY = 1500L` constant and imports `kotlinx.coroutines.delay`; modal launch remains on main via `appCoroutineScope.launch`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f2ce9832a905d6f2b3c4208edf7d9a5f6c2fd09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->