### PR TITLE
Update content scope scripts to version 12.40.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -514,6 +514,23 @@
       createCustomEvent("sendMessageProxy" + messageSecret, { detail: JSON.stringify({ messageType, options }) })
     );
   }
+  function withDefaults(defaults, config) {
+    if (config === void 0) {
+      return defaults;
+    }
+    if (
+      // if defaults are undefined
+      defaults === void 0 || // or either config or defaults are a non-object value that we can't merge
+      Array.isArray(defaults) || defaults === null || typeof defaults !== "object" || Array.isArray(config) || config === null || typeof config !== "object"
+    ) {
+      return config;
+    }
+    const result = {};
+    for (const key of new Set2([...Object.keys(defaults), ...Object.keys(config)])) {
+      result[key] = withDefaults(defaults[key], config[key]);
+    }
+    return result;
+  }
 
   // src/features.js
   var baseFeatures = (
@@ -546,6 +563,7 @@
       "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
+      "webDetection",
       "webInterferenceDetection",
       "windowsPermissionUsage",
       "uaChBrands",
@@ -559,7 +577,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -568,11 +586,21 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon"
+      "favicon",
+      "webDetection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
+    android: [
+      ...baseFeatures,
+      "webCompat",
+      "webDetection",
+      "webInterferenceDetection",
+      "breakageReporting",
+      "duckPlayer",
+      "messageBridge",
+      "pageContext"
+    ],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -584,11 +612,13 @@
       "fingerprintingAudio",
       "fingerprintingBattery",
       "gpc",
+      "webDetection",
       "breakageReporting"
     ],
     windows: [
       "cookie",
       ...baseFeatures,
+      "webDetection",
       "webInterferenceDetection",
       "webTelemetry",
       "windowsPermissionUsage",
@@ -603,9 +633,9 @@
       "performanceMetrics",
       "duckAiChatHistory"
     ],
-    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
+    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
     integration: [...baseFeatures, ...otherFeatures]
   };
 
@@ -3259,25 +3289,8 @@
       }
     }
     /**
-     * Used to match conditional changes for a settings feature.
-     * @typedef {object} ConditionBlock
-     * @property {string[] | string} [domain]
-     * @property {object} [urlPattern]
-     * @property {object} [minSupportedVersion]
-     * @property {object} [maxSupportedVersion]
-     * @property {object} [experiment]
-     * @property {string} [experiment.experimentName]
-     * @property {string} [experiment.cohort]
-     * @property {object} [context]
-     * @property {boolean} [context.frame] - true if the condition applies to frames
-     * @property {boolean} [context.top] - true if the condition applies to the top frame
-     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
-     * @property {boolean} [internal] - true if the condition applies to internal builds
-     * @property {boolean} [preview] - true if the condition applies to preview builds
-     */
-    /**
      * Takes multiple conditional blocks and returns true if any apply.
-     * @param {ConditionBlock|ConditionBlock[]} conditionBlock
+     * @param {ConditionBlockOrArray} conditionBlock
      * @returns {boolean}
      */
     _matchConditionalBlockOrArray(conditionBlock) {
@@ -3434,6 +3447,14 @@
       return isMaxSupportedVersion(conditionBlock.maxSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
+     * Check if a state value is enabled for the current platform.
+     * @param {import('./utils.js').FeatureState | undefined} state
+     * @returns {boolean}
+     */
+    _isStateEnabled(state) {
+      return isStateEnabled(state, __privateGet(this, _args)?.platform);
+    }
+    /**
      * Return the settings object for a feature
      * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
      * @returns {any}
@@ -3471,11 +3492,10 @@
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
-      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return isStateEnabled(result.state, platform);
+        return this._isStateEnabled(result.state);
       }
-      return isStateEnabled(result, platform);
+      return this._isStateEnabled(result);
     }
     /**
      * Return a specific setting from the feature settings
@@ -5928,6 +5948,188 @@
     }
   };
 
+  // src/features/web-detection/parse.js
+  var DEFAULT_RUN_CONDITIONS = (
+    /** @type {import('../../config-feature.js').ConditionBlock[]} */
+    [
+      {
+        context: { top: true }
+      }
+    ]
+  );
+  var DEFAULTS = {
+    state: (
+      /** @type {FeatureState} */
+      "enabled"
+    ),
+    triggers: {
+      breakageReport: {
+        state: (
+          /** @type {FeatureState} */
+          "enabled"
+        ),
+        runConditions: DEFAULT_RUN_CONDITIONS
+      }
+    },
+    actions: {
+      breakageReportData: {
+        state: (
+          /** @type {FeatureState} */
+          "enabled"
+        )
+      }
+    }
+  };
+  function isValidName(name) {
+    return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
+  }
+  function normalizeDetector(config) {
+    return withDefaults(DEFAULTS, config);
+  }
+  function parseDetectors(detectorsConfig) {
+    const detectors = {};
+    if (!detectorsConfig) {
+      return detectors;
+    }
+    for (const [groupName, groupConfig] of Object.entries(detectorsConfig)) {
+      if (!isValidName(groupName)) {
+        continue;
+      }
+      const groupDetectors = {};
+      for (const [detectorId, detectorConfig] of Object.entries(groupConfig)) {
+        if (!isValidName(detectorId)) {
+          continue;
+        }
+        groupDetectors[detectorId] = normalizeDetector(detectorConfig);
+      }
+      detectors[groupName] = groupDetectors;
+    }
+    return detectors;
+  }
+
+  // src/features/web-detection/matching.js
+  function asArray(value, defaultValue = []) {
+    if (value === void 0) return defaultValue;
+    return Array.isArray(value) ? value : [value];
+  }
+  function isVisible(element) {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0.5 && rect.height > 0.5 && style.display !== "none" && style.visibility !== "hidden" && parseFloat(style.opacity) > 0.05;
+  }
+  function evaluateSingleTextCondition(condition) {
+    const patterns = asArray(condition.pattern);
+    const selectors = asArray(condition.selector, ["body"]);
+    const patternComb = new RegExp(patterns.join("|"), "i");
+    return selectors.some((selector) => {
+      const elements = document.querySelectorAll(selector);
+      for (const element of elements) {
+        if (patternComb.test(element.textContent || "")) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  function evaluateSingleElementCondition(config) {
+    const visibility = config.visibility ?? "any";
+    return asArray(config.selector).some((selector) => {
+      if (visibility === "any") {
+        return document.querySelector(selector) !== null;
+      }
+      for (const element of document.querySelectorAll(selector)) {
+        if (visibility === "visible" && isVisible(element)) {
+          return true;
+        }
+        if (visibility === "hidden" && !isVisible(element)) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  function evaluateORCondition(condition, singleConditionEvaluator) {
+    if (condition === void 0) return true;
+    if (Array.isArray(condition)) {
+      return condition.some((v2) => singleConditionEvaluator(v2));
+    }
+    return singleConditionEvaluator(condition);
+  }
+  function evaluateSingleMatchCondition(condition) {
+    if (!evaluateORCondition(condition.text, evaluateSingleTextCondition)) {
+      return false;
+    }
+    if (!evaluateORCondition(condition.element, evaluateSingleElementCondition)) {
+      return false;
+    }
+    return true;
+  }
+  function evaluateMatch(conditions) {
+    return evaluateORCondition(conditions, evaluateSingleMatchCondition);
+  }
+
+  // src/features/web-detection.js
+  var _detectors;
+  var WebDetection = class extends ContentFeature {
+    constructor() {
+      super(...arguments);
+      /** @type {Record<string, Record<string, DetectorConfig>>} */
+      __privateAdd(this, _detectors, {});
+      __publicField(this, "_exposedMethods", this._declareExposedMethods(["runDetectors"]));
+    }
+    /**
+     * Initialize the feature by loading detector configurations
+     */
+    init() {
+      const detectorsConfig = this.getFeatureSetting("detectors");
+      __privateSet(this, _detectors, parseDetectors(detectorsConfig));
+    }
+    /**
+     * Check if a detector should be triggered.
+     *
+     * @param {DetectorConfig} config
+     * @param {RunDetectionOptions} options
+     * @returns {boolean}
+     */
+    _shouldRunDetector(config, options) {
+      if (!this._isStateEnabled(config.state)) return false;
+      const triggerSettings = config.triggers[options.trigger];
+      if (!triggerSettings || !this._isStateEnabled(triggerSettings.state)) return false;
+      if (triggerSettings.runConditions && !this._matchConditionalBlockOrArray(triggerSettings.runConditions)) return false;
+      return true;
+    }
+    /**
+     * Run all detectors for a specific trigger.
+     *
+     * @param {RunDetectionOptions} options
+     * @returns {DetectorResult[]}
+     */
+    runDetectors(options) {
+      const results = [];
+      for (const [groupName, groupDetectors] of Object.entries(__privateGet(this, _detectors))) {
+        for (const [detectorId, detectorConfig] of Object.entries(groupDetectors)) {
+          if (!this._shouldRunDetector(detectorConfig, options)) continue;
+          let detected;
+          try {
+            detected = evaluateMatch(detectorConfig.match);
+          } catch {
+            detected = "error";
+          }
+          if (options.trigger === "breakageReport" && this._isStateEnabled(detectorConfig.actions.breakageReportData.state)) {
+            if (detected !== false) {
+              results.push({
+                detectorId: `${groupName}.${detectorId}`,
+                detected
+              });
+            }
+          }
+        }
+      }
+      return results;
+    }
+  };
+  _detectors = new WeakMap();
+
   // src/features/breakage-reporting/utils.js
   function getJsPerformanceMetrics() {
     const paintResources = performance.getEntriesByType("paint");
@@ -6034,7 +6236,7 @@
     }
     return selectors.some((selector) => {
       const element = document.querySelector(selector);
-      return element && isVisible(element);
+      return element && isVisible2(element);
     });
   }
   function checkWindowProperties(properties) {
@@ -6043,7 +6245,7 @@
     }
     return properties.some((prop) => typeof window?.[prop] !== "undefined");
   }
-  function isVisible(element) {
+  function isVisible2(element) {
     const computedStyle = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
     return rect.width > 0.5 && rect.height > 0.5 && computedStyle.display !== "none" && computedStyle.visibility !== "hidden" && +computedStyle.opacity > 0.05;
@@ -6171,6 +6373,7 @@
     init() {
       const isExpandedPerformanceMetricsEnabled = this.getFeatureSettingEnabled("expandedPerformanceMetrics", "enabled");
       this.messaging.subscribe("getBreakageReportValues", async () => {
+        const breakageDataPayload = {};
         const jsPerformance = getJsPerformanceMetrics();
         const referrer = document.referrer;
         const result = {
@@ -6186,6 +6389,10 @@
           result.pageReloaded = window.performance.navigation && window.performance.navigation.type === 1 || /** @type {PerformanceNavigationTiming[]} */
           window.performance.getEntriesByType("navigation").map((nav) => nav.type).includes("reload");
         }
+        const webDetectionResults = await this.callFeatureMethod("webDetection", "runDetectors", { trigger: "breakageReport" });
+        if (!(webDetectionResults instanceof CallFeatureMethodError) && webDetectionResults.length > 0) {
+          breakageDataPayload.webDetection = webDetectionResults;
+        }
         const detectorSettings = this.getFeatureSetting("interferenceTypes", "webInterferenceDetection");
         if (detectorSettings) {
           result.detectorData = {
@@ -6200,7 +6407,6 @@
             result.expandedPerformanceMetrics = expandedPerformanceMetrics.metrics;
           }
         }
-        const breakageDataPayload = {};
         if (result.detectorData) {
           breakageDataPayload.detectorData = result.detectorData;
         }
@@ -6226,6 +6432,7 @@
     ddg_feature_fingerprintingAudio: FingerprintingAudio,
     ddg_feature_fingerprintingBattery: FingerprintingBattery,
     ddg_feature_gpc: GlobalPrivacyControl,
+    ddg_feature_webDetection: WebDetection,
     ddg_feature_breakageReporting: BreakageReporting
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2081,6 +2081,7 @@
       "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
+      "webDetection",
       "webInterferenceDetection",
       "windowsPermissionUsage",
       "uaChBrands",
@@ -2094,7 +2095,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -2103,11 +2104,21 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon"
+      "favicon",
+      "webDetection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
+    android: [
+      ...baseFeatures,
+      "webCompat",
+      "webDetection",
+      "webInterferenceDetection",
+      "breakageReporting",
+      "duckPlayer",
+      "messageBridge",
+      "pageContext"
+    ],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -2119,11 +2130,13 @@
       "fingerprintingAudio",
       "fingerprintingBattery",
       "gpc",
+      "webDetection",
       "breakageReporting"
     ],
     windows: [
       "cookie",
       ...baseFeatures,
+      "webDetection",
       "webInterferenceDetection",
       "webTelemetry",
       "windowsPermissionUsage",
@@ -2138,9 +2151,9 @@
       "performanceMetrics",
       "duckAiChatHistory"
     ],
-    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
+    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
     integration: [...baseFeatures, ...otherFeatures]
   };
 
@@ -4824,25 +4837,8 @@
       }
     }
     /**
-     * Used to match conditional changes for a settings feature.
-     * @typedef {object} ConditionBlock
-     * @property {string[] | string} [domain]
-     * @property {object} [urlPattern]
-     * @property {object} [minSupportedVersion]
-     * @property {object} [maxSupportedVersion]
-     * @property {object} [experiment]
-     * @property {string} [experiment.experimentName]
-     * @property {string} [experiment.cohort]
-     * @property {object} [context]
-     * @property {boolean} [context.frame] - true if the condition applies to frames
-     * @property {boolean} [context.top] - true if the condition applies to the top frame
-     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
-     * @property {boolean} [internal] - true if the condition applies to internal builds
-     * @property {boolean} [preview] - true if the condition applies to preview builds
-     */
-    /**
      * Takes multiple conditional blocks and returns true if any apply.
-     * @param {ConditionBlock|ConditionBlock[]} conditionBlock
+     * @param {ConditionBlockOrArray} conditionBlock
      * @returns {boolean}
      */
     _matchConditionalBlockOrArray(conditionBlock) {
@@ -4999,6 +4995,14 @@
       return isMaxSupportedVersion(conditionBlock.maxSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
+     * Check if a state value is enabled for the current platform.
+     * @param {import('./utils.js').FeatureState | undefined} state
+     * @returns {boolean}
+     */
+    _isStateEnabled(state) {
+      return isStateEnabled(state, __privateGet(this, _args)?.platform);
+    }
+    /**
      * Return the settings object for a feature
      * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
      * @returns {any}
@@ -5036,11 +5040,10 @@
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
-      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return isStateEnabled(result.state, platform);
+        return this._isStateEnabled(result.state);
       }
-      return isStateEnabled(result, platform);
+      return this._isStateEnabled(result);
     }
     /**
      * Return a specific setting from the feature settings

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2053,6 +2053,7 @@
       "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
+      "webDetection",
       "webInterferenceDetection",
       "windowsPermissionUsage",
       "uaChBrands",
@@ -2066,7 +2067,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -2075,11 +2076,21 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon"
+      "favicon",
+      "webDetection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
+    android: [
+      ...baseFeatures,
+      "webCompat",
+      "webDetection",
+      "webInterferenceDetection",
+      "breakageReporting",
+      "duckPlayer",
+      "messageBridge",
+      "pageContext"
+    ],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -2091,11 +2102,13 @@
       "fingerprintingAudio",
       "fingerprintingBattery",
       "gpc",
+      "webDetection",
       "breakageReporting"
     ],
     windows: [
       "cookie",
       ...baseFeatures,
+      "webDetection",
       "webInterferenceDetection",
       "webTelemetry",
       "windowsPermissionUsage",
@@ -2110,9 +2123,9 @@
       "performanceMetrics",
       "duckAiChatHistory"
     ],
-    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
+    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
     integration: [...baseFeatures, ...otherFeatures]
   };
 
@@ -4793,25 +4806,8 @@
       }
     }
     /**
-     * Used to match conditional changes for a settings feature.
-     * @typedef {object} ConditionBlock
-     * @property {string[] | string} [domain]
-     * @property {object} [urlPattern]
-     * @property {object} [minSupportedVersion]
-     * @property {object} [maxSupportedVersion]
-     * @property {object} [experiment]
-     * @property {string} [experiment.experimentName]
-     * @property {string} [experiment.cohort]
-     * @property {object} [context]
-     * @property {boolean} [context.frame] - true if the condition applies to frames
-     * @property {boolean} [context.top] - true if the condition applies to the top frame
-     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
-     * @property {boolean} [internal] - true if the condition applies to internal builds
-     * @property {boolean} [preview] - true if the condition applies to preview builds
-     */
-    /**
      * Takes multiple conditional blocks and returns true if any apply.
-     * @param {ConditionBlock|ConditionBlock[]} conditionBlock
+     * @param {ConditionBlockOrArray} conditionBlock
      * @returns {boolean}
      */
     _matchConditionalBlockOrArray(conditionBlock) {
@@ -4968,6 +4964,14 @@
       return isMaxSupportedVersion(conditionBlock.maxSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
+     * Check if a state value is enabled for the current platform.
+     * @param {import('./utils.js').FeatureState | undefined} state
+     * @returns {boolean}
+     */
+    _isStateEnabled(state) {
+      return isStateEnabled(state, __privateGet(this, _args)?.platform);
+    }
+    /**
      * Return the settings object for a feature
      * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
      * @returns {any}
@@ -5005,11 +5009,10 @@
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
-      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return isStateEnabled(result.state, platform);
+        return this._isStateEnabled(result.state);
       }
-      return isStateEnabled(result, platform);
+      return this._isStateEnabled(result);
     }
     /**
      * Return a specific setting from the feature settings

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1362,6 +1362,23 @@
     }
     return false;
   }
+  function withDefaults(defaults, config) {
+    if (config === void 0) {
+      return defaults;
+    }
+    if (
+      // if defaults are undefined
+      defaults === void 0 || // or either config or defaults are a non-object value that we can't merge
+      Array.isArray(defaults) || defaults === null || typeof defaults !== "object" || Array.isArray(config) || config === null || typeof config !== "object"
+    ) {
+      return config;
+    }
+    const result = {};
+    for (const key of new Set2([...Object.keys(defaults), ...Object.keys(config)])) {
+      result[key] = withDefaults(defaults[key], config[key]);
+    }
+    return result;
+  }
 
   // src/features.js
   init_define_import_meta_trackerLookup();
@@ -1395,6 +1412,7 @@
       "duckAiChatHistory",
       "harmfulApis",
       "webCompat",
+      "webDetection",
       "webInterferenceDetection",
       "windowsPermissionUsage",
       "uaChBrands",
@@ -1408,7 +1426,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -1417,11 +1435,21 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon"
+      "favicon",
+      "webDetection"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],
-    android: [...baseFeatures, "webCompat", "webInterferenceDetection", "breakageReporting", "duckPlayer", "messageBridge", "pageContext"],
+    android: [
+      ...baseFeatures,
+      "webCompat",
+      "webDetection",
+      "webInterferenceDetection",
+      "breakageReporting",
+      "duckPlayer",
+      "messageBridge",
+      "pageContext"
+    ],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
@@ -1433,11 +1461,13 @@
       "fingerprintingAudio",
       "fingerprintingBattery",
       "gpc",
+      "webDetection",
       "breakageReporting"
     ],
     windows: [
       "cookie",
       ...baseFeatures,
+      "webDetection",
       "webInterferenceDetection",
       "webTelemetry",
       "windowsPermissionUsage",
@@ -1452,9 +1482,9 @@
       "performanceMetrics",
       "duckAiChatHistory"
     ],
-    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
-    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webInterferenceDetection", "breakageReporting"],
+    firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
+    "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webInterferenceDetection", "breakageReporting"],
     integration: [...baseFeatures, ...otherFeatures]
   };
 
@@ -4664,25 +4694,8 @@
       }
     }
     /**
-     * Used to match conditional changes for a settings feature.
-     * @typedef {object} ConditionBlock
-     * @property {string[] | string} [domain]
-     * @property {object} [urlPattern]
-     * @property {object} [minSupportedVersion]
-     * @property {object} [maxSupportedVersion]
-     * @property {object} [experiment]
-     * @property {string} [experiment.experimentName]
-     * @property {string} [experiment.cohort]
-     * @property {object} [context]
-     * @property {boolean} [context.frame] - true if the condition applies to frames
-     * @property {boolean} [context.top] - true if the condition applies to the top frame
-     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
-     * @property {boolean} [internal] - true if the condition applies to internal builds
-     * @property {boolean} [preview] - true if the condition applies to preview builds
-     */
-    /**
      * Takes multiple conditional blocks and returns true if any apply.
-     * @param {ConditionBlock|ConditionBlock[]} conditionBlock
+     * @param {ConditionBlockOrArray} conditionBlock
      * @returns {boolean}
      */
     _matchConditionalBlockOrArray(conditionBlock) {
@@ -4839,6 +4852,14 @@
       return isMaxSupportedVersion(conditionBlock.maxSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
+     * Check if a state value is enabled for the current platform.
+     * @param {import('./utils.js').FeatureState | undefined} state
+     * @returns {boolean}
+     */
+    _isStateEnabled(state) {
+      return isStateEnabled(state, __privateGet(this, _args)?.platform);
+    }
+    /**
      * Return the settings object for a feature
      * @param {string} [featureName] - The name of the feature to get the settings for; defaults to the name of the feature
      * @returns {any}
@@ -4876,11 +4897,10 @@
      */
     getFeatureSettingEnabled(featureKeyName, defaultState, featureName) {
       const result = this.getFeatureSetting(featureKeyName, featureName) || defaultState;
-      const platform = __privateGet(this, _args)?.platform;
       if (typeof result === "object") {
-        return isStateEnabled(result.state, platform);
+        return this._isStateEnabled(result.state);
       }
-      return isStateEnabled(result, platform);
+      return this._isStateEnabled(result);
     }
     /**
      * Return a specific setting from the feature settings
@@ -7872,6 +7892,193 @@
   _webNotifications = new WeakMap();
   var web_compat_default = WebCompat;
 
+  // src/features/web-detection.js
+  init_define_import_meta_trackerLookup();
+
+  // src/features/web-detection/parse.js
+  init_define_import_meta_trackerLookup();
+  var DEFAULT_RUN_CONDITIONS = (
+    /** @type {import('../../config-feature.js').ConditionBlock[]} */
+    [
+      {
+        context: { top: true }
+      }
+    ]
+  );
+  var DEFAULTS = {
+    state: (
+      /** @type {FeatureState} */
+      "enabled"
+    ),
+    triggers: {
+      breakageReport: {
+        state: (
+          /** @type {FeatureState} */
+          "enabled"
+        ),
+        runConditions: DEFAULT_RUN_CONDITIONS
+      }
+    },
+    actions: {
+      breakageReportData: {
+        state: (
+          /** @type {FeatureState} */
+          "enabled"
+        )
+      }
+    }
+  };
+  function isValidName(name) {
+    return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
+  }
+  function normalizeDetector(config) {
+    return withDefaults(DEFAULTS, config);
+  }
+  function parseDetectors(detectorsConfig) {
+    const detectors = {};
+    if (!detectorsConfig) {
+      return detectors;
+    }
+    for (const [groupName, groupConfig] of Object.entries(detectorsConfig)) {
+      if (!isValidName(groupName)) {
+        continue;
+      }
+      const groupDetectors = {};
+      for (const [detectorId, detectorConfig] of Object.entries(groupConfig)) {
+        if (!isValidName(detectorId)) {
+          continue;
+        }
+        groupDetectors[detectorId] = normalizeDetector(detectorConfig);
+      }
+      detectors[groupName] = groupDetectors;
+    }
+    return detectors;
+  }
+
+  // src/features/web-detection/matching.js
+  init_define_import_meta_trackerLookup();
+  function asArray(value, defaultValue = []) {
+    if (value === void 0) return defaultValue;
+    return Array.isArray(value) ? value : [value];
+  }
+  function isVisible(element) {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0.5 && rect.height > 0.5 && style.display !== "none" && style.visibility !== "hidden" && parseFloat(style.opacity) > 0.05;
+  }
+  function evaluateSingleTextCondition(condition) {
+    const patterns = asArray(condition.pattern);
+    const selectors = asArray(condition.selector, ["body"]);
+    const patternComb = new RegExp(patterns.join("|"), "i");
+    return selectors.some((selector) => {
+      const elements = document.querySelectorAll(selector);
+      for (const element of elements) {
+        if (patternComb.test(element.textContent || "")) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  function evaluateSingleElementCondition(config) {
+    const visibility = config.visibility ?? "any";
+    return asArray(config.selector).some((selector) => {
+      if (visibility === "any") {
+        return document.querySelector(selector) !== null;
+      }
+      for (const element of document.querySelectorAll(selector)) {
+        if (visibility === "visible" && isVisible(element)) {
+          return true;
+        }
+        if (visibility === "hidden" && !isVisible(element)) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+  function evaluateORCondition(condition, singleConditionEvaluator) {
+    if (condition === void 0) return true;
+    if (Array.isArray(condition)) {
+      return condition.some((v2) => singleConditionEvaluator(v2));
+    }
+    return singleConditionEvaluator(condition);
+  }
+  function evaluateSingleMatchCondition(condition) {
+    if (!evaluateORCondition(condition.text, evaluateSingleTextCondition)) {
+      return false;
+    }
+    if (!evaluateORCondition(condition.element, evaluateSingleElementCondition)) {
+      return false;
+    }
+    return true;
+  }
+  function evaluateMatch(conditions) {
+    return evaluateORCondition(conditions, evaluateSingleMatchCondition);
+  }
+
+  // src/features/web-detection.js
+  var _detectors;
+  var WebDetection = class extends ContentFeature {
+    constructor() {
+      super(...arguments);
+      /** @type {Record<string, Record<string, DetectorConfig>>} */
+      __privateAdd(this, _detectors, {});
+      __publicField(this, "_exposedMethods", this._declareExposedMethods(["runDetectors"]));
+    }
+    /**
+     * Initialize the feature by loading detector configurations
+     */
+    init() {
+      const detectorsConfig = this.getFeatureSetting("detectors");
+      __privateSet(this, _detectors, parseDetectors(detectorsConfig));
+    }
+    /**
+     * Check if a detector should be triggered.
+     *
+     * @param {DetectorConfig} config
+     * @param {RunDetectionOptions} options
+     * @returns {boolean}
+     */
+    _shouldRunDetector(config, options) {
+      if (!this._isStateEnabled(config.state)) return false;
+      const triggerSettings = config.triggers[options.trigger];
+      if (!triggerSettings || !this._isStateEnabled(triggerSettings.state)) return false;
+      if (triggerSettings.runConditions && !this._matchConditionalBlockOrArray(triggerSettings.runConditions)) return false;
+      return true;
+    }
+    /**
+     * Run all detectors for a specific trigger.
+     *
+     * @param {RunDetectionOptions} options
+     * @returns {DetectorResult[]}
+     */
+    runDetectors(options) {
+      const results = [];
+      for (const [groupName, groupDetectors] of Object.entries(__privateGet(this, _detectors))) {
+        for (const [detectorId, detectorConfig] of Object.entries(groupDetectors)) {
+          if (!this._shouldRunDetector(detectorConfig, options)) continue;
+          let detected;
+          try {
+            detected = evaluateMatch(detectorConfig.match);
+          } catch {
+            detected = "error";
+          }
+          if (options.trigger === "breakageReport" && this._isStateEnabled(detectorConfig.actions.breakageReportData.state)) {
+            if (detected !== false) {
+              results.push({
+                detectorId: `${groupName}.${detectorId}`,
+                detected
+              });
+            }
+          }
+        }
+      }
+      return results;
+    }
+  };
+  _detectors = new WeakMap();
+
   // src/features/web-interference-detection.js
   init_define_import_meta_trackerLookup();
 
@@ -7892,7 +8099,7 @@
     }
     return selectors.some((selector) => {
       const element = document.querySelector(selector);
-      return element && isVisible(element);
+      return element && isVisible2(element);
     });
   }
   function checkWindowProperties(properties) {
@@ -7901,7 +8108,7 @@
     }
     return properties.some((prop) => typeof window?.[prop] !== "undefined");
   }
-  function isVisible(element) {
+  function isVisible2(element) {
     const computedStyle = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
     return rect.width > 0.5 && rect.height > 0.5 && computedStyle.display !== "none" && computedStyle.visibility !== "hidden" && +computedStyle.opacity > 0.05;
@@ -8152,6 +8359,7 @@
     init() {
       const isExpandedPerformanceMetricsEnabled = this.getFeatureSettingEnabled("expandedPerformanceMetrics", "enabled");
       this.messaging.subscribe("getBreakageReportValues", async () => {
+        const breakageDataPayload = {};
         const jsPerformance = getJsPerformanceMetrics();
         const referrer = document.referrer;
         const result = {
@@ -8167,6 +8375,10 @@
           result.pageReloaded = window.performance.navigation && window.performance.navigation.type === 1 || /** @type {PerformanceNavigationTiming[]} */
           window.performance.getEntriesByType("navigation").map((nav) => nav.type).includes("reload");
         }
+        const webDetectionResults = await this.callFeatureMethod("webDetection", "runDetectors", { trigger: "breakageReport" });
+        if (!(webDetectionResults instanceof CallFeatureMethodError) && webDetectionResults.length > 0) {
+          breakageDataPayload.webDetection = webDetectionResults;
+        }
         const detectorSettings = this.getFeatureSetting("interferenceTypes", "webInterferenceDetection");
         if (detectorSettings) {
           result.detectorData = {
@@ -8181,7 +8393,6 @@
             result.expandedPerformanceMetrics = expandedPerformanceMetrics.metrics;
           }
         }
-        const breakageDataPayload = {};
         if (result.detectorData) {
           breakageDataPayload.detectorData = result.detectorData;
         }
@@ -11011,6 +11222,7 @@ ${iframeContent}
     ddg_feature_exceptionHandler: ExceptionHandler,
     ddg_feature_apiManipulation: ApiManipulation,
     ddg_feature_webCompat: web_compat_default,
+    ddg_feature_webDetection: WebDetection,
     ddg_feature_webInterferenceDetection: WebInterferenceDetection,
     ddg_feature_breakageReporting: BreakageReporting,
     ddg_feature_duckPlayer: DuckPlayerFeature,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1478,8 +1478,8 @@
   var u;
   var t;
   var i;
-  var r;
   var o;
+  var r;
   var e;
   var f;
   var c;
@@ -1489,8 +1489,8 @@
   var p = {};
   var v = [];
   var y = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
-  var w = Array.isArray;
-  function d(n2, l3) {
+  var d = Array.isArray;
+  function w(n2, l3) {
     for (var u3 in l3) n2[u3] = l3[u3];
     return n2;
   }
@@ -1498,14 +1498,14 @@
     n2 && n2.parentNode && n2.parentNode.removeChild(n2);
   }
   function _(l3, u3, t3) {
-    var i3, r3, o3, e3 = {};
-    for (o3 in u3) "key" == o3 ? i3 = u3[o3] : "ref" == o3 ? r3 = u3[o3] : e3[o3] = u3[o3];
-    if (arguments.length > 2 && (e3.children = arguments.length > 3 ? n.call(arguments, 2) : t3), "function" == typeof l3 && null != l3.defaultProps) for (o3 in l3.defaultProps) void 0 === e3[o3] && (e3[o3] = l3.defaultProps[o3]);
-    return m(l3, e3, i3, r3, null);
+    var i3, o3, r3, e3 = {};
+    for (r3 in u3) "key" == r3 ? i3 = u3[r3] : "ref" == r3 ? o3 = u3[r3] : e3[r3] = u3[r3];
+    if (arguments.length > 2 && (e3.children = arguments.length > 3 ? n.call(arguments, 2) : t3), "function" == typeof l3 && null != l3.defaultProps) for (r3 in l3.defaultProps) void 0 === e3[r3] && (e3[r3] = l3.defaultProps[r3]);
+    return m(l3, e3, i3, o3, null);
   }
-  function m(n2, t3, i3, r3, o3) {
-    var e3 = { type: n2, props: t3, key: i3, ref: r3, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == o3 ? ++u : o3, __i: -1, __u: 0 };
-    return null == o3 && null != l.vnode && l.vnode(e3), e3;
+  function m(n2, t3, i3, o3, r3) {
+    var e3 = { type: n2, props: t3, key: i3, ref: o3, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == r3 ? ++u : r3, __i: -1, __u: 0 };
+    return null == r3 && null != l.vnode && l.vnode(e3), e3;
   }
   function k(n2) {
     return n2.children;
@@ -1529,27 +1529,27 @@
     }
   }
   function M(n2) {
-    (!n2.__d && (n2.__d = true) && i.push(n2) && !$.__r++ || r != l.debounceRendering) && ((r = l.debounceRendering) || o)($);
+    (!n2.__d && (n2.__d = true) && i.push(n2) && !$.__r++ || o != l.debounceRendering) && ((o = l.debounceRendering) || r)($);
   }
   function $() {
-    for (var n2, u3, t3, r3, o3, f3, c3, s3 = 1; i.length; ) i.length > s3 && i.sort(e), n2 = i.shift(), s3 = i.length, n2.__d && (t3 = void 0, r3 = void 0, o3 = (r3 = (u3 = n2).__v).__e, f3 = [], c3 = [], u3.__P && ((t3 = d({}, r3)).__v = r3.__v + 1, l.vnode && l.vnode(t3), O(u3.__P, t3, r3, u3.__n, u3.__P.namespaceURI, 32 & r3.__u ? [o3] : null, f3, null == o3 ? S(r3) : o3, !!(32 & r3.__u), c3), t3.__v = r3.__v, t3.__.__k[t3.__i] = t3, N(f3, t3, c3), r3.__e = r3.__ = null, t3.__e != o3 && C(t3)));
+    for (var n2, u3, t3, o3, r3, f3, c3, s3 = 1; i.length; ) i.length > s3 && i.sort(e), n2 = i.shift(), s3 = i.length, n2.__d && (t3 = void 0, o3 = void 0, r3 = (o3 = (u3 = n2).__v).__e, f3 = [], c3 = [], u3.__P && ((t3 = w({}, o3)).__v = o3.__v + 1, l.vnode && l.vnode(t3), O(u3.__P, t3, o3, u3.__n, u3.__P.namespaceURI, 32 & o3.__u ? [r3] : null, f3, null == r3 ? S(o3) : r3, !!(32 & o3.__u), c3), t3.__v = o3.__v, t3.__.__k[t3.__i] = t3, N(f3, t3, c3), o3.__e = o3.__ = null, t3.__e != r3 && C(t3)));
     $.__r = 0;
   }
-  function I(n2, l3, u3, t3, i3, r3, o3, e3, f3, c3, s3) {
-    var a3, h3, y3, w3, d3, g3, _3, m3 = t3 && t3.__k || v, b = l3.length;
-    for (f3 = P(u3, l3, m3, f3, b), a3 = 0; a3 < b; a3++) null != (y3 = u3.__k[a3]) && (h3 = -1 == y3.__i ? p : m3[y3.__i] || p, y3.__i = a3, g3 = O(n2, y3, h3, i3, r3, o3, e3, f3, c3, s3), w3 = y3.__e, y3.ref && h3.ref != y3.ref && (h3.ref && B(h3.ref, null, y3), s3.push(y3.ref, y3.__c || w3, y3)), null == d3 && null != w3 && (d3 = w3), (_3 = !!(4 & y3.__u)) || h3.__k === y3.__k ? f3 = A(y3, f3, n2, _3) : "function" == typeof y3.type && void 0 !== g3 ? f3 = g3 : w3 && (f3 = w3.nextSibling), y3.__u &= -7);
-    return u3.__e = d3, f3;
+  function I(n2, l3, u3, t3, i3, o3, r3, e3, f3, c3, s3) {
+    var a3, h3, y3, d3, w3, g3, _3, m3 = t3 && t3.__k || v, b = l3.length;
+    for (f3 = P(u3, l3, m3, f3, b), a3 = 0; a3 < b; a3++) null != (y3 = u3.__k[a3]) && (h3 = -1 == y3.__i ? p : m3[y3.__i] || p, y3.__i = a3, g3 = O(n2, y3, h3, i3, o3, r3, e3, f3, c3, s3), d3 = y3.__e, y3.ref && h3.ref != y3.ref && (h3.ref && B(h3.ref, null, y3), s3.push(y3.ref, y3.__c || d3, y3)), null == w3 && null != d3 && (w3 = d3), (_3 = !!(4 & y3.__u)) || h3.__k === y3.__k ? f3 = A(y3, f3, n2, _3) : "function" == typeof y3.type && void 0 !== g3 ? f3 = g3 : d3 && (f3 = d3.nextSibling), y3.__u &= -7);
+    return u3.__e = w3, f3;
   }
   function P(n2, l3, u3, t3, i3) {
-    var r3, o3, e3, f3, c3, s3 = u3.length, a3 = s3, h3 = 0;
-    for (n2.__k = new Array(i3), r3 = 0; r3 < i3; r3++) null != (o3 = l3[r3]) && "boolean" != typeof o3 && "function" != typeof o3 ? ("string" == typeof o3 || "number" == typeof o3 || "bigint" == typeof o3 || o3.constructor == String ? o3 = n2.__k[r3] = m(null, o3, null, null, null) : w(o3) ? o3 = n2.__k[r3] = m(k, { children: o3 }, null, null, null) : null == o3.constructor && o3.__b > 0 ? o3 = n2.__k[r3] = m(o3.type, o3.props, o3.key, o3.ref ? o3.ref : null, o3.__v) : n2.__k[r3] = o3, f3 = r3 + h3, o3.__ = n2, o3.__b = n2.__b + 1, -1 != (c3 = o3.__i = L(o3, u3, f3, a3)) && (a3--, (e3 = u3[c3]) && (e3.__u |= 2)), null == e3 || null == e3.__v ? (-1 == c3 && (i3 > s3 ? h3-- : i3 < s3 && h3++), "function" != typeof o3.type && (o3.__u |= 4)) : c3 != f3 && (c3 == f3 - 1 ? h3-- : c3 == f3 + 1 ? h3++ : (c3 > f3 ? h3-- : h3++, o3.__u |= 4))) : n2.__k[r3] = null;
-    if (a3) for (r3 = 0; r3 < s3; r3++) null != (e3 = u3[r3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = S(e3)), D(e3, e3));
+    var o3, r3, e3, f3, c3, s3 = u3.length, a3 = s3, h3 = 0;
+    for (n2.__k = new Array(i3), o3 = 0; o3 < i3; o3++) null != (r3 = l3[o3]) && "boolean" != typeof r3 && "function" != typeof r3 ? ("string" == typeof r3 || "number" == typeof r3 || "bigint" == typeof r3 || r3.constructor == String ? r3 = n2.__k[o3] = m(null, r3, null, null, null) : d(r3) ? r3 = n2.__k[o3] = m(k, { children: r3 }, null, null, null) : void 0 === r3.constructor && r3.__b > 0 ? r3 = n2.__k[o3] = m(r3.type, r3.props, r3.key, r3.ref ? r3.ref : null, r3.__v) : n2.__k[o3] = r3, f3 = o3 + h3, r3.__ = n2, r3.__b = n2.__b + 1, e3 = null, -1 != (c3 = r3.__i = L(r3, u3, f3, a3)) && (a3--, (e3 = u3[c3]) && (e3.__u |= 2)), null == e3 || null == e3.__v ? (-1 == c3 && (i3 > s3 ? h3-- : i3 < s3 && h3++), "function" != typeof r3.type && (r3.__u |= 4)) : c3 != f3 && (c3 == f3 - 1 ? h3-- : c3 == f3 + 1 ? h3++ : (c3 > f3 ? h3-- : h3++, r3.__u |= 4))) : n2.__k[o3] = null;
+    if (a3) for (o3 = 0; o3 < s3; o3++) null != (e3 = u3[o3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = S(e3)), D(e3, e3));
     return t3;
   }
   function A(n2, l3, u3, t3) {
-    var i3, r3;
+    var i3, o3;
     if ("function" == typeof n2.type) {
-      for (i3 = n2.__k, r3 = 0; i3 && r3 < i3.length; r3++) i3[r3] && (i3[r3].__ = n2, l3 = A(i3[r3], l3, u3, t3));
+      for (i3 = n2.__k, o3 = 0; i3 && o3 < i3.length; o3++) i3[o3] && (i3[o3].__ = n2, l3 = A(i3[o3], l3, u3, t3));
       return l3;
     }
     n2.__e != l3 && (t3 && (l3 && n2.type && !l3.parentNode && (l3 = S(n2)), u3.insertBefore(n2.__e, l3 || null)), l3 = n2.__e);
@@ -1559,10 +1559,10 @@
     return l3;
   }
   function L(n2, l3, u3, t3) {
-    var i3, r3, o3, e3 = n2.key, f3 = n2.type, c3 = l3[u3], s3 = null != c3 && 0 == (2 & c3.__u);
+    var i3, o3, r3, e3 = n2.key, f3 = n2.type, c3 = l3[u3], s3 = null != c3 && 0 == (2 & c3.__u);
     if (null === c3 && null == e3 || s3 && e3 == c3.key && f3 == c3.type) return u3;
     if (t3 > (s3 ? 1 : 0)) {
-      for (i3 = u3 - 1, r3 = u3 + 1; i3 >= 0 || r3 < l3.length; ) if (null != (c3 = l3[o3 = i3 >= 0 ? i3-- : r3++]) && 0 == (2 & c3.__u) && e3 == c3.key && f3 == c3.type) return o3;
+      for (i3 = u3 - 1, o3 = u3 + 1; i3 >= 0 || o3 < l3.length; ) if (null != (c3 = l3[r3 = i3 >= 0 ? i3-- : o3++]) && 0 == (2 & c3.__u) && e3 == c3.key && f3 == c3.type) return r3;
     }
     return -1;
   }
@@ -1570,13 +1570,13 @@
     "-" == l3[0] ? n2.setProperty(l3, null == u3 ? "" : u3) : n2[l3] = null == u3 ? "" : "number" != typeof u3 || y.test(l3) ? u3 : u3 + "px";
   }
   function j(n2, l3, u3, t3, i3) {
-    var r3, o3;
+    var o3, r3;
     n: if ("style" == l3) if ("string" == typeof u3) n2.style.cssText = u3;
     else {
       if ("string" == typeof t3 && (n2.style.cssText = t3 = ""), t3) for (l3 in t3) u3 && l3 in u3 || T(n2.style, l3, "");
       if (u3) for (l3 in u3) t3 && u3[l3] == t3[l3] || T(n2.style, l3, u3[l3]);
     }
-    else if ("o" == l3[0] && "n" == l3[1]) r3 = l3 != (l3 = l3.replace(f, "$1")), o3 = l3.toLowerCase(), l3 = o3 in n2 || "onFocusOut" == l3 || "onFocusIn" == l3 ? o3.slice(2) : l3.slice(2), n2.l || (n2.l = {}), n2.l[l3 + r3] = u3, u3 ? t3 ? u3.u = t3.u : (u3.u = c, n2.addEventListener(l3, r3 ? a : s, r3)) : n2.removeEventListener(l3, r3 ? a : s, r3);
+    else if ("o" == l3[0] && "n" == l3[1]) o3 = l3 != (l3 = l3.replace(f, "$1")), r3 = l3.toLowerCase(), l3 = r3 in n2 || "onFocusOut" == l3 || "onFocusIn" == l3 ? r3.slice(2) : l3.slice(2), n2.l || (n2.l = {}), n2.l[l3 + o3] = u3, u3 ? t3 ? u3.u = t3.u : (u3.u = c, n2.addEventListener(l3, o3 ? a : s, o3)) : n2.removeEventListener(l3, o3 ? a : s, o3);
     else {
       if ("http://www.w3.org/2000/svg" == i3) l3 = l3.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
       else if ("width" != l3 && "height" != l3 && "href" != l3 && "list" != l3 && "form" != l3 && "tabIndex" != l3 && "download" != l3 && "rowSpan" != l3 && "colSpan" != l3 && "role" != l3 && "popover" != l3 && l3 in n2) try {
@@ -1597,12 +1597,12 @@
       }
     };
   }
-  function O(n2, u3, t3, i3, r3, o3, e3, f3, c3, s3) {
+  function O(n2, u3, t3, i3, o3, r3, e3, f3, c3, s3) {
     var a3, h3, p3, v3, y3, _3, m3, b, S2, C3, M2, $2, P2, A3, H, L2, T3, j3 = u3.type;
-    if (null != u3.constructor) return null;
-    128 & t3.__u && (c3 = !!(32 & t3.__u), o3 = [f3 = u3.__e = t3.__e]), (a3 = l.__b) && a3(u3);
+    if (void 0 !== u3.constructor) return null;
+    128 & t3.__u && (c3 = !!(32 & t3.__u), r3 = [f3 = u3.__e = t3.__e]), (a3 = l.__b) && a3(u3);
     n: if ("function" == typeof j3) try {
-      if (b = u3.props, S2 = "prototype" in j3 && j3.prototype.render, C3 = (a3 = j3.contextType) && i3[a3.__c], M2 = a3 ? C3 ? C3.props.value : a3.__ : i3, t3.__c ? m3 = (h3 = u3.__c = t3.__c).__ = h3.__E : (S2 ? u3.__c = h3 = new j3(b, M2) : (u3.__c = h3 = new x(b, M2), h3.constructor = j3, h3.render = E), C3 && C3.sub(h3), h3.state || (h3.state = {}), h3.__n = i3, p3 = h3.__d = true, h3.__h = [], h3._sb = []), S2 && null == h3.__s && (h3.__s = h3.state), S2 && null != j3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = d({}, h3.__s)), d(h3.__s, j3.getDerivedStateFromProps(b, h3.__s))), v3 = h3.props, y3 = h3.state, h3.__v = u3, p3) S2 && null == j3.getDerivedStateFromProps && null != h3.componentWillMount && h3.componentWillMount(), S2 && null != h3.componentDidMount && h3.__h.push(h3.componentDidMount);
+      if (b = u3.props, S2 = "prototype" in j3 && j3.prototype.render, C3 = (a3 = j3.contextType) && i3[a3.__c], M2 = a3 ? C3 ? C3.props.value : a3.__ : i3, t3.__c ? m3 = (h3 = u3.__c = t3.__c).__ = h3.__E : (S2 ? u3.__c = h3 = new j3(b, M2) : (u3.__c = h3 = new x(b, M2), h3.constructor = j3, h3.render = E), C3 && C3.sub(h3), h3.state || (h3.state = {}), h3.__n = i3, p3 = h3.__d = true, h3.__h = [], h3._sb = []), S2 && null == h3.__s && (h3.__s = h3.state), S2 && null != j3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = w({}, h3.__s)), w(h3.__s, j3.getDerivedStateFromProps(b, h3.__s))), v3 = h3.props, y3 = h3.state, h3.__v = u3, p3) S2 && null == j3.getDerivedStateFromProps && null != h3.componentWillMount && h3.componentWillMount(), S2 && null != h3.componentDidMount && h3.__h.push(h3.componentDidMount);
       else {
         if (S2 && null == j3.getDerivedStateFromProps && b !== v3 && null != h3.componentWillReceiveProps && h3.componentWillReceiveProps(b, M2), u3.__v == t3.__v || !h3.__e && null != h3.shouldComponentUpdate && false === h3.shouldComponentUpdate(b, h3.__s, M2)) {
           for (u3.__v != t3.__v && (h3.props = b, h3.state = h3.__s, h3.__d = false), u3.__e = t3.__e, u3.__k = t3.__k, u3.__k.some(function(n3) {
@@ -1621,19 +1621,19 @@
       } else do {
         h3.__d = false, P2 && P2(u3), a3 = h3.render(h3.props, h3.state, h3.context), h3.state = h3.__s;
       } while (h3.__d && ++A3 < 25);
-      h3.state = h3.__s, null != h3.getChildContext && (i3 = d(d({}, i3), h3.getChildContext())), S2 && !p3 && null != h3.getSnapshotBeforeUpdate && (_3 = h3.getSnapshotBeforeUpdate(v3, y3)), L2 = a3, null != a3 && a3.type === k && null == a3.key && (L2 = V(a3.props.children)), f3 = I(n2, w(L2) ? L2 : [L2], u3, t3, i3, r3, o3, e3, f3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && e3.push(h3), m3 && (h3.__E = h3.__ = null);
+      h3.state = h3.__s, null != h3.getChildContext && (i3 = w(w({}, i3), h3.getChildContext())), S2 && !p3 && null != h3.getSnapshotBeforeUpdate && (_3 = h3.getSnapshotBeforeUpdate(v3, y3)), L2 = a3, null != a3 && a3.type === k && null == a3.key && (L2 = V(a3.props.children)), f3 = I(n2, d(L2) ? L2 : [L2], u3, t3, i3, o3, r3, e3, f3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && e3.push(h3), m3 && (h3.__E = h3.__ = null);
     } catch (n3) {
-      if (u3.__v = null, c3 || null != o3) if (n3.then) {
+      if (u3.__v = null, c3 || null != r3) if (n3.then) {
         for (u3.__u |= c3 ? 160 : 128; f3 && 8 == f3.nodeType && f3.nextSibling; ) f3 = f3.nextSibling;
-        o3[o3.indexOf(f3)] = null, u3.__e = f3;
+        r3[r3.indexOf(f3)] = null, u3.__e = f3;
       } else {
-        for (T3 = o3.length; T3--; ) g(o3[T3]);
+        for (T3 = r3.length; T3--; ) g(r3[T3]);
         z(u3);
       }
       else u3.__e = t3.__e, u3.__k = t3.__k, n3.then || z(u3);
       l.__e(n3, u3, t3);
     }
-    else null == o3 && u3.__v == t3.__v ? (u3.__k = t3.__k, u3.__e = t3.__e) : f3 = u3.__e = q(t3.__e, u3, t3, i3, r3, o3, e3, c3, s3);
+    else null == r3 && u3.__v == t3.__v ? (u3.__k = t3.__k, u3.__e = t3.__e) : f3 = u3.__e = q(t3.__e, u3, t3, i3, o3, r3, e3, c3, s3);
     return (a3 = l.diffed) && a3(u3), 128 & u3.__u ? void 0 : f3;
   }
   function z(n2) {
@@ -1652,33 +1652,33 @@
     });
   }
   function V(n2) {
-    return "object" != typeof n2 || null == n2 || n2.__b && n2.__b > 0 ? n2 : w(n2) ? n2.map(V) : d({}, n2);
+    return "object" != typeof n2 || null == n2 || n2.__b && n2.__b > 0 ? n2 : d(n2) ? n2.map(V) : w({}, n2);
   }
-  function q(u3, t3, i3, r3, o3, e3, f3, c3, s3) {
-    var a3, h3, v3, y3, d3, _3, m3, b = i3.props || p, k3 = t3.props, x3 = t3.type;
-    if ("svg" == x3 ? o3 = "http://www.w3.org/2000/svg" : "math" == x3 ? o3 = "http://www.w3.org/1998/Math/MathML" : o3 || (o3 = "http://www.w3.org/1999/xhtml"), null != e3) {
-      for (a3 = 0; a3 < e3.length; a3++) if ((d3 = e3[a3]) && "setAttribute" in d3 == !!x3 && (x3 ? d3.localName == x3 : 3 == d3.nodeType)) {
-        u3 = d3, e3[a3] = null;
+  function q(u3, t3, i3, o3, r3, e3, f3, c3, s3) {
+    var a3, h3, v3, y3, w3, _3, m3, b = i3.props || p, k3 = t3.props, x3 = t3.type;
+    if ("svg" == x3 ? r3 = "http://www.w3.org/2000/svg" : "math" == x3 ? r3 = "http://www.w3.org/1998/Math/MathML" : r3 || (r3 = "http://www.w3.org/1999/xhtml"), null != e3) {
+      for (a3 = 0; a3 < e3.length; a3++) if ((w3 = e3[a3]) && "setAttribute" in w3 == !!x3 && (x3 ? w3.localName == x3 : 3 == w3.nodeType)) {
+        u3 = w3, e3[a3] = null;
         break;
       }
     }
     if (null == u3) {
       if (null == x3) return document.createTextNode(k3);
-      u3 = document.createElementNS(o3, x3, k3.is && k3), c3 && (l.__m && l.__m(t3, e3), c3 = false), e3 = null;
+      u3 = document.createElementNS(r3, x3, k3.is && k3), c3 && (l.__m && l.__m(t3, e3), c3 = false), e3 = null;
     }
     if (null == x3) b === k3 || c3 && u3.data == k3 || (u3.data = k3);
     else {
-      if (e3 = e3 && n.call(u3.childNodes), !c3 && null != e3) for (b = {}, a3 = 0; a3 < u3.attributes.length; a3++) b[(d3 = u3.attributes[a3]).name] = d3.value;
-      for (a3 in b) if (d3 = b[a3], "children" == a3) ;
-      else if ("dangerouslySetInnerHTML" == a3) v3 = d3;
+      if (e3 = e3 && n.call(u3.childNodes), !c3 && null != e3) for (b = {}, a3 = 0; a3 < u3.attributes.length; a3++) b[(w3 = u3.attributes[a3]).name] = w3.value;
+      for (a3 in b) if (w3 = b[a3], "children" == a3) ;
+      else if ("dangerouslySetInnerHTML" == a3) v3 = w3;
       else if (!(a3 in k3)) {
         if ("value" == a3 && "defaultValue" in k3 || "checked" == a3 && "defaultChecked" in k3) continue;
-        j(u3, a3, null, d3, o3);
+        j(u3, a3, null, w3, r3);
       }
-      for (a3 in k3) d3 = k3[a3], "children" == a3 ? y3 = d3 : "dangerouslySetInnerHTML" == a3 ? h3 = d3 : "value" == a3 ? _3 = d3 : "checked" == a3 ? m3 = d3 : c3 && "function" != typeof d3 || b[a3] === d3 || j(u3, a3, d3, b[a3], o3);
+      for (a3 in k3) w3 = k3[a3], "children" == a3 ? y3 = w3 : "dangerouslySetInnerHTML" == a3 ? h3 = w3 : "value" == a3 ? _3 = w3 : "checked" == a3 ? m3 = w3 : c3 && "function" != typeof w3 || b[a3] === w3 || j(u3, a3, w3, b[a3], r3);
       if (h3) c3 || v3 && (h3.__html == v3.__html || h3.__html == u3.innerHTML) || (u3.innerHTML = h3.__html), t3.__k = [];
-      else if (v3 && (u3.innerHTML = ""), I("template" == t3.type ? u3.content : u3, w(y3) ? y3 : [y3], t3, i3, r3, "foreignObject" == x3 ? "http://www.w3.org/1999/xhtml" : o3, e3, f3, e3 ? e3[0] : i3.__k && S(i3, 0), c3, s3), null != e3) for (a3 = e3.length; a3--; ) g(e3[a3]);
-      c3 || (a3 = "value", "progress" == x3 && null == _3 ? u3.removeAttribute("value") : null != _3 && (_3 !== u3[a3] || "progress" == x3 && !_3 || "option" == x3 && _3 != b[a3]) && j(u3, a3, _3, b[a3], o3), a3 = "checked", null != m3 && m3 != u3[a3] && j(u3, a3, m3, b[a3], o3));
+      else if (v3 && (u3.innerHTML = ""), I("template" == t3.type ? u3.content : u3, d(y3) ? y3 : [y3], t3, i3, o3, "foreignObject" == x3 ? "http://www.w3.org/1999/xhtml" : r3, e3, f3, e3 ? e3[0] : i3.__k && S(i3, 0), c3, s3), null != e3) for (a3 = e3.length; a3--; ) g(e3[a3]);
+      c3 || (a3 = "value", "progress" == x3 && null == _3 ? u3.removeAttribute("value") : null != _3 && (_3 !== u3[a3] || "progress" == x3 && !_3 || "option" == x3 && _3 != b[a3]) && j(u3, a3, _3, b[a3], r3), a3 = "checked", null != m3 && m3 != u3[a3] && j(u3, a3, m3, b[a3], r3));
     }
     return u3;
   }
@@ -1693,7 +1693,7 @@
     }
   }
   function D(n2, u3, t3) {
-    var i3, r3;
+    var i3, o3;
     if (l.unmount && l.unmount(n2), (i3 = n2.ref) && (i3.current && i3.current != n2.__e || B(i3, null, u3)), null != (i3 = n2.__c)) {
       if (i3.componentWillUnmount) try {
         i3.componentWillUnmount();
@@ -1702,15 +1702,15 @@
       }
       i3.base = i3.__P = null;
     }
-    if (i3 = n2.__k) for (r3 = 0; r3 < i3.length; r3++) i3[r3] && D(i3[r3], u3, t3 || "function" != typeof n2.type);
+    if (i3 = n2.__k) for (o3 = 0; o3 < i3.length; o3++) i3[o3] && D(i3[o3], u3, t3 || "function" != typeof n2.type);
     t3 || g(n2.__e), n2.__c = n2.__ = n2.__e = void 0;
   }
   function E(n2, l3, u3) {
     return this.constructor(n2, u3);
   }
   function G(u3, t3, i3) {
-    var r3, o3, e3, f3;
-    t3 == document && (t3 = document.documentElement), l.__ && l.__(u3, t3), o3 = (r3 = "function" == typeof i3) ? null : i3 && i3.__k || t3.__k, e3 = [], f3 = [], O(t3, u3 = (!r3 && i3 || t3).__k = _(k, null, [u3]), o3 || p, p, t3.namespaceURI, !r3 && i3 ? [i3] : o3 ? null : t3.firstChild ? n.call(t3.childNodes) : null, e3, !r3 && i3 ? i3 : o3 ? o3.__e : t3.firstChild, r3, f3), N(e3, u3, f3);
+    var o3, r3, e3, f3;
+    t3 == document && (t3 = document.documentElement), l.__ && l.__(u3, t3), r3 = (o3 = "function" == typeof i3) ? null : i3 && i3.__k || t3.__k, e3 = [], f3 = [], O(t3, u3 = (!o3 && i3 || t3).__k = _(k, null, [u3]), r3 || p, p, t3.namespaceURI, !o3 && i3 ? [i3] : r3 ? null : t3.firstChild ? n.call(t3.childNodes) : null, e3, !o3 && i3 ? i3 : r3 ? r3.__e : t3.firstChild, o3, f3), N(e3, u3, f3);
   }
   function Q(n2) {
     function l3(n3) {
@@ -1736,20 +1736,20 @@
     }).contextType = l3, l3;
   }
   n = v.slice, l = { __e: function(n2, l3, u3, t3) {
-    for (var i3, r3, o3; l3 = l3.__; ) if ((i3 = l3.__c) && !i3.__) try {
-      if ((r3 = i3.constructor) && null != r3.getDerivedStateFromError && (i3.setState(r3.getDerivedStateFromError(n2)), o3 = i3.__d), null != i3.componentDidCatch && (i3.componentDidCatch(n2, t3 || {}), o3 = i3.__d), o3) return i3.__E = i3;
+    for (var i3, o3, r3; l3 = l3.__; ) if ((i3 = l3.__c) && !i3.__) try {
+      if ((o3 = i3.constructor) && null != o3.getDerivedStateFromError && (i3.setState(o3.getDerivedStateFromError(n2)), r3 = i3.__d), null != i3.componentDidCatch && (i3.componentDidCatch(n2, t3 || {}), r3 = i3.__d), r3) return i3.__E = i3;
     } catch (l4) {
       n2 = l4;
     }
     throw n2;
   } }, u = 0, t = function(n2) {
-    return null != n2 && null == n2.constructor;
+    return null != n2 && void 0 === n2.constructor;
   }, x.prototype.setState = function(n2, l3) {
     var u3;
-    u3 = null != this.__s && this.__s != this.state ? this.__s : this.__s = d({}, this.state), "function" == typeof n2 && (n2 = n2(d({}, u3), this.props)), n2 && d(u3, n2), null != n2 && this.__v && (l3 && this._sb.push(l3), M(this));
+    u3 = null != this.__s && this.__s != this.state ? this.__s : this.__s = w({}, this.state), "function" == typeof n2 && (n2 = n2(w({}, u3), this.props)), n2 && w(u3, n2), null != n2 && this.__v && (l3 && this._sb.push(l3), M(this));
   }, x.prototype.forceUpdate = function(n2) {
     this.__v && (this.__e = true, n2 && this.__h.push(n2), M(this));
-  }, x.prototype.render = k, i = [], o = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e = function(n2, l3) {
+  }, x.prototype.render = k, i = [], r = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e = function(n2, l3) {
     return n2.__v.__b - l3.__v.__b;
   }, $.__r = 0, f = /(PointerCapture)$|Capture$/i, c = 0, s = F(false), a = F(true), h = 0;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.39.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.40.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#47e02ea1edba9adb259e4033c0a8904529548381",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9b0a860b46bb12ea8ccf89601b7ab31d1349ffcd",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.21",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.21.tgz",
-      "integrity": "sha512-oVOMdHvgjqyzUZH1rOESgJP1uNe2bVrfK0jUHHmiM2rpEiRbf3j4BrsIc6JigJRbHGanQwuZv/R+LTcHsw+bLA==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.21",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.21.tgz",
-      "integrity": "sha512-q6HaDyDWu98swXCT28oDD/xTeQI5mb7wbk9T34rbJocxnrBpI/gQHCwDteka5DpDXX1HwL4WGDI8B4myBOcqMQ==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.22.tgz",
+      "integrity": "sha512-SHhoOcwbcARDYeXX1pcNI41MYdejjbBHf5aX5cF39Up8+dgwtyD8nKkgYFVH39r+apOVbW4HaoU390X6eXlQ4Q==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.21"
+        "tldts-core": "^7.0.22"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.39.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.40.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213126183923939/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates shipped injected `content-scope-scripts` logic and expands breakage reporting to run new DOM-based `webDetection` detectors, which could impact page compatibility/performance or change telemetry payloads. Most changes are vendored build output, making regressions harder to review at the source level.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `12.39.0` to `12.40.0` and updates the vendored Android build outputs.
> 
> Adds a new `webDetection` content feature (enabled across supported platforms) that runs configurable DOM/text/visibility detectors and, on breakage report requests, attaches `webDetection` results into the encoded `breakageData` payload.
> 
> Includes small internal refactors in the bundled scripts (e.g., default-merging helper `withDefaults`, `_isStateEnabled` wrapper, and a visibility helper rename to avoid symbol clashes) plus regenerated bundled assets (e.g., Duck Player page dist).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5265e1d729018dd19e7a4e9620741dfba471a069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->