### PR TITLE
Add form_factor to verified install pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/verified_install.json5
+++ b/PixelDefinitions/pixels/verified_install.json5
@@ -4,6 +4,7 @@
         "description": "Fires once ever on first app open for verified Play Store installs",
         "owners": ["CDRussell"],
         "triggers": ["other"],
+        "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -18,6 +19,7 @@
         "description": "Fires once for every subsequent app update for verified Play Store installs",
         "owners": ["CDRussell"],
         "triggers": ["other"],
+        "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213063476446281?focus=true: 

### Description
Adds `form_factor` to pixel definition for verified installed pixels

### Steps to test this PR
- None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only pixel metadata to include a new suffix, with no runtime logic changes. Main risk is downstream consumers expecting unsuffixed pixel names.
> 
> **Overview**
> Adds `suffixes: ["form_factor"]` to the `verified_app_install` and `verified_app_update` pixel definitions so these events can be segmented by device form factor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1b4769e83e81fbf46aac31c0c121a54461d1083. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->