### PR TITLE
Fix flakey maestro test around input screen

### DIFF
--- a/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
+++ b/.maestro/input_screen/shared/input_screen_search_mode_flow.yaml
@@ -29,7 +29,8 @@ appId: com.duckduckgo.mobile.android
 - runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
 - tapOn:
     text: "add bookmark"
-- runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
+- tapOn:
+    id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
 - tapOn:
     text: "bookmarks"
 - tapOn:
@@ -79,7 +80,7 @@ appId: com.duckduckgo.mobile.android
       id: "remoteMessage"
     optional: true
 - assertVisible:
-    text: "reddit at DuckDuckGo"
+    id: "com.duckduckgo.mobile.android:id/quickAccessFavicon"
     childOf:
       id: "focusedFavourites"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213237094766900

### Description
Fixes flakey maestro test

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that mainly swap a brittle text assertion for a stable view-id check and add an extra tap step; no production logic is affected.
> 
> **Overview**
> Stabilizes the `input_screen_search_mode_flow.yaml` Maestro test by adjusting the “add to favorites” sequence to explicitly re-tap the browser menu button after selecting “add bookmark”.
> 
> Replaces a text-based assertion for the favorite (“reddit at DuckDuckGo”) with an ID-based assertion (`quickAccessFavicon` under `focusedFavourites`) to reduce flakiness from variable copy/UI content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f7fc6b2da1617fdeb18a26e86664e13faca5dbb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213237094766900