### PR TITLE
Logo behaviour in input screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -20,6 +20,7 @@ data class InputScreenVisibilityState(
     val submitButtonVisible: Boolean = false,
     val voiceInputButtonVisible: Boolean = false,
     val autoCompleteSuggestionsVisible: Boolean = false,
+    val chatSuggestionsVisible: Boolean = false,
     val bottomFadeVisible: Boolean = false,
     val showChatLogo: Boolean = true,
     val showSearchLogo: Boolean = true,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -1412,7 +1412,7 @@ class InputScreenViewModelTest {
         }
 
     @Test
-    fun `when onTabTapped and has content then SetLogoProgress is emitted`() =
+    fun `when onTabTapped and has content then no command is emitted`() =
         runTest {
             val viewModel = createViewModel()
             val capturedCommands = mutableListOf<Command>()
@@ -1426,12 +1426,11 @@ class InputScreenViewModelTest {
             viewModel.onNewTabPageContentChanged(hasContent = true)
             viewModel.onTabTapped(index = 1)
 
-            assertEquals(1, capturedCommands.size)
-            assertEquals(SetLogoProgress(1f), capturedCommands[0])
+            assertEquals(0, capturedCommands.size)
         }
 
     @Test
-    fun `when onTabTapped with input text and autocomplete visible then SetLogoProgress is emitted`() =
+    fun `when onTabTapped and search logo hidden by autocomplete then no command is emitted`() =
         runTest {
             val viewModel = createViewModel("search query")
             val capturedCommands = mutableListOf<Command>()
@@ -1443,14 +1442,13 @@ class InputScreenViewModelTest {
             }
 
             assertTrue(viewModel.visibilityState.value.autoCompleteSuggestionsVisible)
-            viewModel.onTabTapped(index = 1, currentInputText = "search query")
+            viewModel.onTabTapped(index = 1)
 
-            assertEquals(1, capturedCommands.size)
-            assertEquals(SetLogoProgress(1f), capturedCommands[0])
+            assertEquals(0, capturedCommands.size)
         }
 
     @Test
-    fun `when onTabTapped with input text but autocomplete not visible then AnimateLogoToProgress is emitted`() =
+    fun `when onTabTapped and both logos visible then AnimateLogoToProgress is emitted`() =
         runTest {
             val viewModel = createViewModel("https://example.com")
             val capturedCommands = mutableListOf<Command>()
@@ -1462,7 +1460,7 @@ class InputScreenViewModelTest {
             }
 
             assertFalse(viewModel.visibilityState.value.autoCompleteSuggestionsVisible)
-            viewModel.onTabTapped(index = 1, currentInputText = "https://example.com")
+            viewModel.onTabTapped(index = 1)
 
             assertEquals(1, capturedCommands.size)
             assertEquals(AnimateLogoToProgress(1f), capturedCommands[0])
@@ -1584,9 +1582,9 @@ class InputScreenViewModelTest {
         }
 
     @Test
-    fun `when onPageScrolled with wasAutoCompleteVisibleOnSwipeStart true then SetLogoProgress is not emitted`() =
+    fun `when onPageScrolled and search logo hidden then SetLogoProgress is not emitted`() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel("search query")
             val capturedCommands = mutableListOf<Command>()
 
             viewModel.command.observeForever { command ->
@@ -1595,22 +1593,20 @@ class InputScreenViewModelTest {
                 }
             }
 
+            assertFalse(viewModel.visibilityState.value.showSearchLogo)
+
             val position = 0
             val positionOffset = 0.3f
             val easedOffset = positionOffset * positionOffset * 2f
 
-            viewModel.onPageScrolled(
-                position = position,
-                positionOffset = positionOffset,
-                wasAutoCompleteVisibleOnSwipeStart = true,
-            )
+            viewModel.onPageScrolled(position, positionOffset)
 
             assertEquals(1, capturedCommands.size)
             assertEquals(SetInputModeWidgetScrollPosition(position = position, offset = easedOffset), capturedCommands[0])
         }
 
     @Test
-    fun `when onPageScrolled with hadInputTextOnSwipeStart true then SetLogoProgress is not emitted`() =
+    fun `when onPageScrolled with both logos visible then SetLogoProgress is emitted`() =
         runTest {
             val viewModel = createViewModel()
             val capturedCommands = mutableListOf<Command>()
@@ -1621,42 +1617,14 @@ class InputScreenViewModelTest {
                 }
             }
 
-            val position = 0
-            val positionOffset = 0.3f
-            val easedOffset = positionOffset * positionOffset * 2f
-
-            viewModel.onPageScrolled(
-                position = position,
-                positionOffset = positionOffset,
-                hadInputTextOnSwipeStart = true,
-            )
-
-            assertEquals(1, capturedCommands.size)
-            assertEquals(SetInputModeWidgetScrollPosition(position = position, offset = easedOffset), capturedCommands[0])
-        }
-
-    @Test
-    fun `when onPageScrolled with both swipe start flags false then SetLogoProgress is emitted`() =
-        runTest {
-            val viewModel = createViewModel()
-            val capturedCommands = mutableListOf<Command>()
-
-            viewModel.command.observeForever { command ->
-                if (command != null) {
-                    capturedCommands.add(command)
-                }
-            }
+            assertTrue(viewModel.visibilityState.value.showSearchLogo)
+            assertTrue(viewModel.visibilityState.value.showChatLogo)
 
             val position = 0
             val positionOffset = 0.3f
             val easedOffset = positionOffset * positionOffset * 2f
 
-            viewModel.onPageScrolled(
-                position = position,
-                positionOffset = positionOffset,
-                wasAutoCompleteVisibleOnSwipeStart = false,
-                hadInputTextOnSwipeStart = false,
-            )
+            viewModel.onPageScrolled(position, positionOffset)
 
             assertEquals(2, capturedCommands.size)
             assertEquals(SetLogoProgress(positionOffset), capturedCommands[0])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213218251714196

### Description
With the addition of the recent chat overlay ([PR](https://github.com/duckduckgo/Android/pull/7685)), the Duck.ai logo should be hidden when chat suggestions are available and visible when they are not. 
The implementation simplifies the code by removing multiple boolean checks and accommodates for all different transition use cases and interactions with the DuckDuckGo logo (that shows on the Search tab). 

When moving from one tab to another:
- If both logos are visible —> transition with animation
- If one logo is visible while the other hidden by an overlay or favourites —> logo fades in/out
- Both tap and swipe gestures follow same behaviour. Swiping animates progression. 
- Dismissing the overlay on the current tab shows the correct logo depending on which tab you are in

### Additional notes
- Addressed the use cases where changing text on one tab, should reflect properly on the other tab when going back (logo animations should accommodate for what both tabs are showing)
- Fixed an existing bug when we access the input screen from a website (click on the address bar while visiting a website). The search box is not empty but the autocomplete overlay is hidden, this breaks the logo swipe animation due to it relying on the box being empty to do transitions.

### Steps to test this PR
Note: in order to facilitate testing, I created an additional branch with static data. Feel free to pull the `feature/youssef/do_not_merge/test_input_screen_logo_transition` branch to test with suggestions.

- Pull the changes
- Go to the input screen, make sure the omnibar is enabled
- Switch between search tab and duck.ai tab with no overlays (both logos visible)
- Write a search query for the auto complete to show up and switch between tabs to see fade in/out animations
- Add favourite and switch between tabs
- Write a search query in the search tab, toggle the duck.ai tab, delete the text from the chat box, swipe back to the search tab —> animation should play because autocomplete is now hidden.
- Go to a website (example.com) tap on the address bar to show the input screen. Swipe between the tabs. Logo should animate properly (existing bug fixed)
- Test with feature flag OFF —> No changes or regression from current production behaviour


### UI changes
Demo for the full feature: 

https://github.com/user-attachments/assets/96abf963-59f5-4b2e-8742-753d957e1142





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UI state and animation logic for the input screen; regressions would primarily be visual/interaction-related (logo/overlay transitions) rather than data or security, but the behavior matrix is broad.
> 
> **Overview**
> Updates input-screen logo behavior so the Duck.ai logo hides when chat suggestions are present and logo transitions only *morph* when both the search and chat logos are visible; otherwise mode changes use simple fade in/out based on per-mode logo visibility.
> 
> Simplifies gesture handling by removing swipe-start state flags and relying on `showSearchLogo`/`showChatLogo` in `onPageScrolled`/`onTabTapped`, adds `chatSuggestionsVisible` to `InputScreenVisibilityState`, and proactively clears stale search text when chat input is emptied to keep logo state/animations consistent (including the “opened from URL” case). Tests are updated to match the new command-emission rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84ee39d132a54b54d96732ff0450bc8ce21373d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->