### PR TITLE
PIR: Allow 1 retry to all actions during scan

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
-import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.duckduckgo.pir.impl.scripts.models.asActionType
@@ -105,8 +104,8 @@ class BrokerActionFailedEventHandler @Inject constructor(
             // for optout, for ANY action we retry at most 3 times
             state.actionRetryCount < MAX_RETRY_COUNT_OPTOUT
         } else {
-            // For scans, we ONLY retry once if the action is expectation
-            (currentAction is Expectation && state.actionRetryCount < MAX_RETRY_COUNT_SCAN)
+            // For scans, we ONLY retry once
+            state.actionRetryCount < MAX_RETRY_COUNT_SCAN
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -286,7 +286,7 @@ class BrokerActionFailedEventHandlerTest {
     }
 
     @Test
-    fun whenScanNonExpectationActionFailedThenFailsImmediately() = runTest {
+    fun whenScanNonExpectationActionFailedThenRetryOnce() = runTest {
         val scanStep = ScanStep(
             broker = testBroker,
             step = ScanStepActions(
@@ -311,10 +311,10 @@ class BrokerActionFailedEventHandlerTest {
 
         val result = testee.invoke(state, event)
 
-        val nextEvent = result.nextEvent as BrokerStepCompleted
-        assertEquals(false, nextEvent.needsEmailConfirmation)
-        val stepStatus = nextEvent.stepStatus as Failure
-        assertEquals(testError, stepStatus.error)
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(1, result.nextState.actionRetryCount)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213296574890082 

### Description
See attached task description

### Steps to test this PR
Smoke test PIR and observe that scan finishes and finds profiles as normal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR scan error-handling behavior to retry more cases, which can alter scan completion timing and potentially repeat side-effecting actions; limited in scope to the scan failure handler and covered by updated unit tests.
> 
> **Overview**
> Allows PIR *scan* runs to retry a failed broker action **once regardless of action type** (previously restricted to `Expectation` actions) when `allowRetry` is true.
> 
> Updates `BrokerActionFailedEventHandler` retry gating to remove the `Expectation` check, and adjusts tests to assert that non-expectation scan actions now re-dispatch `ExecuteBrokerStepAction` with an incremented retry count instead of failing the broker step immediately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca09539116158fc37bec0707c950b7742090f6e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->