### PR TITLE
Add maestro tests for Recent Chats Suggestions

### DIFF
--- a/.maestro/input_screen/input_screen_chat_suggestions_config.yaml
+++ b/.maestro/input_screen/input_screen_chat_suggestions_config.yaml
@@ -1,0 +1,16 @@
+appId: com.duckduckgo.mobile.android
+androidWebViewHierarchy: devtools
+name: "Input Screen Chat Suggestions test"
+tags:
+  - inputScreenTest
+  - chatSuggestionsTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+      - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: ./shared/input_screen_enable_flow.yaml
+      - runFlow: ./shared/input_screen_chat_suggestions_flow.yaml

--- a/.maestro/input_screen/shared/input_screen_chat_suggestions_flow.yaml
+++ b/.maestro/input_screen/shared/input_screen_chat_suggestions_flow.yaml
@@ -1,0 +1,146 @@
+appId: com.duckduckgo.mobile.android
+---
+
+# TEST 1: Empty state — no suggestions with no history
+- tapOn:
+    id: "omnibarTextInput"
+    optional: true
+- assertVisible:
+    id: "inputModeWidget"
+- tapOn:
+    text: "Duck.ai"
+
+# On a fresh install, no chat history exists
+- assertNotVisible:
+    id: "chatSuggestionsRecyclerView"
+- assertVisible:
+    id: "ddgLogoContainer"
+
+
+# SETUP: Create a chat to populate history
+- inputText: "What is DuckDuckGo"
+- tapOn:
+    id: "actionSend"
+
+# Wait for the Duck.ai WebView to open
+- extendedWaitUntil:
+    visible:
+      text: "Duck.ai"
+      childOf:
+        id: "toolbar"
+    timeout: 10000
+
+# Accept the duck.ai agreement prompt (first time only)
+- runFlow: ../../shared/accept_duckai_agreement.yaml
+
+# Verify the chat message appears in the WebView
+- extendedWaitUntil:
+    visible:
+      text: ".*What is DuckDuckGo.*"
+    timeout: 10000
+
+# Tap the toolbar to return to the input screen (opens in Duck.ai mode)
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/duckAIHeader"
+
+# Wait for chat suggestions to load
+- extendedWaitUntil:
+    visible:
+      id: "chatSuggestionsRecyclerView"
+    timeout: 10000
+
+- assertVisible:
+    id: "chatSuggestionsOverlay"
+- assertVisible:
+    id: "chatSuggestionTitle"
+- assertVisible:
+    id: "chatSuggestionIcon"
+
+# TEST 3: Suggestions hidden in Search mode
+- tapOn:
+    text: "Search"
+- assertNotVisible:
+    id: "chatSuggestionsOverlay"
+
+# Switch back to Chat mode -> suggestions should reappear
+- tapOn:
+    text: "Duck.ai"
+- extendedWaitUntil:
+    visible:
+      id: "chatSuggestionsRecyclerView"
+    timeout: 10000
+- assertVisible:
+    id: "chatSuggestionsOverlay"
+
+# TEST 4: Suggestions filter as user types
+
+# Type a query that won't match any chat title
+- inputText: "xyznonexistent"
+
+# Wait for debounce + fetch —> suggestions should disappear
+- extendedWaitUntil:
+    notVisible:
+      id: "chatSuggestionTitle"
+    timeout: 5000
+- assertNotVisible:
+    id: "chatSuggestionTitle"
+
+# Clear text — suggestions should return
+- tapOn:
+    id: "inputFieldClearText"
+- extendedWaitUntil:
+    visible:
+      id: "chatSuggestionTitle"
+    timeout: 10000
+- assertVisible:
+    id: "chatSuggestionTitle"
+
+# TEST 5: Tapping a suggestion opens the chat
+- tapOn:
+    id: "chatSuggestionTitle"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "Duck.ai"
+      childOf:
+        id: "toolbar"
+    timeout: 10000
+- assertVisible:
+    text: "Duck.ai"
+    childOf:
+      id: "toolbar"
+
+
+# TEST 6: Deleting a chat removes it from suggestions
+# We are currently in the Duck.ai WebView (from Test 5)
+# Open the side panel menu
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/duckAiSidebar"
+
+# Scroll to the Chats section and find our chat
+- scrollUntilVisible:
+    element:
+      text: "Chats"
+    direction: DOWN
+- scrollUntilVisible:
+    element:
+      text: ".*DuckDuckGo.*"
+    direction: DOWN
+
+# Tap the three-dot menu next to the chat and clear it
+- tapOn: "menu"
+- tapOn: "Clear"
+
+# Return to the input screen
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/duckAIHeader"
+
+# Verify suggestions are gone and logo is back
+- extendedWaitUntil:
+    notVisible:
+      id: "chatSuggestionTitle"
+    timeout: 10000
+- assertNotVisible:
+    id: "chatSuggestionsRecyclerView"
+- assertVisible:
+    id: "ddgLogoContainer"

--- a/.maestro/shared/accept_duckai_agreement.yaml
+++ b/.maestro/shared/accept_duckai_agreement.yaml
@@ -1,0 +1,14 @@
+appId: com.duckduckgo.mobile.android
+---
+# Handle the duck.ai agreement/terms prompt that appears on first use.
+# This dialog is rendered in the duck.ai WebView frontend.
+#
+- extendedWaitUntil:
+    visible:
+      text: ".*Agree and Continue.*"
+    timeout: 10000
+    optional: true
+
+- tapOn:
+    text: ".*Agree and Continue.*"
+    optional: true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213405987220424?focus=true

### Description

Added tests for the Duck.ai chat suggestions

- Empty state: no suggestions when no chat history
- Suggestions appear after creating a chat
- Suggestions filter as user types
- Tapping a suggestion opens the chat
- Suggestions hidden in Search mode
- Deleting the chat will clear the list

### Steps to test this PR
- Pull the changes
- run maestro test
`maestro test .maestro/input_screen/input_screen_chat_suggestions.yaml`

### Video showing the test running

https://github.com/user-attachments/assets/98f2a06b-5a94-4c86-aa21-54c33ce47bd5





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes adding Maestro flows; primary risk is UI flakiness from WebView/async waits and selector brittleness, not production behavior.
> 
> **Overview**
> Adds a new Maestro test (`input_screen_chat_suggestions_config.yaml` + `input_screen_chat_suggestions_flow.yaml`) to validate Duck.ai recent chat suggestions on the input screen, including empty state, appearance after creating a chat, hiding in Search mode, filtering while typing, opening a chat from a suggestion, and clearing suggestions after deleting a chat.
> 
> Introduces a shared helper flow (`accept_duckai_agreement.yaml`) to optionally accept the first-run Duck.ai “Agree and Continue” WebView prompt during test execution, and wraps the test in a retryable launch/onboarding-skip + input-screen-enable sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f359fae13ea1b6d3546fe071e8164317c9e0a61a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->