### PR TITLE
refresh duck.ai when subscription state changes (full screen mode)

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -294,6 +294,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermis
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
@@ -568,6 +569,7 @@ class BrowserTabViewModelTest {
     private val mockDuckChat: DuckChat = mock()
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()
+    private val subscriptionStatusFlow = MutableSharedFlow<SubscriptionStatus>()
     private val mockHistory: NavigationHistory = mock()
 
     private val defaultBrowserPromptsExperimentShowPopupMenuItemFlow = MutableStateFlow(false)
@@ -747,6 +749,7 @@ class BrowserTabViewModelTest {
 
             whenever(mockDuckChat.getDuckChatUrl(any(), any())).thenReturn(duckChatURL)
             whenever(mockSyncStatusChangedObserver.syncStatusChangedEvents).thenReturn(syncStatusChangedEventsFlow)
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(subscriptionStatusFlow)
 
             initialiseViewModel()
 
@@ -8552,5 +8555,54 @@ class BrowserTabViewModelTest {
         assertEquals(duckAIUrl, command.url)
 
         verify(mockDuckChat, never()).openDuckChat()
+    }
+
+    @Test
+    fun whenSubscriptionChangesWhileOnDuckAiThenAuthUpdateEventSent() = runTest {
+        val duckAiUrl = "https://duck.ai/chat"
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        loadUrl(duckAiUrl, title = "Duck.ai")
+
+        testee.subscriptionEventDataFlow.test {
+            subscriptionStatusFlow.emit(SubscriptionStatus.AUTO_RENEWABLE)
+
+            val event = awaitItem()
+            assertEquals(SUBSCRIPTIONS_FEATURE_NAME, event.featureName)
+            assertEquals("authUpdate", event.subscriptionName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSubscriptionChangesWhileNotOnDuckAiThenNoAuthUpdateEventSent() = runTest {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
+        loadUrl(exampleUrl, title = "Example")
+
+        testee.subscriptionEventDataFlow.test {
+            subscriptionStatusFlow.emit(SubscriptionStatus.AUTO_RENEWABLE)
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenOnViewVisibleWithPendingAuthUpdateOnDuckAiThenAuthUpdateEventSent() = runTest {
+        val duckAiUrl = "https://duck.ai/chat"
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        loadUrl(duckAiUrl, title = "Duck.ai")
+
+        // Trigger subscription change to set pending flag
+        subscriptionStatusFlow.emit(SubscriptionStatus.AUTO_RENEWABLE)
+
+        testee.subscriptionEventDataFlow.test {
+            // Simulate returning to the view (e.g., after purchase flow)
+            testee.onViewVisible()
+
+            val event = awaitItem()
+            assertEquals(SUBSCRIPTIONS_FEATURE_NAME, event.featureName)
+            assertEquals("authUpdate", event.subscriptionName)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -599,6 +599,7 @@ class BrowserTabViewModel @Inject constructor(
     private var isCustomTabScreen: Boolean = false
     private var alreadyShownKeyboard: Boolean = false
     private var handleAboutBlankEnabled: Boolean = false
+    private var pendingDuckChatAuthUpdate: Boolean = false
 
     private val isFullUrlEnabled = urlDisplayRepository.isFullUrlEnabled
         .stateIn(
@@ -698,6 +699,7 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         observeSyncStatusChangesForDuckChat()
+        observeSubscriptionChangesForDuckChat()
 
         tabRepository.childClosedTabs
             .onEach { closedTab ->
@@ -893,6 +895,37 @@ class BrowserTabViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    private fun observeSubscriptionChangesForDuckChat() {
+        subscriptions.getSubscriptionStatusFlow()
+            .distinctUntilChanged()
+            .onEach { _ ->
+                if (!androidBrowserConfig.refreshDuckAiOnSubscriptionChanges().isEnabled()) return@onEach
+
+                // Only send subscription auth events when viewing duck.ai
+                val currentUrl = url
+                if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) {
+                    // Mark pending in case WebView is paused (e.g., during purchase flow)
+                    pendingDuckChatAuthUpdate = true
+                    // Try to send immediately (will work if WebView is active)
+                    withContext(dispatchers.main()) {
+                        sendDuckChatAuthUpdate()
+                    }
+                }
+            }
+            .flowOn(dispatchers.io())
+            .launchIn(viewModelScope)
+    }
+
+    private fun sendDuckChatAuthUpdate() {
+        val authUpdateEvent = SubscriptionEventData(
+            featureName = SUBSCRIPTIONS_FEATURE_NAME,
+            subscriptionName = "authUpdate",
+            params = JSONObject(),
+        )
+        _subscriptionEventDataChannel.trySend(authUpdateEvent)
+        logcat { "DuckChat-Subscription: sent authUpdate event from BrowserTabViewModel" }
+    }
+
     override fun getCurrentTabId(): String = tabId
 
     fun onMessageProcessed() {
@@ -1019,6 +1052,16 @@ class BrowserTabViewModel @Inject constructor(
 
         viewModelScope.launch {
             refreshOnViewVisible.emit(true)
+        }
+
+        // Send pending auth update if returning to duck.ai after subscription change (e.g., after purchase flow)
+        // ensures we emit the event even if the WebView was paused
+        if (pendingDuckChatAuthUpdate) {
+            val currentUrl = url
+            if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) {
+                sendDuckChatAuthUpdate()
+                pendingDuckChatAuthUpdate = false
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -275,4 +275,7 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun sendVerifiedInstallPixels(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun refreshDuckAiOnSubscriptionChanges(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212891983397163?focus=true 

### Description
Fixes refreshing duck.ai state after subscription changes

### Steps to test this PR

_Feature 1_
- [ ] apply latest patch in https://app.asana.com/1/137249556945/task/1210448620621729/comment/1212836955103729?focus=true
- [ ] fresh install
- [ ] Open duck.ai full screen mode
- [ ] Purchase a subscription
- [ ] Go back to duck.ai (clicking on the X, purchase flow toolbar)
- [ ] Ensure UI reflects current subscription state

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new subscription-status observation that triggers JS events into `duck.ai` and defers delivery via a pending flag on view visibility; mistakes could cause missed/duplicate events or extra background work. Gated by a new remote-config toggle, reducing blast radius.
> 
> **Overview**
> **Duck.ai now reacts to subscription status changes.** `BrowserTabViewModel` observes `subscriptions.getSubscriptionStatusFlow()` and, when the user is currently on a Duck.ai URL and the new `androidBrowserConfig.refreshDuckAiOnSubscriptionChanges` toggle is enabled, emits a `SubscriptionEventData` with `subscriptionName="authUpdate"`.
> 
> If the WebView is paused during flows like purchase, the ViewModel tracks a *pending* auth update and re-sends it in `onViewVisible()` when returning to Duck.ai.
> 
> Updates/adds Android tests to cover emitting (on Duck.ai), not emitting (off Duck.ai), and the pending resend behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80dfa5e2b08afbfdbb688e72daecccf3e8ef358f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->