### PR TITLE
Enqueue free trial vpn activation pixel

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -29,6 +29,7 @@ enum class SubscriptionPixel(
     private val types: Set<PixelType>,
     private val withSuffix: Boolean = true,
     val includedParameters: Set<PixelParameter> = emptySet(),
+    val enqueue: Boolean = false,
 ) {
     SUBSCRIPTION_ACTIVE(
         baseName = "m_privacy-pro_app_subscription_active",
@@ -265,6 +266,7 @@ enum class SubscriptionPixel(
         baseName = "subscription_free_trial_vpn_activation",
         type = Unique(),
         includedParameters = setOf(APP_VERSION),
+        enqueue = true,
     ),
     ;
 
@@ -273,7 +275,8 @@ enum class SubscriptionPixel(
         type: PixelType,
         withSuffix: Boolean = true,
         includedParameters: Set<PixelParameter> = emptySet(),
-    ) : this(baseName, setOf(type), withSuffix, includedParameters)
+        enqueue: Boolean = false,
+    ) : this(baseName, setOf(type), withSuffix, includedParameters, enqueue)
 
     fun getPixelNames(): Map<PixelType, String> =
         types.associateWith { type -> if (withSuffix) "${baseName}_${type.pixelNameSuffix}" else baseName }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -312,7 +312,11 @@ class SubscriptionPixelSenderImpl @Inject constructor(
         params: Map<String, String> = emptyMap(),
     ) {
         pixel.getPixelNames().forEach { (pixelType, pixelName) ->
-            pixelSender.fire(pixelName = pixelName, type = pixelType, parameters = params)
+            if (pixel.enqueue) {
+                pixelSender.enqueueFire(pixelName = pixelName, type = pixelType, parameters = params)
+            } else {
+                pixelSender.fire(pixelName = pixelName, type = pixelType, parameters = params)
+            }
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213218785316169

### Description

This PR fixes the issue where sending a pixel shortly after enabling VPN may fail.

### Steps to test this PR

- [x] Apply patch on https://app.asana.com/1/137249556945/task/1210448620621729
- [x] Fresh install
- [x] Purchase a test subscription (Free Trial)
- [x] Before it expires activate VPN
- [x] Check in logcat that `subscription_free_trial_vpn_activation` pixel is fired with the new `platform` parameter

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to pixel delivery behavior; risk is limited to analytics event timing/delivery for pixels using the new `enqueue` flag.
> 
> **Overview**
> Adds an `enqueue` flag to `SubscriptionPixel` and updates `SubscriptionPixelSenderImpl.fire` to *conditionally* send pixels via `pixelSender.enqueueFire` instead of immediate `fire`.
> 
> Marks `FREE_TRIAL_VPN_ACTIVATION` to use the queued send path, reducing the chance the pixel is lost when VPN is enabled and network conditions are transient.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daeb40571cd5e2a8b52bf6e0020d40bae2bcd242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->