### PR TITLE
Develocity: Add develocity env variable to github workflows

### DIFF
--- a/.github/actions/checkout-and-assemble/action.yml
+++ b/.github/actions/checkout-and-assemble/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Additional flags to pass to the gradlew command'
     required: false
     default: ''
+  develocity_access_key:
+    description: 'Develocity access key for Gradle remote caching'
+    required: false
+    default: ''
 
 outputs:
   play_apk_path:
@@ -73,6 +77,8 @@ runs:
     - name: Assemble release APK
       if: ${{ inputs.flavours == 'all' || inputs.flavours == 'play' }}
       shell: bash
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ inputs.develocity_access_key }}
       run: ./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint ${{ inputs.gradle_flags }}
 
     - name: Move Play APK
@@ -83,6 +89,8 @@ runs:
     - name: Assemble internal release APK
       if: ${{ inputs.flavours == 'all' || inputs.flavours == 'internal' }}
       shell: bash
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ inputs.develocity_access_key }}
       run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding -x lint ${{ inputs.gradle_flags }}
 
     - name: Move Internal APK

--- a/.github/workflows/build-ad-hoc.yml
+++ b/.github/workflows/build-ad-hoc.yml
@@ -28,6 +28,8 @@ jobs:
   build-apk:
     name: Generate and upload universal APK to GH Action Run
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-benchmark-nightly.yml
+++ b/.github/workflows/build-benchmark-nightly.yml
@@ -12,6 +12,8 @@ jobs:
     name: Run Benchmark
     runs-on: android-large-runner
     timeout-minutes: 120
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Determine branch

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -17,6 +17,8 @@ jobs:
   build_debug_apk:
     name: Build debug apk
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-fdroid-apk.yml
+++ b/.github/workflows/build-fdroid-apk.yml
@@ -21,6 +21,8 @@ jobs:
   build_fdroid_apk:
     name: Build F-Droid apk
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
   android_tests:
     runs-on: android-large-runner
     name: Android CI tests
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/design-system-composable-pr-test.yml
+++ b/.github/workflows/design-system-composable-pr-test.yml
@@ -14,6 +14,8 @@ jobs:
   maestro_test:
     runs-on: ubuntu-latest
     name: Run Design System Maestro Tests
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-nightly-android-design-system.yml
+++ b/.github/workflows/e2e-nightly-android-design-system.yml
@@ -29,6 +29,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run ADS Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -30,6 +30,7 @@ jobs:
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           gradle_flags: '-Pautofill-disable-auth-requirement'
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Autofill Critical Path E2E Flows
         id: maestro-critical-path

--- a/.github/workflows/e2e-nightly-custom-tabs.yml
+++ b/.github/workflows/e2e-nightly-custom-tabs.yml
@@ -38,6 +38,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Custom Tabs Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-duckplayer.yml
+++ b/.github/workflows/e2e-nightly-duckplayer.yml
@@ -38,6 +38,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Duck Player Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -37,6 +37,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Upload Internal Binary to Maestro
         id: maestro-upload-internal-binary

--- a/.github/workflows/e2e-nightly-input-screen.yml
+++ b/.github/workflows/e2e-nightly-input-screen.yml
@@ -26,6 +26,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Input Screen Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-omnibar.yml
+++ b/.github/workflows/e2e-nightly-omnibar.yml
@@ -28,6 +28,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Omnibar Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-sync-critical-path.yml
+++ b/.github/workflows/e2e-nightly-sync-critical-path.yml
@@ -36,6 +36,7 @@ jobs:
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           gradle_flags: '-Psync-disable-auth-requirement'
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Sync Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-privacy-dashboard.yml
+++ b/.github/workflows/e2e-privacy-dashboard.yml
@@ -31,6 +31,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Ad Click Maestro Tests
         id: maestro-ad-click

--- a/.github/workflows/e2e-security-internal.yml
+++ b/.github/workflows/e2e-security-internal.yml
@@ -26,6 +26,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Security Internal Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-security.yml
+++ b/.github/workflows/e2e-security.yml
@@ -26,6 +26,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Security Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -17,6 +17,8 @@ jobs:
   unit_tests:
     name: External content scope script tests
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -61,6 +61,8 @@ jobs:
   android_tests:
     runs-on: ubuntu-latest
     name: External reference tests android tests
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,6 +125,8 @@ jobs:
   android_tests:
     runs-on: android-large-runner
     name: Android CI checks
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -30,6 +30,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'workflow_call' || github.event_name == 'pull_request' }}
     name: Privacy Tests
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -32,6 +32,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Maestro tests flows
         id: release-tests

--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -15,6 +15,8 @@ jobs:
   create-tag:
     name: Generate and upload bundle to Play Store Internal track
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -25,6 +25,8 @@ jobs:
   release-production:
     runs-on: ubuntu-latest
     name: Publish Bundle to Play Store Internal track
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1213015357038408?focus=true

### Description
Configures github workflows to use the develocity access key

### Steps to test this PR
Run CI build on develop

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures GitHub Actions to provide Develocity credentials for Gradle remote caching.
> 
> - Adds `DEVELOCITY_ACCESS_KEY` to multiple workflows (CI, nightly, release, E2E, docs, ad-hoc, etc.) and job envs
> - Updates `./.github/actions/checkout-and-assemble` to accept `develocity_access_key` and export `DEVELOCITY_ACCESS_KEY` during `assemblePlayRelease`/`assembleInternalRelease`
> - Minor YAML cleanups (newline/whitespace)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ded55b96f4f6f7b6989091f529f161a13df8525e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->