### PR TITLE
Launch sync settings upon sendToSyncSettings regardless of sign sign in state

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/SetUpSyncHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/SetUpSyncHandler.kt
@@ -54,7 +54,7 @@ class SetUpSyncHandler @Inject constructor(
 
                 val responder = SyncJsResponder(jsMessaging, jsMessage, featureName)
 
-                val setupError = validateSetupState()
+                val setupError = validateSetupState(jsMessage.method)
                 if (setupError != null) {
                     responder.sendError(setupError)
                     return
@@ -65,11 +65,11 @@ class SetUpSyncHandler @Inject constructor(
                 }?.let { context.startActivity(it) }
             }
 
-            private fun validateSetupState(): String? {
+            private fun validateSetupState(method: String): String? {
                 if (!deviceSyncState.isFeatureEnabled()) {
                     return ERROR_SETUP_UNAVAILABLE
                 }
-                if (deviceSyncState.getAccountState() is SignedIn) {
+                if (method == METHOD_SETUP_SYNC && deviceSyncState.getAccountState() is SignedIn) {
                     return ERROR_SYNC_ALREADY_ON
                 }
                 return null
@@ -82,10 +82,12 @@ class SetUpSyncHandler @Inject constructor(
                 )
 
             override val featureName: String = DuckChatConstants.JS_MESSAGING_FEATURE_NAME
-            override val methods: List<String> = listOf("sendToSyncSettings", "sendToSetupSync")
+            override val methods: List<String> = listOf(METHOD_SYNC_SETTINGS, METHOD_SETUP_SYNC)
         }
 
     private companion object {
+        private const val METHOD_SYNC_SETTINGS = "sendToSyncSettings"
+        private const val METHOD_SETUP_SYNC = "sendToSetupSync"
         private const val ERROR_SETUP_UNAVAILABLE = "setup unavailable"
         private const val ERROR_SYNC_ALREADY_ON = "sync already on"
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213228272275032 

### Description
Updates SetUpSyncHandler validation so the "sync already on" error is only returned for sendToSetupSync; sendToSyncSettings now proceeds to open Sync settings regardless of sign-in state.

### Steps to test this PR
- QA optional
- [ ] Enable internal duck ai chat state: [Internal Testing Chat Sync Integration with Native Apps](https://app.asana.com/1/137249556945/task/1212472824864986?focus=true)
- [ ] Enable sync
- [ ] Visit duck ai chat settings and click on the `Manage` button under `Sync & Backup`; verify sync settings activity is launched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to JS message validation/gating that only affects whether the Sync settings activity is launched.
> 
> **Overview**
> Updates `SetUpSyncHandler` validation so the **"sync already on"** error is only returned for `sendToSetupSync`; `sendToSyncSettings` now proceeds to open Sync settings regardless of sign-in state.
> 
> Refactors method names into constants and expands tests to cover the new behavior (error when feature disabled for both methods, and activity launch for `sendToSyncSettings` when already signed in).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafd87e87b03af733b79db05502c5661890409b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->