### PR TITLE
Increase delay to show bottom sheet menu and avoid conflict with keyboard

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1662,7 +1662,7 @@ class BrowserTabFragment :
     }
 
     private fun launchBottomSheetMenu(addExtraDelay: Boolean) {
-        val delay = if (addExtraDelay) POPUP_MENU_DELAY * 2 else POPUP_MENU_DELAY
+        val delay = if (addExtraDelay) BOTTOM_SHEET_MENU_DELAY * 2 else BOTTOM_SHEET_MENU_DELAY
         // small delay added to let keyboard disappear and avoid jarring transition
         binding.rootView.postDelayed(delay) {
             if (isAdded) {
@@ -4608,6 +4608,7 @@ class BrowserTabFragment :
         const val KEYBOARD_DELAY = 200L
         private const val NAVIGATION_DELAY = 100L
         private const val POPUP_MENU_DELAY = 200L
+        private const val BOTTOM_SHEET_MENU_DELAY = 300L
         private const val WIDGET_PROMPT_DELAY = 200L
         private const val CHECK_IF_ABOUT_BLANK_DELAY = 200L
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212992299141088?focus=true 

### Description

Increase delay to show browser bottom sheet menu to avoid conflict with keyboard on specific devices (like Samsung S25)

### Steps to test this PR

> Note: You can reproduce this issue only with specific devices (Samsung S25)

_Conflict between keyboard and bottom sheet menu_
- [x] Open the application
- [x] Turn on the new browser bottom sheet menu
- [x] Open a new tab with the keyboard visible
- [x] Open the menu with the keyboard open
- [x] Check the keyboard disappears and stay closed

### UI changes

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI timing tweak that only changes when the bottom-sheet browser menu is shown; potential impact is limited to perceived responsiveness of opening the menu.
> 
> **Overview**
> Increases the delay before showing the browser bottom-sheet menu to reduce keyboard/menu transition conflicts on some devices.
> 
> This introduces a dedicated `BOTTOM_SHEET_MENU_DELAY` (300ms) and uses it in `launchBottomSheetMenu`, leaving the popup menu delay unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 840a1070129d401521c87eb13c6ac08692da43e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->