### PR TITLE
Refine pixels for syncing duck ai chats

### DIFF
--- a/PixelDefinitions/pixels/sync.json5
+++ b/PixelDefinitions/pixels/sync.json5
@@ -38,5 +38,12 @@
                 "type": "string"
             }
         ]
+    },
+    "sync_ai_chat_active": {
+        "description": "Fired daily when AI Chat sync is used (via getScopedSyncAuthToken, encrypt, or decrypt), shows enrolled Sync devices using AI Chat",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/DecryptWithSyncMasterKeyHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/DecryptWithSyncMasterKeyHandler.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugi
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.DuckChatConstants
 import com.duckduckgo.duckchat.impl.DuckChatConstants.HOST_DUCK_AI
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
@@ -40,6 +41,7 @@ import javax.inject.Inject
 class DecryptWithSyncMasterKeyHandler @Inject constructor(
     private val crypto: SyncCrypto,
     private val deviceSyncState: DeviceSyncState,
+    private val duckChatPixels: DuckChatPixels,
 ) : ContentScopeJsMessageHandlersPlugin {
 
     override fun getJsMessageHandler(): JsMessageHandler =
@@ -94,6 +96,7 @@ class DecryptWithSyncMasterKeyHandler @Inject constructor(
                 val decryptedData = Base64.encodeToString(decryptedBytes, Base64.NO_WRAP).applyUrlSafetyFromB64()
 
                 logcat { "DuckChat-Sync: Decrypted data successfully" }
+                duckChatPixels.reportChatSyncActive()
 
                 // send decrypted data back to JS
                 val payload = JSONObject().apply { put(RESPONSE_KEY_DECRYPTED_DATA, decryptedData) }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandler.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugi
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.DuckChatConstants
 import com.duckduckgo.duckchat.impl.DuckChatConstants.HOST_DUCK_AI
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
@@ -40,6 +41,7 @@ import javax.inject.Inject
 class EncryptWithSyncMasterKeyHandler @Inject constructor(
     private val crypto: SyncCrypto,
     private val deviceSyncState: DeviceSyncState,
+    private val duckChatPixels: DuckChatPixels,
 ) : ContentScopeJsMessageHandlersPlugin {
 
     override fun getJsMessageHandler(): JsMessageHandler =
@@ -94,6 +96,7 @@ class EncryptWithSyncMasterKeyHandler @Inject constructor(
                 val encryptedData = Base64.encodeToString(encryptedBytes, Base64.NO_WRAP).applyUrlSafetyFromB64()
 
                 logcat { "DuckChat-Sync: Encrypted data successfully" }
+                duckChatPixels.reportChatSyncActive()
 
                 // send encrypted data back to JS
                 val payload = JSONObject().apply { put(RESPONSE_KEY_ENCRYPTED_DATA, encryptedData) }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -133,6 +133,8 @@ interface DuckChatPixels {
     fun reportContextualSummarizePromptSelected()
     fun reportContextualPlaceholderContextTapped()
     fun reportContextualPlaceholderContextShown()
+
+    fun reportChatSyncActive()
 }
 
 @ContributesBinding(AppScope::class)
@@ -309,6 +311,10 @@ class RealDuckChatPixels @Inject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY, type = Pixel.PixelType.Daily())
         }
     }
+
+    override fun reportChatSyncActive() {
+        pixel.fire(DuckChatPixelName.SYNC_AI_CHAT_ACTIVE, type = Pixel.PixelType.Daily())
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -428,6 +434,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_COUNT("m_aichat_settings_auto_context_disabled_count"),
     DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_DAILY("m_aichat_settings_auto_context_disabled_daily"),
     DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DAILY("m_aichat_settings_auto_context"),
+
+    SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
 }
 
 object DuckChatPixelParameters {
@@ -551,6 +559,7 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/sync/EncryptWithSyncMasterKeyHandlerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.messaging.sync
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.duckchat.impl.DuckChatConstants.HOST_DUCK_AI
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -45,6 +46,7 @@ class EncryptWithSyncMasterKeyHandlerTest {
     private val mockCrypto: SyncCrypto = mock()
     private val mockDeviceSyncState: DeviceSyncState = mock()
     private val mockJsMessaging: JsMessaging = mock()
+    private val mockDuckChatPixels: DuckChatPixels = mock()
 
     val callbackDataCaptor = argumentCaptor<JsCallbackData>()
 
@@ -55,6 +57,7 @@ class EncryptWithSyncMasterKeyHandlerTest {
         handler = EncryptWithSyncMasterKeyHandler(
             crypto = mockCrypto,
             deviceSyncState = mockDeviceSyncState,
+            duckChatPixels = mockDuckChatPixels,
         )
     }
 
@@ -188,6 +191,18 @@ class EncryptWithSyncMasterKeyHandlerTest {
         assertEquals(FEATURE_NAME, response.featureName)
         assertEquals(METHOD_NAME, response.method)
         verifySuccessResponse(response.params)
+    }
+
+    @Test
+    fun `when encryption succeeds then ai chat sync active pixel is fired`() {
+        configureSyncEnabled()
+        configureSignedIn()
+        whenever(mockCrypto.encrypt(any<ByteArray>())).thenReturn(ENCRYPTED_BYTES)
+        val jsMessage = createJsMessage(TEST_MESSAGE_ID, JSONObject().apply { put("data", BASE64_URL_DATA) })
+
+        handler.getJsMessageHandler().process(jsMessage, mockJsMessaging, null)
+
+        verify(mockDuckChatPixels).reportChatSyncActive()
     }
 
     private fun configureSyncEnabled() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -329,4 +329,11 @@ class RealDuckChatPixelsTest {
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT)
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY, type = Pixel.PixelType.Daily())
     }
+
+    @Test
+    fun `when reportChatSyncActive then fires daily pixel`() {
+        testee.reportChatSyncActive()
+
+        verify(mockPixel).fire(DuckChatPixelName.SYNC_AI_CHAT_ACTIVE, emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
+    }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandler.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandler.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.sync.api.DeviceSyncState
 import com.duckduckgo.sync.api.DeviceSyncState.SyncAccountState.SignedIn
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
-import com.duckduckgo.sync.impl.pixels.SyncAccountOperation
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -85,12 +84,13 @@ class GetScopedSyncAuthTokenHandler @Inject constructor(
                 return when (result) {
                     is Result.Success -> {
                         logcat(LogPriority.INFO) { "DuckChat-Sync: rescope token succeeded" }
+                        syncPixels.fireAiChatActive()
                         createSuccessPayload(result.data)
                     }
 
                     is Result.Error -> {
                         logcat(LogPriority.ERROR) { "DuckChat-Sync: rescope token failed: code=${result.code}, reason=${result.reason}" }
-                        syncPixels.fireSyncAccountErrorPixel(result, SyncAccountOperation.RESCOPE_TOKEN)
+                        syncPixels.fireAiChatsRescopeTokenError(result)
                         createErrorPayload(result.reason)
                     }
                 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandlerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandlerTest.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.sync.api.DeviceSyncState
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
-import com.duckduckgo.sync.impl.pixels.SyncAccountOperation
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import org.json.JSONObject
@@ -189,6 +188,19 @@ class GetScopedSyncAuthTokenHandlerTest {
     }
 
     @Test
+    fun `when rescope token succeeds then usage pixel is fired`() {
+        configureSyncEnabled()
+        configureSignedIn()
+        whenever(mockSyncStore.token).thenReturn(ORIGINAL_TOKEN)
+        whenever(mockSyncApi.rescopeToken(ORIGINAL_TOKEN, SCOPE)).thenReturn(Result.Success(SCOPED_TOKEN))
+        val jsMessage = createJsMessage(TEST_MESSAGE_ID)
+
+        handler.getJsMessageHandler().process(jsMessage, mockJsMessaging, null)
+
+        verify(mockSyncPixels).fireAiChatActive()
+    }
+
+    @Test
     fun `when rescope token fails then error pixel is fired`() {
         configureSyncEnabled()
         configureSignedIn()
@@ -199,7 +211,7 @@ class GetScopedSyncAuthTokenHandlerTest {
 
         handler.getJsMessageHandler().process(jsMessage, mockJsMessaging, null)
 
-        verify(mockSyncPixels).fireSyncAccountErrorPixel(error, SyncAccountOperation.RESCOPE_TOKEN)
+        verify(mockSyncPixels).fireAiChatsRescopeTokenError(error)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213137494984800 

### Description
Refine pixels for syncing duck ai chats

### Steps to test this PR

**Logcat filter:** `DuckChat-Sync:|Pixel sent: sync_ai_chat_active|Pixel ignored: sync_ai_chat_active`

**Refine duck ai chat Sync pixel**
- [x] Fresh install `internal` build
- [x] [Enable internal testing](https://app.asana.com/1/137249556945/project/488551667048375/task/1213325707832249?focus=true)
- [x] Enable Sync (`Sync & Backup -> Sync and Back Up This Device`)
- [x] Start a new duck chat conversation (this should trigger the sync encrypt/decrypt/token handlers)
- [x] Verify in logs you see pixel `sync_ai_chat_active` is sent
- [x] Repeat the above with a new chat; verify pixel ignored `Pixel ignored: sync_ai_chat_active` (is a daily type)

_Note: The `sync_ai_chat_active` pixel is fired from 3 handlers (`getScopedSyncAuthToken`, `encryptWithSyncMasterKey`, `decryptWithSyncMasterKey`) but it's the same underlying pixel, only once per day regardless of which handler triggers it first. Testing any one path is sufficient._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a0d5b168f3d28893e8e1c289175b83fcadddc80f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->