### PR TITLE
PIR: Fix copy feedback

### DIFF
--- a/pir/pir-impl/src/main/res/values/donottranslate.xml
+++ b/pir/pir-impl/src/main/res/values/donottranslate.xml
@@ -17,7 +17,7 @@
 <resources>
     <string name="activityPirDashboard" translatable="false">PIR</string>
     <string name="pirFeatureName" translatable="false">Personal Information Removal</string>
-    <string name="pirNotificationMessageInProgress">A scan is currently in progress.</string>
+    <string name="pirNotificationMessageInProgress">Your scan is in progress…</string>
     <string name="pirNotificationTitleComplete">Scan complete!</string>
     <string name="pirNotificationMessageComplete">DuckDuckGo has started the process to remove records matching your personal info online. See what we found…</string>
     <string name="pirOptOutNotificationMessageInProgress">Opt out is currently in progress…</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213226424542893 

### Description
Update incorrect string in PIR initial scan started notification

### Steps to test this PR
QA_optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only UI copy change with no functional or data-handling impact; risk is limited to messaging/consistency.
> 
> **Overview**
> Updates the PIR foreground scan notification copy by changing `pirNotificationMessageInProgress` from “A scan is currently in progress.” to “Your scan is in progress…”, improving feedback when an initial scan starts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c1d78308d9a18cf6c9c364411c4636ad8fcaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->