### PR TITLE
Fix failing bookmark tests

### DIFF
--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -19,6 +19,11 @@ tags:
       - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "add bookmark"
+      # Wait for prompt to disappear
+      - extendedWaitUntil:
+          notVisible:
+            text: "Bookmark added.*"
+          timeout: 5000
       # Navigate to bookmarks screen
       - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -21,6 +21,11 @@ tags:
           text: "add bookmark"
       - tapOn:
           text: "add bookmark"
+      # Wait for prompt to disappear
+      - extendedWaitUntil:
+          notVisible:
+            text: "Bookmark added.*"
+          timeout: 5000
       # Add favorite from edit saved site
       - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213210377163129

### Description
* Don't try to open context menu until bookmark added botomSheet has disappeared 

### Steps to test this PR

_Feature 1_
- [ ] [Release tests](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/app/app_01hkqhj1thevwtn9ym8a2ctn2r/upload/mupload_01kh6eembtfm6vpmdhhfptas7c?sort=name) are passing on Maestro

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing change; no production code or data flows are modified, with minimal risk beyond potentially masking a real UI hang if the prompt never dismisses.
> 
> **Overview**
> Stabilizes the Maestro release tests for adding/removing favorites from bookmarks by inserting an `extendedWaitUntil` step after tapping **add bookmark**.
> 
> Both `favorites_bookmarks_add.yaml` and `favorites_bookmarks_delete.yaml` now wait up to 5s for the "Bookmark added" bottom-sheet/prompt to disappear before reopening the menu and continuing, reducing flakiness from UI timing/race conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45dd0d9d9f65f51df3bc29fe33e94d8b9e3fe439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->