### PR TITLE
Dismiss the "Get Desktop Browser" item from "Complete your setup" section when the link is clicked and copied to the clipboard

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/desktopbrowser/GetDesktopBrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/desktopbrowser/GetDesktopBrowserViewModel.kt
@@ -86,6 +86,7 @@ class GetDesktopBrowserViewModel @AssistedInject constructor(
     fun onLinkClicked() {
         viewModelScope.launch(dispatchers.io()) {
             pixel.fire(AppPixelName.GET_DESKTOP_BROWSER_LINK_CLICK)
+            settingsDataStore.getDesktopBrowserSettingDismissed = true
             if (!clipboardInteractor.copyToClipboard(DESKTOP_BROWSER_URL, isSensitive = false)) {
                 _command.send(Command.ShowCopiedNotification)
             }

--- a/app/src/test/java/com/duckduckgo/app/desktopbrowser/GetDesktopBrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/desktopbrowser/GetDesktopBrowserViewModelTest.kt
@@ -160,6 +160,15 @@ class GetDesktopBrowserViewModelTest {
     }
 
     @Test
+    fun whenOnLinkClickedThenSettingIsDismissed() = runTest {
+        whenever(clipboardInteractorMock.copyToClipboard(any(), any())).thenReturn(true)
+
+        testee.onLinkClicked()
+
+        verify(settingsDataStoreMock).getDesktopBrowserSettingDismissed = true
+    }
+
+    @Test
     fun whenOnLinkClickedThenPixelIsFired() = runTest {
         whenever(clipboardInteractorMock.copyToClipboard(any(), any())).thenReturn(true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1213420216450696?focus=true

### Description

When users click the desktop browser link, the setting is now automatically dismissed by setting `getDesktopBrowserSettingDismissed` to true. This prevents the desktop browser prompt from appearing again after the user has already engaged with it.

### Steps to test this PR

_Desktop Browser Link Interaction_
- [ ] Navigate to the desktop browser promotion screen
- [ ] Click on the desktop browser link
- [ ] Verify that the desktop browser setting is dismissed from “Complete your setup"

### UI changes
[uploading Screen_recording_20260224_191852.mp4…]
[Screen_recording_20260224_191852.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/46521b79-e661-4898-abb9-3c22442154f4.mp4" />](https://app.graphite.com/user-attachments/video/46521b79-e661-4898-abb9-3c22442154f4.mp4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to a single promo flow; it only sets an existing settings flag and adds a unit test, with minimal risk of regressions elsewhere.
> 
> **Overview**
> Clicking the desktop browser download link now also sets `settingsDataStore.getDesktopBrowserSettingDismissed = true`, ensuring the "Get Desktop Browser" item is dismissed after user engagement (in addition to the existing "No thanks" path).
> 
> Adds a unit test to assert the dismissal flag is set when `onLinkClicked` is invoked (alongside the existing pixel firing and clipboard behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5675cb099576e59fecd4e6752a9c6f170af26695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->