### PR TITLE
Enqueue wide event daily pixels

### DIFF
--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSender.kt
@@ -67,12 +67,20 @@ class PixelWideEventSender @Inject constructor(
 
         val basePixelName = PIXEL_NAME_PREFIX + event.name
         val countPixelName = basePixelName + COUNT_PIXEL_SUFFIX
+        val dailyPixelName = basePixelName + DAILY_PIXEL_SUFFIX
 
         if (shouldEnqueuePixel()) {
             pixelSender.enqueueFire(
                 pixelName = countPixelName,
                 parameters = parameters,
                 encodedParameters = encodedParameters,
+            )
+
+            pixelSender.enqueueFire(
+                pixelName = dailyPixelName,
+                parameters = parameters,
+                encodedParameters = encodedParameters,
+                type = Pixel.PixelType.Daily(),
             )
         } else {
             pixelSender.fire(
@@ -81,14 +89,14 @@ class PixelWideEventSender @Inject constructor(
                 encodedParameters = encodedParameters,
                 type = Pixel.PixelType.Count,
             )
-        }
 
-        pixelSender.fire(
-            pixelName = basePixelName + DAILY_PIXEL_SUFFIX,
-            parameters = parameters,
-            encodedParameters = encodedParameters,
-            type = Pixel.PixelType.Daily(),
-        )
+            pixelSender.fire(
+                pixelName = dailyPixelName,
+                parameters = parameters,
+                encodedParameters = encodedParameters,
+                type = Pixel.PixelType.Daily(),
+            )
+        }
     }
 
     private fun getCommonPixelParameters(): Map<String, String> {

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/PixelWideEventSenderTest.kt
@@ -111,7 +111,7 @@ class PixelWideEventSenderTest {
                 type = any(),
             )
 
-            verify(pixel).fire(
+            verify(pixel).enqueueFire(
                 pixelName = eq("wide_${eventName}_d"),
                 parameters = eq(expectedParameters),
                 encodedParameters = eq(expectedEncodedParameters),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1213076046472940?focus=true

### Description

This PR switches the API used for sending daily wide event pixels from fire() to enqueueFire().

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry delivery semantics by switching daily wide-event pixels from immediate `fire` to `enqueueFire` under a feature flag, which could affect ordering or delivery timing if the queue behaves differently.
> 
> **Overview**
> When `enqueueWideEventPixels` is enabled, `PixelWideEventSender` now enqueues **both** the count (`_c`) and daily (`_d`) wide-event pixels instead of only enqueuing the count pixel and firing the daily pixel immediately.
> 
> Tests were updated to assert that the daily pixel is also sent via `enqueueFire` in the enqueue-enabled scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8af1583e2b4bfcab6ade0a1eb8f481dc99153748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->