### PR TITLE
Expose upgrade and purchase screens to in-app deeplink

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -134,8 +134,8 @@ data class SubscriptionsWebViewActivityWithParams(
     scope = ActivityScope::class,
     delayGeneration = true, // Delayed because it has a dependency on DownloadConfirmationFragment from another module
 )
-@ContributeToActivityStarter(SubscriptionPurchase::class)
-@ContributeToActivityStarter(SubscriptionUpgrade::class)
+@ContributeToActivityStarter(SubscriptionPurchase::class, screenName = "subscriptions.purchase")
+@ContributeToActivityStarter(SubscriptionUpgrade::class, screenName = "subscriptions.upgrade")
 @ContributeToActivityStarter(SubscriptionsWebViewActivityWithParams::class)
 class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationDialogListener {
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213400521825647?focus=true 

### Description
Adds entry point to purchase and upgrade screen through in-app navigation (deeplink).
Plan is to use them from RMF promo

### Steps to test this PR

_Feature 1_
- [ ] This can be tested by using `https://api.jsonblob.com/019c8a43-d692-7e2c-86c4-a5439d27ffdf`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change that affects navigation/deeplink registration for purchase/upgrade screens; risk is limited to potential misrouting if the `screenName` values are incorrect.
> 
> **Overview**
> **Expose purchase/upgrade screens to in-app navigation** by updating `SubscriptionsWebViewActivity`’s `@ContributeToActivityStarter` entries for `SubscriptionPurchase` and `SubscriptionUpgrade` to include explicit `screenName`s (`subscriptions.purchase` / `subscriptions.upgrade`).
> 
> This makes these flows addressable via the app’s screen-name based routing/deeplink mechanism without changing the underlying webview behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4184d8f7e6fda4737dd2198ff7e8571ac456e9e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->