### PR TITLE
PIR: Fix shared webview being destroyed in PIR debug runs

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirOptOut.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirOptOut.kt
@@ -307,7 +307,7 @@ class RealPirOptOut @Inject constructor(
         allSteps.forEach { (profileQuery, step) ->
             logcat { "PIR-OPT-OUT: Start thread=${Thread.currentThread().name}, profile=$profileQuery and step=$step" }
             runners[0].startOn(webView, profileQuery, listOf(step))
-            runners[0].stop()
+            // don't call stop() here to avoid destroying the WebView as it's reused for all steps
             logcat { "PIR-OPT-OUT: Finish thread=${Thread.currentThread().name}, profile=$profileQuery and step=$step" }
         }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScan.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScan.kt
@@ -235,7 +235,7 @@ class RealPirScan @Inject constructor(
         allSteps.forEach { (profileQuery, step) ->
             logcat { "PIR-SCAN: Start thread=${Thread.currentThread().name}, profile=$profileQuery and step=$step" }
             runners[0].startOn(webView, profileQuery, listOf(step))
-            runners[0].stop()
+            // don't call stop() here to avoid destroying the WebView as it's reused for all steps
             logcat { "PIR-SCAN: Finish thread=${Thread.currentThread().name}, profile=$profileQuery and step=$step" }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212923242657599

### Description
Shared WebView that is passed to a PIR runner was destroyed between jobs. This delegates the cleanup to the owner of the WebView (activity) instead of to the runner.

### Steps to test this PR
QA optional - can run debug scans or opt-outs

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, debug-only control-flow change that avoids calling runner cleanup which destroys the shared WebView; low blast radius outside debug runs.
> 
> **Overview**
> Prevents PIR *debug* scan/opt-out flows from destroying the caller-provided (shared) `WebView` between sequential steps.
> 
> In `RealPirScan.debugExecute` and `RealPirOptOut.debugExecute`, removes the per-step `runners[0].stop()` call (with an explanatory comment), leaving WebView lifecycle/cleanup to the debug WebView owner while still cleaning WebView data at the end of the run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3343a963098e4c1c77ff230c7de1b7adf960ded. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->