### PR TITLE
Update content scope scripts to version 13.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
-      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.22",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.22.tgz",
-      "integrity": "sha512-SHhoOcwbcARDYeXX1pcNI41MYdejjbBHf5aX5cF39Up8+dgwtyD8nKkgYFVH39r+apOVbW4HaoU390X6eXlQ4Q==",
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.23.tgz",
+      "integrity": "sha512-jsBnhWMTWVodIrvNEM0vFUf/rNr8fwt9AwsbaObiEQxR0q958ZkVOmvyR+0iaIYBq00FkGGqfnbfIG5Y7GU9MA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.22"
+        "tldts-core": "^7.0.23"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213205345136338/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no application code changes; risk is limited to any upstream behavior change in `tldts`.
> 
> **Overview**
> Updates `package-lock.json` to bump `tldts-core` and `tldts-experimental` from `7.0.22` to `7.0.23`, including updated tarball URLs/integrity hashes and the `tldts-experimental` dependency on `tldts-core`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5944ddc0035d3caadab6b68fa2913650aaad9791. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->