### PR TITLE
Update content scope scripts to version 13.0.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -3598,12 +3598,11 @@
 
   // src/content-feature.js
   function createDeferred() {
-    const deferred = {};
-    deferred.promise = new Promise((resolve, reject) => {
-      deferred.resolve = resolve;
-      deferred.reject = reject;
+    let res;
+    const promise = new Promise((resolve) => {
+      res = resolve;
     });
-    return deferred;
+    return { promise, resolve: res };
   }
   var CallFeatureMethodError = class extends Error {
     /**
@@ -3614,8 +3613,6 @@
       Object.setPrototypeOf(this, new.target.prototype);
       this.name = new.target.name;
     }
-  };
-  var FeatureSkippedError = class extends Error {
   };
   var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
@@ -3683,7 +3680,7 @@
     /**
      * Returns a promise that resolves when the feature has been initialised with `init`.
      *
-     * @returns {Promise<void>}
+     * @returns {Promise<ReadyStatus>}
      */
     get _ready() {
       return __privateGet(this, _ready).promise;
@@ -3803,13 +3800,12 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
-      try {
-        await feature._ready;
-      } catch (e) {
-        if (e instanceof FeatureSkippedError) {
-          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
-        }
-        throw e;
+      const isReady = await feature._ready;
+      if (isReady.status === "skipped") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${isReady.reason}`);
+      }
+      if (isReady.status === "error") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' failed: ${isReady.error}`);
       }
       return method.call(feature, ...args);
     }
@@ -3864,9 +3860,9 @@
       try {
         this.setArgs(args);
         await this.init(this.args);
-        __privateGet(this, _ready).resolve?.();
+        __privateGet(this, _ready).resolve({ status: "ready" });
       } catch (error) {
-        __privateGet(this, _ready).reject?.(error);
+        __privateGet(this, _ready).resolve({ status: "error", error: String(error) });
         throw error;
       } finally {
         mark.end();
@@ -3881,7 +3877,7 @@
      * @param {string} reason - The reason the feature was skipped
      */
     markFeatureAsSkipped(reason) {
-      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
+      __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
     setArgs(args) {
       this.args = args;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -5146,12 +5146,11 @@
 
   // src/content-feature.js
   function createDeferred() {
-    const deferred = {};
-    deferred.promise = new Promise((resolve, reject) => {
-      deferred.resolve = resolve;
-      deferred.reject = reject;
+    let res;
+    const promise = new Promise((resolve) => {
+      res = resolve;
     });
-    return deferred;
+    return { promise, resolve: res };
   }
   var CallFeatureMethodError = class extends Error {
     /**
@@ -5162,8 +5161,6 @@
       Object.setPrototypeOf(this, new.target.prototype);
       this.name = new.target.name;
     }
-  };
-  var FeatureSkippedError = class extends Error {
   };
   var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
@@ -5231,7 +5228,7 @@
     /**
      * Returns a promise that resolves when the feature has been initialised with `init`.
      *
-     * @returns {Promise<void>}
+     * @returns {Promise<ReadyStatus>}
      */
     get _ready() {
       return __privateGet(this, _ready).promise;
@@ -5351,13 +5348,12 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
-      try {
-        await feature._ready;
-      } catch (e) {
-        if (e instanceof FeatureSkippedError) {
-          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
-        }
-        throw e;
+      const isReady = await feature._ready;
+      if (isReady.status === "skipped") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${isReady.reason}`);
+      }
+      if (isReady.status === "error") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' failed: ${isReady.error}`);
       }
       return method.call(feature, ...args);
     }
@@ -5412,9 +5408,9 @@
       try {
         this.setArgs(args);
         await this.init(this.args);
-        __privateGet(this, _ready).resolve?.();
+        __privateGet(this, _ready).resolve({ status: "ready" });
       } catch (error) {
-        __privateGet(this, _ready).reject?.(error);
+        __privateGet(this, _ready).resolve({ status: "error", error: String(error) });
         throw error;
       } finally {
         mark.end();
@@ -5429,7 +5425,7 @@
      * @param {string} reason - The reason the feature was skipped
      */
     markFeatureAsSkipped(reason) {
-      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
+      __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
     setArgs(args) {
       this.args = args;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -5003,12 +5003,11 @@
 
   // src/content-feature.js
   function createDeferred() {
-    const deferred = {};
-    deferred.promise = new Promise((resolve, reject) => {
-      deferred.resolve = resolve;
-      deferred.reject = reject;
+    let res;
+    const promise = new Promise((resolve) => {
+      res = resolve;
     });
-    return deferred;
+    return { promise, resolve: res };
   }
   var CallFeatureMethodError = class extends Error {
     /**
@@ -5019,8 +5018,6 @@
       Object.setPrototypeOf(this, new.target.prototype);
       this.name = new.target.name;
     }
-  };
-  var FeatureSkippedError = class extends Error {
   };
   var _messaging, _isDebugFlagSet, _importConfig, _features, _ready;
   var ContentFeature = class extends ConfigFeature {
@@ -5088,7 +5085,7 @@
     /**
      * Returns a promise that resolves when the feature has been initialised with `init`.
      *
-     * @returns {Promise<void>}
+     * @returns {Promise<ReadyStatus>}
      */
     get _ready() {
       return __privateGet(this, _ready).promise;
@@ -5208,13 +5205,12 @@
       if (!method) return new CallFeatureMethodError(`'${methodName}' not found in feature '${featureName}'`);
       if (!(method instanceof Function))
         return new CallFeatureMethodError(`'${methodName}' is not a function in feature '${featureName}'`);
-      try {
-        await feature._ready;
-      } catch (e) {
-        if (e instanceof FeatureSkippedError) {
-          return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${e.message}`);
-        }
-        throw e;
+      const isReady = await feature._ready;
+      if (isReady.status === "skipped") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' was skipped: ${isReady.reason}`);
+      }
+      if (isReady.status === "error") {
+        return new CallFeatureMethodError(`Initialisation of feature '${featureName}' failed: ${isReady.error}`);
       }
       return method.call(feature, ...args);
     }
@@ -5269,9 +5265,9 @@
       try {
         this.setArgs(args);
         await this.init(this.args);
-        __privateGet(this, _ready).resolve?.();
+        __privateGet(this, _ready).resolve({ status: "ready" });
       } catch (error) {
-        __privateGet(this, _ready).reject?.(error);
+        __privateGet(this, _ready).resolve({ status: "error", error: String(error) });
         throw error;
       } finally {
         mark.end();
@@ -5286,7 +5282,7 @@
      * @param {string} reason - The reason the feature was skipped
      */
     markFeatureAsSkipped(reason) {
-      __privateGet(this, _ready).reject?.(new FeatureSkippedError(reason));
+      __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
     setArgs(args) {
       this.args = args;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.40.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.0.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.51.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.51.0.tgz",
-      "integrity": "sha512-FgaCJQGqbmc71N9LjTWtmVcTVJQbKBDTC9av8S78qOJkIT8t/l7PEsuiJGf7IfzWFjh0RGtY3wByi6wtW99XeA==",
+      "version": "14.52.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.52.0.tgz",
+      "integrity": "sha512-Xg38Ypoe9S1ESZYSEVNKGF3Fn8hSEdTHsz9rQ97Pa+d8Z0HtgrE1OpBt5C/6ZUCMLSdn6BOcvaULt0A6/OTLsg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9b0a860b46bb12ea8ccf89601b7ab31d1349ffcd",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#b1159d84315d5b12fdbb9041a08353c510805dec",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
+      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.40.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.0.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213145885484575/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump plus generated JS changes in feature initialization/ready semantics; could affect inter-feature calls and error handling if any callers relied on promise rejection behavior.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `12.40.0` to `13.0.0` (with corresponding `package-lock.json` updates).
> 
> The updated Android build artifacts change `ContentFeature` readiness signaling: the internal deferred no longer rejects, and `_ready` now resolves to a `ReadyStatus` (`ready`/`skipped`/`error`) that `callFeatureMethod` inspects to return clearer initialization failure/skip errors instead of throwing or hanging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 037f0d773b7f8057e44a18c65fa213c63784a2c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->