### PR TITLE
Fix Duck.ai 'Not now' button not working in fullscreenMode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -641,7 +641,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
 
         if (intent.getBooleanExtra(CLOSE_DUCK_CHAT, false)) {
-            closeDuckChat()
+            if (duckAiFeatureState.showFullScreenMode.value && currentTab?.isInDuckAiMode() == true) {
+                closeDuckChatFullScreen()
+            } else {
+                closeDuckChat()
+            }
             return
         }
 
@@ -857,6 +861,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     fun launchDownloads() {
         globalActivityStarter.start(this, DownloadsScreenNoParams)
+    }
+
+    fun closeDuckChatFullScreen() {
+        isDuckChatVisible = false
+        externalIntentProcessingState.onDuckAiClosed()
+        currentTab?.closeCurrentTab()
     }
 
     fun closeDuckChat() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4276,6 +4276,13 @@ class BrowserTabFragment :
         return viewModel.onUserPressedBack(isCustomTab)
     }
 
+    fun isInDuckAiMode(): Boolean = getOmnibar()?.viewMode == ViewMode.DuckAI
+
+    fun closeCurrentTab() {
+        if (!isAdded) return
+        viewModel.closeCurrentTab()
+    }
+
     private fun resetWebView() {
         logcat { "Duck.ai: resetWebView" }
         destroyWebView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213003207482136?focus=true

### Description

- Fixes the “Not now” button in Duck.ai onboarding not working when `fullscreenMode` is enabled.

### Steps to test this PR

- [ ] Fresh install
- [ ] Tap the Duck.ai omnibar icon
- [ ] Tap “Not now” on the onboarding dialog
- [ ] Verify that the current tab is closed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Duck.ai onboarding “Not now” correctly closes the chat when `fullscreenMode` is enabled.
> 
> - `BrowserActivity`: On `CLOSE_DUCK_CHAT`, if `showFullScreenMode` and current tab is in `DuckAI` mode, call new `closeDuckChatFullScreen()`; otherwise fallback to existing `closeDuckChat()`
> - `closeDuckChatFullScreen()`: marks Duck.ai hidden and closes the current tab
> - `BrowserTabFragment`: adds `isInDuckAiMode()` and `closeCurrentTab()` helpers used by the activity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c13a16a1f91094483ced71e5f3a23347e948949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->