### PR TITLE
Create pixel definition for app startup time

### DIFF
--- a/PixelDefinitions/pixels/app_startup_metrics.json5
+++ b/PixelDefinitions/pixels/app_startup_metrics.json5
@@ -22,6 +22,11 @@
                 "description": "Device memory capacity bucket for classification",
                 "type": "string",
                 "enum": ["<1GB", "1GB", "2GB", "4GB", "6GB", "8GB", "12GB", "16GB+"]
+            },
+            {
+                "key": "api_level",
+                "description": "Android API level of the device",
+                "type": "integer"
             }
         ]
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213167063549546?focus=true 

### Description

Pixel definition for the future contribution about app startup time performance.
Need a dedicate PR to validate privacy concerns first.

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new analytics schema file only; no runtime logic changes, with minimal risk beyond ensuring the new parameters meet privacy/telemetry expectations.
> 
> **Overview**
> Adds a new pixel definition `m_app_startup_time` in `PixelDefinitions/pixels/app_startup_metrics.json5` to support future app startup performance reporting.
> 
> The definition captures startup classification (`startup_type`), time-to-interactive duration (`ttid_duration_ms`), and coarse device context (`device_ram_bucket`, `api_level`) alongside `appVersion`, with `form_factor` suffixing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbfdd6ca2993dc725d57857103b5bca7d62d04cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->