### PR TITLE
Open Duck.ai in a new tab according to fullscreen mode parameter

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1597,7 +1597,11 @@ class BrowserTabFragment :
                     it.hideKeyboard()
                     it.clearFocus()
                 }
-                viewModel.onDuckChatMenuClicked()
+                if (duckAiFeatureState.showFullScreenMode.value) {
+                    viewModel.openNewDuckChat(omnibar.viewMode)
+                } else {
+                    viewModel.onDuckChatMenuClicked()
+                }
             }
             onMenuItemClicked(duckChatHistoryMenuItem) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212983686979062?focus=true 

### Description

Open Duck.ai in a new tab according to fullscreen mode parameter with bottom sheet menu.

### Steps to test this PR

_Open Duck.ai in a tab_
- [x] Open the application
- [x] Go to Appearance settings and turn on the experimental browser menu
- [x] Come back to browser screen and open a new tab
- [x] Open the menu and click on "Duck.ai" menu item
- [x] Check Duck.ai is opened in a new tab and not in an activity

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Duck.ai launch behavior from the browser menu based on fullscreen mode.
> 
> - When `DuckAiFeatureState.showFullScreenMode` is true, clicking `"Duck.ai"` opens a new Duck.ai tab (`openNewDuckChat`) instead of the previous in-place/activity flow; otherwise retains existing `onDuckChatMenuClicked`
> - Applies to the bottom sheet menu (and mirrors existing behavior already present in the classic popup menu)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f4ce7c362d19f55569a15dec46417e8f0009ca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->