### PR TITLE
bugfix: Add favicon max allowed size to handle unreasonably large favicons.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
@@ -52,6 +52,10 @@ class GlideFaviconDownloader @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : FaviconDownloader {
 
+    companion object {
+        private const val MAX_FAVICON_SIZE_PX = 512
+    }
+
     override suspend fun getFaviconFromDisk(file: File): Bitmap? = withContext(dispatcherProvider.io()) {
         if (androidBrowserConfigFeature.glideSuspend().isEnabled()) {
             getFaviconFromDiskAsync(file)
@@ -136,7 +140,7 @@ class GlideFaviconDownloader @Inject constructor(
 
     private suspend fun RequestBuilder<Bitmap>.awaitBitmap(context: Context): Bitmap? = suspendCancellableCoroutine { continuation ->
         kotlin.runCatching {
-            val target = object : CustomTarget<Bitmap>() {
+            val target = object : CustomTarget<Bitmap>(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX) {
                 override fun onResourceReady(
                     resource: Bitmap,
                     transition: Transition<in Bitmap>?,
@@ -170,7 +174,8 @@ class GlideFaviconDownloader @Inject constructor(
     }
 
     private fun getFaviconFromDiskSync(file: File): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(file).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).submit().get()
+        Glide.with(context).asBitmap().load(file).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true)
+            .submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
     }.getOrNull()
 
     private fun getFaviconFromDiskSync(
@@ -190,6 +195,7 @@ class GlideFaviconDownloader @Inject constructor(
     }.getOrNull()
 
     private fun getFaviconFromUrlSync(uri: Uri): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(uri).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).submit().get()
+        Glide.with(context).asBitmap().load(uri).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true)
+            .submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
     }.getOrNull()
 }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1212341818869426

### Description
Handle unreasonably large favicons gracefully, by setting a max size in pixels.

### Steps to test this PR
        
  1. Start a local HTTP server serving a page with a large apple-touch-icon:                                                                                                           
  cd /tmp/favicon_test && python3 -m http.server 8888 (The test page serves a 6708×6708 PNG as its touch icon)
  2. On the device, open the DuckDuckGo browser and navigate to http://{your-server-ip}:8888
  3. Wait ~2 seconds for the touch icon to be discovered and downloaded
  4. Open the tab switcher
  5. Without the changes: App crashes with:
  `RuntimeException: Canvas: trying to draw too large(179989056bytes) bitmap` But with the changes shouldn't crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only constrains favicon bitmap dimensions; low risk aside from potential quality reduction for very large icons.
> 
> **Overview**
> Prevents crashes from *unreasonably large* favicons by introducing a `MAX_FAVICON_SIZE_PX` cap (512px) and enforcing it across Glide favicon fetches.
> 
> Both async (`CustomTarget`) and sync (`submit`) download paths for disk and URL loads now request bitmaps at the capped size, limiting memory usage during decoding/rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91ca90992b7d4ffd8b99f63804eccdf31331c792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->