### PR TITLE
Fix Input Screen swipe gesture not working with overlay

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/SwipeableRecyclerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/SwipeableRecyclerView.kt
@@ -53,6 +53,11 @@ class SwipeableRecyclerView @JvmOverloads constructor(
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(e: MotionEvent): Boolean {
         val pager = viewPager ?: return super.onTouchEvent(e)
+
+        if (e.action == MotionEvent.ACTION_MOVE && !isHorizontalSwipe) {
+            detectHorizontalSwipe(e)
+        }
+
         if (!isHorizontalSwipe) return super.onTouchEvent(e)
 
         dispatchDownEvent(e, pager)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213210525832193
### Description

On the input screen view, we are able to switch tabs (between Search and Duck.ai) using the swipe gesture. When we type something in the search box the autocomplete overlay is shown and a list of autocomplete suggestions is displayed. Swipe gesture works inside the list items but not in empty areas.

### Steps to reproduce 
- Go to Settings → AI Features → Make sure “Duck.ai” is turned on and “Search & Duck.ai” mode is selected.
- Go back to the Input screen with the omnibar. The Search tab is selected by default
- Swipe to the left anywhere on the page → Tab switches to Duck.ai tab correctly
- Go back to the Search and type something in the chat box for the autocomplete list to show up
- Swipe to the left inside the list → Tab switches correctly
- Swipe to the left somewhere outside the list (in any empty area) → Tab does NOT switch. Swipe gesture is ignored.

### Root cause and fix
When touching a list item, `onInterceptTouchEvent` receives ACTION_MOVE events (to allow the parent to steal it from the child). This is where horizontal swipe detection is currently implemented.                                                            
When touching empty space below the items, no child handles ACTION_DOWN, so Android skips onInterceptTouchEvent for subsequent MOVE events and routes them directly to the recycler view's own onTouchEvent.
onInterceptTouchEvent is never called for the ACTION_MOVE when no list item claimed the ACTION_DOWN.
   
Fix: Added horizontal swipe detection in the recycler view's onTouchEvent to cover this path. If it's a move action, and the interceptor didn't already detect it, we detect it here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized touch-handling change in a single custom `RecyclerView`; risk is limited to potential gesture-detection regressions in this view.
> 
> **Overview**
> Fixes swipe-to-switch-tabs when interacting with empty space in the autocomplete/chat suggestions overlays by adding horizontal-swipe detection to `SwipeableRecyclerView.onTouchEvent` (not just `onInterceptTouchEvent`).
> 
> This ensures `ViewPager2` receives the gesture even when `ACTION_MOVE` events bypass interception, improving tab switching consistency during overlay display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e425554905b1aada4e380d49c0ffa186f50b3ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->