### PR TITLE
Only show fade if blur not supported on Input Screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/BottomBlurView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/BottomBlurView.kt
@@ -96,6 +96,7 @@ class BottomBlurView @JvmOverloads constructor(
     }
 
     override fun onDraw(canvas: Canvas) {
+        if (!canvas.isHardwareAccelerated) return
         val viewToBlur = targetView ?: return
 
         val w = width


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213134850512700?focus=true

### Description

- Only renders the bottom blur if the canvas supports hardware acceleration.

### Steps to test this PR

_Remove the check and just return_
- [x] Go to the Input Screen and type something in Search
- [x] Verify that only the fade is visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-guard change in UI drawing code; low risk but could affect appearance on devices/configurations that render this view without hardware acceleration.
> 
> **Overview**
> Prevents the input screen’s `BottomBlurView` blur effect from rendering on non-hardware-accelerated canvases by early-returning in `onDraw`, so the fade/blur overlay only appears when blur is actually supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5ce922572f147710cce018d135598190e2632e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->