### PR TITLE
Fix RMF deeplink crash for empty payload

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributeToActivityStarterCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributeToActivityStarterCodeGenerator.kt
@@ -242,7 +242,7 @@ class ContributeToActivityStarterCodeGenerator : CodeGenerator {
                     .add(
                         """
                             return kotlin.runCatching {
-                                moshi.adapter(clazz).fromJson(deeplinkActivityParams.jsonArguments)
+                                moshi.adapter(clazz).fromJson(deeplinkActivityParams.jsonArguments.ifEmpty { "{}" })
                             }.getOrNull()
                         """.trimIndent(),
                     ).build(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1213390598201722?focus=true

### Description
Ensure navigation works safely when optional deeplink parameters are empty by defaulting to an empty JSON object

### Steps to test this PR
- [ ] This can be tested by using `https://api.jsonblob.com/019c8a43-d692-7e2c-86c4-a5439d27ffdf`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to deeplink JSON deserialization behavior; only affects cases where the payload is empty.
> 
> **Overview**
> Prevents deeplink parameter parsing crashes by treating an empty `jsonArguments` payload as an empty JSON object when generating `tryCreateActivityParams` in `ContributeToActivityStarterCodeGenerator`.
> 
> This changes Moshi deserialization to use `deeplinkActivityParams.jsonArguments.ifEmpty { "{}" }`, so optional deeplink params can be omitted without failing navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acb488bac3157dcd1e08f0627c031d7dffaaaf5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->