### PR TITLE
Implement RMF isCurrentPIRUser

### DIFF
--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(':js-messaging-api')
     implementation project(':navigation-api')
     implementation project(':network-protection-api')
+    implementation project(':remote-messaging-api')
     implementation project(':subscriptions-api')
     implementation project(':statistics-api')
     implementation "com.squareup.logcat:logcat:_"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirUserUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirUserUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.store.PirRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+interface PirUserUtils {
+    suspend fun isActiveUser(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealPirUserUtils @Inject constructor(
+    private val pirWorkHandler: PirWorkHandler,
+    private val pirRepository: PirRepository,
+) : PirUserUtils {
+
+    /**
+     * A user is considered active if they:
+     * - Have a valid subscription
+     * - Has PIR enabled
+     * - Has a userprofile set up for scanning
+     */
+    override suspend fun isActiveUser(): Boolean {
+        return pirWorkHandler.canRunPir().firstOrNull() == true && pirRepository.getValidUserProfileQueries().isNotEmpty()
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/rmf/PirUserAttributeMatcherPlugin.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/rmf/PirUserAttributeMatcherPlugin.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.rmf
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.PirUserUtils
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class PirUserAttributeMatcherPlugin @Inject constructor(
+    private val pirUserUtils: PirUserUtils,
+) : AttributeMatcherPlugin {
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        return when (matchingAttribute) {
+            is PirUserJsonMatchingAttribute -> {
+                matchingAttribute.remoteValue == pirUserUtils.isActiveUser()
+            }
+
+            else -> return null
+        }
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/rmf/PirUserJsonMatchingAttributeMapper.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/rmf/PirUserJsonMatchingAttributeMapper.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.rmf
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class PirUserJsonMatchingAttributeMapper @Inject constructor() : JsonToMatchingAttributeMapper {
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        return when (key) {
+            PirUserJsonMatchingAttribute.KEY -> {
+                jsonMatchingAttribute.value?.let {
+                    PirUserJsonMatchingAttribute(
+                        jsonMatchingAttribute.value as Boolean,
+                    )
+                }
+            }
+
+            else -> null
+        }
+    }
+}
+
+data class PirUserJsonMatchingAttribute(
+    val remoteValue: Boolean,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "isCurrentPIRUser"
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl
+
+import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.store.PirRepository
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RealPirUserUtilsTest {
+
+    private lateinit var testee: RealPirUserUtils
+
+    private val mockPirWorkHandler: PirWorkHandler = mock()
+    private val mockPirRepository: PirRepository = mock()
+
+    private val testProfileQuery = ProfileQuery(
+        id = 1L,
+        firstName = "John",
+        lastName = "Doe",
+        city = "New York",
+        state = "NY",
+        addresses = emptyList(),
+        birthYear = 1990,
+        fullName = "John Doe",
+        age = 33,
+        deprecated = false,
+    )
+
+    @Before
+    fun setUp() {
+        testee = RealPirUserUtils(
+            pirWorkHandler = mockPirWorkHandler,
+            pirRepository = mockPirRepository,
+        )
+    }
+
+    @Test
+    fun whenCanRunPirAndHasProfileQueriesThenIsActiveUserReturnsTrue() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
+
+        val result = testee.isActiveUser()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenCannotRunPirThenIsActiveUserReturnsFalse() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(false))
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
+
+        val result = testee.isActiveUser()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenCanRunPirButNoProfileQueriesThenIsActiveUserReturnsFalse() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
+
+        val result = testee.isActiveUser()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenCannotRunPirAndNoProfileQueriesThenIsActiveUserReturnsFalse() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(false))
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
+
+        val result = testee.isActiveUser()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenCanRunPirFlowIsEmptyThenIsActiveUserReturnsFalse() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(emptyFlow())
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
+
+        val result = testee.isActiveUser()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenHasMultipleProfileQueriesAndCanRunPirThenIsActiveUserReturnsTrue() = runTest {
+        val profileQuery2 = ProfileQuery(
+            id = 2L,
+            firstName = "Jane",
+            lastName = "Smith",
+            city = "Los Angeles",
+            state = "CA",
+            addresses = emptyList(),
+            birthYear = 1985,
+            fullName = "Jane Smith",
+            age = 38,
+            deprecated = false,
+        )
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery, profileQuery2))
+
+        val result = testee.isActiveUser()
+
+        assertTrue(result)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/rmf/PirUserAttributeMatcherPluginTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/rmf/PirUserAttributeMatcherPluginTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.rmf
+
+import com.duckduckgo.pir.impl.PirUserUtils
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class PirUserAttributeMatcherPluginTest {
+
+    private lateinit var testee: PirUserAttributeMatcherPlugin
+
+    private val mockPirUserUtils: PirUserUtils = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirUserAttributeMatcherPlugin(mockPirUserUtils)
+    }
+
+    @Test
+    fun whenEvaluateWithNonPirUserMatchingAttributeThenReturnsNull() = runTest {
+        val result = testee.evaluate(FakeMatchingAttribute())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenEvaluateWithPirUserAttributeAndUserIsActiveAndRemoteValueTrueThenReturnsTrue() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(true)
+        val attribute = PirUserJsonMatchingAttribute(remoteValue = true)
+
+        val result = testee.evaluate(attribute)
+
+        assertTrue(result!!)
+    }
+
+    @Test
+    fun whenEvaluateWithPirUserAttributeAndUserIsActiveAndRemoteValueFalseThenReturnsFalse() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(true)
+        val attribute = PirUserJsonMatchingAttribute(remoteValue = false)
+
+        val result = testee.evaluate(attribute)
+
+        assertFalse(result!!)
+    }
+
+    @Test
+    fun whenEvaluateWithPirUserAttributeAndUserIsNotActiveAndRemoteValueTrueThenReturnsFalse() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(false)
+        val attribute = PirUserJsonMatchingAttribute(remoteValue = true)
+
+        val result = testee.evaluate(attribute)
+
+        assertFalse(result!!)
+    }
+
+    @Test
+    fun whenEvaluateWithPirUserAttributeAndUserIsNotActiveAndRemoteValueFalseThenReturnsTrue() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(false)
+        val attribute = PirUserJsonMatchingAttribute(remoteValue = false)
+
+        val result = testee.evaluate(attribute)
+
+        assertTrue(result!!)
+    }
+
+    @Test
+    fun whenRemoteValueMatchesActiveUserStatusThenReturnsTrue() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(true)
+        val attributeTrue = PirUserJsonMatchingAttribute(remoteValue = true)
+        assertEquals(true, testee.evaluate(attributeTrue))
+
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(false)
+        val attributeFalse = PirUserJsonMatchingAttribute(remoteValue = false)
+        assertEquals(true, testee.evaluate(attributeFalse))
+    }
+
+    @Test
+    fun whenRemoteValueDoesNotMatchActiveUserStatusThenReturnsFalse() = runTest {
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(true)
+        val attributeFalse = PirUserJsonMatchingAttribute(remoteValue = false)
+        assertEquals(false, testee.evaluate(attributeFalse))
+
+        whenever(mockPirUserUtils.isActiveUser()).thenReturn(false)
+        val attributeTrue = PirUserJsonMatchingAttribute(remoteValue = true)
+        assertEquals(false, testee.evaluate(attributeTrue))
+    }
+
+    private class FakeMatchingAttribute : MatchingAttribute
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/rmf/PirUserJsonMatchingAttributeMapperTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/rmf/PirUserJsonMatchingAttributeMapperTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.rmf
+
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PirUserJsonMatchingAttributeMapperTest {
+
+    private lateinit var testee: PirUserJsonMatchingAttributeMapper
+
+    @Before
+    fun setUp() {
+        testee = PirUserJsonMatchingAttributeMapper()
+    }
+
+    @Test
+    fun whenMapWithCorrectKeyAndValueTrueThenReturnsPirUserJsonMatchingAttribute() {
+        val result = testee.map("isCurrentPIRUser", JsonMatchingAttribute(value = true))
+
+        assertTrue(result is PirUserJsonMatchingAttribute)
+        assertEquals(true, (result as PirUserJsonMatchingAttribute).remoteValue)
+    }
+
+    @Test
+    fun whenMapWithCorrectKeyAndValueFalseThenReturnsPirUserJsonMatchingAttribute() {
+        val result = testee.map("isCurrentPIRUser", JsonMatchingAttribute(value = false))
+
+        assertTrue(result is PirUserJsonMatchingAttribute)
+        assertEquals(false, (result as PirUserJsonMatchingAttribute).remoteValue)
+    }
+
+    @Test
+    fun whenMapWithCorrectKeyAndValueNullThenReturnsNull() {
+        val result = testee.map("isCurrentPIRUser", JsonMatchingAttribute(value = null))
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenMapWithWrongKeyThenReturnsNull() {
+        assertNull(testee.map("wrongKey", JsonMatchingAttribute(value = true)))
+        assertNull(testee.map("wrongKey", JsonMatchingAttribute(value = false)))
+        assertNull(testee.map("wrongKey", JsonMatchingAttribute(value = null)))
+    }
+
+    @Test
+    fun whenMapWithEmptyKeyThenReturnsNull() {
+        val result = testee.map("", JsonMatchingAttribute(value = true))
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenMapWithSimilarKeyThenReturnsNull() {
+        assertNull(testee.map("isCurrentPIRuser", JsonMatchingAttribute(value = true)))
+        assertNull(testee.map("IsCurrentPIRUser", JsonMatchingAttribute(value = true)))
+        assertNull(testee.map("iscurrentpiruser", JsonMatchingAttribute(value = true)))
+    }
+
+    @Test
+    fun whenMapWithKeyConstantThenReturnsPirUserJsonMatchingAttribute() {
+        val result = testee.map(PirUserJsonMatchingAttribute.KEY, JsonMatchingAttribute(value = true))
+
+        assertTrue(result is PirUserJsonMatchingAttribute)
+        assertEquals(true, (result as PirUserJsonMatchingAttribute).remoteValue)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1212738846036095?focus=true 

### Description
Add matching attibute for isCurrentPIRUser that should match RMF messages to active current PIR users

### Steps to test this PR

- [x] Apply patch
```
Subject: [PATCH] rmf-pir-test
---
Index: remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt	(revision 86d416e7d4c452cfe96c1e0240e99ed8c7146e18)
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt	(date 1772198221467)
@@ -23,6 +23,6 @@
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("https://gist.githubusercontent.com/karlenDimla/6474ce4003efd86dde0b02eb6622d967/raw/76fe5dc7bc4c6627350e134a86aac49cfa462a68/test-currentpir.json")
     suspend fun config(): JsonRemoteMessagingConfig
 }
```
- [x] Build
- [x] Verify no message is shown in new tab
- [x] Obtain subscription
- [x] Restart app and open new tab
- [x] Verify no message is shown in new tab
- [x] Start PIR scan via the dashboard
- [x] Wait for it to complete
- [x]  Restart app and open new tab
- [x] Verify test message appears
- [x] Close tab
- [x] Go to PIR Settings > scroll down > Turn off PIR
- [x] Restart app and open new tab
- [x] Verify test message disappears


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Remote Messaging Framework matching attribute tied to PIR subscription/enablement state, which can affect message targeting and engagement reporting behavior if the active-user check is wrong.
> 
> **Overview**
> Introduces a shared `PirUserUtils.isActiveUser()` helper and refactors `RealPirEngagementReporter` to use it for gating DAU/WAU/MAU pixel firing.
> 
> Adds Remote Messaging Framework support for matching on `isCurrentPIRUser` via a new JSON key mapper (`PirUserJsonMatchingAttributeMapper`) and an `AttributeMatcherPlugin` (`PirUserAttributeMatcherPlugin`) that evaluates the attribute against the local active PIR user status.
> 
> Updates PIR module dependencies to include `:remote-messaging-api` and adds unit tests covering the new helper, mapper, and matcher behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d1e191d1f4758ba79b5e10b35ce33e3711d8610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->