### PR TITLE
Duck.ai Contextual: Ensure tab timestamp is persisted on app background

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -888,6 +888,7 @@ class DuckChatContextualFragment :
     }
 
     override fun onPause() {
+        viewModel.persistTabClosed()
         downloadMessagesJob.cancel()
         simpleWebview.onPause()
         appCoroutineScope.launch(dispatcherProvider.io()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -291,13 +291,15 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onContextualClose() {
-        persistTabClosed()
         viewModelScope.launch(dispatchers.main()) {
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_HIDDEN))
         }
     }
 
     fun persistTabClosed() {
+        if (_viewState.value.sheetMode != SheetMode.WEBVIEW) {
+            return
+        }
         viewModelScope.launch(dispatchers.io()) {
             val tabId = _viewState.value.tabId
             if (tabId.isNotBlank()) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -506,7 +506,7 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `onContextualClose stores last closed timestamp`() = runTest {
+    fun `onContextualClose in input mode does not store last closed timestamp`() = runTest {
         val tabId = "tab-1"
         val now = 55_000L
         timeProvider.nowMs = now
@@ -515,7 +515,7 @@ class DuckChatContextualViewModelTest {
         testee.onContextualClose()
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(now, contextualDataStore.getTabClosedTimestamp(tabId))
+        assertNull(contextualDataStore.getTabClosedTimestamp(tabId))
     }
 
     @Test
@@ -525,6 +525,7 @@ class DuckChatContextualViewModelTest {
         timeProvider.nowMs = now
 
         testee.onSheetOpened(tabId)
+        testee.onPromptSent("hello")
         testee.persistTabClosed()
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213133974212714

### Description
This PR ensures that the contextual timestamp is stored when the app is moved to the background

### Steps to test this PR
- Change `sessionTimeoutMillis` in `RealDuckChatContextualSessionTimeoutProvider` to return `MINUTES_TO_MS`
- Enable contextualMode FF

_Session expired - Close sheet_
- [x] Open a contextual chat, and start a conversation
- [x] Close the sheet
- [x] Wait for 1 minute (or whatever value you chose above)
- [x] Open the sheet again
- [x] Verify that the sheet opens in Native mode

_Session expired - Hide sheet_
- [x] Open a contextual chat, and start a conversation
- [x] Hide the sheet by dragging it down
- [x] Wait for 1 minute (or whatever value you chose above)
- [x] Open the sheet again
- [x] Verify that the sheet opens in Native mode

_Session expired - App in background_
- [x] Open a contextual chat, and start a conversation
- [x] Move the app to background (Home button)
- [x] Wait for 1 minute (or whatever value you chose above)
- [x] Open the sheet again
- [x] Verify that the sheet opens in Native mode

_Session not expired_
- [x] Open a contextual chat, and start a conversation
- [x] Close the sheet
- [x] Wait less than 1 minute (or whatever value you chose above)
- [x] Open the sheet again
- [x] Verify that the sheet opens in the previous state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle/state change limited to persisting a timestamp; main risk is subtle session-timeout behavior changes if `sheetMode` is incorrect during background transitions.
> 
> **Overview**
> Ensures the contextual chat tab close timestamp is persisted when the contextual sheet is backgrounded by calling `persistTabClosed()` from `DuckChatContextualFragment.onPause()`.
> 
> Moves timestamp persistence out of `onContextualClose()` and guards `persistTabClosed()` so it only records a close time in `SheetMode.WEBVIEW`, with tests updated to reflect that input-mode closes no longer write a timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24141b437a18f8708a7ab354cd091525673569b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213133974212714