### PR TITLE
PIR: Add vpn_connection_state to eligible pixels

### DIFF
--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(':data-store-api')
     implementation project(':js-messaging-api')
     implementation project(':navigation-api')
+    implementation project(':network-protection-api')
     implementation project(':subscriptions-api')
     implementation project(':statistics-api')
     implementation "com.squareup.logcat:logcat:_"

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.pir.impl.integration.fakes.FakeCurrentTimeProvider
 import com.duckduckgo.pir.impl.integration.fakes.FakeDbpService
 import com.duckduckgo.pir.impl.integration.fakes.FakeEventHandlerPluginPoint
 import com.duckduckgo.pir.impl.integration.fakes.FakeNativeBrokerActionHandler
+import com.duckduckgo.pir.impl.integration.fakes.FakeNetworkProtectionState
 import com.duckduckgo.pir.impl.integration.fakes.FakePirCssScriptLoader
 import com.duckduckgo.pir.impl.integration.fakes.FakePirDataStore
 import com.duckduckgo.pir.impl.integration.fakes.FakePirDetachedWebViewProvider
@@ -167,6 +168,7 @@ class PirEndToEndTest {
     private lateinit var fakeNativeBrokerActionHandler: FakeNativeBrokerActionHandler
     private lateinit var fakePirCssScriptLoader: FakePirCssScriptLoader
     private lateinit var fakePirWebViewDataCleaner: FakeWebViewDataCleaner
+    private lateinit var fakeNetworkProtectionState: FakeNetworkProtectionState
 
     private val activeBrokerName = "FakeBroker"
     private val removedBrokerName = "FakeRemovedBroker"
@@ -241,6 +243,7 @@ class PirEndToEndTest {
         fakePixel = FakePixel()
         pixelSender = RealPirPixelSender(fakePixel)
         fakePirWebViewDataCleaner = FakeWebViewDataCleaner()
+        fakeNetworkProtectionState = FakeNetworkProtectionState()
 
         pirRepository = RealPirRepository(
             dispatcherProvider = dispatcherProvider,
@@ -287,6 +290,7 @@ class PirEndToEndTest {
             pirSchedulingRepository = pirSchedulingRepository,
             currentTimeProvider = fakeTimeProvider,
             moshi = moshi,
+            networkProtectionState = fakeNetworkProtectionState,
         )
 
         brokerActionProcessor = RealBrokerActionProcessor(fakePirMessagingInterface, moshi)

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakeNetworkProtectionState.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakeNetworkProtectionState.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.integration.fakes
+
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeNetworkProtectionState : NetworkProtectionState {
+    override suspend fun isOnboarded(): Boolean = false
+    override suspend fun isEnabled(): Boolean = false
+    override suspend fun isRunning(): Boolean = false
+    override fun start() {}
+    override fun restart() {}
+    override fun clearVPNConfigurationAndRestart() {}
+    override suspend fun stop() {}
+    override fun clearVPNConfigurationAndStop() {}
+    override fun serverLocation(): String? = null
+    override fun getConnectionStateFlow(): Flow<NetworkProtectionState.ConnectionState> = flowOf()
+    override suspend fun getExcludedApps(): List<String> = emptyList()
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -142,6 +142,7 @@ interface PirPixelSender {
         durationMs: Long,
         optOutAttemptCount: Int,
         emailPattern: String?,
+        isVpnRunning: Boolean,
     )
 
     /**
@@ -167,6 +168,7 @@ interface PirPixelSender {
         emailPattern: String?,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     )
 
     /**
@@ -406,6 +408,7 @@ interface PirPixelSender {
         durationMs: Long,
         inManualStarted: Boolean,
         parentUrl: String,
+        isVpnRunning: Boolean,
     )
 
     fun reportScanNoMatch(
@@ -416,6 +419,7 @@ interface PirPixelSender {
         parentUrl: String,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     )
 
     fun reportScanError(
@@ -428,6 +432,7 @@ interface PirPixelSender {
         parentUrl: String,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     )
 
     fun reportOptOutStageStart(
@@ -617,6 +622,7 @@ class RealPirPixelSender @Inject constructor(
         durationMs: Long,
         optOutAttemptCount: Int,
         emailPattern: String?,
+        isVpnRunning: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_BROKER to brokerUrl,
@@ -624,8 +630,17 @@ class RealPirPixelSender @Inject constructor(
             PARAM_DURATION to durationMs.toString(),
             PARAM_TRIES to optOutAttemptCount.toString(),
             PARAM_KEY_PATTERN to (emailPattern ?: ""),
+            PARAM_KEY_VPN_STATE to isVpnRunning.toVpnConnectionState(),
         )
         fire(PIR_OPTOUT_SUBMIT_SUCCESS, params)
+    }
+
+    private fun Boolean.toVpnConnectionState(): String {
+        return if (this) {
+            "connected"
+        } else {
+            "disconnected"
+        }
     }
 
     override fun reportOptOutFailed(
@@ -638,6 +653,7 @@ class RealPirPixelSender @Inject constructor(
         emailPattern: String?,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_BROKER to brokerUrl,
@@ -649,6 +665,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PATTERN to (emailPattern ?: ""),
             PARAM_ACTION_ID to actionId,
             PARAM_KEY_ACTION_TYPE to actionType,
+            PARAM_KEY_VPN_STATE to isVpnRunning.toVpnConnectionState(),
         )
 
         fire(PIR_OPTOUT_SUBMIT_FAILURE, params)
@@ -936,6 +953,7 @@ class RealPirPixelSender @Inject constructor(
         durationMs: Long,
         inManualStarted: Boolean,
         parentUrl: String,
+        isVpnRunning: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_BROKER to brokerUrl,
@@ -944,6 +962,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PARENT to parentUrl,
             PARAM_KEY_MANUAL_STARTED to inManualStarted.toString(),
             PARAM_KEY_PARENT to parentUrl,
+            PARAM_KEY_VPN_STATE to isVpnRunning.toVpnConnectionState(),
         )
 
         fire(PIR_SCAN_STAGE_RESULT_MATCHES, params)
@@ -957,6 +976,7 @@ class RealPirPixelSender @Inject constructor(
         parentUrl: String,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_BROKER to brokerUrl,
@@ -966,6 +986,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PARENT to parentUrl,
             PARAM_ACTION_ID to actionId,
             PARAM_KEY_ACTION_TYPE to actionType,
+            PARAM_KEY_VPN_STATE to isVpnRunning.toVpnConnectionState(),
         )
 
         fire(PIR_SCAN_STAGE_RESULT_NO_MATCH, params)
@@ -981,6 +1002,7 @@ class RealPirPixelSender @Inject constructor(
         parentUrl: String,
         actionId: String,
         actionType: String,
+        isVpnRunning: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_BROKER to brokerUrl,
@@ -992,6 +1014,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PARENT to parentUrl,
             PARAM_ACTION_ID to actionId,
             PARAM_KEY_ACTION_TYPE to actionType,
+            PARAM_KEY_VPN_STATE to isVpnRunning.toVpnConnectionState(),
         )
 
         fire(PIR_SCAN_STAGE_RESULT_ERROR, params)
@@ -1384,5 +1407,6 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_DURATION_MS = "duration_in_ms"
         private const val PARAM_KEY_PROFILE_QUERY_COUNT = "profile_queries"
         private const val PARAM_KEY_SCAN_FREQUENCY = "scanFrequencyWithinThreshold"
+        private const val PARAM_KEY_VPN_STATE = "vpn_connection_state"
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -151,6 +151,7 @@ class RealPirPixelSenderTest {
             durationMs = 5000L,
             optOutAttemptCount = 2,
             emailPattern = "pattern-abc",
+            isVpnRunning = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -167,6 +168,7 @@ class RealPirPixelSenderTest {
         assert(params["duration"] == "5000")
         assert(params["tries"] == "2")
         assert(params["pattern"] == "pattern-abc")
+        assert(params["vpn_connection_state"] == "disconnected")
     }
 
     @Test
@@ -177,6 +179,7 @@ class RealPirPixelSenderTest {
             durationMs = 5000L,
             optOutAttemptCount = 2,
             emailPattern = null,
+            isVpnRunning = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -202,6 +205,7 @@ class RealPirPixelSenderTest {
             emailPattern = "pattern-xyz",
             actionId = "action-1",
             actionType = "fillform",
+            isVpnRunning = true,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -223,6 +227,7 @@ class RealPirPixelSenderTest {
         assert(params["pattern"] == "pattern-xyz")
         assert(params["action_id"] == "action-1")
         assert(params["action_type"] == "fillform")
+        assert(params["vpn_connection_state"] == "connected")
     }
 
     @Test
@@ -653,6 +658,7 @@ class RealPirPixelSenderTest {
             durationMs = 5000L,
             inManualStarted = true,
             parentUrl = "https://parent.com",
+            isVpnRunning = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -669,6 +675,7 @@ class RealPirPixelSenderTest {
         assert(params["duration"] == "5000")
         assert(params["is_manual_scan"] == "true")
         assert(params["parent"] == "https://parent.com")
+        assert(params["vpn_connection_state"] == "disconnected")
     }
 
     @Test
@@ -681,6 +688,7 @@ class RealPirPixelSenderTest {
             parentUrl = "https://parent.com",
             actionId = "action-scan-2",
             actionType = "extract",
+            isVpnRunning = true,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -699,6 +707,7 @@ class RealPirPixelSenderTest {
         assert(params["parent"] == "https://parent.com")
         assert(params["action_id"] == "action-scan-2")
         assert(params["action_type"] == "extract")
+        assert(params["vpn_connection_state"] == "connected")
     }
 
     @Test
@@ -713,6 +722,7 @@ class RealPirPixelSenderTest {
             parentUrl = "https://parent.com",
             actionId = "action-scan-3",
             actionType = "navigate",
+            isVpnRunning = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -733,6 +743,7 @@ class RealPirPixelSenderTest {
         assert(params["parent"] == "https://parent.com")
         assert(params["action_id"] == "action-scan-3")
         assert(params["action_type"] == "navigate")
+        assert(params["vpn_connection_state"] == "disconnected")
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213085863198314
### Description
See attached task description

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1213176315984932

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics/pixel APIs and their call sites, requiring signature updates across production and tests; runtime risk is mitigated by wrapping VPN state lookup in `runCatching` and defaulting to `false`.
> 
> **Overview**
> PIR now enriches eligible scan/opt-out result pixels with a new `vpn_connection_state` parameter (mapped to `connected`/`disconnected`) for `PIR_SCAN_STAGE_RESULT_*` and opt-out submit success/failure pixels.
> 
> `RealPirRunStateHandler` is updated to depend on `NetworkProtectionState` and safely query `isRunning()` (fail-closed) when emitting these pixels; tests and the end-to-end instrumentation setup add a `FakeNetworkProtectionState`, and `pir-impl` now depends on `:network-protection-api`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 754362f2465a7a29830ef06d9bbfbc8db67a66e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->