### PR TITLE
Update content scope scripts to version 13.6.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -74,7 +74,7 @@
   var debug = false;
   function initStringExemptionLists(args) {
     const { stringExemptionLists } = args;
-    debug = args.debug;
+    debug = args.debug || false;
     for (const type in stringExemptionLists) {
       exemptionLists[type] = [];
       for (const stringExemption of stringExemptionLists[type]) {
@@ -119,6 +119,7 @@
   var lineTest = /(\()?(https?:[^)]+):[0-9]+:[0-9]+(\))?/;
   function getStackTraceUrls(stack) {
     const urls = new Set2();
+    if (!stack) return urls;
     try {
       const errorLines = stack.split("\n");
       for (const line of errorLines) {
@@ -144,6 +145,7 @@
       return false;
     }
     const stack = getStack();
+    if (!stack) return false;
     const errorFiles = getStackTraceUrls(stack);
     for (const path of errorFiles) {
       if (shouldExemptUrl(type, path.href)) {
@@ -154,7 +156,7 @@
   }
   function iterateDataKey(key, callback) {
     let item = key.charCodeAt(0);
-    for (const i in key) {
+    for (let i = 0; i < key.length; i++) {
       let byte = key.charCodeAt(i);
       for (let j2 = 8; j2 >= 0; j2--) {
         const res = callback(item, byte);
@@ -270,8 +272,8 @@
     /**
      * @param {import('./content-feature').default} feature
      * @param {P} objectScope
-     * @param {string} property
-     * @param {ProxyObject<P>} proxyObject
+     * @param {K} property
+     * @param {ProxyObject<P, K>} proxyObject
      */
     constructor(feature, objectScope, property, proxyObject) {
       this.objectScope = objectScope;
@@ -317,7 +319,7 @@
     }
     // Actually apply the proxy to the native property
     overload() {
-      this.objectScope[this.property] = this.internal;
+      Reflect.set(this.objectScope, this.property, this.internal);
     }
     overloadDescriptor() {
       this.feature.defineProperty(this.objectScope, this.property, {
@@ -330,12 +332,9 @@
   };
   var maxCounter = /* @__PURE__ */ new Map();
   function numberOfTimesDebugged(feature) {
-    if (!maxCounter.has(feature)) {
-      maxCounter.set(feature, 1);
-    } else {
-      maxCounter.set(feature, maxCounter.get(feature) + 1);
-    }
-    return maxCounter.get(feature);
+    const current = maxCounter.get(feature) ?? 0;
+    maxCounter.set(feature, current + 1);
+    return current + 1;
   }
   var DEBUG_MAX_TIMES = 5e3;
   function postDebugMessage(feature, message, allowNonDebug = false) {
@@ -512,7 +511,10 @@
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
-    return platformSpecificFeatures.includes(featureName);
+    return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
   }
   function createCustomEvent(eventName, eventDetail) {
     return new OriginalCustomEvent(eventName, eventDetail);
@@ -524,20 +526,44 @@
   }
   function withDefaults(defaults, config) {
     if (config === void 0) {
-      return defaults;
+      return (
+        /** @type {D & C} */
+        defaults
+      );
     }
     if (
       // if defaults are undefined
       defaults === void 0 || // or either config or defaults are a non-object value that we can't merge
       Array.isArray(defaults) || defaults === null || typeof defaults !== "object" || Array.isArray(config) || config === null || typeof config !== "object"
     ) {
-      return config;
+      return (
+        /** @type {D & C} */
+        /** @type {unknown} */
+        config
+      );
     }
     const result = {};
-    for (const key of new Set2([...Object.keys(defaults), ...Object.keys(config)])) {
-      result[key] = withDefaults(defaults[key], config[key]);
+    const d = (
+      /** @type {any} */
+      defaults
+    );
+    const c = (
+      /** @type {any} */
+      config
+    );
+    for (const key of new Set2([...Object.keys(d), ...Object.keys(c)])) {
+      result[key] = withDefaults(
+        /** @type {any} */
+        d[key],
+        /** @type {any} */
+        c[key]
+      );
     }
-    return result;
+    return (
+      /** @type {D & C} */
+      /** @type {unknown} */
+      result
+    );
   }
 
   // src/features.js
@@ -785,9 +811,13 @@
     if (!origFn || typeof origFn !== "function") {
       throw new Error(`Property ${propertyName} does not look like a method`);
     }
-    const newFn = wrapToString(function() {
-      return wrapperFn.call(this, origFn, ...arguments);
-    }, origFn);
+    const newFn = wrapToString(
+      /** @this {any} */
+      function() {
+        return wrapperFn.call(this, origFn, ...arguments);
+      },
+      origFn
+    );
     definePropertyFn(object, propertyName, {
       ...origDescriptor,
       value: newFn
@@ -795,11 +825,12 @@
     return origDescriptor;
   }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origInterfaceDescriptors) globalThis.origInterfaceDescriptors = {};
+      if (!g.origInterfaceDescriptors) g.origInterfaceDescriptors = {};
       const descriptor = Object.getOwnPropertyDescriptor(globalThis, interfaceName);
-      globalThis.origInterfaceDescriptors[interfaceName] = descriptor;
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origInterfaceDescriptors[interfaceName] = descriptor;
+      g.ddgShimMark = ddgShimMark;
     }
     const defaultOptions = {
       allowConstructorCall: false,
@@ -860,11 +891,12 @@
   }
   function shimProperty(baseObject, propertyName, implInstance, readOnly, definePropertyFn, injectName) {
     const ImplClass = implInstance.constructor;
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origPropDescriptors) globalThis.origPropDescriptors = [];
+      if (!g.origPropDescriptors) g.origPropDescriptors = [];
       const descriptor2 = Object.getOwnPropertyDescriptor(baseObject, propertyName);
-      globalThis.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
+      g.ddgShimMark = ddgShimMark;
       if (ImplClass[ddgShimMark] !== true) {
         throw new TypeError("implInstance must be an instance of a shimmed class");
       }
@@ -2155,10 +2187,11 @@
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {
-      if (node[sub] === 1) {
+      const next = node[sub];
+      if (next === 1) {
         return true;
-      } else if (node[sub]) {
-        node = node[sub];
+      } else if (next) {
+        node = next;
       } else {
         return false;
       }
@@ -3240,8 +3273,8 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
-        __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
+        const enabledFeatures = computeEnabledFeatures(__privateGet(this, _bundledConfig), site.domain, platform);
+        __privateGet(this, _args).featureSettings = parseFeatureSettings(__privateGet(this, _bundledConfig), enabledFeatures);
       }
     }
     /**
@@ -3634,8 +3667,7 @@
      */
     constructor(featureName, importConfig, features, args) {
       super(featureName, args);
-      /** @type {import('./utils.js').RemoteConfig | undefined} */
-      /** @type {import('../../messaging').Messaging} */
+      /** @type {import('../../messaging').Messaging | undefined} */
       // eslint-disable-next-line no-unused-private-class-members
       __privateAdd(this, _messaging);
       /** @type {boolean} */
@@ -3748,7 +3780,7 @@
       return this.args?.assets;
     }
     /**
-     * @returns {ImportMeta['trackerLookup']}
+     * @returns {import('./trackers.js').TrackerNode | {}}
      **/
     get trackerLookup() {
       return __privateGet(this, _importConfig).trackerLookup || {};
@@ -3860,6 +3892,9 @@
       const configSetting = this.getFeatureSetting(attrName);
       return processAttr(configSetting, defaultValue);
     }
+    /**
+     * @param {any} [_args]
+     */
     init(_args2) {
     }
     /**
@@ -3889,10 +3924,16 @@
     markFeatureAsSkipped(reason) {
       __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
+    /**
+     * @param {any} args
+     */
     setArgs(args) {
       this.args = args;
       this.platform = args.platform;
     }
+    /**
+     * @param {any} [_args]
+     */
     load(_args2) {
     }
     /**
@@ -3971,23 +4012,32 @@
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
-     * @param {string} propertyName
+     * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
     defineProperty(object, propertyName, descriptor) {
-      ["value", "get", "set"].forEach((k) => {
-        const descriptorProp = descriptor[k];
-        if (typeof descriptorProp === "function") {
-          const addDebugFlag = this.addDebugFlag.bind(this);
-          const wrapper = new Proxy2(descriptorProp, {
-            apply(_2, thisArg, argumentsList) {
-              addDebugFlag();
-              return Reflect2.apply(descriptorProp, thisArg, argumentsList);
-            }
-          });
-          descriptor[k] = wrapToString(wrapper, descriptorProp);
-        }
-      });
+      const addDebugFlag = this.addDebugFlag.bind(this);
+      const wrapWithDebugFlag = (fn) => {
+        const wrapper = new Proxy2(fn, {
+          apply(_2, thisArg, argumentsList) {
+            addDebugFlag();
+            return Reflect2.apply(fn, thisArg, argumentsList);
+          }
+        });
+        return (
+          /** @type {F} */
+          wrapToString(wrapper, fn)
+        );
+      };
+      if ("value" in descriptor && typeof descriptor.value === "function") {
+        descriptor.value = wrapWithDebugFlag(descriptor.value);
+      }
+      if ("get" in descriptor && typeof descriptor.get === "function") {
+        descriptor.get = wrapWithDebugFlag(descriptor.get);
+      }
+      if ("set" in descriptor && typeof descriptor.set === "function") {
+        descriptor.set = wrapWithDebugFlag(descriptor.set);
+      }
       return defineProperty(object, propertyName, descriptor);
     }
     /**
@@ -4004,7 +4054,7 @@
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
-     * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
      */
     wrapMethod(object, propertyName, wrapperFn) {
@@ -4023,7 +4073,7 @@
      * Define a missing standard property on a global (prototype) object. Only for data properties.
      * For constructors, use shimInterface().
      * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
-     * @template Base
+     * @template {object} Base
      * @template {keyof Base & string} K
      * @param {Base} instanceHost - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
      * @param {K} instanceProp - name of the property to shim (e.g. 'mediaSession')
@@ -5793,8 +5843,18 @@
 
   // src/crypto.js
   function getDataKeySync(sessionKey, domainKey, inputData) {
-    const hmac = new sjcl.misc.hmac(sjcl.codec.utf8String.toBits(sessionKey + domainKey), sjcl.hash.sha256);
-    return sjcl.codec.hex.fromBits(hmac.encrypt(inputData));
+    const hmac = new /** @type {any} */
+    sjcl.misc.hmac(
+      /** @type {any} */
+      sjcl.codec.utf8String.toBits(sessionKey + domainKey),
+      /** @type {any} */
+      sjcl.hash.sha256
+    );
+    return (
+      /** @type {string} */
+      /** @type {any} */
+      sjcl.codec.hex.fromBits(hmac.encrypt(inputData))
+    );
   }
 
   // src/features/fingerprinting-audio.js
@@ -7072,13 +7132,23 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
-    if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
+    const urlChangedInstance = new ContentFeature(
+      "urlChanged",
+      {},
+      {},
+      /** @type {any} */
+      {}
+    );
+    const nav = (
+      /** @type {any} */
+      globalThis.navigation
+    );
+    if (nav && "addEventListener" in nav) {
       const navigations = /* @__PURE__ */ new WeakMap();
-      globalThis.navigation.addEventListener("navigate", (event) => {
+      nav.addEventListener("navigate", (event) => {
         navigations.set(event.target, event.navigationType);
       });
-      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+      nav.addEventListener("navigatesuccess", (event) => {
         const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
@@ -7150,7 +7220,9 @@
     if (!isHTMLDocument) {
       return;
     }
-    registerMessageSecret(args.messageSecret);
+    if (args.messageSecret) {
+      registerMessageSecret(args.messageSecret);
+    }
     initStringExemptionLists(args);
     const features = await getFeatures();
     await Promise.allSettled(
@@ -7206,7 +7278,7 @@
   async function updateFeaturesInner(args) {
     const features = await getFeatures();
     Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
+      if (initArgs && !isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }
     });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1594,7 +1594,7 @@
   var debug = false;
   function initStringExemptionLists(args) {
     const { stringExemptionLists } = args;
-    debug = args.debug;
+    debug = args.debug || false;
     for (const type in stringExemptionLists) {
       exemptionLists[type] = [];
       for (const stringExemption of stringExemptionLists[type]) {
@@ -1639,6 +1639,7 @@
   var lineTest = /(\()?(https?:[^)]+):[0-9]+:[0-9]+(\))?/;
   function getStackTraceUrls(stack) {
     const urls = new Set2();
+    if (!stack) return urls;
     try {
       const errorLines = stack.split("\n");
       for (const line of errorLines) {
@@ -1664,6 +1665,7 @@
       return false;
     }
     const stack = getStack();
+    if (!stack) return false;
     const errorFiles = getStackTraceUrls(stack);
     for (const path of errorFiles) {
       if (shouldExemptUrl(type, path.href)) {
@@ -1776,8 +1778,8 @@
     /**
      * @param {import('./content-feature').default} feature
      * @param {P} objectScope
-     * @param {string} property
-     * @param {ProxyObject<P>} proxyObject
+     * @param {K} property
+     * @param {ProxyObject<P, K>} proxyObject
      */
     constructor(feature, objectScope, property, proxyObject) {
       this.objectScope = objectScope;
@@ -1823,7 +1825,7 @@
     }
     // Actually apply the proxy to the native property
     overload() {
-      this.objectScope[this.property] = this.internal;
+      Reflect.set(this.objectScope, this.property, this.internal);
     }
     overloadDescriptor() {
       this.feature.defineProperty(this.objectScope, this.property, {
@@ -1836,12 +1838,9 @@
   };
   var maxCounter = /* @__PURE__ */ new Map();
   function numberOfTimesDebugged(feature) {
-    if (!maxCounter.has(feature)) {
-      maxCounter.set(feature, 1);
-    } else {
-      maxCounter.set(feature, maxCounter.get(feature) + 1);
-    }
-    return maxCounter.get(feature);
+    const current = maxCounter.get(feature) ?? 0;
+    maxCounter.set(feature, current + 1);
+    return current + 1;
   }
   var DEBUG_MAX_TIMES = 5e3;
   function postDebugMessage(feature, message, allowNonDebug = false) {
@@ -2018,7 +2017,10 @@
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
-    return platformSpecificFeatures.includes(featureName);
+    return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
   }
   function createCustomEvent(eventName, eventDetail) {
     return new OriginalCustomEvent(eventName, eventDetail);
@@ -2268,9 +2270,13 @@
     if (!origFn || typeof origFn !== "function") {
       throw new Error(`Property ${propertyName} does not look like a method`);
     }
-    const newFn = wrapToString(function() {
-      return wrapperFn.call(this, origFn, ...arguments);
-    }, origFn);
+    const newFn = wrapToString(
+      /** @this {any} */
+      function() {
+        return wrapperFn.call(this, origFn, ...arguments);
+      },
+      origFn
+    );
     definePropertyFn(object, propertyName, {
       ...origDescriptor,
       value: newFn
@@ -2278,11 +2284,12 @@
     return origDescriptor;
   }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origInterfaceDescriptors) globalThis.origInterfaceDescriptors = {};
+      if (!g.origInterfaceDescriptors) g.origInterfaceDescriptors = {};
       const descriptor = Object.getOwnPropertyDescriptor(globalThis, interfaceName);
-      globalThis.origInterfaceDescriptors[interfaceName] = descriptor;
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origInterfaceDescriptors[interfaceName] = descriptor;
+      g.ddgShimMark = ddgShimMark;
     }
     const defaultOptions = {
       allowConstructorCall: false,
@@ -2343,11 +2350,12 @@
   }
   function shimProperty(baseObject, propertyName, implInstance, readOnly, definePropertyFn, injectName) {
     const ImplClass = implInstance.constructor;
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origPropDescriptors) globalThis.origPropDescriptors = [];
+      if (!g.origPropDescriptors) g.origPropDescriptors = [];
       const descriptor2 = Object.getOwnPropertyDescriptor(baseObject, propertyName);
-      globalThis.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
+      g.ddgShimMark = ddgShimMark;
       if (ImplClass[ddgShimMark] !== true) {
         throw new TypeError("implInstance must be an instance of a shimmed class");
       }
@@ -3653,10 +3661,11 @@
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {
-      if (node[sub] === 1) {
+      const next = node[sub];
+      if (next === 1) {
         return true;
-      } else if (node[sub]) {
-        node = node[sub];
+      } else if (next) {
+        node = next;
       } else {
         return false;
       }
@@ -4757,8 +4766,8 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
-        __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
+        const enabledFeatures = computeEnabledFeatures(__privateGet(this, _bundledConfig), site.domain, platform);
+        __privateGet(this, _args).featureSettings = parseFeatureSettings(__privateGet(this, _bundledConfig), enabledFeatures);
       }
     }
     /**
@@ -5151,8 +5160,7 @@
      */
     constructor(featureName, importConfig, features, args) {
       super(featureName, args);
-      /** @type {import('./utils.js').RemoteConfig | undefined} */
-      /** @type {import('../../messaging').Messaging} */
+      /** @type {import('../../messaging').Messaging | undefined} */
       // eslint-disable-next-line no-unused-private-class-members
       __privateAdd(this, _messaging);
       /** @type {boolean} */
@@ -5265,7 +5273,7 @@
       return this.args?.assets;
     }
     /**
-     * @returns {ImportMeta['trackerLookup']}
+     * @returns {import('./trackers.js').TrackerNode | {}}
      **/
     get trackerLookup() {
       return __privateGet(this, _importConfig).trackerLookup || {};
@@ -5377,6 +5385,9 @@
       const configSetting = this.getFeatureSetting(attrName);
       return processAttr(configSetting, defaultValue);
     }
+    /**
+     * @param {any} [_args]
+     */
     init(_args2) {
     }
     /**
@@ -5406,10 +5417,16 @@
     markFeatureAsSkipped(reason) {
       __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
+    /**
+     * @param {any} args
+     */
     setArgs(args) {
       this.args = args;
       this.platform = args.platform;
     }
+    /**
+     * @param {any} [_args]
+     */
     load(_args2) {
     }
     /**
@@ -5488,23 +5505,32 @@
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
-     * @param {string} propertyName
+     * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
     defineProperty(object, propertyName, descriptor) {
-      ["value", "get", "set"].forEach((k) => {
-        const descriptorProp = descriptor[k];
-        if (typeof descriptorProp === "function") {
-          const addDebugFlag = this.addDebugFlag.bind(this);
-          const wrapper = new Proxy2(descriptorProp, {
-            apply(_2, thisArg, argumentsList) {
-              addDebugFlag();
-              return Reflect2.apply(descriptorProp, thisArg, argumentsList);
-            }
-          });
-          descriptor[k] = wrapToString(wrapper, descriptorProp);
-        }
-      });
+      const addDebugFlag = this.addDebugFlag.bind(this);
+      const wrapWithDebugFlag = (fn) => {
+        const wrapper = new Proxy2(fn, {
+          apply(_2, thisArg, argumentsList) {
+            addDebugFlag();
+            return Reflect2.apply(fn, thisArg, argumentsList);
+          }
+        });
+        return (
+          /** @type {F} */
+          wrapToString(wrapper, fn)
+        );
+      };
+      if ("value" in descriptor && typeof descriptor.value === "function") {
+        descriptor.value = wrapWithDebugFlag(descriptor.value);
+      }
+      if ("get" in descriptor && typeof descriptor.get === "function") {
+        descriptor.get = wrapWithDebugFlag(descriptor.get);
+      }
+      if ("set" in descriptor && typeof descriptor.set === "function") {
+        descriptor.set = wrapWithDebugFlag(descriptor.set);
+      }
       return defineProperty(object, propertyName, descriptor);
     }
     /**
@@ -5521,7 +5547,7 @@
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
-     * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
      */
     wrapMethod(object, propertyName, wrapperFn) {
@@ -5540,7 +5566,7 @@
      * Define a missing standard property on a global (prototype) object. Only for data properties.
      * For constructors, use shimInterface().
      * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
-     * @template Base
+     * @template {object} Base
      * @template {keyof Base & string} K
      * @param {Base} instanceHost - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
      * @param {K} instanceProp - name of the property to shim (e.g. 'mediaSession')
@@ -9101,7 +9127,7 @@
       try {
         lastResult = await Promise.resolve(fn());
       } catch (e) {
-        exceptions.push(e.toString());
+        exceptions.push(String(e));
       }
       if (lastResult && "success" in lastResult) break;
       if (i === config.maxAttempts - 1) break;
@@ -9227,13 +9253,23 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
-    if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
+    const urlChangedInstance = new ContentFeature(
+      "urlChanged",
+      {},
+      {},
+      /** @type {any} */
+      {}
+    );
+    const nav = (
+      /** @type {any} */
+      globalThis.navigation
+    );
+    if (nav && "addEventListener" in nav) {
       const navigations = /* @__PURE__ */ new WeakMap();
-      globalThis.navigation.addEventListener("navigate", (event) => {
+      nav.addEventListener("navigate", (event) => {
         navigations.set(event.target, event.navigationType);
       });
-      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+      nav.addEventListener("navigatesuccess", (event) => {
         const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
@@ -9305,7 +9341,9 @@
     if (!isHTMLDocument) {
       return;
     }
-    registerMessageSecret(args.messageSecret);
+    if (args.messageSecret) {
+      registerMessageSecret(args.messageSecret);
+    }
     initStringExemptionLists(args);
     const features = await getFeatures();
     await Promise.allSettled(
@@ -9345,7 +9383,7 @@
   async function updateFeaturesInner(args) {
     const features = await getFeatures();
     Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
+      if (initArgs && !isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }
     });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -913,7 +913,7 @@
   var debug = false;
   function initStringExemptionLists(args) {
     const { stringExemptionLists } = args;
-    debug = args.debug;
+    debug = args.debug || false;
     for (const type in stringExemptionLists) {
       exemptionLists[type] = [];
       for (const stringExemption of stringExemptionLists[type]) {
@@ -958,6 +958,7 @@
   var lineTest = /(\()?(https?:[^)]+):[0-9]+:[0-9]+(\))?/;
   function getStackTraceUrls(stack) {
     const urls = new Set2();
+    if (!stack) return urls;
     try {
       const errorLines = stack.split("\n");
       for (const line of errorLines) {
@@ -983,6 +984,7 @@
       return false;
     }
     const stack = getStack();
+    if (!stack) return false;
     const errorFiles = getStackTraceUrls(stack);
     for (const path of errorFiles) {
       if (shouldExemptUrl(type, path.href)) {
@@ -993,7 +995,7 @@
   }
   function iterateDataKey(key, callback) {
     let item = key.charCodeAt(0);
-    for (const i in key) {
+    for (let i = 0; i < key.length; i++) {
       let byte = key.charCodeAt(i);
       for (let j2 = 8; j2 >= 0; j2--) {
         const res = callback(item, byte);
@@ -1109,8 +1111,8 @@
     /**
      * @param {import('./content-feature').default} feature
      * @param {P} objectScope
-     * @param {string} property
-     * @param {ProxyObject<P>} proxyObject
+     * @param {K} property
+     * @param {ProxyObject<P, K>} proxyObject
      */
     constructor(feature, objectScope, property, proxyObject) {
       this.objectScope = objectScope;
@@ -1156,7 +1158,7 @@
     }
     // Actually apply the proxy to the native property
     overload() {
-      this.objectScope[this.property] = this.internal;
+      Reflect.set(this.objectScope, this.property, this.internal);
     }
     overloadDescriptor() {
       this.feature.defineProperty(this.objectScope, this.property, {
@@ -1169,12 +1171,9 @@
   };
   var maxCounter = /* @__PURE__ */ new Map();
   function numberOfTimesDebugged(feature) {
-    if (!maxCounter.has(feature)) {
-      maxCounter.set(feature, 1);
-    } else {
-      maxCounter.set(feature, maxCounter.get(feature) + 1);
-    }
-    return maxCounter.get(feature);
+    const current = maxCounter.get(feature) ?? 0;
+    maxCounter.set(feature, current + 1);
+    return current + 1;
   }
   var DEBUG_MAX_TIMES = 5e3;
   function postDebugMessage(feature, message, allowNonDebug = false) {
@@ -1351,7 +1350,10 @@
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
-    return platformSpecificFeatures.includes(featureName);
+    return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
   }
   function createCustomEvent(eventName, eventDetail) {
     return new OriginalCustomEvent(eventName, eventDetail);
@@ -1372,20 +1374,44 @@
   }
   function withDefaults(defaults, config) {
     if (config === void 0) {
-      return defaults;
+      return (
+        /** @type {D & C} */
+        defaults
+      );
     }
     if (
       // if defaults are undefined
       defaults === void 0 || // or either config or defaults are a non-object value that we can't merge
       Array.isArray(defaults) || defaults === null || typeof defaults !== "object" || Array.isArray(config) || config === null || typeof config !== "object"
     ) {
-      return config;
+      return (
+        /** @type {D & C} */
+        /** @type {unknown} */
+        config
+      );
     }
     const result = {};
-    for (const key of new Set2([...Object.keys(defaults), ...Object.keys(config)])) {
-      result[key] = withDefaults(defaults[key], config[key]);
+    const d = (
+      /** @type {any} */
+      defaults
+    );
+    const c = (
+      /** @type {any} */
+      config
+    );
+    for (const key of new Set2([...Object.keys(d), ...Object.keys(c)])) {
+      result[key] = withDefaults(
+        /** @type {any} */
+        d[key],
+        /** @type {any} */
+        c[key]
+      );
     }
-    return result;
+    return (
+      /** @type {D & C} */
+      /** @type {unknown} */
+      result
+    );
   }
 
   // src/features.js
@@ -2052,8 +2078,18 @@
 
   // src/crypto.js
   function getDataKeySync(sessionKey, domainKey, inputData) {
-    const hmac = new sjcl.misc.hmac(sjcl.codec.utf8String.toBits(sessionKey + domainKey), sjcl.hash.sha256);
-    return sjcl.codec.hex.fromBits(hmac.encrypt(inputData));
+    const hmac = new /** @type {any} */
+    sjcl.misc.hmac(
+      /** @type {any} */
+      sjcl.codec.utf8String.toBits(sessionKey + domainKey),
+      /** @type {any} */
+      sjcl.hash.sha256
+    );
+    return (
+      /** @type {string} */
+      /** @type {any} */
+      sjcl.codec.hex.fromBits(hmac.encrypt(inputData))
+    );
   }
 
   // src/content-feature.js
@@ -2156,9 +2192,13 @@
     if (!origFn || typeof origFn !== "function") {
       throw new Error(`Property ${propertyName} does not look like a method`);
     }
-    const newFn = wrapToString(function() {
-      return wrapperFn.call(this, origFn, ...arguments);
-    }, origFn);
+    const newFn = wrapToString(
+      /** @this {any} */
+      function() {
+        return wrapperFn.call(this, origFn, ...arguments);
+      },
+      origFn
+    );
     definePropertyFn(object, propertyName, {
       ...origDescriptor,
       value: newFn
@@ -2166,11 +2206,12 @@
     return origDescriptor;
   }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origInterfaceDescriptors) globalThis.origInterfaceDescriptors = {};
+      if (!g.origInterfaceDescriptors) g.origInterfaceDescriptors = {};
       const descriptor = Object.getOwnPropertyDescriptor(globalThis, interfaceName);
-      globalThis.origInterfaceDescriptors[interfaceName] = descriptor;
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origInterfaceDescriptors[interfaceName] = descriptor;
+      g.ddgShimMark = ddgShimMark;
     }
     const defaultOptions = {
       allowConstructorCall: false,
@@ -2231,11 +2272,12 @@
   }
   function shimProperty(baseObject, propertyName, implInstance, readOnly, definePropertyFn, injectName) {
     const ImplClass = implInstance.constructor;
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origPropDescriptors) globalThis.origPropDescriptors = [];
+      if (!g.origPropDescriptors) g.origPropDescriptors = [];
       const descriptor2 = Object.getOwnPropertyDescriptor(baseObject, propertyName);
-      globalThis.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
+      g.ddgShimMark = ddgShimMark;
       if (ImplClass[ddgShimMark] !== true) {
         throw new TypeError("implInstance must be an instance of a shimmed class");
       }
@@ -3541,10 +3583,11 @@
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {
-      if (node[sub] === 1) {
+      const next = node[sub];
+      if (next === 1) {
         return true;
-      } else if (node[sub]) {
-        node = node[sub];
+      } else if (next) {
+        node = next;
       } else {
         return false;
       }
@@ -4645,8 +4688,8 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
-        __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
+        const enabledFeatures = computeEnabledFeatures(__privateGet(this, _bundledConfig), site.domain, platform);
+        __privateGet(this, _args).featureSettings = parseFeatureSettings(__privateGet(this, _bundledConfig), enabledFeatures);
       }
     }
     /**
@@ -5039,8 +5082,7 @@
      */
     constructor(featureName, importConfig, features, args) {
       super(featureName, args);
-      /** @type {import('./utils.js').RemoteConfig | undefined} */
-      /** @type {import('../../messaging').Messaging} */
+      /** @type {import('../../messaging').Messaging | undefined} */
       // eslint-disable-next-line no-unused-private-class-members
       __privateAdd(this, _messaging);
       /** @type {boolean} */
@@ -5153,7 +5195,7 @@
       return this.args?.assets;
     }
     /**
-     * @returns {ImportMeta['trackerLookup']}
+     * @returns {import('./trackers.js').TrackerNode | {}}
      **/
     get trackerLookup() {
       return __privateGet(this, _importConfig).trackerLookup || {};
@@ -5265,6 +5307,9 @@
       const configSetting = this.getFeatureSetting(attrName);
       return processAttr(configSetting, defaultValue);
     }
+    /**
+     * @param {any} [_args]
+     */
     init(_args2) {
     }
     /**
@@ -5294,10 +5339,16 @@
     markFeatureAsSkipped(reason) {
       __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
+    /**
+     * @param {any} args
+     */
     setArgs(args) {
       this.args = args;
       this.platform = args.platform;
     }
+    /**
+     * @param {any} [_args]
+     */
     load(_args2) {
     }
     /**
@@ -5376,23 +5427,32 @@
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
-     * @param {string} propertyName
+     * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
     defineProperty(object, propertyName, descriptor) {
-      ["value", "get", "set"].forEach((k) => {
-        const descriptorProp = descriptor[k];
-        if (typeof descriptorProp === "function") {
-          const addDebugFlag = this.addDebugFlag.bind(this);
-          const wrapper = new Proxy2(descriptorProp, {
-            apply(_2, thisArg, argumentsList) {
-              addDebugFlag();
-              return Reflect2.apply(descriptorProp, thisArg, argumentsList);
-            }
-          });
-          descriptor[k] = wrapToString(wrapper, descriptorProp);
-        }
-      });
+      const addDebugFlag = this.addDebugFlag.bind(this);
+      const wrapWithDebugFlag = (fn) => {
+        const wrapper = new Proxy2(fn, {
+          apply(_2, thisArg, argumentsList) {
+            addDebugFlag();
+            return Reflect2.apply(fn, thisArg, argumentsList);
+          }
+        });
+        return (
+          /** @type {F} */
+          wrapToString(wrapper, fn)
+        );
+      };
+      if ("value" in descriptor && typeof descriptor.value === "function") {
+        descriptor.value = wrapWithDebugFlag(descriptor.value);
+      }
+      if ("get" in descriptor && typeof descriptor.get === "function") {
+        descriptor.get = wrapWithDebugFlag(descriptor.get);
+      }
+      if ("set" in descriptor && typeof descriptor.set === "function") {
+        descriptor.set = wrapWithDebugFlag(descriptor.set);
+      }
       return defineProperty(object, propertyName, descriptor);
     }
     /**
@@ -5409,7 +5469,7 @@
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
-     * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
      */
     wrapMethod(object, propertyName, wrapperFn) {
@@ -5428,7 +5488,7 @@
      * Define a missing standard property on a global (prototype) object. Only for data properties.
      * For constructors, use shimInterface().
      * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
-     * @template Base
+     * @template {object} Base
      * @template {keyof Base & string} K
      * @param {Base} instanceHost - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
      * @param {K} instanceProp - name of the property to shim (e.g. 'mediaSession')
@@ -9443,6 +9503,10 @@
   // src/dom-utils.js
   init_define_import_meta_trackerLookup();
   var Template = class _Template {
+    /**
+     * @param {readonly string[]} strings
+     * @param {unknown[]} values
+     */
     constructor(strings, values) {
       this.values = values;
       this.strings = strings;
@@ -9465,6 +9529,10 @@
       };
       return String(str).replace(/[&"'<>/]/g, (m) => replacements[m]);
     }
+    /**
+     * @param {unknown} value
+     * @returns {string | Template}
+     */
     potentiallyEscape(value) {
       if (typeof value === "object") {
         if (value instanceof Array) {
@@ -9475,7 +9543,10 @@
         }
         throw new Error("Unknown object to escape");
       }
-      return this.escapeXML(value);
+      return this.escapeXML(
+        /** @type {string} */
+        value
+      );
     }
     toString() {
       const result = [];
@@ -9495,8 +9566,14 @@
     return html([string]);
   }
   function createPolicy() {
-    if (globalThis.trustedTypes) {
-      return globalThis.trustedTypes?.createPolicy?.("ddg-default", { createHTML: (s) => s });
+    if (
+      /** @type {any} */
+      globalThis.trustedTypes
+    ) {
+      return (
+        /** @type {any} */
+        globalThis.trustedTypes?.createPolicy?.("ddg-default", { createHTML: (s) => s })
+      );
     }
     return {
       createHTML: (s) => s
@@ -11872,13 +11949,23 @@ ${iframeContent}
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
-    if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
+    const urlChangedInstance = new ContentFeature(
+      "urlChanged",
+      {},
+      {},
+      /** @type {any} */
+      {}
+    );
+    const nav = (
+      /** @type {any} */
+      globalThis.navigation
+    );
+    if (nav && "addEventListener" in nav) {
       const navigations = /* @__PURE__ */ new WeakMap();
-      globalThis.navigation.addEventListener("navigate", (event) => {
+      nav.addEventListener("navigate", (event) => {
         navigations.set(event.target, event.navigationType);
       });
-      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+      nav.addEventListener("navigatesuccess", (event) => {
         const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
@@ -11950,7 +12037,9 @@ ${iframeContent}
     if (!isHTMLDocument) {
       return;
     }
-    registerMessageSecret(args.messageSecret);
+    if (args.messageSecret) {
+      registerMessageSecret(args.messageSecret);
+    }
     initStringExemptionLists(args);
     const features = await getFeatures();
     await Promise.allSettled(
@@ -11990,7 +12079,7 @@ ${iframeContent}
   async function updateFeaturesInner(args) {
     const features = await getFeatures();
     Object.entries(features).forEach(([featureName, featureInstance2]) => {
-      if (!isFeatureBroken(initArgs, featureName) && featureInstance2.listenForUpdateChanges) {
+      if (initArgs && !isFeatureBroken(initArgs, featureName) && featureInstance2.listenForUpdateChanges) {
         featureInstance2.update(args);
       }
     });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -70,7 +70,7 @@
   var debug = false;
   function initStringExemptionLists(args) {
     const { stringExemptionLists } = args;
-    debug = args.debug;
+    debug = args.debug || false;
     for (const type in stringExemptionLists) {
       exemptionLists[type] = [];
       for (const stringExemption of stringExemptionLists[type]) {
@@ -115,6 +115,7 @@
   var lineTest = /(\()?(https?:[^)]+):[0-9]+:[0-9]+(\))?/;
   function getStackTraceUrls(stack) {
     const urls = new Set2();
+    if (!stack) return urls;
     try {
       const errorLines = stack.split("\n");
       for (const line of errorLines) {
@@ -140,6 +141,7 @@
       return false;
     }
     const stack = getStack();
+    if (!stack) return false;
     const errorFiles = getStackTraceUrls(stack);
     for (const path of errorFiles) {
       if (shouldExemptUrl(type, path.href)) {
@@ -252,8 +254,8 @@
     /**
      * @param {import('./content-feature').default} feature
      * @param {P} objectScope
-     * @param {string} property
-     * @param {ProxyObject<P>} proxyObject
+     * @param {K} property
+     * @param {ProxyObject<P, K>} proxyObject
      */
     constructor(feature, objectScope, property, proxyObject) {
       this.objectScope = objectScope;
@@ -299,7 +301,7 @@
     }
     // Actually apply the proxy to the native property
     overload() {
-      this.objectScope[this.property] = this.internal;
+      Reflect.set(this.objectScope, this.property, this.internal);
     }
     overloadDescriptor() {
       this.feature.defineProperty(this.objectScope, this.property, {
@@ -312,12 +314,9 @@
   };
   var maxCounter = /* @__PURE__ */ new Map();
   function numberOfTimesDebugged(feature) {
-    if (!maxCounter.has(feature)) {
-      maxCounter.set(feature, 1);
-    } else {
-      maxCounter.set(feature, maxCounter.get(feature) + 1);
-    }
-    return maxCounter.get(feature);
+    const current = maxCounter.get(feature) ?? 0;
+    maxCounter.set(feature, current + 1);
+    return current + 1;
   }
   var DEBUG_MAX_TIMES = 5e3;
   function postDebugMessage(feature, message, allowNonDebug = false) {
@@ -494,7 +493,10 @@
     "webInterferenceDetection"
   ];
   function isPlatformSpecificFeature(featureName) {
-    return platformSpecificFeatures.includes(featureName);
+    return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
   }
   function createCustomEvent(eventName, eventDetail) {
     return new OriginalCustomEvent(eventName, eventDetail);
@@ -732,9 +734,13 @@
     if (!origFn || typeof origFn !== "function") {
       throw new Error(`Property ${propertyName} does not look like a method`);
     }
-    const newFn = wrapToString(function() {
-      return wrapperFn.call(this, origFn, ...arguments);
-    }, origFn);
+    const newFn = wrapToString(
+      /** @this {any} */
+      function() {
+        return wrapperFn.call(this, origFn, ...arguments);
+      },
+      origFn
+    );
     definePropertyFn(object, propertyName, {
       ...origDescriptor,
       value: newFn
@@ -742,11 +748,12 @@
     return origDescriptor;
   }
   function shimInterface(interfaceName, ImplClass, options, definePropertyFn, injectName) {
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origInterfaceDescriptors) globalThis.origInterfaceDescriptors = {};
+      if (!g.origInterfaceDescriptors) g.origInterfaceDescriptors = {};
       const descriptor = Object.getOwnPropertyDescriptor(globalThis, interfaceName);
-      globalThis.origInterfaceDescriptors[interfaceName] = descriptor;
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origInterfaceDescriptors[interfaceName] = descriptor;
+      g.ddgShimMark = ddgShimMark;
     }
     const defaultOptions = {
       allowConstructorCall: false,
@@ -807,11 +814,12 @@
   }
   function shimProperty(baseObject, propertyName, implInstance, readOnly, definePropertyFn, injectName) {
     const ImplClass = implInstance.constructor;
+    const g = globalThis;
     if (injectName === "integration") {
-      if (!globalThis.origPropDescriptors) globalThis.origPropDescriptors = [];
+      if (!g.origPropDescriptors) g.origPropDescriptors = [];
       const descriptor2 = Object.getOwnPropertyDescriptor(baseObject, propertyName);
-      globalThis.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
-      globalThis.ddgShimMark = ddgShimMark;
+      g.origPropDescriptors.push([baseObject, propertyName, descriptor2]);
+      g.ddgShimMark = ddgShimMark;
       if (ImplClass[ddgShimMark] !== true) {
         throw new TypeError("implInstance must be an instance of a shimmed class");
       }
@@ -2102,10 +2110,11 @@
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {
-      if (node[sub] === 1) {
+      const next = node[sub];
+      if (next === 1) {
         return true;
-      } else if (node[sub]) {
-        node = node[sub];
+      } else if (next) {
+        node = next;
       } else {
         return false;
       }
@@ -3187,8 +3196,8 @@
       __privateSet(this, _bundledConfig, bundledConfig);
       __privateSet(this, _args, args);
       if (__privateGet(this, _bundledConfig) && __privateGet(this, _args)) {
-        const enabledFeatures = computeEnabledFeatures(bundledConfig, site.domain, platform);
-        __privateGet(this, _args).featureSettings = parseFeatureSettings(bundledConfig, enabledFeatures);
+        const enabledFeatures = computeEnabledFeatures(__privateGet(this, _bundledConfig), site.domain, platform);
+        __privateGet(this, _args).featureSettings = parseFeatureSettings(__privateGet(this, _bundledConfig), enabledFeatures);
       }
     }
     /**
@@ -3581,8 +3590,7 @@
      */
     constructor(featureName, importConfig, features, args) {
       super(featureName, args);
-      /** @type {import('./utils.js').RemoteConfig | undefined} */
-      /** @type {import('../../messaging').Messaging} */
+      /** @type {import('../../messaging').Messaging | undefined} */
       // eslint-disable-next-line no-unused-private-class-members
       __privateAdd(this, _messaging);
       /** @type {boolean} */
@@ -3695,7 +3703,7 @@
       return this.args?.assets;
     }
     /**
-     * @returns {ImportMeta['trackerLookup']}
+     * @returns {import('./trackers.js').TrackerNode | {}}
      **/
     get trackerLookup() {
       return __privateGet(this, _importConfig).trackerLookup || {};
@@ -3807,6 +3815,9 @@
       const configSetting = this.getFeatureSetting(attrName);
       return processAttr(configSetting, defaultValue);
     }
+    /**
+     * @param {any} [_args]
+     */
     init(_args2) {
     }
     /**
@@ -3836,10 +3847,16 @@
     markFeatureAsSkipped(reason) {
       __privateGet(this, _ready).resolve({ status: "skipped", reason });
     }
+    /**
+     * @param {any} args
+     */
     setArgs(args) {
       this.args = args;
       this.platform = args.platform;
     }
+    /**
+     * @param {any} [_args]
+     */
     load(_args2) {
     }
     /**
@@ -3918,23 +3935,32 @@
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
-     * @param {string} propertyName
+     * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
     defineProperty(object, propertyName, descriptor) {
-      ["value", "get", "set"].forEach((k) => {
-        const descriptorProp = descriptor[k];
-        if (typeof descriptorProp === "function") {
-          const addDebugFlag = this.addDebugFlag.bind(this);
-          const wrapper = new Proxy2(descriptorProp, {
-            apply(_2, thisArg, argumentsList) {
-              addDebugFlag();
-              return Reflect2.apply(descriptorProp, thisArg, argumentsList);
-            }
-          });
-          descriptor[k] = wrapToString(wrapper, descriptorProp);
-        }
-      });
+      const addDebugFlag = this.addDebugFlag.bind(this);
+      const wrapWithDebugFlag = (fn) => {
+        const wrapper = new Proxy2(fn, {
+          apply(_2, thisArg, argumentsList) {
+            addDebugFlag();
+            return Reflect2.apply(fn, thisArg, argumentsList);
+          }
+        });
+        return (
+          /** @type {F} */
+          wrapToString(wrapper, fn)
+        );
+      };
+      if ("value" in descriptor && typeof descriptor.value === "function") {
+        descriptor.value = wrapWithDebugFlag(descriptor.value);
+      }
+      if ("get" in descriptor && typeof descriptor.get === "function") {
+        descriptor.get = wrapWithDebugFlag(descriptor.get);
+      }
+      if ("set" in descriptor && typeof descriptor.set === "function") {
+        descriptor.set = wrapWithDebugFlag(descriptor.set);
+      }
       return defineProperty(object, propertyName, descriptor);
     }
     /**
@@ -3951,7 +3977,7 @@
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
-     * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
      */
     wrapMethod(object, propertyName, wrapperFn) {
@@ -3970,7 +3996,7 @@
      * Define a missing standard property on a global (prototype) object. Only for data properties.
      * For constructors, use shimInterface().
      * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
-     * @template Base
+     * @template {object} Base
      * @template {keyof Base & string} K
      * @param {Base} instanceHost - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
      * @param {K} instanceProp - name of the property to shim (e.g. 'mediaSession')
@@ -4138,13 +4164,23 @@
     }
   }
   function listenForURLChanges() {
-    const urlChangedInstance = new ContentFeature("urlChanged", {}, {}, {});
-    if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
+    const urlChangedInstance = new ContentFeature(
+      "urlChanged",
+      {},
+      {},
+      /** @type {any} */
+      {}
+    );
+    const nav = (
+      /** @type {any} */
+      globalThis.navigation
+    );
+    if (nav && "addEventListener" in nav) {
       const navigations = /* @__PURE__ */ new WeakMap();
-      globalThis.navigation.addEventListener("navigate", (event) => {
+      nav.addEventListener("navigate", (event) => {
         navigations.set(event.target, event.navigationType);
       });
-      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+      nav.addEventListener("navigatesuccess", (event) => {
         const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
@@ -4216,7 +4252,9 @@
     if (!isHTMLDocument) {
       return;
     }
-    registerMessageSecret(args.messageSecret);
+    if (args.messageSecret) {
+      registerMessageSecret(args.messageSecret);
+    }
     initStringExemptionLists(args);
     const features = await getFeatures();
     await Promise.allSettled(
@@ -4256,7 +4294,7 @@
   async function updateFeaturesInner(args) {
     const features = await getFeatures();
     Object.entries(features).forEach(([featureName, featureInstance]) => {
-      if (!isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
+      if (initArgs && !isFeatureBroken(initArgs, featureName) && featureInstance.listenForUpdateChanges) {
         featureInstance.update(args);
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.53.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.53.0.tgz",
-      "integrity": "sha512-mYPQOCXd0xcBMNmDDaV+sqACo/pfVvu4vAR7MzfWvByW+znpkRIgODduIlMIyQnk+7hL4PiC6EcL2g4deiMVOw==",
+      "version": "14.54.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.54.0.tgz",
+      "integrity": "sha512-Khb/2zRhzzUojf4LfteXmiqaTKGxoe9FcvaskihxeRdOsTNPWpIWWu+V9CosxdkWu47OPlnzRbtegjkXi2YadQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7cd3f9438234a82dd5561cf98c0b7d0633512b62",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#48f06000707dc4eb3a5703374791b1e9056ad385",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.0.tgz",
-      "integrity": "sha512-AdqTWU8IUwJDkuJ5KVzWeL8GtRfIde+M0HOLs5TW8ezQy/gvVpL1J90V/SUwDRO2Ay3Wj1B3ZHE15Kv0tRRPEA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.1.tgz",
+      "integrity": "sha512-/cQTMJRd4/7zpgFHWqe+9wqiRPGTy+BhqfkxplvejPgq8d6spBjC6bSJV61rVHJZw5F4KOO5ReKOvuguaKG28A==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.14.0",
-        "@ghostery/adblocker-extended-selectors": "^2.14.0",
+        "@ghostery/adblocker-content": "^2.14.1",
+        "@ghostery/adblocker-extended-selectors": "^2.14.1",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.0.tgz",
-      "integrity": "sha512-XCgGu+b4spvPHMhrqKaAG4NAe6NzGsqj54rNRXpDnCJZowTCuBr2DXfqtLbKlHWy0XBsuoDjP0gddtm7XA27+w==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.1.tgz",
+      "integrity": "sha512-hDE6RAL9xgQonJQiK1knOHy527PEwlAuvKaha4snE0XO6Vmtk0HThce1M2JFVRxGayWR3nTxoWbvEfGWXU7O/A==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.14.0"
+        "@ghostery/adblocker-extended-selectors": "^2.14.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.0.tgz",
-      "integrity": "sha512-kmFfyo71FUPdi4OMeNo65JcGZgZZGHU9DOfCYCmBupwVhxU9P4zC12/bGx1vC+RNd3jkqUBKmQ3lTTK+yYfu2Q==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.1.tgz",
+      "integrity": "sha512-3RARO2ukDrfwDqVEMD+HKZIwsM9QjjII+U1zqxhLXZ0dZRHjbtUHlZCsokqfjZ1JAa3ZVKcZrF0nZv5SA2LgyA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run