### PR TITLE
PIR: Move js injection to page start

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
@@ -118,6 +118,7 @@ class RealPirDetachedWebViewProvider @Inject constructor() :
                     logcat { "PIR-SCAN: webview onPageStarted $url" }
                     requestedUrl = url
                     receivedError = false
+                    view?.evaluateJavascript("javascript:$scriptToLoad", null)
                 }
 
                 override fun onPageFinished(
@@ -126,7 +127,6 @@ class RealPirDetachedWebViewProvider @Inject constructor() :
                 ) {
                     if (!receivedError) {
                         logcat { "PIR-SCAN: webview onPageFinished receivedError $receivedError requestedUrl $requestedUrl for url $url" }
-                        view?.evaluateJavascript("javascript:$scriptToLoad", null)
                         onPageLoaded(url)
                     }
                     super.onPageFinished(view, url)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212975172246279?focus=true 

### Description
See attached task description

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1212975172246292?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs PIR JS earlier in the navigation lifecycle.
> 
> - Moves `evaluateJavascript("javascript:$scriptToLoad")` from `onPageFinished` to `onPageStarted` in `PirDetachedWebViewProvider.kt`, so the script executes as soon as navigation begins
> - `onPageFinished` now only logs and triggers `onPageLoaded` when no errors occur
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1195a3aa79b2df9231f6b359862f6784e67c64b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->