### PR TITLE
Return early in onUserSubmittedQuery coroutine if state is Invalidated

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1260,6 +1260,10 @@ class BrowserTabViewModel @Inject constructor(
                     withContext(dispatchers.io()) {
                         queryUrlConverter.convertQueryToUrl(trimmedInput, verticalParameter, queryOrigin)
                     }
+                if (currentGlobalLayoutState() is Invalidated) {
+                    recoverTabWithQuery(query)
+                    return@launch
+                }
 
                 when (val type = specialUrlDetector.determineType(trimmedInput)) {
                     is ShouldLaunchDuckChatLink -> {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1440,6 +1440,20 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenGlobalLayoutInvalidatedDuringQueryConversionThenOpenInNewTabAndStateRemainsInvalidated() {
+        givenOneActiveTabSelected()
+        whenever(mockOmnibarConverter.convertQueryToUrl(any(), anyOrNull(), any(), any())).thenAnswer {
+            testee.recoverFromRenderProcessGone()
+            "foo.com"
+        }
+
+        testee.onUserSubmittedQuery("foo")
+
+        assertCommandIssued<Command.OpenInNewTab>()
+        assertTrue(testee.globalLayoutState.value is GlobalLayoutViewState.Invalidated)
+    }
+
+    @Test
     fun whenBrowsingAndUrlLoadedThenSiteVisitedEntryAddedToLeaderboardDao() =
         runTest {
             loadUrl("http://example.com/abc", isBrowserShowing = true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213310129933673

### Description

- Fix for `BrowserTabFragmentRenderer.renderGlobalViewState` `IllegalStateException`: https://app.asana.com/1/137249556945/task/1213295005578646

### Steps to test this PR

- [x] Submit a query in the omnibar
- [x] Verify it works as expected


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change gated on `GlobalLayoutViewState.Invalidated`, plus a focused unit test; main risk is unintended early-return masking navigation in edge cases.
> 
> **Overview**
> Prevents `onUserSubmittedQuery` from continuing navigation/state updates if the tab’s global layout becomes `Invalidated` while the query is being converted to a URL (e.g., after a render process crash). The coroutine now **returns early** by calling `recoverTabWithQuery(query)` to close the broken tab and reopen the query in a new tab.
> 
> Adds a regression test covering the mid-conversion invalidation case and asserting the `OpenInNewTab` command is issued while the `Invalidated` state is preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccac1e04d260b4b8ad439a8988caa5e1f21bd787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->