### PR TITLE
Replace runtime reflection with static calls in FeatureTogglesInventory codegen

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -165,18 +165,17 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                 .addCode(
                                     CodeBlock.of(
                                         """
-                                            return object : FeatureTogglesInventory {
-                                                override suspend fun getAll(): List<Toggle> {
-                                                    return feature.javaClass.declaredMethods.mapNotNull { method ->
-                                                        if (method.genericReturnType.toString().contains(Toggle::class.java.canonicalName!!)) {
-                                                            method.invoke(feature) as Toggle
-                                                        } else {
-                                                            null
-                                                        }
-                                                    }
+                                            return object : %T {
+                                                override suspend fun getAll(): %T<%T> {
+                                                    return listOf(
+                                                        ${boundType.declaredFunctions().joinToString(separator = ",\n                                                        ") { "feature.${it.name}()" }}
+                                                    )
                                                 }
                                             }
                                         """.trimIndent(),
+                                        FeatureTogglesInventory::class.asClassName(),
+                                        List::class.asClassName(),
+                                        Toggle::class.asClassName(),
                                     ),
                                 )
                                 .returns(FeatureTogglesInventory::class.asClassName())


### PR DESCRIPTION
Task/Issue URL: 

### Description

The generated `provides{Feature}Inventory()` function was discovering toggle methods at runtime via `javaClass.declaredMethods` reflection. Since the codegen already knows every method name at compile time via `boundType.declaredFunctions()`, this PR replaces the reflection loop with a static `listOf(feature.toggle1(), feature.toggle2(), ...)` emitted directly into the generated source.

**Before:**
```kotlin
return object : FeatureTogglesInventory {
    override suspend fun getAll(): List<Toggle> {
        return feature.javaClass.declaredMethods.mapNotNull { method ->
            if (method.genericReturnType.toString().contains("com.duckduckgo.feature.toggles.api.Toggle")) {
                method.invoke(feature) as Toggle
            } else { null }
        }
    }
}
```

**After:**
```kotlin
return object : FeatureTogglesInventory {
    override suspend fun getAll(): List<Toggle> {
        return listOf(
            feature.self(),
            feature.enqueueWideEventPixels(),
            // ...
        )
    }
}
```

Also adds two missing tests for `getAll()` — there were previously zero tests exercising `FeatureTogglesInventory` at the behavioral level.

### Steps to test this PR

- [ ] `./gradlew :feature-toggles-impl:test` passes
- [ ] Inspect a generated `*_ProxyModule.kt` file under `build/anvil/` and verify the inventory function contains direct `feature.xxx()` calls instead of a reflection loop

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Anvil code generation used across many features; incorrect function enumeration or ordering could change which toggles are reported in inventories at runtime. No auth/security or persistence logic changes beyond inventory listing.
> 
> **Overview**
> **Eliminates runtime reflection in inventory generation.** `ContributesRemoteFeatureCodeGenerator` now emits `FeatureTogglesInventory.getAll()` as a static `listOf(feature.<toggle>()...)` based on `boundType.declaredFunctions()` rather than scanning `javaClass.declaredMethods` at runtime.
> 
> **Adds coverage for the new behavior.** New tests assert `getAll()` returns exactly the toggle methods declared on the feature interface (including the `self()` root) and that `Object` methods like `equals`/`hashCode`/`toString` are not included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad82ef7da3a8b6c2f701d95fd0067ae6ba69d702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->