### PR TITLE
build(native): make NDK outputs path-stable

### DIFF
--- a/anrs/anrs-impl/CMakeLists.txt
+++ b/anrs/anrs-impl/CMakeLists.txt
@@ -20,6 +20,14 @@ find_library( # Sets the name of the path variable.
         # you want CMake to locate.
         log)
 
+# Normalize source/build paths in debug metadata so native outputs are reproducible
+# across different checkout locations.
+target_compile_options(
+       crash-ndk
+       PRIVATE
+       "-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=."
+       "-fdebug-prefix-map=${CMAKE_BINARY_DIR}=.")
+
 target_link_libraries(
         # Specifies the target library.
        crash-ndk
@@ -31,5 +39,6 @@ target_link_libraries(
 target_link_options(
        crash-ndk
        PRIVATE
+       "-Wl,--build-id=none"
        "-Wl,-z,common-page-size=16384"
        "-Wl,-z,max-page-size=16384")

--- a/httpsupgrade/httpsupgrade-impl/CMakeLists.txt
+++ b/httpsupgrade/httpsupgrade-impl/CMakeLists.txt
@@ -37,8 +37,17 @@ find_library( # Sets the name of the path variable.
         # you want CMake to locate.
         log)
 
+# Normalize source/build paths in debug metadata so native outputs are reproducible
+# across different checkout locations.
+target_compile_options(
+       https-bloom-lib
+       PRIVATE
+       "-fdebug-prefix-map=${CMAKE_SOURCE_DIR}=."
+       "-fdebug-prefix-map=${CMAKE_BINARY_DIR}=.")
+
 target_link_options(
        https-bloom-lib
        PRIVATE
+       "-Wl,--build-id=none"
        "-Wl,-z,common-page-size=16384"
        "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213227245294013

### Description
NDK Debug C/C++ builds were producing location-dependent .so files. Absolute source/build paths were embedded in debug metadata and linker-generated GNU build IDs varied by build location, which changed JNI artifacts between equivalent checkouts.

Apply target-specific reproducibility flags in both native modules: add -fdebug-prefix-map for CMAKE_SOURCE_DIR/CMAKE_BINARY_DIR and set -Wl,--build-id=none.

Updated targets: crash-ndk (anrs-impl) and https-bloom-lib (httpsupgrade-impl). This stabilizes stripped native library bytes across checkout paths and prevents downstream lint/local AAR input drift that triggers cache misses.

Thanks for the contribution, @ribafish !

### Steps to test this PR

- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-system-only changes limited to native CMake flags; main risk is unexpected toolchain/linker incompatibility or debugging metadata differences.
> 
> **Overview**
> Ensures Android NDK shared libraries are *path-stable/reproducible* across different checkout locations.
> 
> Updates both native modules (`crash-ndk` and `https-bloom-lib`) to normalize source/build paths embedded in debug metadata via `-fdebug-prefix-map`, and disables linker-generated build IDs with `-Wl,--build-id=none` to prevent location-dependent `.so` byte differences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09e85f864b99d18900bcb67a291329c77fc265e8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->