### PR TITLE
Change duckplayer maestro test expectation to drop youtube suffix

### DIFF
--- a/.maestro/duckplayer/common/load_serp_videos_organic.yaml
+++ b/.maestro/duckplayer/common/load_serp_videos_organic.yaml
@@ -1,6 +1,6 @@
 appId: com.duckduckgo.mobile.android
 ---
-# Select a YouTube video from SERP videos vertical
+# Select a YouTube video from SERP videos organic
 - runFlow: input_search.yaml
 
 - extendedWaitUntil:
@@ -9,10 +9,9 @@ appId: com.duckduckgo.mobile.android
     timeout: 5000
 
 - scrollUntilVisible:
-      element:
-          text: "DuckDuckGo vs Google: 5 Reasons You Should Switch - YouTube"
-      direction: DOWN
+    element:
+      text: "There are tons of.*"
+    direction: DOWN
 
 - tapOn:
-      text: "DuckDuckGo vs Google: 5 Reasons You Should Switch - YouTube"
-      index: 0
+    text: "There are tons of.*"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213047003592785?focus=true 

### Description
Adjusts a Maestro UI test string match in duckplayer to align with updated SERP video titles

### Steps to test this PR
- Confirm this passes: https://github.com/duckduckgo/Android/actions/runs/21546126430

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a Maestro UI test string match to align with updated SERP video titles; no production code changes.
> 
> **Overview**
> Updates the DuckPlayer Maestro flow `load_serp_videos_organic.yaml` to match a YouTube result title *without* the `- YouTube` suffix when scrolling and tapping the target video in the SERP videos vertical.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63370f5ac734791b6c4719fa964bfb7b66a0bf4b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->