### PR TITLE
Recreate and render bottom sheet at every launch to avoid unexpected state

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1377,8 +1377,13 @@ class BrowserTabFragment :
     }
 
     private fun launchBrowserMenu(addExtraDelay: Boolean = false) {
-        val useBottomSheetMenu = viewModel.browserViewState.value?.useBottomSheetMenu ?: false
+        val viewState = viewModel.browserViewState.value
+        val useBottomSheetMenu = viewState?.useBottomSheetMenu ?: false
         if (useBottomSheetMenu && bottomSheetMenu != null) {
+            recreateBrowserMenu()
+            viewState?.let {
+                renderBrowserMenu(viewState = viewState, omnibarViewMode = omnibar.viewMode)
+            }
             launchBottomSheetMenu(addExtraDelay)
         } else if (!useBottomSheetMenu && popupMenu != null) {
             val isSplitOmnibarEnabled = omnibarRepository.omnibarType == OmnibarType.SPLIT


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212992299141095?focus=true

### Description

> Note: Please, don't merge. The actual implementation is used to discuss about one possible solution to fix a glitch with the browser bottom sheet menu.

### Steps to test this PR

_Bottom sheet menu opened from bottom after a full expand_
- [x] Open the application
- [x] Turn on the new browser menu from appearance settings
- [x] Come back to browser screen and open the menu
- [x] Expand the menu and close it with a back button
- [x] Open the menu again, it should be opened from the bottom
- [x] Check the menu is well up dated for all modes (website, new tab, duck.ai and custom tab)

### UI changes

https://github.com/user-attachments/assets/afbeadbe-c0e4-42bc-830b-eeaa7131d62b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change, but it touches the menu launch path and could affect menu responsiveness or state continuity across opens.
> 
> **Overview**
> When the experimental bottom-sheet browser menu is enabled, opening the menu now **recreates the menu instance and re-renders it from the latest `BrowserViewState`** on every launch (instead of reusing the existing bottom sheet).
> 
> Popup menu behavior is unchanged; this specifically targets avoiding stale/incorrect bottom-sheet state between successive openings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a67d77cac17376ceedffaa4263c158c8ff2cd99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->