### PR TITLE
Update root project gradle name to workaround an Android Studio bug

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 
-rootProject.name = "android"
+rootProject.name = "androidRoot"
 
 def isCI = System.getenv('CI') != null
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213147991577417 

### Description
Working around an AS bug by setting the `rootProject.name` to be something less likely to match the default project folder on disk (to avoid them ending up different only because of a casing difference)

If the `rootProject.name` and folder name on disk are exact matches **except for casing** there is a bug where Android Studio will fail to sync. e.g.,
- `rootProject.name` == `android` and folder on disk is `Android` is problematic
- `rootProject.name` == `android` and folder on disk is `android` is fine
- `rootProject.name` == `foo` and folder on disk is `bar` is fine

### Steps to test this PR
- Check AS syncs ok

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build configuration rename with no runtime behavior changes; main risk is tooling/scripts that assume the old root project name.
> 
> **Overview**
> Renames the Gradle root project by changing `rootProject.name` from `android` to `androidRoot` in `settings.gradle` (intended as a workaround for an Android Studio issue).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcff65bb6bfbeb291c55a34bf6d966d6371d53ca. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->