### PR TITLE
Blocks UX when allowPurchase is disabled

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -95,6 +95,11 @@ class RealSubscriptions @Inject constructor(
         val supportsEncryption = subscriptionsManager.canSupportEncryption()
         val isActive = subscriptionsManager.subscriptionStatus().isActiveOrWaiting()
         val isEligible = subscriptionsManager.getSubscriptionOffer().isNotEmpty()
+
+        if (!subscriptionsFeature.get().allowPurchase().isEnabled()) {
+            return isActive
+        }
+
         return isActive || (isEligible && supportsEncryption)
     }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -183,7 +183,23 @@ class RealSubscriptionsTest {
     }
 
     @Test
+    fun whenIsEligibleIfAllowPurchaseDisabledAndNoActiveSubscriptionThenReturnFalse() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(false))
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
+        assertFalse(subscriptions.isEligible())
+    }
+
+    @Test
+    fun whenIsEligibleIfAllowPurchaseDisabledButHasActiveSubscriptionThenReturnTrue() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(false))
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
+        assertTrue(subscriptions.isEligible())
+    }
+
+    @Test
     fun whenIsEligibleIfOffersReturnedThenReturnTrueRegardlessOfStatus() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         assertTrue(subscriptions.isEligible())
@@ -191,24 +207,28 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnFalseIfNotActiveOrWaiting() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
         assertFalse(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnTrueIfWaiting() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(WAITING)
         assertTrue(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnTrueIfActive() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
         assertTrue(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotEncryptionThenReturnTrueIfActive() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(false)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -217,6 +237,7 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenIsEligibleIfNotEncryptionAndNotActiveThenReturnFalse() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(false)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
@@ -225,6 +246,7 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenShouldLaunchPrivacyProForUrlThenReturnCorrectValue() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
 
@@ -240,6 +262,7 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenShouldLaunchPrivacyProForUrlThenReturnTrue() = runTest {
+        subscriptionFeature.allowPurchase().setRawStoredState(State(true))
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213419489119408?focus=true 

### Description
This PR hides subscriptions UX when allowPurchase is disabled

### Steps to test this PR
- [x] Build staging and disable allowPurchase FF 
- [x] Subscription should not show up in settings unless you are subscribed already
- [x] Upsell vpn in menu should not show up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `isEligible` decision that controls whether subscription UX can be shown; incorrect gating could hide purchase flows or block access for some users. Logic is small and covered by new tests, keeping overall risk moderate.
> 
> **Overview**
> Updates `RealSubscriptions.isEligible()` to **block purchase-related eligibility when the `privacyPro.allowPurchase` toggle is disabled**, while still returning eligible for users with an *active/waiting* subscription.
> 
> Adds unit tests covering the new `allowPurchase`-disabled behavior and explicitly sets `allowPurchase` enabled in existing eligibility-related tests to avoid relying on default toggle state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7bf57761f5d958d44ce1b2973ace90cd669beba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->