### PR TITLE
Fix fullscreen video status bar not hiding on modern Android devices

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
@@ -21,16 +21,19 @@ import android.app.UiModeManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import android.view.WindowManager
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.duckduckgo.common.ui.DuckDuckGoTheme.DARK
 import com.duckduckgo.common.ui.store.ThemingDataStore
-import com.duckduckgo.common.ui.view.isFullScreen
 import com.duckduckgo.mobile.android.R
 import dagger.android.AndroidInjection
 import dagger.android.DaggerActivity
@@ -43,6 +46,13 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
     @Inject lateinit var themingDataStore: ThemingDataStore
 
     private var themeChangeReceiver: BroadcastReceiver? = null
+
+    /**
+     * Tracks fullscreen state internally because WindowInsetsController updates
+     * are asynchronous on API 30+, so we can't rely on reading rootWindowInsets
+     * immediately after toggling.
+     */
+    private var isInFullScreenMode: Boolean = false
 
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -109,16 +119,70 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
     }
 
     open fun toggleFullScreen() {
-        if (isFullScreen()) {
-            // If we are exiting full screen, reset the orientation
+        if (isInFullScreenMode) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            exitImmersiveMode()
+        } else {
+            enterImmersiveMode()
+        }
+    }
+
+    /**
+     * Returns the current fullscreen state.
+     * This uses internal tracking because WindowInsetsController updates are
+     * asynchronous on API 30+, making rootWindowInsets unreliable immediately
+     * after toggling.
+     */
+    fun isFullScreenMode(): Boolean = isInFullScreenMode
+
+    private fun enterImmersiveMode() {
+        isInFullScreenMode = true
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            window.insetsController?.let { controller ->
+                controller.hide(WindowInsets.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_FULLSCREEN
+                )
         }
 
-        val newUiOptions = window.decorView.systemUiVisibility
-            .xor(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
-            .xor(View.SYSTEM_UI_FLAG_FULLSCREEN)
-            .xor(View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+        // Handle display cutout for notched devices (API 28+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+        }
+    }
 
-        window.decorView.systemUiVisibility = newUiOptions
+    private fun exitImmersiveMode() {
+        isInFullScreenMode = false
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(true)
+            window.insetsController?.show(WindowInsets.Type.systemBars())
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+        }
+
+        // Reset display cutout mode
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+            }
+        }
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/ActivityExtensions.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/ActivityExtensions.kt
@@ -18,9 +18,7 @@ package com.duckduckgo.common.ui.view
 
 import android.content.Context
 import android.os.Bundle
-import android.view.View
 import androidx.core.app.ActivityOptionsCompat
-import androidx.fragment.app.FragmentActivity
 
 fun Context.fadeTransitionConfig(): Bundle? {
     val config = ActivityOptionsCompat.makeCustomAnimation(this, android.R.anim.fade_in, android.R.anim.fade_out)
@@ -29,12 +27,3 @@ fun Context.fadeTransitionConfig(): Bundle? {
 
 fun Context.noAnimationConfig(): Bundle? =
     ActivityOptionsCompat.makeCustomAnimation(this, 0, 0).toBundle()
-
-fun FragmentActivity.isFullScreen(): Boolean {
-    return window.decorView.systemUiVisibility.and(View.SYSTEM_UI_FLAG_FULLSCREEN) == View.SYSTEM_UI_FLAG_FULLSCREEN
-}
-
-fun FragmentActivity.isImmersiveModeEnabled(): Boolean {
-    val uiOptions = window.decorView.systemUiVisibility
-    return uiOptions or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY == uiOptions
-}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -106,7 +106,6 @@ import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
-import com.duckduckgo.common.ui.view.isFullScreen
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -1159,7 +1158,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         super.toggleFullScreen()
 
         if (swipingTabsFeature.isEnabled) {
-            viewModel.onFullScreenModeChanged(isFullScreen())
+            viewModel.onFullScreenModeChanged(isFullScreenMode())
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -268,8 +268,6 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.hideKeyboard
-import com.duckduckgo.common.ui.view.isFullScreen
-import com.duckduckgo.common.ui.view.isImmersiveModeEnabled
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
@@ -5000,12 +4998,13 @@ class BrowserTabFragment :
 
         private fun renderFullscreenMode(viewState: BrowserViewState) {
             if (!this@BrowserTabFragment.isVisible) return
-            activity?.isImmersiveModeEnabled()?.let {
-                if (viewState.isFullScreen) {
-                    if (!it) goFullScreen()
-                } else {
-                    if (it) exitFullScreen()
-                }
+            // Use isFullScreenMode() which tracks state internally, because
+            // WindowInsetsController updates are asynchronous on API 30+
+            val isCurrentlyFullScreen = (activity as? DuckDuckGoActivity)?.isFullScreenMode() ?: return
+            if (viewState.isFullScreen) {
+                if (!isCurrentlyFullScreen) goFullScreen()
+            } else {
+                if (isCurrentlyFullScreen) exitFullScreen()
             }
         }
 
@@ -5446,7 +5445,7 @@ private class JsOrientationHandler {
         val response =
             if (activity == null) {
                 NO_ACTIVITY_ERROR
-            } else if (!activity.isFullScreen()) {
+            } else if ((activity as? DuckDuckGoActivity)?.isFullScreenMode() != true) {
                 NOT_FULL_SCREEN_ERROR
             } else {
                 val requestedOrientation = data.params.optString("orientation")


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/6845

### Description

This PR fixes an issue where the system status bar doesn't fully hide during fullscreen video playback on certain devices (reported on Xiaomi Pad 7 Pro with HyperOS 2.0). The status bar content would disappear but the bar itself remained visible.

**Root Cause:** The existing implementation uses deprecated `systemUiVisibility` flags which don't work correctly on modern Android versions (11+) with custom OEM skins.

**Solution:** 
- Use `WindowInsetsController` API (Android 11+) for hiding system bars
- Maintain backward compatibility with deprecated flags for Android 10 and below
- Add display cutout handling for notched devices (API 28+)

**Key Changes:**
| Change | Purpose |
|--------|---------|
| `WindowInsetsController.hide()` | Modern API for hiding system bars (API 30+) |
| `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` | Allows temporary reveal on swipe, auto-hides |
| `setDecorFitsSystemWindows(false)` | Content extends behind system bars |
| `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` | True fullscreen on notched devices |

### Steps to test this PR

_Fullscreen Video_
- [x] Open the DuckDuckGo browser and navigate to a website with video (e.g., youtube.com)
- [x] Play a video and tap the fullscreen button
- [ ] Verify that both status bar AND navigation bar completely disappear
- [x] Swipe from top/bottom edge - bars should appear temporarily then auto-hide
- [x] Exit fullscreen - bars should return to normal

_Backward Compatibility_
- [ ] Test on Android 10 or below device/emulator if available
- [ ] Verify fullscreen still works on older API levels

### UI changes
| Before  | After |
| ------ | ----- |
| Status bar content hidden but bar visible | Status bar completely hidden |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates fullscreen/immersive handling and state tracking at the base `DuckDuckGoActivity` level, which can affect system bar visibility and layout across activities, especially with OEM-specific behavior and API-version branching.
> 
> **Overview**
> Fixes fullscreen video system bars not fully hiding on Android 11+ by reworking `DuckDuckGoActivity.toggleFullScreen()` to enter/exit immersive mode via `WindowInsetsController` (with legacy `systemUiVisibility` flags for older APIs) and adding display cutout handling.
> 
> Removes the `FragmentActivity.isFullScreen`/`isImmersiveModeEnabled` extensions and updates browser code paths (`BrowserActivity`, `BrowserTabFragment`, and JS orientation lock checks) to rely on the activity’s internally tracked `isFullScreenMode()` state to avoid async insets timing issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82d24cac5363bc18d9ff1ba8b15374a76c9c6f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->