### PR TITLE
Remove auth v1 sign-in temporary pixel

### DIFF
--- a/PixelDefinitions/pixels/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/subscription_pixels.json5
@@ -36,14 +36,6 @@
             }
         ]
     },
-    "subscription_auth_v1_sign_in_attempt": {
-        "description": "Fired when subscription frontend initiates sign-in using auth v1 token.",
-        "owners": ["lmac012"],
-        "triggers": ["other"],
-        "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"],
-        "expires": "2026-02-01"
-    },
     "m_privacy-pro_app_subscription_active_d": {
         "description": "Fired once daily on app start for an active subscription",
         "owners": ["lmac012"],

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -208,7 +208,6 @@ class SubscriptionMessagingInterface @Inject constructor(
         override fun process(jsMessage: JsMessage, jsMessaging: JsMessaging, jsMessageCallback: JsMessageCallback?) {
             try {
                 val token = jsMessage.params.getString("token")
-                pixelSender.reportAuthV1SignInAttempt()
                 appCoroutineScope.launch(dispatcherProvider.io()) {
                     subscriptionsManager.signInV1(token)
                     subscriptionsChecker.runChecker()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -256,11 +256,6 @@ enum class SubscriptionPixel(
         types = setOf(Count, Daily()),
         includedParameters = setOf(APP_VERSION),
     ),
-    AUTH_V1_SIGN_IN_ATTEMPT(
-        baseName = "subscription_auth_v1_sign_in_attempt",
-        types = setOf(Count, Daily()),
-        includedParameters = setOf(APP_VERSION),
-    ),
     FREE_TRIAL_START(
         baseName = "subscription_free_trial_start",
         type = Unique(),

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_G
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_IDTR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_PIR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_RESTORE_PURCHASE_CLICK
-import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V1_SIGN_IN_ATTEMPT
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_DETECTED
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_RECOVERED
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_SIGNED_OUT
@@ -122,7 +121,6 @@ interface SubscriptionPixelSender {
     fun reportAuthV2TokenValidationError()
     fun reportAuthV2TokenStoreError()
     fun reportSubscriptionsWebViewRenderProcessCrash(isRepeated: Boolean)
-    fun reportAuthV1SignInAttempt()
     fun reportFreeTrialStart()
     fun reportFreeTrialVpnActivation(activationDay: String)
 }
@@ -298,10 +296,6 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportSubscriptionsWebViewRenderProcessCrash(isRepeated: Boolean) {
         fire(SUBSCRIPTION_WEBVIEW_RENDER_PROCESS_CRASH, mapOf("is_repeated" to isRepeated.toString()))
-    }
-
-    override fun reportAuthV1SignInAttempt() {
-        fire(AUTH_V1_SIGN_IN_ATTEMPT)
     }
 
     override fun reportFreeTrialStart() {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelTest.kt
@@ -3,7 +3,6 @@ package com.duckduckgo.subscriptions.impl.pixels
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
-import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V1_SIGN_IN_ATTEMPT
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.FREE_TRIAL_START
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.FREE_TRIAL_VPN_ACTIVATION
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_SUCCESS_ORIGIN
@@ -25,7 +24,6 @@ class SubscriptionPixelTest(
             pixel in listOf(
                 PURCHASE_SUCCESS_ORIGIN,
                 SUBSCRIPTION_WEBVIEW_RENDER_PROCESS_CRASH,
-                AUTH_V1_SIGN_IN_ATTEMPT,
                 FREE_TRIAL_START,
                 FREE_TRIAL_VPN_ACTIVATION,
             ),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205278999335242/task/1212990019305819?focus=true

### Description

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a temporary analytics pixel and its call sites; subscription sign-in behavior is otherwise unchanged.
> 
> **Overview**
> Removes the temporary `subscription_auth_v1_sign_in_attempt` pixel end-to-end.
> 
> This deletes the pixel definition from `subscription_pixels.json5`, drops `AUTH_V1_SIGN_IN_ATTEMPT` from `SubscriptionPixel`, removes `reportAuthV1SignInAttempt` from `SubscriptionPixelSender`, and stops firing it from the subscription JS messaging `setSubscription` flow. Tests are updated to no longer treat that pixel as a non-namespaced exception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6f6b96cc4b16eeb8fea8ae30198def1a4c992d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->