### PR TITLE
Add feature flag for the new "Install our Desktop Browser" setting

### DIFF
--- a/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
+++ b/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
@@ -33,4 +33,7 @@ interface SettingsPageFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun whatsNewEnabled(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun newDesktopBrowserSettingEnabled(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1213263854651423

### Description
Added a new toggle `newDesktopBrowserSettingEnabled` to the `SettingsPageFeature` interface. This toggle will control the visibility of the new desktop browser setting in the settings page.

### Steps to test this PR
QA-optional. 

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new feature flag API surface with default-off behavior; minimal logic change and no security- or data-sensitive impact.
> 
> **Overview**
> Adds a new `SettingsPageFeature.newDesktopBrowserSettingEnabled()` toggle (default `FALSE`) to gate visibility of the new “Install our Desktop Browser” setting on the settings page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 819242c18d05a747783f9bf7ebb76237a9983d1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->