### PR TITLE
Fix input screen OnGlobalLayoutListener IllegalStateException

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -184,8 +184,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         globalLayoutListener =
             ViewTreeObserver.OnGlobalLayoutListener {
                 val r = Rect()
-                binding.root.getWindowVisibleDisplayFrame(r)
-                val screenHeight = binding.root.rootView.height
+                if (!view.isAttachedToWindow) return@OnGlobalLayoutListener
+                view.getWindowVisibleDisplayFrame(r)
+                val screenHeight = view.rootView.height
                 val keypadHeight = screenHeight - r.bottom
 
                 val previouslyVisible = isKeyboardCurrentlyVisible
@@ -196,11 +197,13 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                         logcat { "inputScreenLauncher: Keyboard shown (GlobalLayout)" }
                     } else {
                         logcat { "inputScreenLauncher: Keyboard hidden (GlobalLayout)" }
-                        inputModeWidget.clearInputFocus()
+                        if (::inputModeWidget.isInitialized) {
+                            inputModeWidget.clearInputFocus()
+                        }
                     }
                 }
             }
-        binding.root.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+        view.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
 
         inputModeWidget =
             InputModeWidget(requireContext()).also {
@@ -306,7 +309,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         binding.newTabContainerScrollView.animate().cancel()
         binding.viewPager.unregisterOnPageChangeCallback(pageChangeCallback)
         globalLayoutListener?.let {
-            binding.root.viewTreeObserver.removeOnGlobalLayoutListener(it)
+            view?.viewTreeObserver?.removeOnGlobalLayoutListener(it)
         }
         globalLayoutListener = null
         super.onDestroyView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213278865716051

### Description

- Fixes an `IllegalStateException` when hiding the keyboard on the input screen.

### Steps to test this PR

- [ ] Open the input screen and focus the input
- [ ] Hide the keyboard
- [ ] Verify that the input loses focus

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle-safety changes to a keyboard visibility listener; low risk aside from potentially missing a focus-clear in edge timing cases.
> 
> **Overview**
> Prevents `InputScreenFragment` from running keyboard-visibility `OnGlobalLayoutListener` logic when the fragment view is no longer attached, avoiding lifecycle-related `IllegalStateException`s.
> 
> The listener is now registered/unregistered on the `view` (not `binding.root`), uses `view.getWindowVisibleDisplayFrame`, and guards `inputModeWidget.clearInputFocus()` behind `::inputModeWidget.isInitialized` to avoid accessing views/widgets after teardown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a9fe32edff3cc0ce696aabab71cf1e544b69b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213278865716051