### PR TITLE
Minimize risk for errors/conflicts when finalizing hotfix

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -517,8 +517,10 @@ platform :android do
        lane :"hotfix-finish" do
             ensure_git_status_clean
             ensure_git_branch( branch: '^hotfix/*' )
-
             version = property_file_read(file: "app/version/version.properties")["VERSION"]
+            sh('git checkout main && git pull')
+            sh('git checkout develop && git pull')
+            sh("git checkout hotfix/#{version}")
             sh("git flow hotfix finish -m '#{version}' '#{version}'")
 
             sh "git push origin #{version}"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1213076006735844?focus=true

### Description

### Steps to test this PR
n/a

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes automated git branching/merging steps used during releases; incorrect branch state or pulls could disrupt the hotfix finish flow.
> 
> **Overview**
> Improves the `fastlane` `hotfix-finish` flow by pulling the latest `main` and `develop` before completing the hotfix, then explicitly checking out `hotfix/<version>` prior to running `git flow hotfix finish`.
> 
> This aims to reduce conflicts and branch-state errors when finalizing and pushing the hotfix tag/merges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76221a2ec90bc00ac86b7b3d77a0695e6a4f5dcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->