### PR TITLE
Use tabular numerals for trackers blocked banner

### DIFF
--- a/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
+++ b/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
@@ -47,6 +47,7 @@
         android:layout_marginTop="@dimen/keyline_4"
         android:layout_marginEnd="@dimen/keyline_3"
         android:layout_marginBottom="@dimen/keyline_4"
+        android:fontFeatureSettings="tnum"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/infoIcon"
         app:layout_constraintStart_toEndOf="@+id/infoPanelAnimatedImage"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213112270312883?focus=true

### Description

- Fixes a resizing issue with the trackers blocked banner which was causing a jump.

### Steps to test this PR

- [ ] Visit some sites with trackers or manually set to >1000
- [ ] Verify that the banner no longer jumps (See recordings)

### UI changes

### Before

https://github.com/user-attachments/assets/170247c8-a71e-45a4-a414-5ef5a3ec7e74

### After

https://github.com/user-attachments/assets/d16bc52e-9b3d-456b-9cf5-d2df83c00282




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single XML layout attribute change affecting only text rendering in one UI component.
> 
> **Overview**
> Applies **tabular numerals** to the trackers-blocked info panel text by adding `android:fontFeatureSettings="tnum"` to `infoPanelText` in `item_tab_switcher_animation_info_panel.xml`, improving numeric alignment/consistency in the banner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe0ae04f5c836cb3efe2d1c884dba3ed9dba7ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->