### PR TITLE
Add privacy config for the duck AI chat history

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.feature
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "duckAiChatHistory",
+)
+interface DuckAiChatHistoryFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -174,8 +174,8 @@ interface DuckChatFeature {
 
     /**
      * @return `true` when the AI chat suggestions (pinned and recent chats) are enabled
-     * If the remote feature is not present defaults to `false`
+     * If the remote feature is not present defaults to `internal`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun aiChatSuggestions(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213348309066297?focus=true 

### Description
Adds privacy configuration to control the duck ai chat history feature. We are fetching chats from the frontend local storage. It allows us to enable/disable it, control the max number of chat history to fetch, and the chatsLocalStorageKeys.
We also need to add a privacy config for the feature flag on Android to enable/disable the feature

### Steps to test this PR
- Pull the changes
- validate that aiChatSuggestions is turned on for internal by default.
- Validate that you are able to see recent chats in the duck.ai input screen
- Validate that the max number of chats is 10
- Note: If the privacy config changes are not fully deployed yet you can go to Settings -> Developer Settings -> Override PRivacy Remote Config URL and test with the following URL:
https://duckduckgo.github.io/privacy-configuration/pr-4551/v4/android-config.json


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the privacy/feature-toggle inputs that drive WebView-injected JS and how many local-history items are fetched, so misconfiguration could unintentionally enable/disable history or alter data exposure scope.
> 
> **Overview**
> Adds a new remote feature toggle `duckAiChatHistory` (default *enabled*) and wires it into chat-suggestion fetching so the injected JS receives a content-scope config containing the toggle state, settings, and domain exceptions.
> 
> Chat suggestion retrieval now reads `maxHistoryCount` from the feature settings to control how many chats are requested/returned, and `aiChatSuggestions` default is changed to *internal* (was *disabled*) when remote config is absent. Tests are expanded to cover the new content-scope JSON generation and `maxHistoryCount` parsing/fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a96889e7486033ac8a384db1ef46efee5f0b85c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->