### PR TITLE
Wide event pixel changes when switching plans

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -32,16 +32,20 @@ object SubscriptionsConstants {
     const val YEARLY_PLAN_ROW = "ddg-privacy-pro-yearly-renews-row"
     const val MONTHLY_PLAN_ROW = "ddg-privacy-pro-monthly-renews-row"
 
-    val LIST_OF_PLUS_PLANS =
-        listOf(YEARLY_PLAN_US, MONTHLY_PLAN_US, YEARLY_PLAN_ROW, MONTHLY_PLAN_ROW)
+    val LIST_MONTHLY_PLUS_PLANS = listOf(MONTHLY_PLAN_US, MONTHLY_PLAN_ROW)
+    val LIST_YEARLY_PLUS_PLANS = listOf(YEARLY_PLAN_US, YEARLY_PLAN_ROW)
 
-    const val YEARLY_PRO_PLAN_US = "ddg-subscription-pro-sandbox-yearly-renews-us"
-    const val MONTHLY_PRO_PLAN_US = "ddg-subscription-pro-sandbox-monthly-renews-us"
-    const val YEARLY_PRO_PLAN_ROW = "ddg-subscription-pro-sandbox-yearly-renews-row"
-    const val MONTHLY_PRO_PLAN_ROW = "ddg-subscription-pro-sandbox-monthly-renews-row"
+    val LIST_OF_PLUS_PLANS = LIST_MONTHLY_PLUS_PLANS + LIST_YEARLY_PLUS_PLANS
 
-    val LIST_OF_PRO_PLANS =
-        listOf(YEARLY_PRO_PLAN_US, MONTHLY_PRO_PLAN_US, YEARLY_PRO_PLAN_ROW, MONTHLY_PRO_PLAN_ROW)
+    const val YEARLY_PRO_PLAN_US = "ddg-subscription-pro-yearly-renews-us"
+    const val MONTHLY_PRO_PLAN_US = "ddg-subscription-pro-monthly-renews-us"
+    const val YEARLY_PRO_PLAN_ROW = "ddg-subscription-pro-yearly-renews-row"
+    const val MONTHLY_PRO_PLAN_ROW = "ddg-subscription-pro-monthly-renews-row"
+
+    val LIST_MONTHLY_PRO_PLANS = listOf(MONTHLY_PRO_PLAN_US, MONTHLY_PRO_PLAN_ROW)
+    val LIST_YEARLY_PRO_PLANS = listOf(YEARLY_PRO_PLAN_US, YEARLY_PRO_PLAN_ROW)
+
+    val LIST_OF_PRO_PLANS = LIST_MONTHLY_PRO_PLANS + LIST_YEARLY_PRO_PLANS
 
     // List of offers (Plus free trial)
     const val MONTHLY_FREE_TRIAL_OFFER_US = "ddg-privacy-pro-freetrial-monthly-renews-us"
@@ -52,10 +56,10 @@ object SubscriptionsConstants {
         listOf(MONTHLY_FREE_TRIAL_OFFER_US, YEARLY_FREE_TRIAL_OFFER_US, MONTHLY_FREE_TRIAL_OFFER_ROW, YEARLY_FREE_TRIAL_OFFER_ROW)
 
     // List of offers (Pro free trial)
-    const val MONTHLY_PRO_FREE_TRIAL_OFFER_US = "ddg-subscription-pro-sandbox-freetrial-monthly-renews-us"
-    const val YEARLY_PRO_FREE_TRIAL_OFFER_US = "ddg-subscription-pro-sandbox-freetrial-yearly-renews-us"
-    const val MONTHLY_PRO_FREE_TRIAL_OFFER_ROW = "ddg-subscription-pro-sandbox-freetrial-monthly-renews-row"
-    const val YEARLY_PRO_FREE_TRIAL_OFFER_ROW = "ddg-subscription-pro-sandbox-freetrial-yearly-renews-row"
+    const val MONTHLY_PRO_FREE_TRIAL_OFFER_US = "ddg-subscription-pro-freetrial-monthly-renews-us"
+    const val YEARLY_PRO_FREE_TRIAL_OFFER_US = "ddg-subscription-pro-freetrial-yearly-renews-us"
+    const val MONTHLY_PRO_FREE_TRIAL_OFFER_ROW = "ddg-subscription-pro-freetrial-monthly-renews-row"
+    const val YEARLY_PRO_FREE_TRIAL_OFFER_ROW = "ddg-subscription-pro-freetrial-yearly-renews-row"
     val LIST_OF_PRO_FREE_TRIAL_OFFERS =
         listOf(MONTHLY_PRO_FREE_TRIAL_OFFER_US, YEARLY_PRO_FREE_TRIAL_OFFER_US, MONTHLY_PRO_FREE_TRIAL_OFFER_ROW, YEARLY_PRO_FREE_TRIAL_OFFER_ROW)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212162490324012 

### Description
Updates switch wide event pixel to include tier information following agreed specs.

### Steps to test this PR
- Perform switching plans and ensure Wide Event reports what's in the specs https://app.asana.com/1/137249556945/task/1212746090558006

Or review Test cases and ensure they pass.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Wide Events flow name/metadata for subscription plan switches and updates Pro plan/offer IDs and plan lists, which can affect analytics attribution and any code relying on these product identifiers.
> 
> **Overview**
> Updates the subscription switch Wide Event from `subscription-switch` to `subscription-plan-change`, renaming the metadata key to `billing_cycle_switch_type` and adding `from_tier`/`to_tier` plus a new `tier_change_type` derived from Plus/Pro tiers and monthly vs yearly plans.
> 
> Refactors `SubscriptionsConstants` to split Plus/Pro plans into monthly/yearly lists and replaces Pro plan + free-trial offer IDs (removing the `-sandbox-` variants). Tests are expanded/updated to cover multiple tier and billing-cycle switch combinations and the new flow name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff52dd2bb29ae496a92a6c745d3119f83ba5856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->