### PR TITLE
fix pixel definition

### DIFF
--- a/PixelDefinitions/pixels/appearance_settings.json5
+++ b/PixelDefinitions/pixels/appearance_settings.json5
@@ -4,6 +4,12 @@
         "description": "Fired when the user toggles the 'Show tracker count in address bar' setting in appearance settings.",
         "owners": ["aibrahim-"],
         "triggers": ["other"],
-        "suffixes": ["form_factor"]
+        "suffixes": ["form_factor"],
+        "parameters": [
+            {
+                "key": "is_enabled",
+                "description": "whether the setting is enabled or disabled after the toggle"
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1210856607616307/task/1213179366895625

### Description
Fix pixel definition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only change to an analytics/pixel definition with minimal functional impact; main risk is downstream validation/consumers expecting the old shape.
> 
> **Overview**
> Updates the `m_appearance_settings_is_tracker_count_in_address_bar_toggled` pixel definition in `appearance_settings.json5` to include a new `parameters` entry, `is_enabled`, capturing whether the setting is enabled or disabled after the toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ccc9db16d14f0152d0991fd83fa242540a8c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->