### PR TITLE
add downloaded files sync onResume to avoid viewing stale list of files

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
@@ -92,6 +92,11 @@ class DownloadsActivity : DuckDuckGoActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.syncDownloads()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.downloads_activity_menu, menu)
         return true

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
@@ -143,6 +143,18 @@ class DownloadsViewModel @Inject constructor(
         }
     }
 
+    fun syncDownloads() {
+        viewModelScope.launch(dispatcher.io()) {
+            val downloads = downloadsRepository.getDownloads()
+            val staleDownloadIds = downloads
+                .filter { it.downloadStatus == DownloadStatus.FINISHED && !File(it.filePath).exists() }
+                .map { it.downloadId }
+            if (staleDownloadIds.isNotEmpty()) {
+                downloadsRepository.delete(staleDownloadIds)
+            }
+        }
+    }
+
     private fun filtered(items: List<DownloadViewItem>, newText: String): List<DownloadViewItem> {
         val filtered = LinkedHashMap<Header, List<Item>>()
         items.forEach { item ->


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/715106103902962/task/1212685679620803

### Description
Update the downloaded files list onResume to avoid showing a stale list in case files were deleted in different app (e.g. file managers).

### Steps to test this PR
- Download a file.
- open file manager and delete it.
- open DDG/Downloads
- Before: file still exists in the list, After: file is no longer seen.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data consistency change that deletes only `FINISHED` downloads whose files no longer exist, triggered on `DownloadsActivity.onResume`; main risk is unintended removal if file paths are temporarily inaccessible or added IO on resume.
> 
> **Overview**
> Prevents the Downloads screen from showing stale entries by triggering a sync on `DownloadsActivity.onResume`.
> 
> Adds `DownloadsViewModel.syncDownloads()` to fetch stored downloads and delete any *finished* items whose `filePath` no longer exists on disk, with new unit tests covering stale cleanup and ensuring in-progress downloads aren’t removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e05fd3a061c07bf0b41823fb569c4964a482c369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->