### PR TITLE
Add _u to unique VPN activation pixel definition

### DIFF
--- a/PixelDefinitions/pixels/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/subscription_pixels.json5
@@ -1,12 +1,12 @@
 {
-    "subscription_free_trial_start": {
+    "subscription_free_trial_start_u": {
         "description": "Fired when a user starts a free trial. Used to measure total count of trialists independent of whether they complete the trial.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
-    "subscription_free_trial_vpn_activation": {
+    "subscription_free_trial_vpn_activation_u": {
         "description": "Fired when a user activates VPN while on a free trial. Used to measure how many trialists activate VPN and compare with wide event data.",
         "owners": ["nalcalag"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213063478006061

### Description
Adds _u to pixel definition for verified VPN activation unique pixels

### Steps to test this PR

N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definition-only rename with no logic changes; main risk is breaking downstream references to the old pixel names.
> 
> **Overview**
> Renames the subscription pixel definitions `subscription_free_trial_start` and `subscription_free_trial_vpn_activation` to `subscription_free_trial_start_u` and `subscription_free_trial_vpn_activation_u`, keeping the same metadata/parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e087edf399196ee03ef3672ccc8f5945ad92616a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->