### PR TITLE
Update UI test to use a different site to avoid DRM permission popup

### DIFF
--- a/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
+++ b/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
@@ -84,21 +84,21 @@ appId: com.duckduckgo.mobile.android
       id: "focusedFavourites"
 
 # verify that typing shows autocomplete again
-- inputText: "amazo"
+- inputText: "wiki"
 - assertVisible:
     id: "autoCompleteSuggestionsList"
 - assertVisible:
-    text: "amazon.com"
+    text: "wikipedia.org"
 
 # verify that tapping on a suggestion opens the web page
 - tapOn:
-    text: "amazon.com"
+    text: "wikipedia.org"
 - assertNotVisible:
     id: "inputModeWidget"
 - assertVisible:
     id: "browserLayout"
 - assertVisible:
-    text: ".*amazon.com.*"
+    text: ".*wikipedia.org.*"
     childOf:
       id: "omnibarTextInput"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213028774341900?focus=true

### Description

### Steps to test this PR

- [ ] Verify that https://github.com/duckduckgo/Android/actions/runs/21512277371 passed 

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a Maestro UI test’s expected autocomplete suggestion and navigation target; no production code changes.
> 
> **Overview**
> Updates the Maestro Input Screen search-mode flow to type `wiki` and assert/select `wikipedia.org` instead of `amazo`/`amazon.com`, and updates the URL assertion accordingly. This stabilizes the test by avoiding the prior site’s DRM/permission popup during navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 804ef60192dc9d4021eb2da0aa3deac7f49a6c1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->