### PR TITLE
Add chat suggestions reader and fetch chats from JS

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsJsMessaging.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsJsMessaging.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader
+
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessageHandler
+import com.duckduckgo.js.messaging.api.JsMessageHelper
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.js.messaging.api.JsRequestResponse
+import com.duckduckgo.js.messaging.api.SubscriptionEvent
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
+import logcat.logcat
+import okio.Buffer
+import org.json.JSONException
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * JsMessaging for the headless chat suggestions WebView.
+ * Handles the @JavascriptInterface bridge for receiving messages from the injected JS.
+ */
+class ChatSuggestionsJsMessaging @Inject constructor(
+    private val jsMessageHelper: JsMessageHelper,
+) : JsMessaging {
+
+    override val secret: String = "duckduckgo-android-messaging-secret"
+    override val callbackName: String = "messageCallback"
+
+    private val moshi by lazy { Moshi.Builder().add(JSONObjectAdapter()).build() }
+    private val handlers = listOf(DuckAiChatHistoryMessageHandler())
+    private lateinit var jsMessageCallback: JsMessageCallback
+    private lateinit var webView: WebView
+
+    override val context: String = "contentScopeScripts"
+    override val allowedDomains: List<String> = emptyList()
+
+    override fun register(webView: WebView, jsMessageCallback: JsMessageCallback?) {
+        if (jsMessageCallback == null) throw IllegalArgumentException("Callback cannot be null")
+        this.webView = webView
+        this.jsMessageCallback = jsMessageCallback
+        this.webView.addJavascriptInterface(this, JS_INTERFACE_NAME)
+    }
+
+    @JavascriptInterface
+    override fun process(message: String, secret: String) {
+        try {
+            val jsMessage = moshi.adapter(JsMessage::class.java).fromJson(message)
+            jsMessage?.let {
+                if (this.secret == secret && context == jsMessage.context) {
+                    handlers.firstOrNull {
+                        it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName
+                    }?.process(jsMessage, this, jsMessageCallback)
+                }
+            }
+        } catch (e: Exception) {
+            logcat { "Exception is ${e.message}" }
+        }
+    }
+
+    override fun onResponse(response: JsCallbackData) {
+        val jsResponse = JsRequestResponse.Success(
+            context = context,
+            featureName = response.featureName,
+            method = response.method,
+            id = response.id,
+            result = response.params,
+        )
+        jsMessageHelper.sendJsResponse(jsResponse, callbackName, secret, webView)
+    }
+
+    override fun sendSubscriptionEvent(subscriptionEventData: SubscriptionEventData) {
+        val subscriptionEvent = SubscriptionEvent(
+            context,
+            subscriptionEventData.featureName,
+            subscriptionEventData.subscriptionName,
+            subscriptionEventData.params,
+        )
+        if (::webView.isInitialized) {
+            jsMessageHelper.sendSubscriptionEvent(subscriptionEvent, callbackName, secret, webView)
+        }
+    }
+
+    class DuckAiChatHistoryMessageHandler : JsMessageHandler {
+        override fun process(jsMessage: JsMessage, jsMessaging: JsMessaging, jsMessageCallback: JsMessageCallback?) {
+            jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id ?: "", jsMessage.params)
+        }
+
+        override val allowedDomains: List<String> = emptyList()
+        override val featureName: String = "duckAiChatHistory"
+        override val methods: List<String> = listOf("duckAiChatsResult")
+    }
+
+    companion object {
+        const val JS_INTERFACE_NAME = "chatSuggestionsInterface"
+    }
+}
+
+internal class JSONObjectAdapter {
+    @FromJson
+    fun fromJson(reader: JsonReader): JSONObject? {
+        return (reader.readJsonValue() as? Map<*, *>)?.let { data ->
+            try {
+                JSONObject(data)
+            } catch (_: JSONException) {
+                null
+            }
+        }
+    }
+
+    @ToJson
+    fun toJson(writer: JsonWriter, value: JSONObject?) {
+        value?.let { writer.run { value(Buffer().writeUtf8(value.toString())) } }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Bitmap
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.annotation.VisibleForTesting
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import javax.inject.Inject
+
+interface ChatSuggestionsReader {
+    suspend fun fetchSuggestions(query: String = ""): List<ChatSuggestion>
+    fun tearDown()
+}
+
+@ContributesBinding(AppScope::class)
+class RealChatSuggestionsReader @Inject constructor(
+    private val context: Context,
+    private val dispatchers: DispatcherProvider,
+    private val appBuildConfig: AppBuildConfig,
+    private val messaging: ChatSuggestionsJsMessaging,
+) : ChatSuggestionsReader {
+
+    private var webView: WebView? = null
+    private var pageLoadDeferred: CompletableDeferred<Unit>? = null
+    private var chatsResultDeferred: CompletableDeferred<JSONObject>? = null
+
+    // Script loader state
+    private var cachedScript: String? = null
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override suspend fun fetchSuggestions(query: String): List<ChatSuggestion> {
+        return withContext(dispatchers.main()) {
+            val script = getScript()
+            val wv = getOrCreateWebView(script)
+
+            val results = mutableListOf<DomainResult>()
+            for (domain in DOMAINS) {
+                val result = fetchFromDomain(wv, domain, query)
+                if (result != null) {
+                    results.add(result)
+                }
+            }
+
+            val bestResult = results.maxByOrNull { result ->
+                (result.pinnedChats + result.recentChats).maxOfOrNull { it.lastEdit } ?: LocalDateTime.MIN
+            } ?: return@withContext emptyList()
+            mergeSuggestions(bestResult.pinnedChats, bestResult.recentChats)
+        }
+    }
+
+    override fun tearDown() {
+        pageLoadDeferred?.cancel()
+        pageLoadDeferred = null
+        chatsResultDeferred?.cancel()
+        chatsResultDeferred = null
+        webView?.destroy()
+        webView = null
+    }
+
+    // region Script Loading
+
+    private suspend fun getScript(): String {
+        return withContext(dispatchers.io()) {
+            if (cachedScript.isNullOrBlank()) {
+                cachedScript = loadJs(JS_FILE_NAME)
+                    .replace(CONTENT_SCOPE_PLACEHOLDER, getContentScopeJson())
+                    .replace(USER_UNPROTECTED_DOMAINS_PLACEHOLDER, "[]")
+                    .replace(USER_PREFERENCES_PLACEHOLDER, getUserPreferencesJson())
+                    .replace(
+                        MESSAGING_PARAMETERS_PLACEHOLDER,
+                        "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}",
+                    )
+            }
+            cachedScript!!
+        }
+    }
+
+    // TODO: Get this from privacy config instead of hardcoding
+    private fun getContentScopeJson(): String {
+        return """{"features":{"duckAiChatHistory":{"state":"enabled","exceptions":[],"settings":{}}},"unprotectedTemporary":[]}"""
+    }
+
+    private fun getUserPreferencesJson(): String {
+        val params = "${getVersionNumberKeyValuePair()},${getPlatformKeyValuePair()},${getLanguageKeyValuePair()}," +
+            "${getSessionKeyValuePair()},${getDesktopModeKeyValuePair()},$MESSAGING_PARAMETERS_PLACEHOLDER"
+        return "{$params}"
+    }
+
+    private fun getVersionNumberKeyValuePair() = "\"versionNumber\":${appBuildConfig.versionCode}"
+    private fun getPlatformKeyValuePair() = "\"platform\":{\"name\":\"android\"}"
+    private fun getLanguageKeyValuePair() = "\"locale\":\"${Locale.getDefault().language}\""
+    private fun getSessionKeyValuePair() = "\"sessionKey\":\"sessionKey\""
+    private fun getDesktopModeKeyValuePair() = "\"desktopModeEnabled\":false"
+    private fun getSecretKeyValuePair(): String = "\"messageSecret\":\"${messaging.secret}\""
+    private fun getCallbackKeyValuePair(): String = "\"messageCallback\":\"${messaging.callbackName}\""
+    private fun getInterfaceKeyValuePair(): String = "\"javascriptInterface\":\"${ChatSuggestionsJsMessaging.JS_INTERFACE_NAME}\""
+
+    private fun loadJs(resourceName: String): String {
+        return javaClass.classLoader?.getResource(resourceName)?.openStream()?.bufferedReader()?.use { it.readText() }.orEmpty()
+    }
+
+    // endregion
+
+    // region WebView Setup
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun getOrCreateWebView(script: String): WebView {
+        webView?.let { return it }
+
+        return WebView(context).apply {
+            settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                cacheMode = WebSettings.LOAD_NO_CACHE
+            }
+
+            webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    view?.evaluateJavascript("javascript:$script", null)
+                }
+
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    pageLoadDeferred?.complete(Unit)
+                }
+            }
+
+            messaging.register(
+                this,
+                object : JsMessageCallback() {
+                    override fun process(
+                        featureName: String,
+                        method: String,
+                        id: String?,
+                        data: JSONObject?,
+                    ) {
+                        if (method == METHOD_CHATS_RESULT && data != null) {
+                            chatsResultDeferred?.complete(data)
+                        }
+                    }
+                },
+            )
+
+            webView = this
+        }
+    }
+
+    // endregion
+
+    // region Fetching
+
+    private suspend fun fetchFromDomain(webView: WebView, domain: String, query: String): DomainResult? {
+        pageLoadDeferred = CompletableDeferred()
+        webView.loadDataWithBaseURL(domain, EMPTY_HTML, "text/html", "utf-8", null)
+        withTimeoutOrNull(FETCH_TIMEOUT_MS) { pageLoadDeferred?.await() } ?: return null
+
+        chatsResultDeferred = CompletableDeferred()
+        val params = buildFetchParams(query)
+        messaging.sendSubscriptionEvent(
+            SubscriptionEventData(
+                FEATURE_NAME,
+                SUBSCRIPTION_GET_CHATS,
+                params,
+            ),
+        )
+
+        val response = withTimeoutOrNull(FETCH_TIMEOUT_MS) { chatsResultDeferred?.await() } ?: return null
+        return parseResponse(response)
+    }
+
+    private fun buildFetchParams(query: String): JSONObject {
+        return JSONObject().apply {
+            if (query.isNotEmpty()) {
+                put("query", query)
+            }
+            put("max_chats", MAX_SUGGESTIONS)
+            if (query.isEmpty()) {
+                put("since", System.currentTimeMillis() - SEVEN_DAYS_MS)
+            }
+        }
+    }
+
+    // endregion
+
+    // region Parsing
+
+    @VisibleForTesting
+    internal fun parseResponse(response: JSONObject): DomainResult? {
+        val success = response.optBoolean("success", false)
+        if (!success) return null
+
+        val pinnedChats = parseChats(response.optJSONArray("pinnedChats"), pinned = true)
+        val recentChats = parseChats(response.optJSONArray("chats"), pinned = false)
+
+        return DomainResult(
+            pinnedChats = pinnedChats,
+            recentChats = recentChats,
+        )
+    }
+
+    @VisibleForTesting
+    internal fun parseChats(jsonArray: org.json.JSONArray?, pinned: Boolean): List<ChatSuggestion> {
+        if (jsonArray == null) return emptyList()
+
+        return (0 until jsonArray.length()).mapNotNull { i ->
+            val chat = jsonArray.optJSONObject(i) ?: return@mapNotNull null
+            val chatId = chat.optString("chatId", "").takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            val title = chat.optString("title", "").ifEmpty { "Untitled Chat" }
+            val lastEdit = parseLastEdit(chat.optString("lastEdit", ""))
+
+            ChatSuggestion(
+                chatId = chatId,
+                title = title,
+                lastEdit = lastEdit,
+                pinned = pinned,
+            )
+        }
+    }
+
+    private fun parseLastEdit(lastEditStr: String): LocalDateTime {
+        if (lastEditStr.isEmpty()) return LocalDateTime.now()
+        return try {
+            val instant = Instant.parse(lastEditStr)
+            LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+        } catch (_: DateTimeParseException) {
+            LocalDateTime.now()
+        }
+    }
+
+    @VisibleForTesting
+    internal fun mergeSuggestions(
+        pinnedChats: List<ChatSuggestion>,
+        recentChats: List<ChatSuggestion>,
+    ): List<ChatSuggestion> {
+        return (pinnedChats + recentChats)
+            .sortedByDescending { it.lastEdit }
+            .take(MAX_SUGGESTIONS)
+    }
+
+    // endregion
+
+    @VisibleForTesting
+    internal data class DomainResult(
+        val pinnedChats: List<ChatSuggestion>,
+        val recentChats: List<ChatSuggestion>,
+    )
+
+    companion object {
+        private const val FEATURE_NAME = "duckAiChatHistory"
+        private const val SUBSCRIPTION_GET_CHATS = "getDuckAiChats"
+        private const val METHOD_CHATS_RESULT = "duckAiChatsResult"
+        private const val MAX_SUGGESTIONS = 10
+        private const val FETCH_TIMEOUT_MS = 3000L
+        private const val SEVEN_DAYS_MS = 7L * 24 * 60 * 60 * 1000
+        private const val EMPTY_HTML = "<html></html>"
+
+        // TODO: At the time of this implementation, both domains are needed for fetching the recent chats.
+        //  Once domain consolidation is deployed for Android, we can remove the duckduckgo domain.
+        private val DOMAINS = listOf("https://duck.ai", "https://duckduckgo.com")
+
+        private const val JS_FILE_NAME = "duckAiChatHistory.js"
+        private const val CONTENT_SCOPE_PLACEHOLDER = "\$CONTENT_SCOPE$"
+        private const val USER_UNPROTECTED_DOMAINS_PLACEHOLDER = "\$USER_UNPROTECTED_DOMAINS$"
+        private const val USER_PREFERENCES_PLACEHOLDER = "\$USER_PREFERENCES$"
+        private const val MESSAGING_PARAMETERS_PLACEHOLDER = "\$ANDROID_MESSAGING_PARAMETERS$"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -39,12 +39,10 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenFragment
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
-import com.duckduckgo.duckchat.impl.inputscreen.ui.view.RecyclerBottomSpacingDecoration
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import logcat.logcat
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
@@ -82,8 +80,7 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         val parentFragment = requireParentFragment() as InputScreenFragment
 
         chatSuggestionsAdapter = ChatSuggestionsAdapter { suggestion ->
-            // TODO: Handle navigation to chat in duck.ai fullscreen mode
-            logcat { "Chat suggestion clicked: chatId=${suggestion.chatId}, title=${suggestion.title}" }
+            viewModel.onChatSuggestionSelected(suggestion.chatId)
         }
 
         chatSuggestionsRecyclerView = parentFragment.getChatSuggestionsRecyclerView().apply {
@@ -95,9 +92,8 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
             setBackgroundColor(typedValue.data)
 
             if (inputScreenConfigResolver.useTopBar()) {
-                val spacing = resources.getDimensionPixelSize(R.dimen.inputScreenAutocompleteListBottomSpace)
-                addItemDecoration(RecyclerBottomSpacingDecoration(spacing))
-                updatePadding(top = 8f.toPx(context).roundToInt())
+                val bottomSpacing = resources.getDimensionPixelSize(R.dimen.inputScreenAutocompleteListBottomSpace)
+                updatePadding(top = 8f.toPx(context).roundToInt(), bottom = bottomSpacing)
             }
         }
     }
@@ -159,9 +155,6 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     }
 
     override fun onDestroyView() {
-        while ((chatSuggestionsRecyclerView?.itemDecorationCount ?: 0) > 0) {
-            chatSuggestionsRecyclerView?.removeItemDecorationAt(0)
-        }
         chatSuggestionsRecyclerView?.clearOnScrollListeners()
         bottomBlurLayoutListener?.let { listener ->
             chatSuggestionsRecyclerView?.removeOnLayoutChangeListener(listener)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputScreenVisibilitySt
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIconState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.CHAT
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.NONE
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.UserSelectedMode.SEARCH
@@ -83,6 +84,7 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -110,6 +112,7 @@ import kotlinx.coroutines.withContext
 import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
+import kotlin.coroutines.cancellation.CancellationException
 
 enum class UserSelectedMode {
     SEARCH,
@@ -134,6 +137,7 @@ class InputScreenViewModel @AssistedInject constructor(
     private val inputScreenSessionUsageMetric: InputScreenSessionUsageMetric,
     private val inputScreenConfigResolver: InputScreenConfigResolver,
     private val omnibarRepository: OmnibarRepository,
+    private val chatSuggestionsReader: ChatSuggestionsReader,
 ) : ViewModel() {
 
     private val autoComplete: AutoComplete = autoCompleteFactory.create(
@@ -142,6 +146,7 @@ class InputScreenViewModel @AssistedInject constructor(
 
     private var hasUserSeenHistoryIAM = false
     private var isTapTransition = false
+    private var chatSuggestionsFetchJob: Job? = null
 
     private val newTabPageHasContent = MutableStateFlow(false)
     private val voiceServiceAvailable = MutableStateFlow(voiceSearchAvailability.isVoiceSearchAvailable)
@@ -300,6 +305,19 @@ class InputScreenViewModel @AssistedInject constructor(
                 it.copy(showChatLogo = !hasChatSuggestions, chatSuggestionsVisible = hasChatSuggestions)
             }
         }.launchIn(viewModelScope)
+
+        if (duckChatFeature.aiChatSuggestions().isEnabled()) {
+            @OptIn(FlowPreview::class)
+            chatInputTextState
+                .drop(1)
+                .debounce(CHAT_SUGGESTIONS_DEBOUNCE_MS)
+                .onEach { query ->
+                    if (!_visibilityState.value.searchMode) {
+                        fetchChatSuggestionsWithQuery(query)
+                    }
+                }
+                .launchIn(viewModelScope)
+        }
     }
 
     fun onActivityResume() {
@@ -501,9 +519,12 @@ class InputScreenViewModel @AssistedInject constructor(
         }
         userSelectedMode = CHAT
 
-        // Load suggestions when chat tab is selected (only if not already loaded)
-        if (duckChatFeature.aiChatSuggestions().isEnabled() && _chatSuggestions.value.isEmpty()) {
-            loadChatSuggestions()
+        // Fetch if the query hasn't changed since the last fetch. The observer
+        // on chatInputTextState will handle the case where the query changed.
+        if (duckChatFeature.aiChatSuggestions().isEnabled() &&
+            chatInputTextState.value == searchInputTextState.value
+        ) {
+            fetchChatSuggestionsWithQuery(chatInputTextState.value)
         }
     }
 
@@ -708,8 +729,36 @@ class InputScreenViewModel @AssistedInject constructor(
         inputScreenConfigResolver.mainButtonsEnabled() &&
         omnibarRepository.omnibarType != OmnibarType.SPLIT
 
-    private fun loadChatSuggestions() {
-        // TODO: implement load from frontend
+    fun onChatSuggestionSelected(chatId: String) {
+        viewModelScope.launch {
+            val url = duckChat.getDuckChatUrl("", false)
+                .toUri()
+                .buildUpon()
+                .appendQueryParameter(CHAT_ID_PARAM, chatId)
+                .build()
+                .toString()
+            command.value = Command.SubmitSearch(url)
+        }
+    }
+
+    private fun fetchChatSuggestionsWithQuery(query: String) {
+        chatSuggestionsFetchJob?.cancel()
+        chatSuggestionsFetchJob = viewModelScope.launch {
+            try {
+                val suggestions = chatSuggestionsReader.fetchSuggestions(query)
+                _chatSuggestions.value = suggestions
+            } catch (e: Exception) {
+                // Skip logging for CancellationException since it's expected when a new query replaces an in-flight fetch.
+                if (e !is CancellationException) {
+                    logcat(WARN) { "Failed to load chat suggestions: ${e.asLog()}" }
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        chatSuggestionsReader.tearDown()
     }
 
     class InputScreenViewModelProviderFactory(
@@ -727,6 +776,8 @@ class InputScreenViewModel @AssistedInject constructor(
 
     companion object {
         const val DUCK_SCHEME = "duck"
+        private const val CHAT_SUGGESTIONS_DEBOUNCE_MS = 150L
+        private const val CHAT_ID_PARAM = "chatID"
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsJsMessagingTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsJsMessagingTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.inputscreen.suggestions.reader
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsJsMessaging
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsJsMessaging.Companion.JS_INTERFACE_NAME
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessageHelper
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class ChatSuggestionsJsMessagingTest {
+
+    private val jsMessageHelper: JsMessageHelper = mock()
+    private val webView: WebView = mock()
+    private val jsMessageCallback: JsMessageCallback = mock()
+
+    private lateinit var messaging: ChatSuggestionsJsMessaging
+
+    @Before
+    fun setup() {
+        messaging = ChatSuggestionsJsMessaging(
+            jsMessageHelper = jsMessageHelper,
+        )
+        messaging.register(webView, jsMessageCallback)
+    }
+
+    @Test
+    fun `when register called then javascript interface is added to webview`() {
+        val newWebView: WebView = mock()
+        val newMessaging = ChatSuggestionsJsMessaging(jsMessageHelper)
+
+        newMessaging.register(newWebView, jsMessageCallback)
+
+        verify(newWebView).addJavascriptInterface(newMessaging, JS_INTERFACE_NAME)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `when register called with null callback then throws`() {
+        val newMessaging = ChatSuggestionsJsMessaging(jsMessageHelper)
+        newMessaging.register(webView, null)
+    }
+
+    @Test
+    fun `when process called with valid duckAiChatsResult message then callback is invoked`() {
+        val messageJson = """
+            {
+                "context": "contentScopeScripts",
+                "featureName": "duckAiChatHistory",
+                "method": "duckAiChatsResult",
+                "id": "123",
+                "params": {"success": true}
+            }
+        """.trimIndent()
+
+        messaging.process(messageJson, messaging.secret)
+
+        verify(jsMessageCallback).process(
+            eq("duckAiChatHistory"),
+            eq("duckAiChatsResult"),
+            eq("123"),
+            any(),
+        )
+    }
+
+    @Test
+    fun `when process called with wrong secret then callback is not invoked`() {
+        val messageJson = """
+            {
+                "context": "contentScopeScripts",
+                "featureName": "duckAiChatHistory",
+                "method": "duckAiChatsResult",
+                "id": "123",
+                "params": {"success": true}
+            }
+        """.trimIndent()
+
+        messaging.process(messageJson, "wrongsecret")
+
+        verify(jsMessageCallback, never()).process(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when process called with wrong context then callback is not invoked`() {
+        val messageJson = """
+            {
+                "context": "wrongContext",
+                "featureName": "duckAiChatHistory",
+                "method": "duckAiChatsResult",
+                "id": "123",
+                "params": {"success": true}
+            }
+        """.trimIndent()
+
+        messaging.process(messageJson, messaging.secret)
+
+        verify(jsMessageCallback, never()).process(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when process called with unhandled method then callback is not invoked`() {
+        val messageJson = """
+            {
+                "context": "contentScopeScripts",
+                "featureName": "duckAiChatHistory",
+                "method": "unknownMethod",
+                "id": "123",
+                "params": {}
+            }
+        """.trimIndent()
+
+        messaging.process(messageJson, messaging.secret)
+
+        verify(jsMessageCallback, never()).process(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when process called with wrong feature name then callback is not invoked`() {
+        val messageJson = """
+            {
+                "context": "contentScopeScripts",
+                "featureName": "wrongFeature",
+                "method": "duckAiChatsResult",
+                "id": "123",
+                "params": {}
+            }
+        """.trimIndent()
+
+        messaging.process(messageJson, messaging.secret)
+
+        verify(jsMessageCallback, never()).process(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when process called with invalid json then no crash and callback is not invoked`() {
+        messaging.process("not valid json", messaging.secret)
+
+        verify(jsMessageCallback, never()).process(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `when sendSubscriptionEvent called then delegates to jsMessageHelper`() {
+        val eventData = SubscriptionEventData(
+            featureName = "duckAiChatHistory",
+            subscriptionName = "getDuckAiChats",
+            params = JSONObject().apply { put("max_chats", 10) },
+        )
+
+        messaging.sendSubscriptionEvent(eventData)
+
+        verify(jsMessageHelper).sendSubscriptionEvent(any(), eq(messaging.callbackName), eq(messaging.secret), eq(webView))
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.inputscreen.suggestions.reader
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsJsMessaging
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.RealChatSuggestionsReader
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@RunWith(AndroidJUnit4::class)
+class RealChatSuggestionsReaderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context: Context = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val messaging: ChatSuggestionsJsMessaging = mock()
+
+    private lateinit var reader: RealChatSuggestionsReader
+
+    @Before
+    fun setup() {
+        reader = RealChatSuggestionsReader(
+            context = context,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            appBuildConfig = appBuildConfig,
+            messaging = messaging,
+        )
+    }
+
+    // region parseResponse
+
+    @Test
+    fun `when parseResponse called with success true then returns DomainResult`() {
+        val response = JSONObject().apply {
+            put("success", true)
+            put(
+                "pinnedChats",
+                JSONArray().apply {
+                    put(
+                        JSONObject().apply {
+                            put("chatId", "pinned-1")
+                            put("title", "Pinned Chat")
+                            put("lastEdit", "2026-01-15T10:30:00Z")
+                        },
+                    )
+                },
+            )
+            put(
+                "chats",
+                JSONArray().apply {
+                    put(
+                        JSONObject().apply {
+                            put("chatId", "recent-1")
+                            put("title", "Recent Chat")
+                            put("lastEdit", "2026-01-14T08:00:00Z")
+                        },
+                    )
+                },
+            )
+        }
+
+        val result = reader.parseResponse(response)
+
+        assertEquals(1, result!!.pinnedChats.size)
+        assertEquals("pinned-1", result.pinnedChats[0].chatId)
+        assertTrue(result.pinnedChats[0].pinned)
+        assertEquals(1, result.recentChats.size)
+        assertEquals("recent-1", result.recentChats[0].chatId)
+        assertEquals(false, result.recentChats[0].pinned)
+    }
+
+    @Test
+    fun `when parseResponse called with success false then returns null`() {
+        val response = JSONObject().apply {
+            put("success", false)
+        }
+
+        assertNull(reader.parseResponse(response))
+    }
+
+    @Test
+    fun `when parseResponse called without success field then returns null`() {
+        val response = JSONObject()
+
+        assertNull(reader.parseResponse(response))
+    }
+
+    @Test
+    fun `when parseResponse called with empty arrays then returns empty lists`() {
+        val response = JSONObject().apply {
+            put("success", true)
+            put("pinnedChats", JSONArray())
+            put("chats", JSONArray())
+        }
+
+        val result = reader.parseResponse(response)
+
+        assertTrue(result!!.pinnedChats.isEmpty())
+        assertTrue(result.recentChats.isEmpty())
+    }
+
+    @Test
+    fun `when parseResponse called with missing arrays then returns empty lists`() {
+        val response = JSONObject().apply {
+            put("success", true)
+        }
+
+        val result = reader.parseResponse(response)
+
+        assertTrue(result!!.pinnedChats.isEmpty())
+        assertTrue(result.recentChats.isEmpty())
+    }
+
+    // endregion
+
+    // region parseChats
+
+    @Test
+    fun `when parseChats called with null array then returns empty list`() {
+        val result = reader.parseChats(null, pinned = false)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `when parseChats called with valid chat then returns ChatSuggestion`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "My Chat")
+                    put("lastEdit", "2026-01-15T10:30:00Z")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = true)
+
+        assertEquals(1, result.size)
+        assertEquals("chat-1", result[0].chatId)
+        assertEquals("My Chat", result[0].title)
+        assertTrue(result[0].pinned)
+    }
+
+    @Test
+    fun `when parseChats called with missing chatId then skips entry`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("title", "No ID Chat")
+                    put("lastEdit", "2026-01-15T10:30:00Z")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `when parseChats called with empty chatId then skips entry`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "")
+                    put("title", "Empty ID Chat")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `when parseChats called with empty title then uses Untitled Chat`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        assertEquals("Untitled Chat", result[0].title)
+    }
+
+    @Test
+    fun `when parseChats called with missing title then uses Untitled Chat`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        assertEquals("Untitled Chat", result[0].title)
+    }
+
+    @Test
+    fun `when parseChats called with valid ISO timestamp then parses correctly`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "Test")
+                    put("lastEdit", "2026-01-15T10:30:00Z")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        val expectedTime = java.time.Instant.parse("2026-01-15T10:30:00Z")
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime()
+        assertEquals(expectedTime, result[0].lastEdit)
+    }
+
+    @Test
+    fun `when parseChats called with invalid timestamp then falls back to now`() {
+        val before = LocalDateTime.now()
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "Test")
+                    put("lastEdit", "not-a-date")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+        val after = LocalDateTime.now()
+
+        assertTrue(!result[0].lastEdit.isBefore(before))
+        assertTrue(!result[0].lastEdit.isAfter(after))
+    }
+
+    @Test
+    fun `when parseChats called with empty lastEdit then falls back to now`() {
+        val before = LocalDateTime.now()
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "Test")
+                    put("lastEdit", "")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+        val after = LocalDateTime.now()
+
+        assertTrue(!result[0].lastEdit.isBefore(before))
+        assertTrue(!result[0].lastEdit.isAfter(after))
+    }
+
+    @Test
+    fun `when parseChats called with multiple entries then returns all valid ones`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "First")
+                },
+            )
+            put(
+                JSONObject().apply {
+                    put("chatId", "")
+                    put("title", "Invalid - empty id")
+                },
+            )
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-3")
+                    put("title", "Third")
+                },
+            )
+        }
+
+        val result = reader.parseChats(jsonArray, pinned = false)
+
+        assertEquals(2, result.size)
+        assertEquals("chat-1", result[0].chatId)
+        assertEquals("chat-3", result[1].chatId)
+    }
+
+    @Test
+    fun `when parseChats called then sets pinned flag correctly`() {
+        val jsonArray = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put("chatId", "chat-1")
+                    put("title", "Test")
+                },
+            )
+        }
+
+        val pinnedResult = reader.parseChats(jsonArray, pinned = true)
+        val recentResult = reader.parseChats(jsonArray, pinned = false)
+
+        assertTrue(pinnedResult[0].pinned)
+        assertEquals(false, recentResult[0].pinned)
+    }
+
+    // endregion
+
+    // region mergeSuggestions
+
+    @Test
+    fun `when mergeSuggestions called then all sorted by lastEdit descending regardless of pinned`() {
+        val now = LocalDateTime.now()
+        val pinned = listOf(
+            ChatSuggestion("p1", "Pinned Old", now.minusDays(2), pinned = true),
+            ChatSuggestion("p2", "Pinned New", now.minusDays(1), pinned = true),
+        )
+        val recent = listOf(
+            ChatSuggestion("r1", "Recent", now, pinned = false),
+        )
+
+        val result = reader.mergeSuggestions(pinned, recent)
+
+        assertEquals(3, result.size)
+        assertEquals("r1", result[0].chatId)
+        assertEquals("p2", result[1].chatId)
+        assertEquals("p1", result[2].chatId)
+    }
+
+    @Test
+    fun `when mergeSuggestions called with more than 10 total then takes only 10`() {
+        val now = LocalDateTime.now()
+        val pinned = (1..6).map {
+            ChatSuggestion("p$it", "Pinned $it", now.minusHours(it.toLong()), pinned = true)
+        }
+        val recent = (1..6).map {
+            ChatSuggestion("r$it", "Recent $it", now.minusHours(it.toLong() + 6), pinned = false)
+        }
+
+        val result = reader.mergeSuggestions(pinned, recent)
+
+        assertEquals(10, result.size)
+    }
+
+    @Test
+    fun `when mergeSuggestions called with empty pinned then returns only recent`() {
+        val now = LocalDateTime.now()
+        val recent = listOf(
+            ChatSuggestion("r1", "Recent 1", now, pinned = false),
+            ChatSuggestion("r2", "Recent 2", now.minusDays(1), pinned = false),
+        )
+
+        val result = reader.mergeSuggestions(emptyList(), recent)
+
+        assertEquals(2, result.size)
+        assertEquals("r1", result[0].chatId)
+        assertEquals("r2", result[1].chatId)
+    }
+
+    @Test
+    fun `when mergeSuggestions called with empty recent then returns only pinned`() {
+        val now = LocalDateTime.now()
+        val pinned = listOf(
+            ChatSuggestion("p1", "Pinned 1", now, pinned = true),
+        )
+
+        val result = reader.mergeSuggestions(pinned, emptyList())
+
+        assertEquals(1, result.size)
+        assertEquals("p1", result[0].chatId)
+    }
+
+    @Test
+    fun `when mergeSuggestions called with both empty then returns empty`() {
+        val result = reader.mergeSuggestions(emptyList(), emptyList())
+
+        assertTrue(result.isEmpty())
+    }
+
+    // endregion
+
+    // region tearDown
+
+    @Test
+    fun `when tearDown called multiple times then app does not crash`() {
+        reader.tearDown()
+        reader.tearDown()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213017870300880

### Description
- Adds the data layer for fetching recent/pinned AI chat suggestions from localStorage via a headless WebView, using the c-s-s JS messaging bridge
- Wires the fetching into InputScreenViewModel so suggestions load when the Chat tab is selected and re-filter as the user types (debounced)

**How it works**

ChatSuggestionsReader creates a headless WebView and injects the duckAiChatHistory.js content-scope script. For each domain (duck.ai, duckduckgo.com), it:
1. Loads an empty HTML page with loadDataWithBaseURL to set the origin
2. Sends a subscription event via ChatSuggestionsJsMessaging into the JS
3. The JS reads localStorage and responds with duckAiChatsResult via the JavascriptInterface bridge
4. The response is parsed into ChatSuggestion objects, merged between domains, and sorted by lastEdit descending (max 10)

The ViewModel fetches on tab switch and re-fetches with a 150ms debounce as the user types.

### Steps to test this PR

Enable aiChatSuggestions feature flag
- Open Input Screen, switch to Chat tab --> recent chats appear
- Type in the chat box to filter. Suggestions update after debounce
- Type until no matches --> logo appears
- Switch between Search and Chat tabs --> suggestions refresh each time, respecting the current query
- Create new chats in duck.ai, pin/unpin, delete chats, udpate old chats --> list should reflect properly
- Disable feature flag --> no suggestions fetched, no debounce observer running

### Video Demo

https://github.com/user-attachments/assets/b8de0d44-bf63-4ff8-9703-6fb7b4af7da5



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new WebView + JS messaging flows and lifecycle/timeout handling, which can affect stability and correctness of suggestion loading/navigation, but is gated behind a feature toggle.
> 
> **Overview**
> Adds a new chat-suggestions data layer that spins up a headless `WebView`, injects `duckAiChatHistory.js`, and uses a dedicated `ChatSuggestionsJsMessaging` `@JavascriptInterface` bridge to request pinned/recent chats (with query filtering + timeouts) from `duck.ai`/`duckduckgo.com`, parse the JSON response, and return the top 10 sorted by `lastEdit`.
> 
> Wires this into `InputScreenViewModel` behind the `aiChatSuggestions` toggle: suggestions fetch on chat-tab selection and re-fetch on chat input changes with a 150ms debounce (cancelling in-flight jobs), and clicking a suggestion now navigates by submitting a DuckChat URL with a `chatID` query parameter. `ChatTabFragment` is updated to call the new selection handler and simplifies padding/decoration cleanup. Adds unit tests covering messaging validation, parsing/merge logic, and view-model behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ec88a96523aa799021af38fea019f34dbd9da63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->