### PR TITLE
Update content scope scripts to version 12.37.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -3577,6 +3577,14 @@
   _args = new WeakMap();
 
   // src/content-feature.js
+  function createDeferred() {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+      deferred.resolve = resolve;
+      deferred.reject = reject;
+    });
+    return deferred;
+  }
   var CallFeatureMethodError = class extends Error {
     /**
      * @param {string} message
@@ -3587,7 +3595,9 @@
       this.name = new.target.name;
     }
   };
-  var _messaging, _isDebugFlagSet, _importConfig, _features;
+  var FeatureSkippedError = class extends Error {
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
     /**
      * @param {string} featureName
@@ -3624,6 +3634,8 @@
        * @type {Partial<FeatureMap>}
        */
       __privateAdd(this, _features);
+      /** @type {ReturnType<typeof createDeferred>} */
+      __privateAdd(this, _ready);
       /**
        * @template {string} K
        * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
@@ -3640,12 +3652,21 @@
       this.monitor = new PerformanceMonitor();
       __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
+      __privateSet(this, _ready, createDeferred());
     }
     get isDebug() {
       return this.args?.debug || false;
     }
     get shouldLog() {
       return this.isDebug;
+    }
+    /**
+     * Returns a promise that resolves when the feature has been initialised with `init`.
+     *
+     * @returns {Promise<void>}
+     */
+    get _ready() {
+      return __privateGet(this, _ready).promise;
     }
     /**
      * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
@@ -3735,7 +3756,12 @@
     /**
      * Run an exposed method of another feature.
      *
+     * Waits for the feature to be initialized before calling the method.
+     *
      * `args` are the arguments to pass to the feature method.
+     *
+     * NOTE: be aware of potential circular dependencies. Check that the feature
+     * you are calling is not calling you back.
      *
      * @template {keyof FeatureMap} FeatureName
      * @template {FeatureMap[FeatureName]} Feature
@@ -3743,9 +3769,9 @@
      * @param {FeatureName} featureName
      * @param {MethodName} methodName
      * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
-     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     * @returns {Promise<ReturnType<Feature[MethodName]> | CallFeatureMethodError>}
      */
-    callFeatureMethod(featureName, methodName, ...args) {
+    async callFeatureMethod(featureName, methodName, ...args) {
       const feature = __privateGet(this, _features)[featureName];
       if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
       if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
@@ -3757,6 +3783,14 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      try {
+        await feature._ready;
+      } catch (e) {
+        if (e instanceof FeatureSkippedError) {
+          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
+        }
+        throw e;
+      }
       return method.call(feature, ...args);
     }
     /**
@@ -3802,12 +3836,32 @@
     }
     init(_args2) {
     }
-    callInit(args) {
+    /**
+     * @param {object} args
+     */
+    async callInit(args) {
       const mark = this.monitor.mark(this.name + "CallInit");
-      this.setArgs(args);
-      this.init(this.args);
-      mark.end();
-      this.measure();
+      try {
+        this.setArgs(args);
+        await this.init(this.args);
+        __privateGet(this, _ready).resolve?.();
+      } catch (error) {
+        __privateGet(this, _ready).reject?.(error);
+        throw error;
+      } finally {
+        mark.end();
+        this.measure();
+      }
+    }
+    /**
+     * Mark this feature as skipped (not initialized).
+     *
+     * This allows inter-feature communication to fail fast instead of hanging indefinitely.
+     *
+     * @param {string} reason - The reason the feature was skipped
+     */
+    markFeatureAsSkipped(reason) {
+      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
     }
     setArgs(args) {
       this.args = args;
@@ -3958,6 +4012,7 @@
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
   _features = new WeakMap();
+  _ready = new WeakMap();
 
   // src/features/api-manipulation.js
   var ApiManipulation = class extends ContentFeature {
@@ -6258,23 +6313,28 @@
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
     const features = await getFeatures();
-    Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
-        if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
-          return;
+    await Promise.allSettled(
+      Object.entries(features).map(async ([featureName, featureInstance]) => {
+        if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
+          if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
+            featureInstance.markFeatureAsSkipped("additionalCheck disabled");
+            return;
+          }
+          await featureInstance.callInit(args);
+          const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+          if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
+            registerForURLChanges((navigationType) => {
+              featureInstance.recomputeSiteObject();
+              if (hasUrlChangedMethod) {
+                featureInstance.urlChanged(navigationType);
+              }
+            });
+          }
+        } else {
+          featureInstance.markFeatureAsSkipped("feature is broken or disabled on this site");
         }
-        featureInstance.callInit(args);
-        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
-        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
-          registerForURLChanges((navigationType) => {
-            featureInstance.recomputeSiteObject();
-            if (hasUrlChangedMethod) {
-              featureInstance.urlChanged(navigationType);
-            }
-          });
-        }
-      }
-    });
+      })
+    );
     while (updates.length) {
       const update = updates.pop();
       await updateFeaturesInner(update);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -5142,6 +5142,14 @@
   _args = new WeakMap();
 
   // src/content-feature.js
+  function createDeferred() {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+      deferred.resolve = resolve;
+      deferred.reject = reject;
+    });
+    return deferred;
+  }
   var CallFeatureMethodError = class extends Error {
     /**
      * @param {string} message
@@ -5152,7 +5160,9 @@
       this.name = new.target.name;
     }
   };
-  var _messaging, _isDebugFlagSet, _importConfig, _features;
+  var FeatureSkippedError = class extends Error {
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
     /**
      * @param {string} featureName
@@ -5189,6 +5199,8 @@
        * @type {Partial<FeatureMap>}
        */
       __privateAdd(this, _features);
+      /** @type {ReturnType<typeof createDeferred>} */
+      __privateAdd(this, _ready);
       /**
        * @template {string} K
        * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
@@ -5205,12 +5217,21 @@
       this.monitor = new PerformanceMonitor();
       __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
+      __privateSet(this, _ready, createDeferred());
     }
     get isDebug() {
       return this.args?.debug || false;
     }
     get shouldLog() {
       return this.isDebug;
+    }
+    /**
+     * Returns a promise that resolves when the feature has been initialised with `init`.
+     *
+     * @returns {Promise<void>}
+     */
+    get _ready() {
+      return __privateGet(this, _ready).promise;
     }
     /**
      * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
@@ -5300,7 +5321,12 @@
     /**
      * Run an exposed method of another feature.
      *
+     * Waits for the feature to be initialized before calling the method.
+     *
      * `args` are the arguments to pass to the feature method.
+     *
+     * NOTE: be aware of potential circular dependencies. Check that the feature
+     * you are calling is not calling you back.
      *
      * @template {keyof FeatureMap} FeatureName
      * @template {FeatureMap[FeatureName]} Feature
@@ -5308,9 +5334,9 @@
      * @param {FeatureName} featureName
      * @param {MethodName} methodName
      * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
-     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     * @returns {Promise<ReturnType<Feature[MethodName]> | CallFeatureMethodError>}
      */
-    callFeatureMethod(featureName, methodName, ...args) {
+    async callFeatureMethod(featureName, methodName, ...args) {
       const feature = __privateGet(this, _features)[featureName];
       if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
       if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
@@ -5322,6 +5348,14 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      try {
+        await feature._ready;
+      } catch (e) {
+        if (e instanceof FeatureSkippedError) {
+          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
+        }
+        throw e;
+      }
       return method.call(feature, ...args);
     }
     /**
@@ -5367,12 +5401,32 @@
     }
     init(_args2) {
     }
-    callInit(args) {
+    /**
+     * @param {object} args
+     */
+    async callInit(args) {
       const mark = this.monitor.mark(this.name + "CallInit");
-      this.setArgs(args);
-      this.init(this.args);
-      mark.end();
-      this.measure();
+      try {
+        this.setArgs(args);
+        await this.init(this.args);
+        __privateGet(this, _ready).resolve?.();
+      } catch (error) {
+        __privateGet(this, _ready).reject?.(error);
+        throw error;
+      } finally {
+        mark.end();
+        this.measure();
+      }
+    }
+    /**
+     * Mark this feature as skipped (not initialized).
+     *
+     * This allows inter-feature communication to fail fast instead of hanging indefinitely.
+     *
+     * @param {string} reason - The reason the feature was skipped
+     */
+    markFeatureAsSkipped(reason) {
+      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
     }
     setArgs(args) {
       this.args = args;
@@ -5523,6 +5577,7 @@
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
   _features = new WeakMap();
+  _ready = new WeakMap();
 
   // src/features/broker-protection/execute.js
   init_define_import_meta_trackerLookup();
@@ -9809,23 +9864,28 @@
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
     const features = await getFeatures();
-    Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
-        if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
-          return;
+    await Promise.allSettled(
+      Object.entries(features).map(async ([featureName, featureInstance]) => {
+        if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
+          if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
+            featureInstance.markFeatureAsSkipped("additionalCheck disabled");
+            return;
+          }
+          await featureInstance.callInit(args);
+          const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+          if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
+            registerForURLChanges((navigationType) => {
+              featureInstance.recomputeSiteObject();
+              if (hasUrlChangedMethod) {
+                featureInstance.urlChanged(navigationType);
+              }
+            });
+          }
+        } else {
+          featureInstance.markFeatureAsSkipped("feature is broken or disabled on this site");
         }
-        featureInstance.callInit(args);
-        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
-        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
-          registerForURLChanges((navigationType) => {
-            featureInstance.recomputeSiteObject();
-            if (hasUrlChangedMethod) {
-              featureInstance.urlChanged(navigationType);
-            }
-          });
-        }
-      }
-    });
+      })
+    );
     while (updates.length) {
       const update = updates.pop();
       await updateFeaturesInner(update);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -5111,6 +5111,14 @@
   _args = new WeakMap();
 
   // src/content-feature.js
+  function createDeferred() {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+      deferred.resolve = resolve;
+      deferred.reject = reject;
+    });
+    return deferred;
+  }
   var CallFeatureMethodError = class extends Error {
     /**
      * @param {string} message
@@ -5121,7 +5129,9 @@
       this.name = new.target.name;
     }
   };
-  var _messaging, _isDebugFlagSet, _importConfig, _features;
+  var FeatureSkippedError = class extends Error {
+  };
+  var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
     /**
      * @param {string} featureName
@@ -5158,6 +5168,8 @@
        * @type {Partial<FeatureMap>}
        */
       __privateAdd(this, _features);
+      /** @type {ReturnType<typeof createDeferred>} */
+      __privateAdd(this, _ready);
       /**
        * @template {string} K
        * @typedef {K[] & {__brand: 'exposeMethods'}} ExposeMethods
@@ -5174,12 +5186,21 @@
       this.monitor = new PerformanceMonitor();
       __privateSet(this, _features, features);
       __privateSet(this, _importConfig, importConfig);
+      __privateSet(this, _ready, createDeferred());
     }
     get isDebug() {
       return this.args?.debug || false;
     }
     get shouldLog() {
       return this.isDebug;
+    }
+    /**
+     * Returns a promise that resolves when the feature has been initialised with `init`.
+     *
+     * @returns {Promise<void>}
+     */
+    get _ready() {
+      return __privateGet(this, _ready).promise;
     }
     /**
      * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
@@ -5269,7 +5290,12 @@
     /**
      * Run an exposed method of another feature.
      *
+     * Waits for the feature to be initialized before calling the method.
+     *
      * `args` are the arguments to pass to the feature method.
+     *
+     * NOTE: be aware of potential circular dependencies. Check that the feature
+     * you are calling is not calling you back.
      *
      * @template {keyof FeatureMap} FeatureName
      * @template {FeatureMap[FeatureName]} Feature
@@ -5277,9 +5303,9 @@
      * @param {FeatureName} featureName
      * @param {MethodName} methodName
      * @param {Feature[MethodName] extends (...args: infer Args) => any ? Args : never} args
-     * @returns {ReturnType<Feature[MethodName]> | CallFeatureMethodError}
+     * @returns {Promise<ReturnType<Feature[MethodName]> | CallFeatureMethodError>}
      */
-    callFeatureMethod(featureName, methodName, ...args) {
+    async callFeatureMethod(featureName, methodName, ...args) {
       const feature = __privateGet(this, _features)[featureName];
       if (!feature) return new CallFeatureMethodError(`Feature not found: '${featureName}'`);
       if (!(feature._exposedMethods !== void 0 && feature._exposedMethods.some((mn) => mn === methodName)))
@@ -5291,6 +5317,14 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
+      try {
+        await feature._ready;
+      } catch (e) {
+        if (e instanceof FeatureSkippedError) {
+          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
+        }
+        throw e;
+      }
       return method.call(feature, ...args);
     }
     /**
@@ -5336,12 +5370,32 @@
     }
     init(_args2) {
     }
-    callInit(args) {
+    /**
+     * @param {object} args
+     */
+    async callInit(args) {
       const mark = this.monitor.mark(this.name + "CallInit");
-      this.setArgs(args);
-      this.init(this.args);
-      mark.end();
-      this.measure();
+      try {
+        this.setArgs(args);
+        await this.init(this.args);
+        __privateGet(this, _ready).resolve?.();
+      } catch (error) {
+        __privateGet(this, _ready).reject?.(error);
+        throw error;
+      } finally {
+        mark.end();
+        this.measure();
+      }
+    }
+    /**
+     * Mark this feature as skipped (not initialized).
+     *
+     * This allows inter-feature communication to fail fast instead of hanging indefinitely.
+     *
+     * @param {string} reason - The reason the feature was skipped
+     */
+    markFeatureAsSkipped(reason) {
+      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
     }
     setArgs(args) {
       this.args = args;
@@ -5492,6 +5546,7 @@
   _isDebugFlagSet = new WeakMap();
   _importConfig = new WeakMap();
   _features = new WeakMap();
+  _ready = new WeakMap();
 
   // src/features/broker-protection/execute.js
   init_define_import_meta_trackerLookup();
@@ -9209,23 +9264,28 @@
     registerMessageSecret(args.messageSecret);
     initStringExemptionLists(args);
     const features = await getFeatures();
-    Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
-        if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
-          return;
+    await Promise.allSettled(
+      Object.entries(features).map(async ([featureName, featureInstance]) => {
+        if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
+          if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
+            featureInstance.markFeatureAsSkipped("additionalCheck disabled");
+            return;
+          }
+          await featureInstance.callInit(args);
+          const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
+          if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
+            registerForURLChanges((navigationType) => {
+              featureInstance.recomputeSiteObject();
+              if (hasUrlChangedMethod) {
+                featureInstance.urlChanged(navigationType);
+              }
+            });
+          }
+        } else {
+          featureInstance.markFeatureAsSkipped("feature is broken or disabled on this site");
         }
-        featureInstance.callInit(args);
-        const hasUrlChangedMethod = "urlChanged" in featureInstance && typeof featureInstance.urlChanged === "function";
-        if (featureInstance.listenForUrlChanges || hasUrlChangedMethod) {
-          registerForURLChanges((navigationType) => {
-            featureInstance.recomputeSiteObject();
-            if (hasUrlChangedMethod) {
-              featureInstance.urlChanged(navigationType);
-            }
-          });
-        }
-      }
-    });
+      })
+    );
     while (updates.length) {
       const update = updates.pop();
       await updateFeaturesInner(update);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.36.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.37.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.50.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.50.1.tgz",
-      "integrity": "sha512-YZEfo6lmnscMuISlE+Zt8WLjsiQG7AUtZyHwT0XlVY2Brw7vZIlNsJKFyHZFM48FreTpLe8+cLGjicHm5VPZmA==",
+      "version": "14.51.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.51.0.tgz",
+      "integrity": "sha512-FgaCJQGqbmc71N9LjTWtmVcTVJQbKBDTC9av8S78qOJkIT8t/l7PEsuiJGf7IfzWFjh0RGtY3wByi6wtW99XeA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3a6321e5a884e37dfc40dc368b84324c237c5094",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#07c9bafd37e02460c485aee422ea889208a22dac",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
+      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.36.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.37.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213022901643436/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled content-scope scripts and changes feature init/messaging coordination (async init, readiness gating, skip signalling), which can affect runtime ordering and inter-feature calls in content scripts.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` to `12.37.0` and refreshes the generated Android bundles in `node_modules/@duckduckgo/content-scope-scripts/build/android/*`.
> 
> Within those bundles, feature lifecycle is refactored so `ContentFeature` tracks a `_ready` promise: `callInit` becomes `async` (resolving/rejecting readiness), `callFeatureMethod` now awaits target feature initialization (and fails fast if it was skipped), and top-level `init` runs feature initialization concurrently via `Promise.allSettled`, explicitly marking features as skipped when disabled/broken.
> 
> Also updates lockfile dependency resolutions (including `@duckduckgo/autoconsent` and `@types/node`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31c4309982f0c20afa026e30464afeaaa0ea5f72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->