### PR TITLE
Fix pixel definition for data-clearing wide event

### DIFF
--- a/PixelDefinitions/pixels/wide_data_clearing.json5
+++ b/PixelDefinitions/pixels/wide_data_clearing.json5
@@ -55,7 +55,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.web_storage_clear_error",
+                "key": "feature.data.ext.web_storage_clear_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -65,7 +65,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.web_storage_clear_granular_error",
+                "key": "feature.data.ext.web_storage_clear_granular_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -75,7 +75,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.webview_app_webview_clear_error",
+                "key": "feature.data.ext.webview_app_webview_clear_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -85,7 +85,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.webview_default_clear_error",
+                "key": "feature.data.ext.webview_default_clear_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -95,7 +95,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.indexeddb_clear_selective_error",
+                "key": "feature.data.ext.indexeddb_clear_selective_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -105,7 +105,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.indexeddb_clear_duckai_only_error",
+                "key": "feature.data.ext.indexeddb_clear_duckai_only_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             },
@@ -115,7 +115,7 @@
                 "enum": ["true", "false"]
             },
             {
-                "key": "feature.data.ext.step.app_cache_clear_error",
+                "key": "feature.data.ext.app_cache_clear_error",
                 "description": "Error message (exception class) - only present if success=false for this step",
                 "type": "string"
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213242514649312

### Description

### Steps to test this PR

N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definition-only changes to analytics pixel keys; main risk is dashboards/consumers expecting the old key names if any were already shipped.
> 
> **Overview**
> Fixes `wide_data_clearing.json5` parameter definitions by renaming several step error keys from `feature.data.ext.step.*_error` to `feature.data.ext.*_error` (leaving the corresponding `*_success` keys unchanged).
> 
> This corrects the schema for data-clearing wide-event error reporting across web storage, webview, indexeddb, and app cache clearing steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8689990a36b584ae4c8bf7b4569c9fe1fb354b23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->