### PR TITLE
disable tracker animations on app resume

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8178,6 +8178,10 @@ class BrowserTabViewModelTest {
 
     private fun aTabEntity(id: String): TabEntity = TabEntity(tabId = id, position = 0)
 
+    private fun givenDisableTrackerAnimationOnRestartFeature(enabled: Boolean) {
+        fakeAndroidConfigBrowserFeature.disableTrackerAnimationOnRestart().setRawStoredState(State(enable = enabled))
+    }
+
     private fun loadTabWithId(tabId: String) {
         testee.loadData(tabId, initialUrl = null, skipHome = false, isExternal = false)
     }
@@ -8867,5 +8871,56 @@ class BrowserTabViewModelTest {
             assertEquals("authUpdate", event.subscriptionName)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenLoadDataWithInitialUrlThenPreviousUrlIsSetToSkipFirstTrackerAnimation() {
+        givenDisableTrackerAnimationOnRestartFeature(true)
+        val initialUrl = "https://example.com"
+        testee.loadData(tabId = "test-tab", initialUrl = initialUrl, skipHome = false, isExternal = false)
+
+        assertEquals(initialUrl, testee.previousUrl)
+    }
+
+    @Test
+    fun whenLoadDataWithNullInitialUrlThenPreviousUrlRemainsNull() {
+        testee.loadData(tabId = "test-tab", initialUrl = null, skipHome = false, isExternal = false)
+
+        assertNull(testee.previousUrl)
+    }
+
+    @Test
+    fun whenLoadDataWithInitialUrlAndIsExternalTrueThenPreviousUrlIsNotSet() {
+        val initialUrl = "https://example.com"
+        testee.loadData(tabId = "test-tab", initialUrl = initialUrl, skipHome = false, isExternal = true)
+
+        assertNull(testee.previousUrl)
+    }
+
+    @Test
+    fun whenLoadDataWithFeatureFlagDisabledThenPreviousUrlIsNotSet() {
+        givenDisableTrackerAnimationOnRestartFeature(false)
+        val initialUrl = "https://example.com"
+        testee.loadData(tabId = "test-tab", initialUrl = initialUrl, skipHome = false, isExternal = false)
+
+        assertNull(testee.previousUrl)
+    }
+
+    @Test
+    fun whenLoadDataWithFeatureFlagEnabledAndNotExternalThenPreviousUrlIsSet() {
+        givenDisableTrackerAnimationOnRestartFeature(true)
+        val initialUrl = "https://example.com"
+        testee.loadData(tabId = "test-tab", initialUrl = initialUrl, skipHome = false, isExternal = false)
+
+        assertEquals(initialUrl, testee.previousUrl)
+    }
+
+    @Test
+    fun whenLoadDataWithFeatureFlagEnabledButIsExternalThenPreviousUrlIsNotSet() {
+        givenDisableTrackerAnimationOnRestartFeature(true)
+        val initialUrl = "https://example.com"
+        testee.loadData(tabId = "test-tab", initialUrl = initialUrl, skipHome = false, isExternal = true)
+
+        assertNull(testee.previousUrl)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import logcat.logcat
 
 class TabPagerAdapter(
     private val activity: BrowserActivity,
@@ -69,7 +70,8 @@ class TabPagerAdapter(
 
     override fun createFragment(position: Int): Fragment {
         val tab = tabs[position]
-        val isExternal = activity.intent?.getBooleanExtra(BrowserActivity.LAUNCH_FROM_EXTERNAL_EXTRA, false) == true
+        val isExternal = activity.consumeExternalLaunchForTab(tab.tabId)
+        logcat { "createFragment position=$position, tabId=${tab.tabId}, url=${tab.url}, isExternal=$isExternal" }
 
         // Check if there's a message specifically for this tab's source tab ID
         val pendingMessage = pendingMessages.remove(tab.sourceTabId)

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -298,6 +298,15 @@ interface AndroidBrowserConfigFeature {
     fun refreshDuckAiOnSubscriptionChanges(): Toggle
 
     /**
+     * Controls whether tracker animation is disabled when the app restarts.
+     * @return `true` when the remote config has the global "disableTrackerAnimationOnRestart" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `true`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun disableTrackerAnimationOnRestart(): Toggle
+
+    /**
      * Controls whether data clearing wide events are sent.
      * @return `true` when the remote config has the global "sendDataClearingWideEvent" androidBrowserConfig
      * sub-feature flag enabled


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1212999357864763?focus=true

### Description
Introduce a feature flag to control whether we disable the tracker animation upon launching the browser.  This works by setting the prevoiusUrl to the current url being loaded, which would effectively stop the animation from playing.

An edge case of launching the app from an external link should be handled via the isExternal flag already existing in the viewModel. However, there was a race-condition in how the `isExternal` flag was being [evaluated](https://github.com/duckduckgo/Android/blob/df6e0a43589aed21d44cabbbc9e8a0341185a73e/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt#L72). This is problematic on 2 different dimensions: 1- Tab loading order will affect which tab is reading isExternal from the latest intent. 2- Reading wrong intent as sometimes the correct intent to read is a deferred intent stored in [lastIntent](https://github.com/duckduckgo/Android/blob/df6e0a43589aed21d44cabbbc9e8a0341185a73e/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt#L478).

I made minimal changes to fix how the isExternal is being read by storing the intended value for isExternal in a <tabId to isExternal map>, and only reading that once upon creation of the fragment. 

The reason why this shouldn't be in the tabRepository is that isExternal should only be used upon creation of the tab for the first time only. If for example the user relaunches the app, isExternal for an old tab should be set to false.

### Steps to test this PR
- Open app
- Enter a new website.
- observer tracker animation.
- close app and make sure process is killed.
- start app.
- observe same website loading but without tracker animation.




### UI changes
| Before  | After |
| ------ | ----- |
![before](https://github.com/user-attachments/assets/87f50dca-9cc5-4300-95d0-c9eb0505a50c)|![after](https://github.com/user-attachments/assets/0c34dde9-30f1-4ea5-b3d1-4b9b250bc179)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab creation/selection flow and external-intent handling, which can affect navigation behavior and first-load experience across multiple tabs. Changes are scoped and feature-flagged, but regressions could show up as incorrect external-tab treatment or missing/extra animations.
> 
> **Overview**
> Adds a new remote-config toggle `disableTrackerAnimationOnRestart` and a one-shot `suppressTrackerAnimation` path that, on app restart, sets `BrowserTabViewModel.previousUrl` to the initial URL to prevent the tracker animation from playing.
> 
> Refactors how *external launches* are determined by tracking external status per `tabId` in `BrowserActivity` and consuming it when creating/selecting tab fragments, avoiding races from reading the latest `Intent`. Updates fragment/tab creation APIs to pass `suppressTrackerAnimation`, adds debug logging, and extends `BrowserTabViewModelTest` to cover the new `previousUrl` behavior and guardrails (feature flag, external tabs, null URL).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2557255be43a1925e1d082bb141cb7b818be1e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->