### PR TITLE
Add naming dialog before adding page to home screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1890,6 +1890,11 @@ class BrowserTabFragment :
     }
 
     private fun showAddHomeShortcutDialog(command: Command.ShowAddHomeShortcutDialog) {
+        if (!isActiveCustomTab() && !isActiveTab) {
+            logcat(VERBOSE) { "Will not launch a dialog for an inactive tab" }
+            return
+        }
+
         val dialogBinding = DialogAddHomeShortcutBinding.inflate(layoutInflater)
         dialogBinding.shortcutNameInput.text = command.title
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -120,6 +120,7 @@ import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.customtabs.CustomTabActivity
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.customtabs.CustomTabViewModel.Companion.CUSTOM_TAB_NAME_PREFIX
+import com.duckduckgo.app.browser.databinding.DialogAddHomeShortcutBinding
 import com.duckduckgo.app.browser.databinding.FragmentBrowserTabBinding
 import com.duckduckgo.app.browser.databinding.HttpAuthenticationBinding
 import com.duckduckgo.app.browser.downloader.BlobConverterInjector
@@ -1888,6 +1889,30 @@ class BrowserTabFragment :
         shortcutBuilder.requestPinShortcut(context, homeShortcut)
     }
 
+    private fun showAddHomeShortcutDialog(command: Command.ShowAddHomeShortcutDialog) {
+        val dialogBinding = DialogAddHomeShortcutBinding.inflate(layoutInflater)
+        dialogBinding.shortcutNameInput.text = command.title
+
+        CustomAlertDialogBuilder(requireActivity())
+            .setTitle(R.string.addToHomeShortcutDialogTitle)
+            .setPositiveButton(R.string.addToHomeShortcutDialogAdd)
+            .setNegativeButton(R.string.addToHomeShortcutDialogCancel)
+            .setView(dialogBinding)
+            .addEventListener(
+                object : CustomAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        val name = dialogBinding.shortcutNameInput.text.ifBlank { command.title }
+                        viewModel.onPinPageToHomeConfirmed(name, command.url, command.icon)
+                    }
+
+                    override fun onDialogShown() {
+                        dialogBinding.shortcutNameInput.showKeyboardDelayed()
+                    }
+                },
+            )
+            .show()
+    }
+
     private fun configureObservers() {
         viewModel.autoCompleteViewState.observe(
             viewLifecycleOwner,
@@ -2493,6 +2518,10 @@ class BrowserTabFragment :
             is Command.ShowImageCamera -> launchCameraCapture(it.filePathCallback, it.fileChooserParams, MediaStore.ACTION_IMAGE_CAPTURE)
             is Command.ShowVideoCamera -> launchCameraCapture(it.filePathCallback, it.fileChooserParams, MediaStore.ACTION_VIDEO_CAPTURE)
             is Command.ShowSoundRecorder -> launchCameraCapture(it.filePathCallback, it.fileChooserParams, MediaStore.Audio.Media.RECORD_SOUND_ACTION)
+
+            is Command.ShowAddHomeShortcutDialog -> {
+                showAddHomeShortcutDialog(it)
+            }
 
             is Command.AddHomeShortcut -> {
                 context?.let { context ->

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -137,6 +137,7 @@ import com.duckduckgo.app.browser.commands.Command.SendSms
 import com.duckduckgo.app.browser.commands.Command.SetBrowserBackground
 import com.duckduckgo.app.browser.commands.Command.SetOnboardingDialogBackground
 import com.duckduckgo.app.browser.commands.Command.ShareLink
+import com.duckduckgo.app.browser.commands.Command.ShowAddHomeShortcutDialog
 import com.duckduckgo.app.browser.commands.Command.ShowAppLinkPrompt
 import com.duckduckgo.app.browser.commands.Command.ShowAutoconsentAnimation
 import com.duckduckgo.app.browser.commands.Command.ShowBackNavigationHistory
@@ -3078,17 +3079,16 @@ class BrowserTabViewModel @Inject constructor(
     @SuppressLint("CheckResult")
     fun onPinPageToHomeSelected() {
         val currentPage = url ?: return
-        val title =
-            if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(currentPage)) {
-                duckDuckGoUrlDetector.extractQuery(currentPage) ?: currentPage
-            } else {
-                currentPage.toUri().baseHost ?: currentPage
-            }
+        val defaultTitle = title ?: currentPage.toUri().baseHost ?: currentPage
 
         viewModelScope.launch {
             val favicon: Bitmap? = faviconManager.loadFromDisk(tabId = tabId, url = currentPage)
-            command.value = AddHomeShortcut(title, currentPage, favicon)
+            command.value = ShowAddHomeShortcutDialog(defaultTitle, currentPage, favicon)
         }
+    }
+
+    fun onPinPageToHomeConfirmed(title: String, url: String, icon: Bitmap?) {
+        command.value = AddHomeShortcut(title, url, icon)
     }
 
     fun onBrowserMenuClicked(isCustomTab: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3079,7 +3079,7 @@ class BrowserTabViewModel @Inject constructor(
     @SuppressLint("CheckResult")
     fun onPinPageToHomeSelected() {
         val currentPage = url ?: return
-        val defaultTitle = title ?: currentPage.toUri().baseHost ?: currentPage
+        val defaultTitle = title.takeUnless { it.isNullOrBlank() } ?: currentPage.toUri().baseHost ?: currentPage
 
         viewModelScope.launch {
             val favicon: Bitmap? = faviconManager.loadFromDisk(tabId = tabId, url = currentPage)

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -229,6 +229,12 @@ sealed class Command {
         val extractedUrl: String,
     ) : Command()
 
+    class ShowAddHomeShortcutDialog(
+        val title: String,
+        val url: String,
+        val icon: Bitmap? = null,
+    ) : Command()
+
     class AddHomeShortcut(
         val title: String,
         val url: String,

--- a/app/src/main/res/layout/dialog_add_home_shortcut.xml
+++ b/app/src/main/res/layout/dialog_add_home_shortcut.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextInput
+            android:id="@+id/shortcutNameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/addToHomeShortcutDialogHint"
+            app:type="single_line"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,10 @@
 
     <!-- Home Screen Shortcuts -->
 
+    <string name="addToHomeShortcutDialogTitle">Add to Home Screen</string>
+    <string name="addToHomeShortcutDialogHint">Shortcut name</string>
+    <string name="addToHomeShortcutDialogAdd">Add</string>
+    <string name="addToHomeShortcutDialogCancel">Cancel</string>
     <string name="shortcutAddedText" instruction="Placeholder is the name of a website">Success! %1$s has been added to your home screen.</string>
 
     <!-- User Survey -->

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3825,7 +3825,7 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenOnPinPageToHomeSelectedThenAddHomeShortcutCommandIssuedWithFavicon() =
+    fun whenOnPinPageToHomeSelectedThenShowAddHomeShortcutDialogCommandIssuedWithFavicon() =
         runTest {
             val url = exampleUrl
             val bitmap: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)
@@ -3834,15 +3834,15 @@ class BrowserTabViewModelTest {
 
             testee.onPinPageToHomeSelected()
 
-            assertCommandIssued<Command.AddHomeShortcut> {
+            assertCommandIssued<Command.ShowAddHomeShortcutDialog> {
                 assertEquals(bitmap, this.icon)
                 assertEquals(url, this.url)
-                assertEquals("example.com", this.title)
+                assertEquals("A title", this.title)
             }
         }
 
     @Test
-    fun whenOnPinPageToHomeSelectedAndFaviconDoesNotExistThenAddHomeShortcutCommandIssuedWithoutFavicon() =
+    fun whenOnPinPageToHomeSelectedAndFaviconDoesNotExistThenShowAddHomeShortcutDialogCommandIssuedWithoutFavicon() =
         runTest {
             val url = exampleUrl
             whenever(mockFaviconManager.loadFromDisk(any(), any())).thenReturn(null)
@@ -3850,10 +3850,10 @@ class BrowserTabViewModelTest {
 
             testee.onPinPageToHomeSelected()
 
-            assertCommandIssued<Command.AddHomeShortcut> {
+            assertCommandIssued<Command.ShowAddHomeShortcutDialog> {
                 assertNull(this.icon)
                 assertEquals(url, this.url)
-                assertEquals("example.com", this.title)
+                assertEquals("A title", this.title)
             }
         }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                               
  - When the user taps "Add to Home Screen" from the browser menu, a dialog now appears with an editable text field pre-filled with the page title
  - The user can customize the shortcut name before confirming, or cancel to abort
  - The dialog follows existing codebase patterns using `CustomAlertDialogBuilder` with `DaxTextInput`

  Closes #6793

  ## Changes
  - Added `ShowAddHomeShortcutDialog` command to show the naming dialog before creating the shortcut
  - Modified `onPinPageToHomeSelected()` to emit the dialog command instead of directly creating the shortcut
  - Added `onPinPageToHomeConfirmed()` to handle the user's confirmed name
  - Created `dialog_add_home_shortcut.xml` layout with a `DaxTextInput` field
  - Added string resources for the dialog (title, hint, buttons)
  - Updated existing unit tests to reflect the new flow

  ## Test plan
  - [ ] Open any webpage in the browser
  - [ ] Tap the three-dot menu → "Add to Home Screen"
  - [ ] Verify a dialog appears with the page title pre-filled and keyboard shown
  - [ ] Edit the name and tap "Add" → verify the shortcut is created with the custom name
  - [ ] Repeat and tap "Cancel" → verify no shortcut is created
  - [ ] Verify the shortcut name on the home screen matches what was entered
  - [ ] Test with a DuckDuckGo search results page
  - [ ] Test with a page that has no title (falls back to domain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/UX flow change around shortcut creation with limited surface area and no security- or data-sensitive logic changes.
> 
> **Overview**
> Adds a new confirmation flow for *Add to Home Screen*: selecting the menu action now emits `ShowAddHomeShortcutDialog`, displaying a dialog with an editable, pre-filled shortcut name and auto-shown keyboard.
> 
> On confirmation, the entered (or default) name is passed back to the `BrowserTabViewModel` via `onPinPageToHomeConfirmed` to issue the existing `AddHomeShortcut` command; includes a new `dialog_add_home_shortcut.xml` layout, dialog strings, and updated unit tests to match the new command/title behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92f9a514a3a7f9382c2c73d9705c02da2185f8ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->