### PR TITLE
Add UI Components and feature flag for duck.ai recent chats

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -164,4 +164,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun supportsSyncChatsDeletion(): Toggle
+
+    /**
+     * @return `true` when the AI chat suggestions (pinned and recent chats) are enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun aiChatSuggestions(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestion.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestion.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
+
+import java.time.LocalDateTime
+
+/**
+ * Represents a chat suggestion item to be displayed in the input screen
+ */
+data class ChatSuggestion(
+    val chatId: String,
+    val title: String,
+    val lastEdit: LocalDateTime,
+    val pinned: Boolean,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestionsAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestionsAdapter.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.databinding.ItemChatSuggestionBinding
+
+class ChatSuggestionsAdapter(
+    private val onChatClicked: (ChatSuggestion) -> Unit,
+) : ListAdapter<ChatSuggestion, ChatSuggestionsAdapter.ChatSuggestionViewHolder>(ChatSuggestionsDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatSuggestionViewHolder {
+        val binding = ItemChatSuggestionBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false,
+        )
+        return ChatSuggestionViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ChatSuggestionViewHolder, position: Int) {
+        holder.bind(getItem(position), onChatClicked)
+    }
+
+    class ChatSuggestionViewHolder(
+        private val binding: ItemChatSuggestionBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(suggestion: ChatSuggestion, onChatClicked: (ChatSuggestion) -> Unit) {
+            binding.chatSuggestionTitle.text = suggestion.title
+
+            val iconRes = if (suggestion.pinned) {
+                R.drawable.ic_pin_24
+            } else {
+                R.drawable.ic_chat_24
+            }
+            binding.chatSuggestionIcon.setImageResource(iconRes)
+
+            binding.root.setOnClickListener {
+                onChatClicked(suggestion)
+            }
+        }
+    }
+
+    companion object {
+        private val ChatSuggestionsDiffCallback = object : DiffUtil.ItemCallback<ChatSuggestion>() {
+            override fun areItemsTheSame(oldItem: ChatSuggestion, newItem: ChatSuggestion): Boolean {
+                return oldItem.chatId == newItem.chatId
+            }
+
+            override fun areContentsTheSame(oldItem: ChatSuggestion, newItem: ChatSuggestion): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 DuckDuckGo
+ * Copyright (c) 2026 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,164 @@
 
 package com.duckduckgo.duckchat.impl.inputscreen.ui.tabs
 
+import android.os.Build.VERSION
+import android.os.Bundle
+import android.view.View
+import android.view.View.OVER_SCROLL_NEVER
+import android.widget.FrameLayout
+import androidx.core.view.updatePadding
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenFragment
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
+import com.duckduckgo.duckchat.impl.inputscreen.ui.view.RecyclerBottomSpacingDecoration
+import com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
+import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import logcat.logcat
+import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @InjectWith(FragmentScope::class)
-class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab)
+class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
+
+    @Inject
+    lateinit var viewModelFactory: FragmentViewModelFactory
+
+    @Inject
+    lateinit var inputScreenConfigResolver: InputScreenConfigResolver
+
+    @Inject
+    lateinit var duckChatFeature: DuckChatFeature
+
+    private val viewModel: InputScreenViewModel by lazy {
+        ViewModelProvider(requireParentFragment(), viewModelFactory)[InputScreenViewModel::class.java]
+    }
+
+    private var chatSuggestionsRecyclerView: SwipeableRecyclerView? = null
+    private lateinit var chatSuggestionsAdapter: ChatSuggestionsAdapter
+    private var bottomBlurView: BottomBlurView? = null
+    private var bottomBlurLayoutListener: View.OnLayoutChangeListener? = null
+    private var bottomBlurDataObserver: RecyclerView.AdapterDataObserver? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (!duckChatFeature.aiChatSuggestions().isEnabled()) return
+        configureChatSuggestions()
+        configureObservers()
+        configureBottomBlur()
+    }
+
+    private fun configureChatSuggestions() {
+        val parentFragment = requireParentFragment() as InputScreenFragment
+
+        chatSuggestionsAdapter = ChatSuggestionsAdapter { suggestion ->
+            // TODO: Handle navigation to chat in duck.ai fullscreen mode
+            logcat { "Chat suggestion clicked: chatId=${suggestion.chatId}, title=${suggestion.title}" }
+        }
+
+        chatSuggestionsRecyclerView = parentFragment.getChatSuggestionsRecyclerView().apply {
+            setViewPager(parentFragment.getViewPager())
+            adapter = chatSuggestionsAdapter
+            layoutManager = LinearLayoutManager(context)
+            val typedValue = android.util.TypedValue()
+            context.theme.resolveAttribute(com.duckduckgo.mobile.android.R.attr.daxColorBrowserOverlay, typedValue, true)
+            setBackgroundColor(typedValue.data)
+
+            if (inputScreenConfigResolver.useTopBar()) {
+                val spacing = resources.getDimensionPixelSize(R.dimen.inputScreenAutocompleteListBottomSpace)
+                addItemDecoration(RecyclerBottomSpacingDecoration(spacing))
+                updatePadding(top = 8f.toPx(context).roundToInt())
+            }
+        }
+    }
+
+    private fun configureObservers() {
+        val parentFragment = requireParentFragment() as InputScreenFragment
+
+        viewModel.chatSuggestions
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach { suggestions ->
+                chatSuggestionsAdapter.submitList(suggestions)
+                if (!viewModel.visibilityState.value.searchMode) {
+                    parentFragment.updateChatSuggestionsVisibility(suggestions.isNotEmpty())
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun configureBottomBlur() {
+        if (VERSION.SDK_INT >= 33 && inputScreenConfigResolver.useTopBar()) {
+            val recyclerView = chatSuggestionsRecyclerView ?: return
+            val parentFragment = requireParentFragment() as InputScreenFragment
+            val bottomFadeContainer = parentFragment.getChatSuggestionsBottomFadeContainer()
+
+            recyclerView.overScrollMode = OVER_SCROLL_NEVER
+
+            bottomBlurView = BottomBlurView(requireContext())
+            bottomBlurView?.setTargetView(recyclerView)
+            bottomFadeContainer.addView(bottomBlurView)
+
+            recyclerView.addOnScrollListener(
+                object : RecyclerView.OnScrollListener() {
+                    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                        bottomBlurView?.invalidate()
+                    }
+                },
+            )
+
+            bottomBlurLayoutListener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                bottomBlurView?.invalidate()
+            }
+            recyclerView.addOnLayoutChangeListener(bottomBlurLayoutListener)
+
+            bottomBlurDataObserver = object : RecyclerView.AdapterDataObserver() {
+                override fun onChanged() {
+                    recyclerView.post { bottomBlurView?.invalidate() }
+                }
+                override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+                    recyclerView.post { bottomBlurView?.invalidate() }
+                }
+                override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                    recyclerView.post { bottomBlurView?.invalidate() }
+                }
+                override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                    recyclerView.post { bottomBlurView?.invalidate() }
+                }
+            }
+            recyclerView.adapter?.registerAdapterDataObserver(bottomBlurDataObserver!!)
+        }
+    }
+
+    override fun onDestroyView() {
+        while ((chatSuggestionsRecyclerView?.itemDecorationCount ?: 0) > 0) {
+            chatSuggestionsRecyclerView?.removeItemDecorationAt(0)
+        }
+        chatSuggestionsRecyclerView?.clearOnScrollListeners()
+        bottomBlurLayoutListener?.let { listener ->
+            chatSuggestionsRecyclerView?.removeOnLayoutChangeListener(listener)
+        }
+        bottomBlurLayoutListener = null
+        bottomBlurDataObserver?.let { observer ->
+            chatSuggestionsRecyclerView?.adapter?.unregisterAdapterDataObserver(observer)
+        }
+        bottomBlurDataObserver = null
+        (bottomBlurView?.parent as? FrameLayout)?.removeView(bottomBlurView)
+        bottomBlurView = null
+        chatSuggestionsRecyclerView = null
+        super.onDestroyView()
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.EditWithSelectedQuery
@@ -58,6 +59,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputFieldState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputScreenVisibilityState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIconState
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.CHAT
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.NONE
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.SEARCH
@@ -125,6 +127,7 @@ class InputScreenViewModel @AssistedInject constructor(
     private val autoCompleteSettings: AutoCompleteSettings,
     private val duckChat: DuckChat,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckChatFeature: DuckChatFeature,
     private val pixel: Pixel,
     private val sessionStore: InputScreenSessionStore,
     private val inputScreenDiscoveryFunnel: InputScreenDiscoveryFunnel,
@@ -168,6 +171,9 @@ class InputScreenViewModel @AssistedInject constructor(
 
     private val _submitButtonIconState = MutableStateFlow(SubmitButtonIconState(SubmitButtonIcon.SEARCH))
     val submitButtonIconState: StateFlow<SubmitButtonIconState> = _submitButtonIconState.asStateFlow()
+
+    private val _chatSuggestions = MutableStateFlow<List<ChatSuggestion>>(emptyList())
+    val chatSuggestions: StateFlow<List<ChatSuggestion>> = _chatSuggestions.asStateFlow()
 
     private val refreshSuggestions = MutableSharedFlow<Unit>()
 
@@ -479,6 +485,11 @@ class InputScreenViewModel @AssistedInject constructor(
             fireModeSwitchedPixel(directionToSearch = false)
         }
         userSelectedMode = CHAT
+
+        // Load suggestions when chat tab is selected (only if not already loaded)
+        if (duckChatFeature.aiChatSuggestions().isEnabled() && _chatSuggestions.value.isEmpty()) {
+            loadChatSuggestions()
+        }
     }
 
     fun onSearchSelected() {
@@ -688,6 +699,10 @@ class InputScreenViewModel @AssistedInject constructor(
         userSelectedMode == SEARCH &&
         inputScreenConfigResolver.mainButtonsEnabled() &&
         omnibarRepository.omnibarType != OmnibarType.SPLIT
+
+    private fun loadChatSuggestions() {
+        // TODO: implement load from frontend
+    }
 
     class InputScreenViewModelProviderFactory(
         private val assistedFactory: InputScreenViewModelFactory,

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_chat_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_chat_24.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.5,10.906C20.5,13.901 18.424,16.598 15.259,17.747L15.2,17.768L15.144,17.794C14.126,18.262 12.228,18.781 10.052,19.265C8.588,19.592 7.063,19.889 5.718,20.135L6.206,19.572C7.157,18.475 6.882,16.93 5.942,16.097C4.406,14.736 3.5,12.898 3.5,10.906C3.5,6.974 7.138,3.5 12,3.5V2C6.477,2 2,5.987 2,10.906C2,13.297 3.058,15.467 4.779,17.067L4.948,17.22C5.334,17.562 5.417,18.149 5.104,18.551L5.073,18.589L3.455,20.454C2.903,21.09 3.438,22.058 4.268,21.916C7.588,21.345 13.408,20.242 15.77,19.157C19.424,17.831 22,14.637 22,10.906C22,5.987 17.523,2 12,2V3.5C16.787,3.5 20.386,6.867 20.497,10.722L20.5,10.906Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd" />
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_pin_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_pin_24.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M8.798,3.482C9.597,2.772 10.871,2.934 11.466,3.824C11.682,4.148 11.746,4.488 11.765,4.758C11.782,4.991 11.767,5.299 11.767,5.421C11.767,5.878 11.998,6.382 12.403,6.785C12.809,7.189 13.314,7.415 13.762,7.416H13.762C15.043,7.416 16.799,7.57 17.947,8.722L18.009,8.788C18.637,9.484 18.616,10.575 17.947,11.244L17.946,11.244L15.125,14.065L20.78,19.72C21.073,20.013 21.073,20.488 20.78,20.781C20.487,21.073 20.013,21.073 19.72,20.781L14.065,15.125L11.244,17.946C10.583,18.608 9.502,18.641 8.801,18.021C8.8,18.02 8.798,18.019 8.797,18.017C7.516,16.868 7.416,15.058 7.416,13.762L7.413,13.678C7.387,13.252 7.164,12.784 6.785,12.403C6.381,11.997 5.877,11.767 5.42,11.767C5.298,11.767 4.991,11.782 4.758,11.765C4.487,11.746 4.147,11.682 3.824,11.466C2.905,10.852 2.762,9.514 3.553,8.722V8.722L8.722,3.554L8.798,3.482ZM10.01,4.54C9.917,4.531 9.836,4.561 9.782,4.614L4.614,9.783C4.561,9.836 4.53,9.917 4.54,10.01C4.549,10.104 4.596,10.178 4.657,10.219C4.682,10.236 4.733,10.259 4.865,10.269C4.932,10.274 5.008,10.274 5.104,10.272C5.186,10.271 5.313,10.267 5.42,10.267H5.421C6.361,10.267 7.229,10.722 7.849,11.345C8.468,11.968 8.915,12.835 8.916,13.762V13.762C8.916,15.105 9.068,16.243 9.796,16.899C9.903,16.992 10.083,16.986 10.183,16.886L10.184,16.885L16.886,10.184C16.991,10.078 16.991,9.888 16.886,9.783L16.884,9.781C16.209,9.102 15.037,8.916 13.762,8.916H13.762C12.835,8.915 11.968,8.468 11.345,7.849C10.722,7.229 10.267,6.361 10.267,5.421V5.421C10.267,5.313 10.271,5.186 10.273,5.103C10.274,5.008 10.274,4.932 10.269,4.866C10.26,4.733 10.236,4.682 10.219,4.657C10.178,4.596 10.105,4.55 10.01,4.54Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd" />
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -114,6 +114,36 @@
     </FrameLayout>
 
     <FrameLayout
+        android:id="@+id/chatSuggestionsOverlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="@dimen/inputScreenMarginHorizontal"
+        android:visibility="gone"
+        android:elevation="3dp"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintBottom_toTopOf="@id/inputModeWidgetContainerBottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inputModeWidgetContainerTop">
+
+        <com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
+            android:id="@+id/chatSuggestionsRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false" />
+
+        <FrameLayout
+            android:id="@+id/chatSuggestionsBottomFadeContainer"
+            android:layout_width="match_parent"
+            android:layout_height="80dp"
+            android:layout_gravity="bottom"
+            android:elevation="8dp"
+            android:foreground="@drawable/bottom_fade_overlay" />
+
+    </FrameLayout>
+
+    <FrameLayout
         android:id="@+id/inputScreenButtonsContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/duckchat/duckchat-impl/src/main/res/layout/item_chat_suggestion.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_chat_suggestion.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingVertical="?attr/autocompleteListItemVerticalPadding"
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding">
+
+    <ImageView
+        android:id="@+id/chatSuggestionIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:src="@drawable/ic_chat_24" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/chatSuggestionTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/autocompleteListItemIconMargin"
+        android:ellipsize="end"
+        android:includeFontPadding="false"
+        android:gravity="center_vertical|start"
+        android:maxLines="1"
+        android:textAlignment="textStart"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/chatSuggestionIcon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:text="Chat suggestion for pinned or recent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.AnimateLogoToProgress
@@ -39,6 +40,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -89,6 +91,7 @@ class InputScreenViewModelTest {
     private val omnibarRepository: OmnibarRepository = mock()
 
     private val duckAiFeatureState: DuckAiFeatureState = mock()
+    private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
     private val fullScreenModeDisabledFlow = MutableStateFlow(false)
     private val fullScreenModeEnabledFlow = MutableStateFlow(true)
     private val duckChatURL = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
@@ -128,6 +131,7 @@ class InputScreenViewModelTest {
             inputScreenConfigResolver = inputScreenConfigResolver,
             omnibarRepository = omnibarRepository,
             duckAiFeatureState = duckAiFeatureState,
+            duckChatFeature = duckChatFeature,
         )
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213130409431278

### Description

First part of the recent chats feature, which implements a chat suggestion list in the duck.ai tab of the input screen.

Introduces a new feature flag: aiChatSuggestions. When enabled, the AI chat suggestions (pinned and recent chats) in the input screen's duck.ai mode.

The UI is currently a work in progress and is using static test data.

*Changes:*

- Added a new overlay in the input screen fragment for the chat suggestions. This follows the same pattern as the autocomplete overlay. 
- Add a recycler view (with its adapter and items) to the chatSuggestionsOverlay to display the list of recent chats. 
- Modified how the Logo visibility is handled. The Duck.ai chat logo should no longer be visible even if there are not recent chat items. Only the search logo will be visible (Follows iOS implementation)
- Added icons for the chats (pin vs chat bubble)
- Added the model for the Chat suggestion. It follow the expected structure for future integration with the JS frontend.
- Modified the Input Screen View Model to load the static list.
- All the changes are UX/fragments, Testing will be done through Maestro. Unit tests will be implemented when real data starts flowing through the view model. 


*Next Steps*
- Connect with the real frontend data once the JS webview interface is ready
- Clicking on a recent chat should navigate you to the Duck.ai page and load the related chat.
- Maestro tests

### Steps to test this PR
Notes: in order to facilitate testing, I created an additional branch with static data. Please pull the `origin/feature/youssef/do_not_merge/recent_ai_chats_ui_test_data` branch to test this PR with data and see the behavior. This would prevent having test data part of the merge and allow PR testing. 

- Pull the changes and run the app
- Go to feature flags settings and turn on "aiChatSuggestions" flag (it's off by default)
- Go back to the input screen, make sure the omnibar is enabled
- Switch to the "Duck.ai" tab. You should see a static list of chats, both pinned and recent.
- Switch back and forth between search and chat to make sure the interaction and visibility is correct. You can test different behaviors on the search tab such as searching or adding a favorite. No impact should be observed.
- If "aiChatSuggestions" is disabled, the app should behave as it is currently in production. No impact should be observed

### UI changes
| Before  | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/345cd1b6-4b19-4a61-9a4d-704335429632)|![after](https://github.com/user-attachments/assets/edf33a8c-c99e-4a2a-83c5-bbf4fee837fe)|
||![after](https://github.com/user-attachments/assets/f774569e-bf60-4e91-b140-2c37f2dd3e7e)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature-flagged but touches core input-screen UI state/animation and overlay interaction, which can introduce subtle regressions in tab switching, visibility, and touch handling.
> 
> **Overview**
> Adds a new remote sub-feature flag, `DuckChatFeature.aiChatSuggestions`, to gate an in-progress “recent/pinned chats” suggestions experience in the Duck.ai input-screen tab.
> 
> When enabled, the input screen now includes a new `chatSuggestionsOverlay` (RecyclerView + bottom fade/blur) and shared overlay animation logic, and updates logo/overlay/viewpager-interaction behavior to avoid showing the Duck.ai logo and to ensure autocomplete/suggestions overlays don’t overlap during mode switches. `ChatTabFragment` is expanded to wire up a `ChatSuggestionsAdapter` and observe a new `InputScreenViewModel.chatSuggestions` flow (loading stubbed via a TODO), with new pin/chat icons and an `item_chat_suggestion` row layout; tests are updated to inject the new feature toggle dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595d297ae49695e54001d4b0fbdc446c3f713cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->