### PR TITLE
Update content scope scripts to version 12.38.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -6200,6 +6200,17 @@
             result.expandedPerformanceMetrics = expandedPerformanceMetrics.metrics;
           }
         }
+        const breakageDataPayload = {};
+        if (result.detectorData) {
+          breakageDataPayload.detectorData = result.detectorData;
+        }
+        if (Object.keys(breakageDataPayload).length > 0) {
+          try {
+            result.breakageData = encodeURIComponent(JSON.stringify(breakageDataPayload));
+          } catch (e) {
+            result.breakageData = encodeURIComponent(JSON.stringify({ error: "encoding_failed" }));
+          }
+        }
         this.messaging.notify("breakageReportResult", result);
       });
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -7799,6 +7799,24 @@
           continue;
         }
         results.push(setValueForInput(inputElem, data2.city + ", " + data2.state));
+      } else if (element.type === "fullState") {
+        if (!Object.prototype.hasOwnProperty.call(data2, "state")) {
+          results.push({
+            result: false,
+            error: `element found with selector '${element.selector}', but data didn't contain the key 'state'`
+          });
+          continue;
+        }
+        const state = data2.state;
+        if (!Object.prototype.hasOwnProperty.call(states, state)) {
+          results.push({
+            result: false,
+            error: `element found with selector '${element.selector}', but data contained an invalid 'state' abbreviation`
+          });
+          continue;
+        }
+        const stateFull = states[state];
+        results.push(setValueForInput(inputElem, stateFull));
       } else {
         if (isElementTypeOptional(element.type)) {
           continue;
@@ -7853,7 +7871,17 @@
         events.forEach((ev) => el.dispatchEvent(ev));
         el.blur();
       } else if (el.tagName === "SELECT") {
-        originalSet.call(el, val);
+        const selectElement = (
+          /** @type {HTMLSelectElement} */
+          el
+        );
+        const selectValues = [...selectElement.options].map((o) => o.value);
+        const valStr = String(val);
+        const matchingValue = selectValues.find((option) => option.toLowerCase() === valStr.toLowerCase());
+        if (matchingValue === void 0) {
+          return { result: false, error: `could not find matching value for select element: ${val}` };
+        }
+        originalSet.call(el, matchingValue);
         const events = [
           new Event("mousedown", { bubbles: true }),
           new Event("mouseup", { bubbles: true }),

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -7768,6 +7768,24 @@
           continue;
         }
         results.push(setValueForInput(inputElem, data2.city + ", " + data2.state));
+      } else if (element.type === "fullState") {
+        if (!Object.prototype.hasOwnProperty.call(data2, "state")) {
+          results.push({
+            result: false,
+            error: `element found with selector '${element.selector}', but data didn't contain the key 'state'`
+          });
+          continue;
+        }
+        const state = data2.state;
+        if (!Object.prototype.hasOwnProperty.call(states, state)) {
+          results.push({
+            result: false,
+            error: `element found with selector '${element.selector}', but data contained an invalid 'state' abbreviation`
+          });
+          continue;
+        }
+        const stateFull = states[state];
+        results.push(setValueForInput(inputElem, stateFull));
       } else {
         if (isElementTypeOptional(element.type)) {
           continue;
@@ -7822,7 +7840,17 @@
         events.forEach((ev) => el.dispatchEvent(ev));
         el.blur();
       } else if (el.tagName === "SELECT") {
-        originalSet.call(el, val);
+        const selectElement = (
+          /** @type {HTMLSelectElement} */
+          el
+        );
+        const selectValues = [...selectElement.options].map((o) => o.value);
+        const valStr = String(val);
+        const matchingValue = selectValues.find((option) => option.toLowerCase() === valStr.toLowerCase());
+        if (matchingValue === void 0) {
+          return { result: false, error: `could not find matching value for select element: ${val}` };
+        }
+        originalSet.call(el, matchingValue);
         const events = [
           new Event("mousedown", { bubbles: true }),
           new Event("mouseup", { bubbles: true }),

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8181,6 +8181,17 @@
             result.expandedPerformanceMetrics = expandedPerformanceMetrics.metrics;
           }
         }
+        const breakageDataPayload = {};
+        if (result.detectorData) {
+          breakageDataPayload.detectorData = result.detectorData;
+        }
+        if (Object.keys(breakageDataPayload).length > 0) {
+          try {
+            result.breakageData = encodeURIComponent(JSON.stringify(breakageDataPayload));
+          } catch (e) {
+            result.breakageData = encodeURIComponent(JSON.stringify({ error: "encoding_failed" }));
+          }
+        }
         this.messaging.notify("breakageReportResult", result);
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.37.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.38.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#07c9bafd37e02460c485aee422ea889208a22dac",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ac7d2b45a396c008942630ff16bd5e426880880c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.37.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.38.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213037757250091/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled content scripts that affect autofill behavior and breakage reporting; regressions could impact form-filling on some sites or alter diagnostic payloads, but changes are scoped to client-side scripts.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `12.37.0` to `12.38.0` (lockfile updated) and refreshes the bundled Android build outputs.
> 
> The updated scripts add an encoded `breakageData` field to breakage report results (currently packaging `detectorData` with a fallback on encoding failure). Autofill/broker-protection form filling is extended to support a `fullState` field (mapping state abbreviations to full names) and improves `<select>` handling by matching option values case-insensitively and returning a clear error when no match exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a6bfd2fdef742885f6247952c1e2cbca1deb4c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->