### PR TITLE
Update content scope scripts to version 13.17.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -636,7 +636,8 @@
       "pageContext",
       "print",
       "pageObserver",
-      "hover"
+      "hover",
+      "browserUiLock"
     ]
   );
   var platformSupport = {
@@ -665,9 +666,11 @@
       "breakageReporting",
       "duckPlayer",
       "messageBridge",
-      "pageContext"
+      "pageContext",
+      "browserUiLock"
     ],
     "android-broker-protection": ["brokerProtection"],
+    "android-ai-history": ["duckAiChatHistory"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
       "apiManipulation",
@@ -681,7 +684,6 @@
       "webDetection",
       "breakageReporting"
     ],
-    "android-ai-history": ["duckAiChatHistory"],
     windows: [
       "cookie",
       ...baseFeatures,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2130,7 +2130,8 @@
       "pageContext",
       "print",
       "pageObserver",
-      "hover"
+      "hover",
+      "browserUiLock"
     ]
   );
   var platformSupport = {
@@ -2159,9 +2160,11 @@
       "breakageReporting",
       "duckPlayer",
       "messageBridge",
-      "pageContext"
+      "pageContext",
+      "browserUiLock"
     ],
     "android-broker-protection": ["brokerProtection"],
+    "android-ai-history": ["duckAiChatHistory"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
       "apiManipulation",
@@ -2175,7 +2178,6 @@
       "webDetection",
       "breakageReporting"
     ],
-    "android-ai-history": ["duckAiChatHistory"],
     windows: [
       "cookie",
       ...baseFeatures,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2102,7 +2102,8 @@
       "pageContext",
       "print",
       "pageObserver",
-      "hover"
+      "hover",
+      "browserUiLock"
     ]
   );
   var platformSupport = {
@@ -2131,9 +2132,11 @@
       "breakageReporting",
       "duckPlayer",
       "messageBridge",
-      "pageContext"
+      "pageContext",
+      "browserUiLock"
     ],
     "android-broker-protection": ["brokerProtection"],
+    "android-ai-history": ["duckAiChatHistory"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
       "apiManipulation",
@@ -2147,7 +2150,6 @@
       "webDetection",
       "breakageReporting"
     ],
-    "android-ai-history": ["duckAiChatHistory"],
     windows: [
       "cookie",
       ...baseFeatures,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -577,7 +577,8 @@
       "pageContext",
       "print",
       "pageObserver",
-      "hover"
+      "hover",
+      "browserUiLock"
     ]
   );
   var platformSupport = {
@@ -606,9 +607,11 @@
       "breakageReporting",
       "duckPlayer",
       "messageBridge",
-      "pageContext"
+      "pageContext",
+      "browserUiLock"
     ],
     "android-broker-protection": ["brokerProtection"],
+    "android-ai-history": ["duckAiChatHistory"],
     "android-autofill-import": ["autofillImport"],
     "android-adsjs": [
       "apiManipulation",
@@ -622,7 +625,6 @@
       "webDetection",
       "breakageReporting"
     ],
-    "android-ai-history": ["duckAiChatHistory"],
     windows: [
       "cookie",
       ...baseFeatures,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.15.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.17.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.55.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.55.0.tgz",
-      "integrity": "sha512-izmIq99kfXGTnqqzwqcdim0gCYWr8OtYb3ysMu/T9Wrx44qW3Cp3EoqF7UKuy1cxt+UGSPtyll9bFp08qi/pgg==",
+      "version": "14.55.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.55.1.tgz",
+      "integrity": "sha512-zxG6Zo7DvZ0BTZafr+PcZTqz2QArkDZZOXERJiPgbuyYo0zaiPlVENatFQ/Ya4c6G/irha1zZK80uYtg3lXOcg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#220554cbcf2ef3ee73bb5f57745653698aabc2f1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5b849f97736f2e0841e280cc8a4efe0ad4a6acd5",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.15.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.17.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213435534507018?focus=true

----

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run