### PR TITLE
build(native): make NDK outputs path-stable

### DIFF
--- a/anrs/anrs-impl/CMakeLists.txt
+++ b/anrs/anrs-impl/CMakeLists.txt
@@ -20,6 +20,14 @@ find_library( # Sets the name of the path variable.
         # you want CMake to locate.
         log)
 
+# Normalize source/build paths in debug metadata so native outputs are reproducible
+# across different checkout locations.
+target_compile_options(
+       crash-ndk
+       PRIVATE
+       "-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=."
+       "-fdebug-prefix-map=${CMAKE_BINARY_DIR}=.")
+
 target_link_libraries(
         # Specifies the target library.
        crash-ndk
@@ -31,5 +39,6 @@ target_link_libraries(
 target_link_options(
        crash-ndk
        PRIVATE
+       "-Wl,--build-id=none"
        "-Wl,-z,common-page-size=16384"
        "-Wl,-z,max-page-size=16384")

--- a/httpsupgrade/httpsupgrade-impl/CMakeLists.txt
+++ b/httpsupgrade/httpsupgrade-impl/CMakeLists.txt
@@ -37,8 +37,17 @@ find_library( # Sets the name of the path variable.
         # you want CMake to locate.
         log)
 
+# Normalize source/build paths in debug metadata so native outputs are reproducible
+# across different checkout locations.
+target_compile_options(
+       https-bloom-lib
+       PRIVATE
+       "-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=."
+       "-fdebug-prefix-map=${CMAKE_BINARY_DIR}=.")
+
 target_link_options(
        https-bloom-lib
        PRIVATE
+       "-Wl,--build-id=none"
        "-Wl,-z,common-page-size=16384"
        "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213227245294013

### Description

NDK Debug C/C++ builds were producing location-dependent .so files. Absolute source/build paths were embedded in debug metadata and linker-generated GNU build IDs varied by build location, which changed JNI artifacts between equivalent checkouts.

Apply target-specific reproducibility flags in both native modules: add -fdebug-prefix-map for CMAKE_SOURCE_DIR/CMAKE_BINARY_DIR and set -Wl,--build-id=none.

Updated targets: crash-ndk (anrs-impl) and https-bloom-lib (httpsupgrade-impl). This stabilizes stripped native library bytes across checkout paths and prevents downstream lint/local AAR input drift that triggers cache misses.

The risk to runtime behavior should be low.
These flags don’t change native logic or code generation paths for your C++ source; they mainly change metadata (-fdebug-prefix-map) and ELF note content (--build-id=none). So app behavior should stay the same. The main potential regression is tooling: removing build-id can affect native crash symbolication workflows that rely on ELF build IDs to match symbols. Also, remapped debug paths can slightly change source-path behavior in low-level debugging tools.

### Steps to test this PR

1. Verify caching: Run a clean build, move / copy the project and run a 2nd clean build. Without the fix, you will see [cache misses](https://ge.solutions-team.gradle.com/c/mhqfmbdqwg4uu/r2zqxtklkaip4/task-inputs?cacheability=cacheable&expanded=WyJobGJmdm9oanNnc2pnLXZhcmlhbnRpbnB1dHMuYW5kcm9pZHRlc3RhcnRpZmFjdC5wcm9qZWN0Y29tcGlsZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTc3MCIsImhsYmZ2b2hqc2dzamctdmFyaWFudGlucHV0cy5hbmRyb2lkdGVzdGFydGlmYWN0LnByb2plY3RydW50aW1lZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tNzcyIiwibnRkZGtuNXRjNDNwcy12YXJpYW50aW5wdXRzLnRlc3RhcnRpZmFjdC5wcm9qZWN0Y29tcGlsZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTc4MCIsIm50ZGRrbjV0YzQzcHMtdmFyaWFudGlucHV0cy50ZXN0YXJ0aWZhY3QucHJvamVjdHJ1bnRpbWVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi03ODIiLCIzYWF4d2F5b2FlZWc0LWphdmFyZXNvdXJjZXNqYXItMTAyNSIsInBjNWVoM2FtczRnNW0tdmFyaWFudGlucHV0cy5tYWluYXJ0aWZhY3QucHJvamVjdGNvbXBpbGVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi04MjQiLCJwYzVlaDNhbXM0ZzVtLXZhcmlhbnRpbnB1dHMubWFpbmFydGlmYWN0LnByb2plY3RydW50aW1lZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tODI2IiwieHlwMnZ1b3dtYXp2NC12YXJpYW50aW5wdXRzLmFuZHJvaWR0ZXN0YXJ0aWZhY3QucHJvamVjdGNvbXBpbGVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi04NjgiLCJ4eXAydnVvd21henY0LXZhcmlhbnRpbnB1dHMuYW5kcm9pZHRlc3RhcnRpZmFjdC5wcm9qZWN0cnVudGltZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTg3MCIsInhlNWVwNXJvdmlnbWstdmFyaWFudGlucHV0cy50ZXN0YXJ0aWZhY3QucHJvamVjdGNvbXBpbGVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi04NzgiLCJ4ZTVlcDVyb3ZpZ21rLXZhcmlhbnRpbnB1dHMudGVzdGFydGlmYWN0LnByb2plY3RydW50aW1lZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tODgwIiwiZHYydDZnZGw0aG1lNi12YXJpYW50aW5wdXRzLm1haW5hcnRpZmFjdC5wcm9qZWN0Y29tcGlsZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTMxNzIiLCJkdjJ0NmdkbDRobWU2LXZhcmlhbnRpbnB1dHMubWFpbmFydGlmYWN0LnByb2plY3RydW50aW1lZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tMzE3NCIsInE2MmVlenFpa3JsZm8tdmFyaWFudGlucHV0cy5hbmRyb2lkdGVzdGFydGlmYWN0LnByb2plY3Rjb21waWxlZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tNDEwMyIsInE2MmVlenFpa3JsZm8tdmFyaWFudGlucHV0cy5hbmRyb2lkdGVzdGFydGlmYWN0LnByb2plY3RydW50aW1lZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tNDEwNSIsImoyaTY2ZXl6cnJsYjQtdmFyaWFudGlucHV0cy50ZXN0YXJ0aWZhY3QucHJvamVjdGNvbXBpbGVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi00MTEzIiwiajJpNjZleXpycmxiNC12YXJpYW50aW5wdXRzLnRlc3RhcnRpZmFjdC5wcm9qZWN0cnVudGltZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTQxMTUiLCJxMndwNmp4ajI0aWVjLXZhcmlhbnRpbnB1dHMuYW5kcm9pZHRlc3RhcnRpZmFjdC5wcm9qZWN0Y29tcGlsZWV4cGxvZGVkYWFyc2ZpbGVjb2xsZWN0aW9uLTY1OTMiLCJuemo2eHZ1bXpmaDJxLXZhcmlhbnRpbnB1dHMudGVzdGFydGlmYWN0LnByb2plY3Rjb21waWxlZXhwbG9kZWRhYXJzZmlsZWNvbGxlY3Rpb24tNjYwMSIsIm56ajZ4dnVtemZoMnEtdmFyaWFudGlucHV0cy50ZXN0YXJ0aWZhY3QucHJvamVjdHJ1bnRpbWVleHBsb2RlZGFhcnNmaWxlY29sbGVjdGlvbi02NjAzIiwidXZrMzVqbGhlNXhiaS1yb290c3BlYyQxJDUtNjI1IiwidXZrMzVqbGhlNXhiaS1yb290U3BlYyQxJDUtMC0wIiwiaWRicDRyandmdjZjMi1wcm9qZWN0bmF0aXZlbGlicy04MCIsImlkYnA0cmp3ZnY2YzItcHJvamVjdE5hdGl2ZUxpYnMtMC0wIiwiaWRicDRyandmdjZjMi1wcm9qZWN0TmF0aXZlTGlicy0wLTAtMCIsInR6ZGR0a2VkdXRqeTYtcHJvamVjdG5hdGl2ZWxpYnMtNzIiLCJ0emRkdGtlZHV0ank2LXByb2plY3ROYXRpdmVMaWJzLTAtMCIsIjJra3ltYnQyZWl4cGktcHJvamVjdG5hdGl2ZWxpYnMtMTMxIiwiMmtreW1idDJlaXhwaS1wcm9qZWN0TmF0aXZlTGlicy0wLTAiXQ) on `AndroidLintAnalysisTask` tasks, after the fix, those now [get cache hits](https://ge.solutions-team.gradle.com/s/p53t66hgd6ohk/timeline?hide-timeline&type=com.android.build.gradle.internal.lint.AndroidLintAnalysisTask).
2. Verify impact on the project runtime - I don't have enough in-depth knowledge about the project, so I would recommend you verify this change doesn't introduce any runtime changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runtime behavior should be unchanged, but disabling ELF build IDs and rewriting debug paths can impact crash symbolication and native debugging/tooling workflows.
> 
> **Overview**
> Makes native `.so` outputs reproducible across different checkout/build locations for the `crash-ndk` and `https-bloom-lib` targets.
> 
> Adds `-fdebug-prefix-map` for `${CMAKE_SOURCE_DIR}` and `${CMAKE_BINARY_DIR}` to normalize paths embedded in debug metadata, and passes `-Wl,--build-id=none` to avoid location-dependent linker-generated build IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b3d774725fc12ccf43213720d9bb28ba8dd68c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->