### PR TITLE
Add pixel definition for sync rescope API error

### DIFF
--- a/PixelDefinitions/pixels/sync.json5
+++ b/PixelDefinitions/pixels/sync.json5
@@ -19,5 +19,24 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_sync_rescope_token_error": {
+        "description": "Fired when rescoping the sync token fails",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "code",
+                "description": "The error code returned from the sync service",
+                "type": "string"
+            },
+            {
+                "key": "reason",
+                "description": "The reason for the rescope token failure",
+                "type": "string"
+            }
+        ]
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -513,6 +513,7 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN.pixelName to removeAtb(),
             SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED.pixelName to removeAtb(),
             SyncPixelName.SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED.pixelName to removeAtb(),
+            SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE.pixelName to removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213002272473269?focus=true 

### Description
Adds pixel definition for pixel (`m_sync_rescope_token_error`) which can fire if the `rescope` API errors inside sync.

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new analytics pixel definition and registers it for ATB parameter removal, with no changes to sync behavior or data flows beyond reporting.
> 
> **Overview**
> Adds a new sync analytics pixel, `m_sync_rescope_token_error`, including `code` and `reason` parameters, to report failures when rescoping a sync token.
> 
> Updates the sync pixel data-cleaning configuration (`SyncPixelsRequiringDataCleaning`) so this new pixel also strips ATB via the existing `PixelParamRemovalPlugin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d626a31d9f36449281f29ef695872aa4208e9d8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->