### PR TITLE
Update content scope scripts to version 13.4.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -508,6 +508,7 @@
     "messageBridge",
     "favicon",
     "breakageReporting",
+    "print",
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
@@ -580,11 +581,12 @@
       "autofillImport",
       "favicon",
       "webTelemetry",
-      "pageContext"
+      "pageContext",
+      "print"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext", "print"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2014,6 +2014,7 @@
     "messageBridge",
     "favicon",
     "breakageReporting",
+    "print",
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
@@ -2098,11 +2099,12 @@
       "autofillImport",
       "favicon",
       "webTelemetry",
-      "pageContext"
+      "pageContext",
+      "print"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext", "print"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -7659,9 +7661,16 @@
     }
     return output;
   }
+  function parseRegexSeparator(separator) {
+    if (typeof separator === "string" && separator.length >= 2 && separator.startsWith("/") && separator.endsWith("/")) {
+      return new RegExp(separator.slice(1, -1));
+    }
+    return separator;
+  }
   function stringToList(inputList, separator) {
     const defaultSeparator = /[|\n•·]/;
-    return cleanArray(inputList.split(separator || defaultSeparator));
+    const splitOn = parseRegexSeparator(separator) || defaultSeparator;
+    return cleanArray(inputList.split(splitOn));
   }
   var rules = {
     profileUrl: function(link) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2014,6 +2014,7 @@
     "messageBridge",
     "favicon",
     "breakageReporting",
+    "print",
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
@@ -2070,11 +2071,12 @@
       "autofillImport",
       "favicon",
       "webTelemetry",
-      "pageContext"
+      "pageContext",
+      "print"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext", "print"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -7628,9 +7630,16 @@
     }
     return output;
   }
+  function parseRegexSeparator(separator) {
+    if (typeof separator === "string" && separator.length >= 2 && separator.startsWith("/") && separator.endsWith("/")) {
+      return new RegExp(separator.slice(1, -1));
+    }
+    return separator;
+  }
   function stringToList(inputList, separator) {
     const defaultSeparator = /[|\n•·]/;
-    return cleanArray(inputList.split(separator || defaultSeparator));
+    const splitOn = parseRegexSeparator(separator) || defaultSeparator;
+    return cleanArray(inputList.split(splitOn));
   }
   var rules = {
     profileUrl: function(link) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1347,6 +1347,7 @@
     "messageBridge",
     "favicon",
     "breakageReporting",
+    "print",
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
@@ -1429,11 +1430,12 @@
       "autofillImport",
       "favicon",
       "webTelemetry",
-      "pageContext"
+      "pageContext",
+      "print"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webDetection", "webInterferenceDetection", "pageContext", "print"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.1.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.4.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ecbc2145c275088c3e7b8c7396ea584c1bba173f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#39e1748d763d2380cf1847cf17e0bcd1af0fddd7",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.13.4.tgz",
-      "integrity": "sha512-rI7MbS+F2ckIr/2brV+QHMyl55W7F1vazAFiJYHcOBi6i4ClI47Ep95HakwB2qM95gv9igQDTE1zFisV2YKgGg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.0.tgz",
+      "integrity": "sha512-AdqTWU8IUwJDkuJ5KVzWeL8GtRfIde+M0HOLs5TW8ezQy/gvVpL1J90V/SUwDRO2Ay3Wj1B3ZHE15Kv0tRRPEA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.13.4",
-        "@ghostery/adblocker-extended-selectors": "^2.13.4",
-        "@ghostery/url-parser": "^1.3.0",
+        "@ghostery/adblocker-content": "^2.14.0",
+        "@ghostery/adblocker-extended-selectors": "^2.14.0",
+        "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.18"
+        "tldts-experimental": "^7.0.23"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.13.4.tgz",
-      "integrity": "sha512-VPa4dyHqTyMWxut/wCYYlHdVRsQ2ZXXezTv31WiRhUC86LFKz8rL/Jnj1baHXlRrO5Ndhpll1/e/J/Tzwu6mqg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.0.tgz",
+      "integrity": "sha512-XCgGu+b4spvPHMhrqKaAG4NAe6NzGsqj54rNRXpDnCJZowTCuBr2DXfqtLbKlHWy0XBsuoDjP0gddtm7XA27+w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.13.4"
+        "@ghostery/adblocker-extended-selectors": "^2.14.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.13.4.tgz",
-      "integrity": "sha512-nDNK72R9Ly+AOBsd3f0SAxtF3FELx7ogOPCDD2MVJtv3qYZG76fHUmUoCGRmN2oHlPPNUQJ+vI4Rm/LRM1B5XQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.0.tgz",
+      "integrity": "sha512-kmFfyo71FUPdi4OMeNo65JcGZgZZGHU9DOfCYCmBupwVhxU9P4zC12/bGx1vC+RNd3jkqUBKmQ3lTTK+yYfu2Q==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
-      "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.1.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.4.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213247766286849/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency/bundled-script update that changes runtime feature flags and parsing behavior inside injected content scripts, which could affect webpage compatibility across platforms.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `13.1.0` to `13.4.0` and refreshes the bundled Android build artifacts.
> 
> The updated scripts add `print` as a platform-specific/remote-config feature (including enabling it for Apple in `platformSupport`) and adjust list parsing in the autofill-import/broker-protection bundles so `stringToList` can accept separators expressed as regex-like strings (e.g., `/.../`).
> 
> `package-lock.json` is updated accordingly (including transitive bumps such as `@ghostery/adblocker` `2.13.4` → `2.14.0` and `@types/node` `25.2.2` → `25.2.3`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ee11d7b0486f2fb3fd993a5a99c42719eca3a85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->