### PR TITLE
Add launch pixel to VPN Reminder notification

### DIFF
--- a/network-protection/network-protection-api/src/main/java/com/duckduckgo/networkprotection/api/NetworkProtectionScreens.kt
+++ b/network-protection/network-protection-api/src/main/java/com/duckduckgo/networkprotection/api/NetworkProtectionScreens.kt
@@ -33,4 +33,10 @@ sealed class NetworkProtectionScreens {
      * Use this model to launch the NetP app exclusion list screen
      */
     data object NetPAppExclusionListNoParams : ActivityParams
+
+    /**
+     * Use this model to launch the NetworkProtectionManagement screen from a notification.
+     * @param pixelName the pixel name to fire when the screen is launched
+     */
+    data class NetworkProtectionManagementScreenWithLaunchPixel(val pixelName: String) : ActivityParams
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetPAppExclusionListNoParams
 import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetworkProtectionManagementScreenAndEnable
 import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetworkProtectionManagementScreenNoParams
+import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetworkProtectionManagementScreenWithLaunchPixel
 import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.impl.autoexclude.VpnAutoExcludePromptFragment
 import com.duckduckgo.networkprotection.impl.autoexclude.VpnAutoExcludePromptFragment.Companion.Source.VPN_SCREEN
@@ -79,6 +80,7 @@ import javax.inject.Inject
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(NetworkProtectionManagementScreenNoParams::class, screenName = "vpn.main")
 @ContributeToActivityStarter(NetworkProtectionManagementScreenAndEnable::class, screenName = "vpn.main")
+@ContributeToActivityStarter(NetworkProtectionManagementScreenWithLaunchPixel::class, screenName = "vpn.main")
 class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
 
     @Inject
@@ -122,8 +124,8 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
             }
         }
 
-        intent.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let { pixelName ->
-            viewModel.onLaunchedFromNotification(pixelName)
+        intent.getActivityParams(NetworkProtectionManagementScreenWithLaunchPixel::class.java)?.let { params ->
+            viewModel.onLaunchedFromNotification(params.pixelName)
         }
 
         observeViewModel()
@@ -550,7 +552,6 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
     }
 
     companion object {
-        private const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
         private const val REPORT_ISSUES_ANNOTATION = "report_issues_link"
         private const val OPEN_SETTINGS_ANNOTATION = "open_settings_link"
         private const val TAG_PROMOTION_DIALOG = "TAG_PROMO_DIALOG"

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModel.kt
@@ -24,7 +24,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -107,7 +106,6 @@ class NetworkProtectionManagementViewModel @Inject constructor(
     private val localConfig: NetPSettingsLocalConfig,
     private val autoExcludePrompt: AutoExcludePrompt,
     private val vpnEnableWideEvent: VpnEnableWideEvent,
-    private val pixel: Pixel,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val refreshVpnRunningState = MutableStateFlow(System.currentTimeMillis())
@@ -444,7 +442,7 @@ class NetworkProtectionManagementViewModel @Inject constructor(
     }
 
     fun onLaunchedFromNotification(pixelName: String) {
-        pixel.fire(pixelName)
+        networkProtectionPixels.reportNotificationLaunched(pixelName)
     }
 
     sealed class Command {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
@@ -303,6 +303,7 @@ interface NetworkProtectionPixels {
     fun reportAutoExcludePromptEnable()
     fun reportAutoExcludeEnableViaExclusionList()
     fun reportAutoExcludeDisableViaExclusionList()
+    fun reportNotificationLaunched(pixelName: String)
 }
 
 @ContributesBinding(AppScope::class)
@@ -673,6 +674,10 @@ class RealNetworkProtectionPixel @Inject constructor(
     override fun reportAutoExcludeDisableViaExclusionList() {
         firePixel(NETP_AUTO_EXCLUDE_DISABLED_VIA_EXCLUSION_LIST)
         tryToFireDailyPixel(NETP_AUTO_EXCLUDE_DISABLED_VIA_EXCLUSION_LIST_DAILY)
+    }
+
+    override fun reportNotificationLaunched(pixelName: String) {
+        firePixel(pixelName)
     }
 
     private fun firePixel(

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModelTest.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -133,9 +132,6 @@ class NetworkProtectionManagementViewModelTest {
     @Mock
     private lateinit var vpnEnableWideEvent: VpnEnableWideEvent
 
-    @Mock
-    private lateinit var pixel: Pixel
-
     private var autoExcludePrompt = FakeAutoExcludePrompt()
 
     private var vpnRemoteFeatures = FakeFeatureToggleFactory.create(VpnRemoteFeatures::class.java)
@@ -189,7 +185,6 @@ class NetworkProtectionManagementViewModelTest {
             localConfig,
             autoExcludePrompt,
             vpnEnableWideEvent,
-            pixel,
         )
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/VpnReminderNotification.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/VpnReminderNotification.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
-import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetworkProtectionManagementScreenNoParams
+import com.duckduckgo.networkprotection.api.NetworkProtectionScreens.NetworkProtectionManagementScreenWithLaunchPixel
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -138,9 +138,10 @@ class VpnReminderNotificationPlugin @Inject constructor(
     }
 
     override fun getLaunchIntent(): PendingIntent? {
-        val intent = globalActivityStarter.startIntent(context, NetworkProtectionManagementScreenNoParams)
-            ?: return null
-        intent.putExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(NOTIFICATION_LAUNCHED_PIXEL))
+        val intent = globalActivityStarter.startIntent(
+            context,
+            NetworkProtectionManagementScreenWithLaunchPixel(pixelName(NOTIFICATION_LAUNCHED_PIXEL)),
+        ) ?: return null
         return taskStackBuilderFactory.createTaskBuilder().run {
             addNextIntentWithParentStack(intent)
             getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
@@ -148,7 +149,6 @@ class VpnReminderNotificationPlugin @Inject constructor(
     }
 
     companion object {
-        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
         private const val NOTIFICATION_SHOWN_PIXEL = "mnot_s"
         private const val NOTIFICATION_CANCELLED_PIXEL = "mnot_c"
         private const val NOTIFICATION_LAUNCHED_PIXEL = "mnot_l"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213129522980997

### Description
Add launch pixel for vpn reminder notification

### Steps to test this PR
- [ ] Apply patch on https://app.asana.com/1/137249556945/task/1213129522980997
      - Allow subscriptions
      -  It will set the notification to launch 15 second after the free trial starts
- [ ] Set device language to English
- [ ] Fresh install
- [ ] Purchase a Test Subscription (Free Trial)
- [ ] Filter in logcat for `vpn_reminder`
- [ ] Wait 15 seconds until notification is shown
- [ ] Tap in the VPN reminder notification
- [ ] Make sure `Pixel sent: mnot_l_vpn_reminder with params: {} {}` is shown in logcat 

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, analytics-only change that adds an extra pixel on notification tap; no auth, payments, or persistent data flow changes.
> 
> **Overview**
> Adds a new navigation params type, `NetworkProtectionManagementScreenWithLaunchPixel`, to allow the VPN management screen to be launched with an associated *launch* pixel.
> 
> Updates the VPN reminder notification to open the management screen using this params object and introduces the `mnot_l_*` pixel, which is fired on activity launch via new plumbing in `NetworkProtectionManagementActivity`/`NetworkProtectionManagementViewModel` and `NetworkProtectionPixels`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08ce32d5ef4d9d3b6013cd99fa29ca03bf599e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->