### PR TITLE
Update Dagger version to 2.53.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -112,7 +112,7 @@ version.google.android.flexbox=3.0.0
 
 version.google.android.material=1.12.0
 
-version.google.dagger=2.53
+version.google.dagger=2.53.1
 
 #Cannot update to 3.1+ because we need at least Kotlin 2.1.0
 version.io.coil-kt.coil3..coil-bom=3.0.4


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213357925038350?focus=true

### Description
Updates Dagger version to 2.53.1 to fix a caching issue with Dagger generated classes changing between builds despite no code changes (thank you @ribafish for finding this).

### Steps to test this PR
Do a quick smoke test through the app

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no runtime code changes; risk is limited to potential DI/build-time regressions from the new Dagger release.
> 
> **Overview**
> Updates the build dependency version for `com.google.dagger` from `2.51.1` to `2.53.1` via `versions.properties`, aiming to stabilize Dagger-generated class outputs between builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28f0e88c7265290f2628f381ed7eaac66097fc0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->