### PR TITLE
Adjust paddings in menu action items

### DIFF
--- a/browser/browser-ui/src/main/res/layout/bottom_sheet_browser_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/bottom_sheet_browser_menu.xml
@@ -53,6 +53,7 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginEnd="@dimen/keyline_1"
                     app:menuActionLabel="@string/browserMenuBack"
                     app:menuActionSrc="@drawable/ic_arrow_left_24" />
 
@@ -61,6 +62,8 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginStart="@dimen/keyline_1"
+                    android:layout_marginEnd="@dimen/keyline_1"
                     app:menuActionLabel="@string/browserMenuForward"
                     app:menuActionSrc="@drawable/ic_arrow_right_24" />
 
@@ -69,6 +72,8 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginStart="@dimen/keyline_1"
+                    android:layout_marginEnd="@dimen/keyline_1"
                     app:menuActionLabel="@string/browserMenuNewTab"
                     app:menuActionSrc="@drawable/ic_add_24" />
 
@@ -77,6 +82,8 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginStart="@dimen/keyline_1"
+                    android:layout_marginEnd="@dimen/keyline_1"
                     android:visibility="gone"
                     app:menuActionLabel="@string/browserMenuNewAIChat"
                     app:menuActionSrc="@drawable/ic_ai_chat_add_24" />
@@ -86,6 +93,8 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginStart="@dimen/keyline_1"
+                    android:layout_marginEnd="@dimen/keyline_1"
                     app:menuActionLabel="@string/browserMenuDuckChat"
                     app:menuActionSrc="@drawable/ic_ai_chat_24" />
 
@@ -94,6 +103,7 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
+                    android:layout_marginStart="@dimen/keyline_1"
                     app:menuActionLabel="@string/browserMenuSettings"
                     app:menuActionSrc="@drawable/ic_settings_24" />
             </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213081940160652?focus=true 

### Description

Change paddings in action menu items

### Steps to test this PR

_Check paddings in menu action items_
- [x] Open the application
- [x] Turn on the new browser menu with Bottom Sheet
- [x] Check paddings are good like described in the Figma project

### UI changes
| Before  | After |
| ------ | ----- |
<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/e6f9e1dc-d580-4886-bc9f-a86f719a2485" /> | <img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/8ebc96cb-d394-471b-962b-2c5a42bca19b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts layout margins; no functional or data/logic changes.
> 
> **Overview**
> Adjusts the bottom-sheet browser menu action row spacing by adding start/end margins to each `MenuActionButtonView` in `bottom_sheet_browser_menu.xml`, improving visual padding between the back/forward/new tab/chat/settings buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c8e1c9df90c35300be017bc1d27ebe396156aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->