### PR TITLE
Update content scope scripts to version 13.15.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1598,7 +1598,9 @@
   }
   var exemptionLists = {};
   function shouldExemptUrl(type, url) {
-    for (const regex of exemptionLists[type]) {
+    const list = exemptionLists[type];
+    if (!list) return false;
+    for (const regex of list) {
       if (regex.test(url)) {
         return true;
       }
@@ -1611,7 +1613,9 @@
     debug = args.debug || false;
     for (const type in stringExemptionLists) {
       exemptionLists[type] = [];
-      for (const stringExemption of stringExemptionLists[type]) {
+      const exemptions = stringExemptionLists[type];
+      if (!exemptions) continue;
+      for (const stringExemption of exemptions) {
         exemptionLists[type].push(new RegExp(stringExemption));
       }
     }
@@ -1658,7 +1662,7 @@
       const errorLines = stack.split("\n");
       for (const line of errorLines) {
         const res = line.match(lineTest);
-        if (res) {
+        if (res && res[2]) {
           urls.add(new URL(res[2], location.href));
         }
       }
@@ -1675,7 +1679,8 @@
     return origins;
   }
   function shouldExemptMethod(type) {
-    if (!(type in exemptionLists) || exemptionLists[type].length === 0) {
+    const typeExemptions = exemptionLists[type];
+    if (!typeExemptions || typeExemptions.length === 0) {
       return false;
     }
     const stack = getStack();
@@ -1998,6 +2003,7 @@
     );
     const enabledFeatures = remoteFeatureNames.filter((featureName) => {
       const feature = data2.features[featureName];
+      if (!feature) return false;
       if (feature.minSupportedVersion && platform?.version) {
         if (!isSupportedVersion(feature.minSupportedVersion, platform.version)) {
           return false;
@@ -2014,7 +2020,9 @@
       if (!enabledFeatures.includes(featureName)) {
         return;
       }
-      featureSettings[featureName] = data2.features[featureName].settings;
+      const feature = data2.features[featureName];
+      if (!feature) return;
+      featureSettings[featureName] = feature.settings;
     });
     return featureSettings;
   }
@@ -7336,7 +7344,7 @@
     }
     name = name.toLowerCase();
     for (const fullName of Object.keys(nicknames)) {
-      if (nicknames[fullName].includes(name)) {
+      if (nicknames[fullName]?.includes(name)) {
         fullNames.add(fullName);
       }
     }
@@ -7468,7 +7476,10 @@
      * @param {import('../actions/extract.js').ExtractorParams} extractorParams
      */
     extract(strs, extractorParams) {
-      return strs.map((x2) => stringToList(x2, extractorParams.separator)).flat().map((x2) => x2.split(",")[0]);
+      return strs.map((x2) => stringToList(x2, extractorParams.separator)).flat().map((x2) => (
+        /** @type {string} */
+        x2.split(",")[0]
+      ));
     }
   };
 
@@ -7481,15 +7492,18 @@
      */
     extract(strs, extractorParams) {
       if (strs.length === 0) return null;
+      const firstStr = (
+        /** @type {string} */
+        strs[0]
+      );
       const profile = {
-        profileUrl: strs[0],
-        identifier: strs[0]
+        profileUrl: firstStr,
+        identifier: firstStr
       };
       if (!extractorParams.identifierType || !extractorParams.identifier) {
         return profile;
       }
-      const profileUrl = strs[0];
-      profile.identifier = this.getIdFromProfileUrl(profileUrl, extractorParams.identifierType, extractorParams.identifier);
+      profile.identifier = this.getIdFromProfileUrl(firstStr, extractorParams.identifierType, extractorParams.identifier);
       return profile;
     }
     /**
@@ -8328,7 +8342,10 @@
     if (!url) {
       return "";
     }
-    return url.split("?")[0];
+    return (
+      /** @type {string} */
+      url.split("?")[0]
+    );
   }
 
   // src/features/broker-protection/captcha-services/get-captcha-provider.js
@@ -9928,11 +9945,17 @@
       trackerLookup: define_import_meta_trackerLookup_default,
       injectName: "android-autofill-import"
     };
-    const bundledFeatureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
+    const bundledFeatureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] ?? [] : [];
     const featuresToLoad = isGloballyDisabled(args) ? platformSpecificFeatures : args.site.enabledFeatures || bundledFeatureNames;
     for (const featureName of bundledFeatureNames) {
       if (featuresToLoad.includes(featureName)) {
         const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
+        if (!ContentFeature2) {
+          if (args.debug) {
+            console.error("Missing feature constructor for", featureName);
+          }
+          continue;
+        }
         const featureInstance = new ContentFeature2(featureName, importConfig, _features2, args);
         if (!featureInstance.getFeatureSettingEnabled("additionalCheck", "enabled")) {
           continue;
@@ -10047,15 +10070,19 @@
     const config = $CONTENT_SCOPE$;
     const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
     const userPreferences = $USER_PREFERENCES$;
-    const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
+    const processedConfig = (
+      /** @type {ProcessedConfig} */
+      processConfig(config, userUnprotectedDomains, userPreferences)
+    );
     const configConstruct = processedConfig;
     const objectName = configConstruct.objectName || "contentScopeAdsjs";
-    processedConfig.messagingConfig = new AndroidAdsjsMessagingConfig({
+    const messagingConfig = new AndroidAdsjsMessagingConfig({
       objectName,
       target: globalThis,
-      debug: processedConfig.debug
+      debug: processedConfig.debug ?? false
     });
-    sendInitialPingAndUpdate(processedConfig.messagingConfig, processedConfig);
+    processedConfig.messagingConfig = messagingConfig;
+    sendInitialPingAndUpdate(messagingConfig, processedConfig);
     load(getLoadArgs(processedConfig));
     init(processedConfig);
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1481,8 +1481,8 @@
   var u;
   var t;
   var i;
-  var o;
   var r;
+  var o;
   var e;
   var f;
   var c;
@@ -1501,14 +1501,14 @@
     n2 && n2.parentNode && n2.parentNode.removeChild(n2);
   }
   function _(l3, u3, t3) {
-    var i3, o3, r3, e3 = {};
-    for (r3 in u3) "key" == r3 ? i3 = u3[r3] : "ref" == r3 ? o3 = u3[r3] : e3[r3] = u3[r3];
-    if (arguments.length > 2 && (e3.children = arguments.length > 3 ? n.call(arguments, 2) : t3), "function" == typeof l3 && null != l3.defaultProps) for (r3 in l3.defaultProps) void 0 === e3[r3] && (e3[r3] = l3.defaultProps[r3]);
-    return m(l3, e3, i3, o3, null);
+    var i3, r3, o3, e3 = {};
+    for (o3 in u3) "key" == o3 ? i3 = u3[o3] : "ref" == o3 ? r3 = u3[o3] : e3[o3] = u3[o3];
+    if (arguments.length > 2 && (e3.children = arguments.length > 3 ? n.call(arguments, 2) : t3), "function" == typeof l3 && null != l3.defaultProps) for (o3 in l3.defaultProps) void 0 === e3[o3] && (e3[o3] = l3.defaultProps[o3]);
+    return m(l3, e3, i3, r3, null);
   }
-  function m(n2, t3, i3, o3, r3) {
-    var e3 = { type: n2, props: t3, key: i3, ref: o3, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == r3 ? ++u : r3, __i: -1, __u: 0 };
-    return null == r3 && null != l.vnode && l.vnode(e3), e3;
+  function m(n2, t3, i3, r3, o3) {
+    var e3 = { type: n2, props: t3, key: i3, ref: r3, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == o3 ? ++u : o3, __i: -1, __u: 0 };
+    return null == o3 && null != l.vnode && l.vnode(e3), e3;
   }
   function k(n2) {
     return n2.children;
@@ -1522,37 +1522,38 @@
     return "function" == typeof n2.type ? S(n2) : null;
   }
   function C(n2) {
-    var l3, u3;
-    if (null != (n2 = n2.__) && null != n2.__c) {
-      for (n2.__e = n2.__c.base = null, l3 = 0; l3 < n2.__k.length; l3++) if (null != (u3 = n2.__k[l3]) && null != u3.__e) {
-        n2.__e = n2.__c.base = u3.__e;
-        break;
-      }
-      return C(n2);
+    if (n2.__P && n2.__d) {
+      var u3 = n2.__v, t3 = u3.__e, i3 = [], r3 = [], o3 = w({}, u3);
+      o3.__v = u3.__v + 1, l.vnode && l.vnode(o3), z(n2.__P, o3, u3, n2.__n, n2.__P.namespaceURI, 32 & u3.__u ? [t3] : null, i3, null == t3 ? S(u3) : t3, !!(32 & u3.__u), r3), o3.__v = u3.__v, o3.__.__k[o3.__i] = o3, V(i3, o3, r3), u3.__e = u3.__ = null, o3.__e != t3 && M(o3);
     }
   }
   function M(n2) {
-    (!n2.__d && (n2.__d = true) && i.push(n2) && !$.__r++ || o != l.debounceRendering) && ((o = l.debounceRendering) || r)($);
+    if (null != (n2 = n2.__) && null != n2.__c) return n2.__e = n2.__c.base = null, n2.__k.some(function(l3) {
+      if (null != l3 && null != l3.__e) return n2.__e = n2.__c.base = l3.__e;
+    }), M(n2);
   }
-  function $() {
-    for (var n2, u3, t3, o3, r3, f3, c3, s3 = 1; i.length; ) i.length > s3 && i.sort(e), n2 = i.shift(), s3 = i.length, n2.__d && (t3 = void 0, o3 = void 0, r3 = (o3 = (u3 = n2).__v).__e, f3 = [], c3 = [], u3.__P && ((t3 = w({}, o3)).__v = o3.__v + 1, l.vnode && l.vnode(t3), O(u3.__P, t3, o3, u3.__n, u3.__P.namespaceURI, 32 & o3.__u ? [r3] : null, f3, null == r3 ? S(o3) : r3, !!(32 & o3.__u), c3), t3.__v = o3.__v, t3.__.__k[t3.__i] = t3, N(f3, t3, c3), o3.__e = o3.__ = null, t3.__e != r3 && C(t3)));
-    $.__r = 0;
+  function $(n2) {
+    (!n2.__d && (n2.__d = true) && i.push(n2) && !I.__r++ || r != l.debounceRendering) && ((r = l.debounceRendering) || o)(I);
   }
-  function I(n2, l3, u3, t3, i3, o3, r3, e3, f3, c3, s3) {
+  function I() {
+    for (var n2, l3 = 1; i.length; ) i.length > l3 && i.sort(e), n2 = i.shift(), l3 = i.length, C(n2);
+    I.__r = 0;
+  }
+  function P(n2, l3, u3, t3, i3, r3, o3, e3, f3, c3, s3) {
     var a3, h3, y3, d3, w3, g3, _3, m3 = t3 && t3.__k || v, b = l3.length;
-    for (f3 = P(u3, l3, m3, f3, b), a3 = 0; a3 < b; a3++) null != (y3 = u3.__k[a3]) && (h3 = -1 == y3.__i ? p : m3[y3.__i] || p, y3.__i = a3, g3 = O(n2, y3, h3, i3, o3, r3, e3, f3, c3, s3), d3 = y3.__e, y3.ref && h3.ref != y3.ref && (h3.ref && B(h3.ref, null, y3), s3.push(y3.ref, y3.__c || d3, y3)), null == w3 && null != d3 && (w3 = d3), (_3 = !!(4 & y3.__u)) || h3.__k === y3.__k ? f3 = A(y3, f3, n2, _3) : "function" == typeof y3.type && void 0 !== g3 ? f3 = g3 : d3 && (f3 = d3.nextSibling), y3.__u &= -7);
+    for (f3 = A(u3, l3, m3, f3, b), a3 = 0; a3 < b; a3++) null != (y3 = u3.__k[a3]) && (h3 = -1 != y3.__i && m3[y3.__i] || p, y3.__i = a3, g3 = z(n2, y3, h3, i3, r3, o3, e3, f3, c3, s3), d3 = y3.__e, y3.ref && h3.ref != y3.ref && (h3.ref && D(h3.ref, null, y3), s3.push(y3.ref, y3.__c || d3, y3)), null == w3 && null != d3 && (w3 = d3), (_3 = !!(4 & y3.__u)) || h3.__k === y3.__k ? f3 = H(y3, f3, n2, _3) : "function" == typeof y3.type && void 0 !== g3 ? f3 = g3 : d3 && (f3 = d3.nextSibling), y3.__u &= -7);
     return u3.__e = w3, f3;
   }
-  function P(n2, l3, u3, t3, i3) {
-    var o3, r3, e3, f3, c3, s3 = u3.length, a3 = s3, h3 = 0;
-    for (n2.__k = new Array(i3), o3 = 0; o3 < i3; o3++) null != (r3 = l3[o3]) && "boolean" != typeof r3 && "function" != typeof r3 ? ("string" == typeof r3 || "number" == typeof r3 || "bigint" == typeof r3 || r3.constructor == String ? r3 = n2.__k[o3] = m(null, r3, null, null, null) : d(r3) ? r3 = n2.__k[o3] = m(k, { children: r3 }, null, null, null) : void 0 === r3.constructor && r3.__b > 0 ? r3 = n2.__k[o3] = m(r3.type, r3.props, r3.key, r3.ref ? r3.ref : null, r3.__v) : n2.__k[o3] = r3, f3 = o3 + h3, r3.__ = n2, r3.__b = n2.__b + 1, e3 = null, -1 != (c3 = r3.__i = L(r3, u3, f3, a3)) && (a3--, (e3 = u3[c3]) && (e3.__u |= 2)), null == e3 || null == e3.__v ? (-1 == c3 && (i3 > s3 ? h3-- : i3 < s3 && h3++), "function" != typeof r3.type && (r3.__u |= 4)) : c3 != f3 && (c3 == f3 - 1 ? h3-- : c3 == f3 + 1 ? h3++ : (c3 > f3 ? h3-- : h3++, r3.__u |= 4))) : n2.__k[o3] = null;
-    if (a3) for (o3 = 0; o3 < s3; o3++) null != (e3 = u3[o3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = S(e3)), D(e3, e3));
+  function A(n2, l3, u3, t3, i3) {
+    var r3, o3, e3, f3, c3, s3 = u3.length, a3 = s3, h3 = 0;
+    for (n2.__k = new Array(i3), r3 = 0; r3 < i3; r3++) null != (o3 = l3[r3]) && "boolean" != typeof o3 && "function" != typeof o3 ? ("string" == typeof o3 || "number" == typeof o3 || "bigint" == typeof o3 || o3.constructor == String ? o3 = n2.__k[r3] = m(null, o3, null, null, null) : d(o3) ? o3 = n2.__k[r3] = m(k, { children: o3 }, null, null, null) : void 0 === o3.constructor && o3.__b > 0 ? o3 = n2.__k[r3] = m(o3.type, o3.props, o3.key, o3.ref ? o3.ref : null, o3.__v) : n2.__k[r3] = o3, f3 = r3 + h3, o3.__ = n2, o3.__b = n2.__b + 1, e3 = null, -1 != (c3 = o3.__i = T(o3, u3, f3, a3)) && (a3--, (e3 = u3[c3]) && (e3.__u |= 2)), null == e3 || null == e3.__v ? (-1 == c3 && (i3 > s3 ? h3-- : i3 < s3 && h3++), "function" != typeof o3.type && (o3.__u |= 4)) : c3 != f3 && (c3 == f3 - 1 ? h3-- : c3 == f3 + 1 ? h3++ : (c3 > f3 ? h3-- : h3++, o3.__u |= 4))) : n2.__k[r3] = null;
+    if (a3) for (r3 = 0; r3 < s3; r3++) null != (e3 = u3[r3]) && 0 == (2 & e3.__u) && (e3.__e == t3 && (t3 = S(e3)), E(e3, e3));
     return t3;
   }
-  function A(n2, l3, u3, t3) {
-    var i3, o3;
+  function H(n2, l3, u3, t3) {
+    var i3, r3;
     if ("function" == typeof n2.type) {
-      for (i3 = n2.__k, o3 = 0; i3 && o3 < i3.length; o3++) i3[o3] && (i3[o3].__ = n2, l3 = A(i3[o3], l3, u3, t3));
+      for (i3 = n2.__k, r3 = 0; i3 && r3 < i3.length; r3++) i3[r3] && (i3[r3].__ = n2, l3 = H(i3[r3], l3, u3, t3));
       return l3;
     }
     n2.__e != l3 && (t3 && (l3 && n2.type && !l3.parentNode && (l3 = S(n2)), u3.insertBefore(n2.__e, l3 || null)), l3 = n2.__e);
@@ -1561,25 +1562,25 @@
     } while (null != l3 && 8 == l3.nodeType);
     return l3;
   }
-  function L(n2, l3, u3, t3) {
-    var i3, o3, r3, e3 = n2.key, f3 = n2.type, c3 = l3[u3], s3 = null != c3 && 0 == (2 & c3.__u);
+  function T(n2, l3, u3, t3) {
+    var i3, r3, o3, e3 = n2.key, f3 = n2.type, c3 = l3[u3], s3 = null != c3 && 0 == (2 & c3.__u);
     if (null === c3 && null == e3 || s3 && e3 == c3.key && f3 == c3.type) return u3;
     if (t3 > (s3 ? 1 : 0)) {
-      for (i3 = u3 - 1, o3 = u3 + 1; i3 >= 0 || o3 < l3.length; ) if (null != (c3 = l3[r3 = i3 >= 0 ? i3-- : o3++]) && 0 == (2 & c3.__u) && e3 == c3.key && f3 == c3.type) return r3;
+      for (i3 = u3 - 1, r3 = u3 + 1; i3 >= 0 || r3 < l3.length; ) if (null != (c3 = l3[o3 = i3 >= 0 ? i3-- : r3++]) && 0 == (2 & c3.__u) && e3 == c3.key && f3 == c3.type) return o3;
     }
     return -1;
   }
-  function T(n2, l3, u3) {
+  function j(n2, l3, u3) {
     "-" == l3[0] ? n2.setProperty(l3, null == u3 ? "" : u3) : n2[l3] = null == u3 ? "" : "number" != typeof u3 || y.test(l3) ? u3 : u3 + "px";
   }
-  function j(n2, l3, u3, t3, i3) {
-    var o3, r3;
+  function F(n2, l3, u3, t3, i3) {
+    var r3, o3;
     n: if ("style" == l3) if ("string" == typeof u3) n2.style.cssText = u3;
     else {
-      if ("string" == typeof t3 && (n2.style.cssText = t3 = ""), t3) for (l3 in t3) u3 && l3 in u3 || T(n2.style, l3, "");
-      if (u3) for (l3 in u3) t3 && u3[l3] == t3[l3] || T(n2.style, l3, u3[l3]);
+      if ("string" == typeof t3 && (n2.style.cssText = t3 = ""), t3) for (l3 in t3) u3 && l3 in u3 || j(n2.style, l3, "");
+      if (u3) for (l3 in u3) t3 && u3[l3] == t3[l3] || j(n2.style, l3, u3[l3]);
     }
-    else if ("o" == l3[0] && "n" == l3[1]) o3 = l3 != (l3 = l3.replace(f, "$1")), r3 = l3.toLowerCase(), l3 = r3 in n2 || "onFocusOut" == l3 || "onFocusIn" == l3 ? r3.slice(2) : l3.slice(2), n2.l || (n2.l = {}), n2.l[l3 + o3] = u3, u3 ? t3 ? u3.u = t3.u : (u3.u = c, n2.addEventListener(l3, o3 ? a : s, o3)) : n2.removeEventListener(l3, o3 ? a : s, o3);
+    else if ("o" == l3[0] && "n" == l3[1]) r3 = l3 != (l3 = l3.replace(f, "$1")), o3 = l3.toLowerCase(), l3 = o3 in n2 || "onFocusOut" == l3 || "onFocusIn" == l3 ? o3.slice(2) : l3.slice(2), n2.l || (n2.l = {}), n2.l[l3 + r3] = u3, u3 ? t3 ? u3.u = t3.u : (u3.u = c, n2.addEventListener(l3, r3 ? a : s, r3)) : n2.removeEventListener(l3, r3 ? a : s, r3);
     else {
       if ("http://www.w3.org/2000/svg" == i3) l3 = l3.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
       else if ("width" != l3 && "height" != l3 && "href" != l3 && "list" != l3 && "form" != l3 && "tabIndex" != l3 && "download" != l3 && "rowSpan" != l3 && "colSpan" != l3 && "role" != l3 && "popover" != l3 && l3 in n2) try {
@@ -1590,7 +1591,7 @@
       "function" == typeof u3 || (null == u3 || false === u3 && "-" != l3[4] ? n2.removeAttribute(l3) : n2.setAttribute(l3, "popover" == l3 && 1 == u3 ? "" : u3));
     }
   }
-  function F(n2) {
+  function O(n2) {
     return function(u3) {
       if (this.l) {
         var t3 = this.l[u3.type + n2];
@@ -1600,50 +1601,47 @@
       }
     };
   }
-  function O(n2, u3, t3, i3, o3, r3, e3, f3, c3, s3) {
-    var a3, h3, p3, v3, y3, _3, m3, b, S2, C3, M2, $2, P2, A3, H, L2, T3, j3 = u3.type;
+  function z(n2, u3, t3, i3, r3, o3, e3, f3, c3, s3) {
+    var a3, h3, p3, y3, _3, m3, b, S2, C3, M2, $2, I2, A3, H2, L, T3 = u3.type;
     if (void 0 !== u3.constructor) return null;
-    128 & t3.__u && (c3 = !!(32 & t3.__u), r3 = [f3 = u3.__e = t3.__e]), (a3 = l.__b) && a3(u3);
-    n: if ("function" == typeof j3) try {
-      if (b = u3.props, S2 = "prototype" in j3 && j3.prototype.render, C3 = (a3 = j3.contextType) && i3[a3.__c], M2 = a3 ? C3 ? C3.props.value : a3.__ : i3, t3.__c ? m3 = (h3 = u3.__c = t3.__c).__ = h3.__E : (S2 ? u3.__c = h3 = new j3(b, M2) : (u3.__c = h3 = new x(b, M2), h3.constructor = j3, h3.render = E), C3 && C3.sub(h3), h3.state || (h3.state = {}), h3.__n = i3, p3 = h3.__d = true, h3.__h = [], h3._sb = []), S2 && null == h3.__s && (h3.__s = h3.state), S2 && null != j3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = w({}, h3.__s)), w(h3.__s, j3.getDerivedStateFromProps(b, h3.__s))), v3 = h3.props, y3 = h3.state, h3.__v = u3, p3) S2 && null == j3.getDerivedStateFromProps && null != h3.componentWillMount && h3.componentWillMount(), S2 && null != h3.componentDidMount && h3.__h.push(h3.componentDidMount);
+    128 & t3.__u && (c3 = !!(32 & t3.__u), o3 = [f3 = u3.__e = t3.__e]), (a3 = l.__b) && a3(u3);
+    n: if ("function" == typeof T3) try {
+      if (S2 = u3.props, C3 = "prototype" in T3 && T3.prototype.render, M2 = (a3 = T3.contextType) && i3[a3.__c], $2 = a3 ? M2 ? M2.props.value : a3.__ : i3, t3.__c ? b = (h3 = u3.__c = t3.__c).__ = h3.__E : (C3 ? u3.__c = h3 = new T3(S2, $2) : (u3.__c = h3 = new x(S2, $2), h3.constructor = T3, h3.render = G), M2 && M2.sub(h3), h3.state || (h3.state = {}), h3.__n = i3, p3 = h3.__d = true, h3.__h = [], h3._sb = []), C3 && null == h3.__s && (h3.__s = h3.state), C3 && null != T3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = w({}, h3.__s)), w(h3.__s, T3.getDerivedStateFromProps(S2, h3.__s))), y3 = h3.props, _3 = h3.state, h3.__v = u3, p3) C3 && null == T3.getDerivedStateFromProps && null != h3.componentWillMount && h3.componentWillMount(), C3 && null != h3.componentDidMount && h3.__h.push(h3.componentDidMount);
       else {
-        if (S2 && null == j3.getDerivedStateFromProps && b !== v3 && null != h3.componentWillReceiveProps && h3.componentWillReceiveProps(b, M2), u3.__v == t3.__v || !h3.__e && null != h3.shouldComponentUpdate && false === h3.shouldComponentUpdate(b, h3.__s, M2)) {
-          for (u3.__v != t3.__v && (h3.props = b, h3.state = h3.__s, h3.__d = false), u3.__e = t3.__e, u3.__k = t3.__k, u3.__k.some(function(n3) {
+        if (C3 && null == T3.getDerivedStateFromProps && S2 !== y3 && null != h3.componentWillReceiveProps && h3.componentWillReceiveProps(S2, $2), u3.__v == t3.__v || !h3.__e && null != h3.shouldComponentUpdate && false === h3.shouldComponentUpdate(S2, h3.__s, $2)) {
+          u3.__v != t3.__v && (h3.props = S2, h3.state = h3.__s, h3.__d = false), u3.__e = t3.__e, u3.__k = t3.__k, u3.__k.some(function(n3) {
             n3 && (n3.__ = u3);
-          }), $2 = 0; $2 < h3._sb.length; $2++) h3.__h.push(h3._sb[$2]);
-          h3._sb = [], h3.__h.length && e3.push(h3);
+          }), v.push.apply(h3.__h, h3._sb), h3._sb = [], h3.__h.length && e3.push(h3);
           break n;
         }
-        null != h3.componentWillUpdate && h3.componentWillUpdate(b, h3.__s, M2), S2 && null != h3.componentDidUpdate && h3.__h.push(function() {
-          h3.componentDidUpdate(v3, y3, _3);
+        null != h3.componentWillUpdate && h3.componentWillUpdate(S2, h3.__s, $2), C3 && null != h3.componentDidUpdate && h3.__h.push(function() {
+          h3.componentDidUpdate(y3, _3, m3);
         });
       }
-      if (h3.context = M2, h3.props = b, h3.__P = n2, h3.__e = false, P2 = l.__r, A3 = 0, S2) {
-        for (h3.state = h3.__s, h3.__d = false, P2 && P2(u3), a3 = h3.render(h3.props, h3.state, h3.context), H = 0; H < h3._sb.length; H++) h3.__h.push(h3._sb[H]);
-        h3._sb = [];
-      } else do {
-        h3.__d = false, P2 && P2(u3), a3 = h3.render(h3.props, h3.state, h3.context), h3.state = h3.__s;
+      if (h3.context = $2, h3.props = S2, h3.__P = n2, h3.__e = false, I2 = l.__r, A3 = 0, C3) h3.state = h3.__s, h3.__d = false, I2 && I2(u3), a3 = h3.render(h3.props, h3.state, h3.context), v.push.apply(h3.__h, h3._sb), h3._sb = [];
+      else do {
+        h3.__d = false, I2 && I2(u3), a3 = h3.render(h3.props, h3.state, h3.context), h3.state = h3.__s;
       } while (h3.__d && ++A3 < 25);
-      h3.state = h3.__s, null != h3.getChildContext && (i3 = w(w({}, i3), h3.getChildContext())), S2 && !p3 && null != h3.getSnapshotBeforeUpdate && (_3 = h3.getSnapshotBeforeUpdate(v3, y3)), L2 = a3, null != a3 && a3.type === k && null == a3.key && (L2 = V(a3.props.children)), f3 = I(n2, d(L2) ? L2 : [L2], u3, t3, i3, o3, r3, e3, f3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && e3.push(h3), m3 && (h3.__E = h3.__ = null);
+      h3.state = h3.__s, null != h3.getChildContext && (i3 = w(w({}, i3), h3.getChildContext())), C3 && !p3 && null != h3.getSnapshotBeforeUpdate && (m3 = h3.getSnapshotBeforeUpdate(y3, _3)), H2 = null != a3 && a3.type === k && null == a3.key ? q(a3.props.children) : a3, f3 = P(n2, d(H2) ? H2 : [H2], u3, t3, i3, r3, o3, e3, f3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && e3.push(h3), b && (h3.__E = h3.__ = null);
     } catch (n3) {
-      if (u3.__v = null, c3 || null != r3) if (n3.then) {
+      if (u3.__v = null, c3 || null != o3) if (n3.then) {
         for (u3.__u |= c3 ? 160 : 128; f3 && 8 == f3.nodeType && f3.nextSibling; ) f3 = f3.nextSibling;
-        r3[r3.indexOf(f3)] = null, u3.__e = f3;
+        o3[o3.indexOf(f3)] = null, u3.__e = f3;
       } else {
-        for (T3 = r3.length; T3--; ) g(r3[T3]);
-        z(u3);
+        for (L = o3.length; L--; ) g(o3[L]);
+        N(u3);
       }
-      else u3.__e = t3.__e, u3.__k = t3.__k, n3.then || z(u3);
+      else u3.__e = t3.__e, u3.__k = t3.__k, n3.then || N(u3);
       l.__e(n3, u3, t3);
     }
-    else null == r3 && u3.__v == t3.__v ? (u3.__k = t3.__k, u3.__e = t3.__e) : f3 = u3.__e = q(t3.__e, u3, t3, i3, o3, r3, e3, c3, s3);
+    else null == o3 && u3.__v == t3.__v ? (u3.__k = t3.__k, u3.__e = t3.__e) : f3 = u3.__e = B(t3.__e, u3, t3, i3, r3, o3, e3, c3, s3);
     return (a3 = l.diffed) && a3(u3), 128 & u3.__u ? void 0 : f3;
   }
-  function z(n2) {
-    n2 && n2.__c && (n2.__c.__e = true), n2 && n2.__k && n2.__k.forEach(z);
+  function N(n2) {
+    n2 && (n2.__c && (n2.__c.__e = true), n2.__k && n2.__k.some(N));
   }
-  function N(n2, u3, t3) {
-    for (var i3 = 0; i3 < t3.length; i3++) B(t3[i3], t3[++i3], t3[++i3]);
+  function V(n2, u3, t3) {
+    for (var i3 = 0; i3 < t3.length; i3++) D(t3[i3], t3[++i3], t3[++i3]);
     l.__c && l.__c(u3, n2), n2.some(function(u4) {
       try {
         n2 = u4.__h, u4.__h = [], n2.some(function(n3) {
@@ -1654,12 +1652,12 @@
       }
     });
   }
-  function V(n2) {
-    return "object" != typeof n2 || null == n2 || n2.__b && n2.__b > 0 ? n2 : d(n2) ? n2.map(V) : w({}, n2);
+  function q(n2) {
+    return "object" != typeof n2 || null == n2 || n2.__b > 0 ? n2 : d(n2) ? n2.map(q) : w({}, n2);
   }
-  function q(u3, t3, i3, o3, r3, e3, f3, c3, s3) {
+  function B(u3, t3, i3, r3, o3, e3, f3, c3, s3) {
     var a3, h3, v3, y3, w3, _3, m3, b = i3.props || p, k3 = t3.props, x3 = t3.type;
-    if ("svg" == x3 ? r3 = "http://www.w3.org/2000/svg" : "math" == x3 ? r3 = "http://www.w3.org/1998/Math/MathML" : r3 || (r3 = "http://www.w3.org/1999/xhtml"), null != e3) {
+    if ("svg" == x3 ? o3 = "http://www.w3.org/2000/svg" : "math" == x3 ? o3 = "http://www.w3.org/1998/Math/MathML" : o3 || (o3 = "http://www.w3.org/1999/xhtml"), null != e3) {
       for (a3 = 0; a3 < e3.length; a3++) if ((w3 = e3[a3]) && "setAttribute" in w3 == !!x3 && (x3 ? w3.localName == x3 : 3 == w3.nodeType)) {
         u3 = w3, e3[a3] = null;
         break;
@@ -1667,25 +1665,20 @@
     }
     if (null == u3) {
       if (null == x3) return document.createTextNode(k3);
-      u3 = document.createElementNS(r3, x3, k3.is && k3), c3 && (l.__m && l.__m(t3, e3), c3 = false), e3 = null;
+      u3 = document.createElementNS(o3, x3, k3.is && k3), c3 && (l.__m && l.__m(t3, e3), c3 = false), e3 = null;
     }
     if (null == x3) b === k3 || c3 && u3.data == k3 || (u3.data = k3);
     else {
       if (e3 = e3 && n.call(u3.childNodes), !c3 && null != e3) for (b = {}, a3 = 0; a3 < u3.attributes.length; a3++) b[(w3 = u3.attributes[a3]).name] = w3.value;
-      for (a3 in b) if (w3 = b[a3], "children" == a3) ;
-      else if ("dangerouslySetInnerHTML" == a3) v3 = w3;
-      else if (!(a3 in k3)) {
-        if ("value" == a3 && "defaultValue" in k3 || "checked" == a3 && "defaultChecked" in k3) continue;
-        j(u3, a3, null, w3, r3);
-      }
-      for (a3 in k3) w3 = k3[a3], "children" == a3 ? y3 = w3 : "dangerouslySetInnerHTML" == a3 ? h3 = w3 : "value" == a3 ? _3 = w3 : "checked" == a3 ? m3 = w3 : c3 && "function" != typeof w3 || b[a3] === w3 || j(u3, a3, w3, b[a3], r3);
+      for (a3 in b) w3 = b[a3], "dangerouslySetInnerHTML" == a3 ? v3 = w3 : "children" == a3 || a3 in k3 || "value" == a3 && "defaultValue" in k3 || "checked" == a3 && "defaultChecked" in k3 || F(u3, a3, null, w3, o3);
+      for (a3 in k3) w3 = k3[a3], "children" == a3 ? y3 = w3 : "dangerouslySetInnerHTML" == a3 ? h3 = w3 : "value" == a3 ? _3 = w3 : "checked" == a3 ? m3 = w3 : c3 && "function" != typeof w3 || b[a3] === w3 || F(u3, a3, w3, b[a3], o3);
       if (h3) c3 || v3 && (h3.__html == v3.__html || h3.__html == u3.innerHTML) || (u3.innerHTML = h3.__html), t3.__k = [];
-      else if (v3 && (u3.innerHTML = ""), I("template" == t3.type ? u3.content : u3, d(y3) ? y3 : [y3], t3, i3, o3, "foreignObject" == x3 ? "http://www.w3.org/1999/xhtml" : r3, e3, f3, e3 ? e3[0] : i3.__k && S(i3, 0), c3, s3), null != e3) for (a3 = e3.length; a3--; ) g(e3[a3]);
-      c3 || (a3 = "value", "progress" == x3 && null == _3 ? u3.removeAttribute("value") : null != _3 && (_3 !== u3[a3] || "progress" == x3 && !_3 || "option" == x3 && _3 != b[a3]) && j(u3, a3, _3, b[a3], r3), a3 = "checked", null != m3 && m3 != u3[a3] && j(u3, a3, m3, b[a3], r3));
+      else if (v3 && (u3.innerHTML = ""), P("template" == t3.type ? u3.content : u3, d(y3) ? y3 : [y3], t3, i3, r3, "foreignObject" == x3 ? "http://www.w3.org/1999/xhtml" : o3, e3, f3, e3 ? e3[0] : i3.__k && S(i3, 0), c3, s3), null != e3) for (a3 = e3.length; a3--; ) g(e3[a3]);
+      c3 || (a3 = "value", "progress" == x3 && null == _3 ? u3.removeAttribute("value") : null != _3 && (_3 !== u3[a3] || "progress" == x3 && !_3 || "option" == x3 && _3 != b[a3]) && F(u3, a3, _3, b[a3], o3), a3 = "checked", null != m3 && m3 != u3[a3] && F(u3, a3, m3, b[a3], o3));
     }
     return u3;
   }
-  function B(n2, u3, t3) {
+  function D(n2, u3, t3) {
     try {
       if ("function" == typeof n2) {
         var i3 = "function" == typeof n2.__u;
@@ -1695,9 +1688,9 @@
       l.__e(n3, t3);
     }
   }
-  function D(n2, u3, t3) {
-    var i3, o3;
-    if (l.unmount && l.unmount(n2), (i3 = n2.ref) && (i3.current && i3.current != n2.__e || B(i3, null, u3)), null != (i3 = n2.__c)) {
+  function E(n2, u3, t3) {
+    var i3, r3;
+    if (l.unmount && l.unmount(n2), (i3 = n2.ref) && (i3.current && i3.current != n2.__e || D(i3, null, u3)), null != (i3 = n2.__c)) {
       if (i3.componentWillUnmount) try {
         i3.componentWillUnmount();
       } catch (n3) {
@@ -1705,17 +1698,17 @@
       }
       i3.base = i3.__P = null;
     }
-    if (i3 = n2.__k) for (o3 = 0; o3 < i3.length; o3++) i3[o3] && D(i3[o3], u3, t3 || "function" != typeof n2.type);
+    if (i3 = n2.__k) for (r3 = 0; r3 < i3.length; r3++) i3[r3] && E(i3[r3], u3, t3 || "function" != typeof n2.type);
     t3 || g(n2.__e), n2.__c = n2.__ = n2.__e = void 0;
   }
-  function E(n2, l3, u3) {
+  function G(n2, l3, u3) {
     return this.constructor(n2, u3);
   }
-  function G(u3, t3, i3) {
-    var o3, r3, e3, f3;
-    t3 == document && (t3 = document.documentElement), l.__ && l.__(u3, t3), r3 = (o3 = "function" == typeof i3) ? null : i3 && i3.__k || t3.__k, e3 = [], f3 = [], O(t3, u3 = (!o3 && i3 || t3).__k = _(k, null, [u3]), r3 || p, p, t3.namespaceURI, !o3 && i3 ? [i3] : r3 ? null : t3.firstChild ? n.call(t3.childNodes) : null, e3, !o3 && i3 ? i3 : r3 ? r3.__e : t3.firstChild, o3, f3), N(e3, u3, f3);
+  function J(u3, t3, i3) {
+    var r3, o3, e3, f3;
+    t3 == document && (t3 = document.documentElement), l.__ && l.__(u3, t3), o3 = (r3 = "function" == typeof i3) ? null : i3 && i3.__k || t3.__k, e3 = [], f3 = [], z(t3, u3 = (!r3 && i3 || t3).__k = _(k, null, [u3]), o3 || p, p, t3.namespaceURI, !r3 && i3 ? [i3] : o3 ? null : t3.firstChild ? n.call(t3.childNodes) : null, e3, !r3 && i3 ? i3 : o3 ? o3.__e : t3.firstChild, r3, f3), V(e3, u3, f3);
   }
-  function Q(n2) {
+  function R(n2) {
     function l3(n3) {
       var u3, t3;
       return this.getChildContext || (u3 = /* @__PURE__ */ new Set(), (t3 = {})[l3.__c] = this, this.getChildContext = function() {
@@ -1724,7 +1717,7 @@
         u3 = null;
       }, this.shouldComponentUpdate = function(n4) {
         this.props.value != n4.value && u3.forEach(function(n5) {
-          n5.__e = true, M(n5);
+          n5.__e = true, $(n5);
         });
       }, this.sub = function(n4) {
         u3.add(n4);
@@ -1739,8 +1732,8 @@
     }).contextType = l3, l3;
   }
   n = v.slice, l = { __e: function(n2, l3, u3, t3) {
-    for (var i3, o3, r3; l3 = l3.__; ) if ((i3 = l3.__c) && !i3.__) try {
-      if ((o3 = i3.constructor) && null != o3.getDerivedStateFromError && (i3.setState(o3.getDerivedStateFromError(n2)), r3 = i3.__d), null != i3.componentDidCatch && (i3.componentDidCatch(n2, t3 || {}), r3 = i3.__d), r3) return i3.__E = i3;
+    for (var i3, r3, o3; l3 = l3.__; ) if ((i3 = l3.__c) && !i3.__) try {
+      if ((r3 = i3.constructor) && null != r3.getDerivedStateFromError && (i3.setState(r3.getDerivedStateFromError(n2)), o3 = i3.__d), null != i3.componentDidCatch && (i3.componentDidCatch(n2, t3 || {}), o3 = i3.__d), o3) return i3.__E = i3;
     } catch (l4) {
       n2 = l4;
     }
@@ -1749,12 +1742,12 @@
     return null != n2 && void 0 === n2.constructor;
   }, x.prototype.setState = function(n2, l3) {
     var u3;
-    u3 = null != this.__s && this.__s != this.state ? this.__s : this.__s = w({}, this.state), "function" == typeof n2 && (n2 = n2(w({}, u3), this.props)), n2 && w(u3, n2), null != n2 && this.__v && (l3 && this._sb.push(l3), M(this));
+    u3 = null != this.__s && this.__s != this.state ? this.__s : this.__s = w({}, this.state), "function" == typeof n2 && (n2 = n2(w({}, u3), this.props)), n2 && w(u3, n2), null != n2 && this.__v && (l3 && this._sb.push(l3), $(this));
   }, x.prototype.forceUpdate = function(n2) {
-    this.__v && (this.__e = true, n2 && this.__h.push(n2), M(this));
-  }, x.prototype.render = k, i = [], r = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e = function(n2, l3) {
+    this.__v && (this.__e = true, n2 && this.__h.push(n2), $(this));
+  }, x.prototype.render = k, i = [], o = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e = function(n2, l3) {
     return n2.__v.__b - l3.__v.__b;
-  }, $.__r = 0, f = /(PointerCapture)$|Capture$/i, c = 0, s = F(false), a = F(true), h = 0;
+  }, I.__r = 0, f = /(PointerCapture)$|Capture$/i, c = 0, s = O(false), a = O(true), h = 0;
 
   // ../node_modules/preact/hooks/dist/hooks.module.js
   var t2;
@@ -1787,13 +1780,13 @@
       var f3 = function(n3, t3, r3) {
         if (!o3.__c.__H) return true;
         var u4 = o3.__c.__H.__.filter(function(n4) {
-          return !!n4.__c;
+          return n4.__c;
         });
         if (u4.every(function(n4) {
           return !n4.__N;
         })) return !c3 || c3.call(this, n3, t3, r3);
         var i4 = o3.__c.props !== n3;
-        return u4.forEach(function(n4) {
+        return u4.some(function(n4) {
           if (n4.__N) {
             var t4 = n4.__[0];
             n4.__ = n4.__N, n4.__N = void 0, t4 !== n4.__[0] && (i4 = true);
@@ -1848,10 +1841,13 @@
     return n2.__;
   }
   function j2() {
-    for (var n2; n2 = f2.shift(); ) if (n2.__P && n2.__H) try {
-      n2.__H.__h.forEach(z2), n2.__H.__h.forEach(B2), n2.__H.__h = [];
-    } catch (t3) {
-      n2.__H.__h = [], c2.__e(t3, n2.__v);
+    for (var n2; n2 = f2.shift(); ) {
+      var t3 = n2.__H;
+      if (n2.__P && t3) try {
+        t3.__h.some(z2), t3.__h.some(B2), t3.__h = [];
+      } catch (r3) {
+        t3.__h = [], c2.__e(r3, n2.__v);
+      }
     }
   }
   c2.__b = function(n2) {
@@ -1861,19 +1857,19 @@
   }, c2.__r = function(n2) {
     a2 && a2(n2), t2 = 0;
     var i3 = (r2 = n2.__c).__H;
-    i3 && (u2 === r2 ? (i3.__h = [], r2.__h = [], i3.__.forEach(function(n3) {
+    i3 && (u2 === r2 ? (i3.__h = [], r2.__h = [], i3.__.some(function(n3) {
       n3.__N && (n3.__ = n3.__N), n3.u = n3.__N = void 0;
-    })) : (i3.__h.forEach(z2), i3.__h.forEach(B2), i3.__h = [], t2 = 0)), u2 = r2;
+    })) : (i3.__h.some(z2), i3.__h.some(B2), i3.__h = [], t2 = 0)), u2 = r2;
   }, c2.diffed = function(n2) {
     v2 && v2(n2);
     var t3 = n2.__c;
-    t3 && t3.__H && (t3.__H.__h.length && (1 !== f2.push(t3) && i2 === c2.requestAnimationFrame || ((i2 = c2.requestAnimationFrame) || w2)(j2)), t3.__H.__.forEach(function(n3) {
+    t3 && t3.__H && (t3.__H.__h.length && (1 !== f2.push(t3) && i2 === c2.requestAnimationFrame || ((i2 = c2.requestAnimationFrame) || w2)(j2)), t3.__H.__.some(function(n3) {
       n3.u && (n3.__H = n3.u), n3.u = void 0;
     })), u2 = r2 = null;
   }, c2.__c = function(n2, t3) {
     t3.some(function(n3) {
       try {
-        n3.__h.forEach(z2), n3.__h = n3.__h.filter(function(n4) {
+        n3.__h.some(z2), n3.__h = n3.__h.filter(function(n4) {
           return !n4.__ || B2(n4);
         });
       } catch (r3) {
@@ -1885,7 +1881,7 @@
   }, c2.unmount = function(n2) {
     m2 && m2(n2);
     var t3, r3 = n2.__c;
-    r3 && r3.__H && (r3.__H.__.forEach(function(n3) {
+    r3 && r3.__H && (r3.__H.__.some(function(n3) {
       try {
         z2(n3);
       } catch (n4) {
@@ -1918,7 +1914,7 @@
   }
 
   // shared/components/EnvironmentProvider.js
-  var EnvironmentContext = Q({
+  var EnvironmentContext = R({
     isReducedMotion: false,
     isDarkMode: false,
     debugState: false,
@@ -2022,7 +2018,7 @@
   }
 
   // shared/components/TranslationsProvider.js
-  var TranslationContext = Q({
+  var TranslationContext = R({
     /** @type {LocalTranslationFn} */
     t: () => {
       throw new Error("must implement");
@@ -2530,19 +2526,19 @@
       t: x2(TranslationContext).t
     };
   }
-  var MessagingContext2 = Q(
+  var MessagingContext2 = R(
     /** @type {import("../src/index.js").DuckplayerPage} */
     {}
   );
   var useMessaging = () => x2(MessagingContext2);
-  var TelemetryContext = Q(
+  var TelemetryContext = R(
     /** @type {import("../src/index.js").Telemetry} */
     {}
   );
   var useTelemetry = () => x2(TelemetryContext);
 
   // pages/duckplayer/app/providers/SettingsProvider.jsx
-  var SettingsContext = Q(
+  var SettingsContext = R(
     /** @type {{settings: Settings}} */
     {}
   );
@@ -2604,7 +2600,7 @@
   }
 
   // pages/duckplayer/app/providers/UserValuesProvider.jsx
-  var UserValuesContext = Q({
+  var UserValuesContext = R({
     /** @type {UserValues} */
     value: {
       privatePlayerMode: { alwaysAsk: {} },
@@ -2796,7 +2792,7 @@
   };
 
   // pages/duckplayer/app/providers/SwitchProvider.jsx
-  var SwitchContext = Q({
+  var SwitchContext = R({
     /** @type {SwitchState} */
     state: "showing",
     /** @type {() => void} */
@@ -3121,7 +3117,7 @@
   }
 
   // pages/duckplayer/app/providers/YouTubeErrorProvider.jsx
-  var YouTubeErrorContext = Q({
+  var YouTubeErrorContext = R({
     /** @type {YouTubeError|null} */
     error: null,
     /** @type {string} - Enables showing different error messages based on locale */
@@ -4118,7 +4114,7 @@
     const root = document.querySelector("body");
     if (!root) throw new Error("could not render, root element missing");
     if (environment.display === "app") {
-      G(
+      J(
         /* @__PURE__ */ _(EnvironmentProvider, { debugState: environment.debugState, injectName: environment.injectName, willThrow: environment.willThrow }, /* @__PURE__ */ _(ErrorBoundary, { didCatch, fallback: /* @__PURE__ */ _(Fallback, { showDetails: environment.env === "development" }) }, /* @__PURE__ */ _(UpdateEnvironment, { search: window.location.search }), /* @__PURE__ */ _(TelemetryContext.Provider, { value: telemetry2 }, /* @__PURE__ */ _(MessagingContext2.Provider, { value: messaging2 }, /* @__PURE__ */ _(SettingsProvider, { settings }, /* @__PURE__ */ _(YouTubeErrorProvider, { initial: initialYouTubeError, locale: environment.locale }, /* @__PURE__ */ _(UserValuesProvider, { initial: init2.userValues }, settings.layout === "desktop" && /* @__PURE__ */ _(
           TranslationProvider,
           {
@@ -4139,7 +4135,7 @@
         root
       );
     } else if (environment.display === "components") {
-      G(
+      J(
         /* @__PURE__ */ _(EnvironmentProvider, { debugState: false, injectName: environment.injectName }, /* @__PURE__ */ _(MessagingContext2.Provider, { value: messaging2 }, /* @__PURE__ */ _(TranslationProvider, { translationObject: duckplayer_default, fallback: duckplayer_default, textLength: environment.textLength }, /* @__PURE__ */ _(Components, null)))),
         root
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.14.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.15.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e2713d7dee5072f2c68ca0b39d84766f6cf07433",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#220554cbcf2ef3ee73bb5f57745653698aabc2f1",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.14.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.15.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213413168447290/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shipped, minified injected content-scope scripts; while changes are largely defensive null-safety, any regression could impact core page injection/feature loading behavior across many sites.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `13.14.0` to `13.15.0` (package.json/lock) and refreshes the vendored Android build artifacts under `node_modules/@duckduckgo/content-scope-scripts`.
> 
> The updated injected scripts add *defensive null/undefined handling* across exemption list processing, stack-trace URL parsing, feature enablement/settings parsing, and DuckPlayer/mobile string lookups, plus a new guard when loading platform features to skip missing constructors (optionally logging in debug).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65ae5cb351f0ae268c6ac7676c323e3b012dd82c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->