### PR TITLE
PIR: Ensure estimated removal data is always in the future

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardStateProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardStateProvider.kt
@@ -199,11 +199,24 @@ abstract class PirDashboardStateProvider(
         optOutRequestedDateInMillis: Long,
         addedDateInMillis: Long,
     ): Long {
-        return if (optOutRequestedDateInMillis != 0L) {
-            optOutRequestedDateInMillis + ESTIMATED_REMOVAL_TIME_IN_MILLIS
+        val now = currentTimeProvider.currentTimeMillis()
+
+        val baseDate = if (optOutRequestedDateInMillis != 0L) {
+            optOutRequestedDateInMillis
         } else {
-            addedDateInMillis + ESTIMATED_REMOVAL_TIME_IN_MILLIS
+            addedDateInMillis
         }
+
+        val estimatedDate = baseDate + ESTIMATED_REMOVAL_TIME_IN_MILLIS
+
+        // If already in the future (strictly greater than today), return as-is
+        if (estimatedDate > now) {
+            return estimatedDate
+        }
+
+        val elapsedTime = now - estimatedDate
+        val periodsElapsed = elapsedTime / ESTIMATED_REMOVAL_TIME_IN_MILLIS
+        return estimatedDate + ((periodsElapsed + 1) * ESTIMATED_REMOVAL_TIME_IN_MILLIS)
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213186643906143 

### Description
See attached task description

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1213260362773654

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a date calculation with extensive new unit coverage; low risk aside from potential off-by-one behavior around the “now” boundary.
> 
> **Overview**
> Updates PIR dashboard scan results to **never surface an `estimatedRemovalDateInMillis` in the past**. `PirDashboardStateProvider.getEstimatedRemovalDateInMillis` now calculates the base estimate (opt-out request date or profile added date + 14 days) and, if it’s not strictly in the future, rolls it forward by one or more 14-day periods until it is.
> 
> Adds comprehensive unit tests covering future/now/past scenarios (including multi-period and “very far in past” cases) and both opt-out-based and added-date-based estimates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a45386f1dbb54bd7e5be98e10f354f30d159b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->