### PR TITLE
Update content scope scripts to version 13.10.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8085,6 +8085,13 @@
           "enabled"
         ),
         runConditions: DEFAULT_RUN_CONDITIONS
+      },
+      auto: {
+        state: (
+          /** @type {FeatureState} */
+          "disabled"
+        ),
+        runConditions: DEFAULT_RUN_CONDITIONS
       }
     },
     actions: {
@@ -8186,12 +8193,14 @@
   }
 
   // src/features/web-detection.js
-  var _detectors;
+  var _detectors, _matchedDetectors;
   var WebDetection = class extends ContentFeature {
     constructor() {
       super(...arguments);
       /** @type {Record<string, Record<string, DetectorConfig>>} */
       __privateAdd(this, _detectors, {});
+      /** @type {Map<string, boolean>} */
+      __privateAdd(this, _matchedDetectors, /* @__PURE__ */ new Map());
       __publicField(this, "_exposedMethods", this._declareExposedMethods(["runDetectors"]));
     }
     /**
@@ -8200,6 +8209,77 @@
     init() {
       const detectorsConfig = this.getFeatureSetting("detectors");
       __privateSet(this, _detectors, parseDetectors(detectorsConfig));
+      this._scheduleAutoRunDetectors();
+    }
+    /**
+     *
+     * @param {DetectorConfig} detectorConfig
+     * @returns {true | false | 'error'}
+     */
+    _evaluateMatch(detectorConfig) {
+      try {
+        return evaluateMatch(detectorConfig.match);
+      } catch {
+        return "error";
+      }
+    }
+    /**
+     * Schedule automatic detector execution based on configured intervals.
+     */
+    _scheduleAutoRunDetectors() {
+      const detectorsByInterval = /* @__PURE__ */ new Map();
+      for (const [groupName, groupDetectors] of Object.entries(__privateGet(this, _detectors))) {
+        for (const [detectorId, detectorConfig] of Object.entries(groupDetectors)) {
+          if (!this._shouldRunDetector(detectorConfig, { trigger: "auto" })) continue;
+          const autoTrigger = detectorConfig.triggers.auto;
+          const fullDetectorId = `${groupName}.${detectorId}`;
+          for (const interval of autoTrigger.when.intervalMs) {
+            const atInterval = detectorsByInterval.get(interval) ?? [];
+            atInterval.push({
+              detectorId: fullDetectorId,
+              config: detectorConfig
+            });
+            detectorsByInterval.set(interval, atInterval);
+          }
+        }
+      }
+      for (const [interval, detectors] of detectorsByInterval.entries()) {
+        setTimeout(() => {
+          for (const { detectorId, config } of detectors) {
+            this._runAutoDetector(detectorId, config);
+          }
+        }, interval);
+      }
+    }
+    /**
+     * Run a single detector with the auto trigger
+     * @param {string} fullDetectorId - The full detector ID (groupName.detectorId)
+     * @param {DetectorConfig} detectorConfig - The detector configuration
+     */
+    _runAutoDetector(fullDetectorId, detectorConfig) {
+      try {
+        if (__privateGet(this, _matchedDetectors).get(fullDetectorId)) {
+          return;
+        }
+        const detected = this._evaluateMatch(detectorConfig);
+        if (detected === true) {
+          __privateGet(this, _matchedDetectors).set(fullDetectorId, true);
+        }
+        if (this.isDebug && detected !== false) {
+          try {
+            this.messaging?.notify("webDetectionAutoRun", {
+              detectorId: fullDetectorId,
+              detected,
+              timestamp: Date.now()
+            });
+          } catch {
+          }
+        }
+      } catch (e) {
+        if (this.isDebug) {
+          this.log.error(`Error running auto-detector ${fullDetectorId}:`, e);
+        }
+      }
     }
     /**
      * Check if a detector should be triggered.
@@ -8226,12 +8306,7 @@
       for (const [groupName, groupDetectors] of Object.entries(__privateGet(this, _detectors))) {
         for (const [detectorId, detectorConfig] of Object.entries(groupDetectors)) {
           if (!this._shouldRunDetector(detectorConfig, options)) continue;
-          let detected;
-          try {
-            detected = evaluateMatch(detectorConfig.match);
-          } catch {
-            detected = "error";
-          }
+          const detected = this._evaluateMatch(detectorConfig);
           if (options.trigger === "breakageReport" && this._isStateEnabled(detectorConfig.actions.breakageReportData.state)) {
             if (detected !== false) {
               results.push({
@@ -8246,6 +8321,7 @@
     }
   };
   _detectors = new WeakMap();
+  _matchedDetectors = new WeakMap();
 
   // src/features/web-interference-detection.js
   init_define_import_meta_trackerLookup();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.9.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.10.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3b66291bab6b8c2c327e6a677787bab6eb94f9fb",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9b3b46ddf42ced07cbc19337d748e045b2a5a89c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.9.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.10.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213345900043214/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of injected content scripts by adding timed detector execution, which could impact page performance or produce unexpected detector matches in the wild.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `13.9.0` to `13.10.0` (including the corresponding built Android bundles).
> 
> The updated scripts add an **`auto` trigger** to web detection and implement scheduled, interval-based auto-running of detectors with one-time match caching and optional debug notifications (`webDetectionAutoRun`), plus a small refactor to centralize match evaluation error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d58b78791a484242931950be1c049f544f7fdf54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->