### PR TITLE
Do not call flow to hide keyboard on bookmark tests

### DIFF
--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -16,16 +16,13 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - tapOn:
           text: "add bookmark"
-      # Wait for prompt to disappear
-      - extendedWaitUntil:
-          notVisible:
-            text: "Bookmark added.*"
-          timeout: 5000
       # Navigate to bookmarks screen
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - tapOn:
           text: "bookmarks"
       # Add favorite from bookmarks screen

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -16,18 +16,15 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
           text: "add bookmark"
       - tapOn:
           text: "add bookmark"
-      # Wait for prompt to disappear
-      - extendedWaitUntil:
-          notVisible:
-            text: "Bookmark added.*"
-          timeout: 5000
       # Add favorite from edit saved site
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
           text: "edit bookmark"
       - tapOn:
@@ -38,7 +35,8 @@ tags:
           text: "add to favorites"
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
           text: "bookmarks"
       - tapOn:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213262447196690

### Description
* Don't call flaky shared flow with hideKeyboard and just tap menu button directly. Remove unnecessary wait 

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML changes; main risk is potential flakiness if the menu button isn’t tappable without the prior hide-keyboard/wait steps.
> 
> **Overview**
> Updates the Maestro favorites bookmark flows to **stop using** the shared `click_on_menu_button.yaml` helper (which conditionally calls `hideKeyboard`) and instead **tap the menu button directly** via `browserMenuImageView`.
> 
> Removes the post-bookmark `extendedWaitUntil` prompt-dismissal waits, simplifying the add/delete favorites-from-bookmarks release tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aa739f83549edc75032c8553397e79b22ba9ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->