### PR TITLE
Support Search & Duck.ai mode with the bottom sheet menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1156,6 +1156,7 @@ class BrowserTabFragment :
                     isTopOmnibar = isTopOmnibar,
                     browserButtonsConfig = InputScreenBrowserButtonsConfig.Enabled(tabs = viewModel.tabs.value?.size ?: 0),
                     launchOnChat = omnibar.viewMode == ViewMode.DuckAI,
+                    useBottomSheetMenu = viewModel.browserViewState.value?.useBottomSheetMenu ?: false,
                 ),
             )
         val enterTransition = browserAndInputScreenTransitionProvider.getInputScreenEnterAnimation(isTopOmnibar)

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -37,6 +37,7 @@ data class InputScreenActivityParams(
     val showInstalledApps: Boolean = false,
     val launchWithVoice: Boolean = false,
     val launchOnChat: Boolean = false,
+    val useBottomSheetMenu: Boolean = false,
 ) : GlobalActivityStarter.ActivityParams
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -273,6 +273,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         } else {
             inputModeWidget.initOnSearch()
         }
+        updateMenuIconButton(params?.useBottomSheetMenu ?: false)
 
         requireActivity().onBackPressedDispatcher.addCallback(
             viewLifecycleOwner,
@@ -666,6 +667,15 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             binding.autoCompleteOverlay.animate().cancel()
             hideAutoComplete()
         }
+    }
+
+    private fun updateMenuIconButton(useBottomSheetMenu: Boolean) {
+        val drawable = if (useBottomSheetMenu) {
+            com.duckduckgo.mobile.android.R.drawable.ic_menu_hamburger_24
+        } else {
+            com.duckduckgo.mobile.android.R.drawable.ic_menu_vertical_24
+        }
+        inputModeWidget.setMenuIcon(drawable)
     }
 
     private fun updateButtonVisibility(state: InputScreenVisibilityState) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -37,7 +37,10 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -79,6 +82,7 @@ class InputModeWidget @JvmOverloads constructor(
     private val inputModeWidgetLayout: View
     val tabSwitcherButton: TabSwitcherButton
     private val menuButton: View
+    private val menuIconImageView: ImageView
     private val fireButton: View
     private val voiceInputButton: View
     private var bottomButtonsMode: Boolean = false
@@ -151,6 +155,7 @@ class InputModeWidget @JvmOverloads constructor(
         inputModeSwitch = findViewById(R.id.inputModeSwitch)
         inputModeWidgetCard = findViewById(R.id.inputModeWidgetCard)
         menuButton = findViewById(R.id.inputFieldBrowserMenu)
+        menuIconImageView = findViewById(R.id.browserMenuImageView)
         fireButton = findViewById(R.id.inputFieldFireButton)
         tabSwitcherButton = findViewById(R.id.inputFieldTabsMenu)
         voiceInputButton = findViewById(R.id.inputFieldVoiceInputButton)
@@ -484,6 +489,12 @@ class InputModeWidget @JvmOverloads constructor(
 
     fun setVoiceButtonVisible(visible: Boolean) {
         voiceInputButton.isVisible = visible
+    }
+
+    fun setMenuIcon(@DrawableRes resId: Int) {
+        ContextCompat.getDrawable(context, resId)?.let {
+            menuIconImageView.setImageDrawable(it)
+        }
     }
 
     fun setMainButtonsVisible(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1212992299141099?focus=true

### Description

When we are using Search & Duck.ai mode in browser screen, instead of the Search only mode, we should display the hamburger menu instead of the 3 dots icon.

### Steps to test this PR

_Search & Duck.ai mode_
- [x] Open the application
- [x] Turn on experimental browser menu in Appearance settings
- [x] Turn on Search & Duck.ai mode in AI features settings
- [x] Go back to browser screen
- [x] Tap on the address bar
- [x] Check the hamburger icon replaced 3 dots icon
- [x] Tap on the hamburger menu
- [x] Check the bottom sheet is opened

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/4dd5a14d-0079-4f3a-8479-dc0b2acdd73e" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/ab17befa-88c0-4b0b-839a-1efc92198d87" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds bottom sheet menu awareness to the Input Screen and updates its menu icon accordingly.
> 
> - Extends `InputScreenActivityParams` with `useBottomSheetMenu` and passes it from `BrowserTabFragment.launchInputScreen`
> - `InputScreenFragment` sets the menu icon on load via `updateMenuIconButton` (hamburger for bottom sheet, vertical dots otherwise)
> - `InputModeWidget` now exposes `setMenuIcon` and wires `browserMenuImageView` to allow dynamic icon updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb5fa3245183660a52b6c4564c48470e65dd8a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->