### PR TITLE
Add error pixels for if sqlcipher async loading fails or times out

### DIFF
--- a/PixelDefinitions/pixels/autofill.json5
+++ b/PixelDefinitions/pixels/autofill.json5
@@ -82,5 +82,19 @@
                 "type": "string"
             }
         ]
+    },
+    "library_load_timeout_sqlcipher": {
+        "description": "Fired when the sqlcipher native library takes longer than the timeout period to load asynchronously",
+        "owners": ["CDRussell"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "library_load_failure_sqlcipher": {
+        "description": "Fired when the sqlcipher native library fails to load asynchronously due to an exception",
+        "owners": ["CDRussell"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -72,6 +72,8 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.BOOKMARK_IMPORT_FRO
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.LIBRARY_LOAD_FAILURE_SQLCIPHER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.LIBRARY_LOAD_TIMEOUT_SQLCIPHER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED_DAILY
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
@@ -232,6 +234,8 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_HARMONY_PREFERENCES_GET_KEY_FAILED("autofill_harmony_preferences_get_key_failed"),
     AUTOFILL_PREFERENCES_UPDATE_KEY_FAILED("autofill_preferences_update_key_failed"),
     AUTOFILL_HARMONY_PREFERENCES_UPDATE_KEY_FAILED("autofill_harmony_preferences_update_key_failed"),
+    LIBRARY_LOAD_TIMEOUT_SQLCIPHER("library_load_timeout_sqlcipher"),
+    LIBRARY_LOAD_FAILURE_SQLCIPHER("library_load_failure_sqlcipher"),
 }
 
 object AutofillPixelParameters {
@@ -318,6 +322,9 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_ERROR.pixelName to PixelParameter.removeAtb(),
             BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_CANCELLED.pixelName to PixelParameter.removeAtb(),
             BOOKMARK_IMPORT_FROM_GOOGLE_FLOW_EXTRA_CHROME_EXPORT.pixelName to PixelParameter.removeAtb(),
+
+            LIBRARY_LOAD_TIMEOUT_SQLCIPHER.pixelName to PixelParameter.removeAtb(),
+            LIBRARY_LOAD_FAILURE_SQLCIPHER.pixelName to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213116557045964 

### Description
Adds error pixels if there's a problem with the new async `sqlcipher` native library loading.

Logcat filter: message~:`"SqlCipher-Init: |Autofill-DB-Init: |library_load_"`
Patches for testing the various error cases: [Testing patches](https://app.asana.com/1/137249556945/task/1213119837878196?focus=true)

### Steps to test this PR

#### Timeouts
- [x] Apply the timeout patch and launch the app
- [x] Wait 10s for timeout, then verify `Pixel sent: library_load_timeout_sqlcipher` in logs

#### Timeouts
- [x] Remove previous patch, and apply the error patch and launch the app
- [x] Wait 10s for timeout, then verify `Pixel sent: library_load_failure_sqlcipher` in logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds telemetry-only behavior gated to async loading; no changes to the actual library loading flow beyond emitting pixels and updating tests.
> 
> **Overview**
> Adds two new *daily* error pixels (`library_load_timeout_sqlcipher`, `library_load_failure_sqlcipher`) to track sqlcipher native library async loading issues, including wiring them into `AutofillPixelNames` and data-cleaning rules.
> 
> Updates `SqlCipherLibraryLoader.waitForLibraryLoad` to fire the appropriate pixel on timeout or exception **only when async loading is enabled**, and extends unit tests to verify pixels fire (or not) across timeout, failure, success, and sync-loading scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60314cdd8e56c575447408c8d6c55e9eab690f73. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->