### PR TITLE
Set the gradle project name, as per develocity recommendations for report consistency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,8 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 
+rootProject.name = "android"
+
 def isCI = System.getenv('CI') != null
 
 develocity {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213076149941929?focus=true 

### Description
Sets the gradle project name so it's consistent for all machines / git worktrees (and not using the project directory name)

### Steps to test this PR
- Check the top value is `android` in the scan: https://duckduckgo.develocity.cloud/s/vk7ibgxay7xcq/projects#:

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8ebeb91c054b81dec6f61624f87cecd5c79a2440. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->