### PR TITLE
Fix flaky bookmark tests

### DIFF
--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -16,12 +16,14 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
           text: "add bookmark"
       - tapOn:
           text: "add bookmark"
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
           text: "bookmarks"
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -24,12 +24,14 @@ tags:
       - pressKey: Enter
       - assertVisible:
             text: "Privacy Test Pages"
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
             text: "add bookmark"
       - tapOn:
             text: "add bookmark"
-      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
       - assertVisible:
             text: "bookmarks"
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -18,7 +18,8 @@ tags:
             - pressKey: Enter
             - assertVisible:
                   text: "Privacy Test Pages"
-            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+            - tapOn:
+                id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
             - assertVisible:
                   text: "add bookmark"
             - tapOn:
@@ -29,7 +30,8 @@ tags:
             - pressKey: Enter
             - assertVisible:
                 text: "Search engine"
-            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+            - tapOn:
+                id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
             - assertVisible:
                   text: "bookmarks"
             - tapOn:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213430504228545?focus=true

### Description
Fix flaky Maestro tests for bookmarks by removing step to hide keyboard

### Steps to test this PR

_Feature 1_
- [x] Check [release tests](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/app/app_01hkqhj1thevwtn9ym8a2ctn2r/upload/mupload_01kja2htwrfr8s79saxhmeta0g?sort=name) pass in Maestro. In particular:
    - [x] [ReleaseTest: Bookmarks can be added and deleted](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/flow/run_01kja2hvageaqtmsb82h954nat)
    - [x] [ReleaseTest: Bookmark open and back navigation](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/flow/run_01kja2hv6sesh88cr4mxykf19f)
    - [x] [ReleaseTest: Bookmark open in folder and back navigation](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/flow/run_01kja2hv8mfgh8bvjtcgjmwfsm)

### UI changes
n/a
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust UI automation steps; no production code paths or data handling are affected.
> 
> **Overview**
> Stabilizes the Maestro bookmark release tests by replacing the shared `click_on_menu_button` subflow with direct `tapOn` interactions on `browserMenuImageView` when opening the browser menu.
> 
> This updates three bookmark flows (add/delete, open+back, and folder navigation) to remove conditional logic/keyboard handling from the menu-opening step, reducing flakiness during menu access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07fad30678dd0c6ec0ba6f3df044633e43cf0463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->