### PR TITLE
Fix favorites sometimes displaying incorrect favicon

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FavoritesQuickAccessAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FavoritesQuickAccessAdapter.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.browser.newtab.QuickAccessAdapterDiffCallback.Companio
 import com.duckduckgo.app.browser.newtab.QuickAccessAdapterDiffCallback.Companion.DIFF_KEY_URL
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.savedsites.api.models.SavedSite
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import logcat.LogPriority.VERBOSE
 import logcat.logcat
@@ -71,6 +72,7 @@ class FavoritesQuickAccessAdapter(
 
         private var itemState: ItemState = ItemState.Stale
         private var popupMenu: PopupMenu? = null
+        private var faviconJob: Job? = null
 
         sealed class ItemState {
             data object Stale : ItemState()
@@ -94,6 +96,7 @@ class FavoritesQuickAccessAdapter(
         }
 
         fun bind(item: QuickAccessFavorite) {
+            faviconJob?.cancel()
             with(item.favorite) {
                 binding.quickAccessTitle.text = title
                 loadFavicon(url)
@@ -123,6 +126,7 @@ class FavoritesQuickAccessAdapter(
             item: QuickAccessFavorite,
             payloads: MutableList<Any>,
         ) {
+            faviconJob?.cancel()
             for (payload in payloads) {
                 val bundle = payload as Bundle
 
@@ -192,7 +196,7 @@ class FavoritesQuickAccessAdapter(
         }
 
         private fun loadFavicon(url: String) {
-            lifecycleOwner.lifecycleScope.launch {
+            faviconJob = lifecycleOwner.lifecycleScope.launch {
                 faviconManager.loadToViewMaybeFromRemoteWithPlaceholder(url = url, view = binding.quickAccessFavicon)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FavoritesQuickAccessAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FavoritesQuickAccessAdapter.kt
@@ -126,7 +126,6 @@ class FavoritesQuickAccessAdapter(
             item: QuickAccessFavorite,
             payloads: MutableList<Any>,
         ) {
-            faviconJob?.cancel()
             for (payload in payloads) {
                 val bundle = payload as Bundle
 
@@ -139,6 +138,7 @@ class FavoritesQuickAccessAdapter(
                 }
 
                 bundle[DIFF_KEY_URL]?.let {
+                    faviconJob?.cancel()
                     loadFavicon(it as String)
                 }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionsAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionsAdapter.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.savedsites.impl.newtab.FavouriteNewTabSectionsItem.Placeho
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.FavouriteViewHolder.ItemState.Drag
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.FavouriteViewHolder.ItemState.LongPress
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.FavouriteViewHolder.ItemState.Stale
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 
@@ -148,6 +149,7 @@ class FavouritesNewTabSectionsAdapter(
 
         private var itemState: ItemState = Stale
         private var popupMenu: PopupMenu? = null
+        private var faviconJob: Job? = null
 
         sealed class ItemState {
             data object Stale : ItemState()
@@ -173,6 +175,7 @@ class FavouritesNewTabSectionsAdapter(
         fun bind(
             item: FavouriteItemFavourite,
         ) {
+            faviconJob?.cancel()
             with(binding.root) {
                 setItemType(FavouriteItemType.Favicon)
                 setPrimaryText(item.favorite.title)
@@ -183,7 +186,7 @@ class FavouritesNewTabSectionsAdapter(
         }
 
         private fun loadFavicon(url: String) {
-            lifecycleOwner.lifecycleScope.launch {
+            faviconJob = lifecycleOwner.lifecycleScope.launch {
                 faviconManager.loadToViewMaybeFromRemoteWithPlaceholder(url = url, view = binding.root.favicon())
             }
         }


### PR DESCRIPTION

  - Cancel the previous favicon-loading coroutine when a RecyclerView ViewHolder is recycled and rebound to a different favorite
  - Applied the fix to both FavouritesNewTabSectionsAdapter and FavoritesQuickAccessAdapter
  - Also handles the bindFromPayload path in FavoritesQuickAccessAdapter

  Problem

  When scrolling through favorites on the home screen or new tab page, favicons are loaded asynchronously via lifecycleScope.launch. If a ViewHolder is recycled and
  rebound to a new favorite before the previous coroutine completes, the stale favicon overwrites the correct one — causing favorites to display each other's icons.

  Fix

  Track the favicon-loading coroutine Job in each ViewHolder and cancel it on rebind, preventing the race condition between old and new favicon loads.

  Test plan

  - Add multiple favorites with distinct favicons
  - Scroll the favorites grid quickly to trigger ViewHolder recycling
  - Verify favicons remain correctly assigned after scrolling
  - Verify favicons load correctly on fresh app launch
  - Verify drag-and-drop reordering still displays correct favicons

  Fixes #5657

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI concurrency change (cancelling coroutines on ViewHolder rebind) with minimal behavioral impact beyond preventing stale favicon updates.
> 
> **Overview**
> Fixes a RecyclerView race where async favicon loads could complete after a ViewHolder is rebound, causing favorites to show the wrong icon.
> 
> Both `FavoritesQuickAccessAdapter` and `FavouritesNewTabSectionsAdapter` now track the favicon-loading coroutine `Job` per ViewHolder and cancel it on rebind; `FavoritesQuickAccessAdapter` also cancels/reloads in the `bindFromPayload` URL-update path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09859d33189b864bcdd1c36123de445314faa13b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->