### PR TITLE
Update content scope scripts to version 13.22.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -532,6 +532,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -3327,7 +3328,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -3725,7 +3726,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -4330,9 +4331,9 @@
   var WebCompat = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeShareRequest, null);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
       /** @type {Map<string, object>} */
       __privateAdd(this, _webNotifications, /* @__PURE__ */ new Map());

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2038,6 +2038,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -4852,7 +4853,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5250,7 +5251,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2038,6 +2038,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -4821,7 +4822,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5219,7 +5220,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1387,6 +1387,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -4759,7 +4760,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5157,7 +5158,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -6836,7 +6837,12 @@
       if (shouldInjectStyleTag) {
         shouldInjectStyleTag = this.matchConditionalFeatureSetting("styleTagExceptions").length === 0;
       }
-      const activeDomainRules = this.matchConditionalFeatureSetting("domains").flatMap((item) => item.rules);
+      const activeDomainRules = this.matchConditionalFeatureSetting("domains").flatMap((item) => {
+        return (
+          /** @type {ElementHidingRule[]} */
+          item.rules || []
+        );
+      });
       const overrideRules = activeDomainRules.filter((rule) => {
         return rule.type === "override";
       });
@@ -7139,9 +7145,9 @@
   var WebCompat = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeShareRequest, null);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
       /** @type {Map<string, object>} */
       __privateAdd(this, _webNotifications, /* @__PURE__ */ new Map());
@@ -9440,7 +9446,10 @@
         try {
           assertCustomEvent(evt);
           if (evt.detail.kind === MSG_NAME_SET_VALUES) {
-            return this.setUserValues(evt.detail.data).then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
+            return this.setUserValues(
+              /** @type {import("../duck-player.js").UserValues} */
+              evt.detail.data
+            ).then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
           }
           if (evt.detail.kind === MSG_NAME_READ_VALUES_SERP) {
             return this.getUserValues().then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
@@ -9457,7 +9466,11 @@
   };
   function assertCustomEvent(event) {
     if (!("detail" in event)) throw new Error("none-custom event");
-    if (typeof event.detail.kind !== "string") throw new Error("custom event requires detail.kind to be a string");
+    const detail = (
+      /** @type {{kind: unknown}} */
+      event.detail
+    );
+    if (typeof detail.kind !== "string") throw new Error("custom event requires detail.kind to be a string");
   }
   var Pixel = class {
     /**
@@ -12148,8 +12161,8 @@ ${iframeContent}
   var BrowserUiLock = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {boolean} */
-      __publicField(this, "_currentLockState", false);
+      /** @type {boolean | null} Null ensures the first evaluation always sends a notification */
+      __publicField(this, "_currentLockState", null);
       /** @type {MutationObserver | null} */
       __publicField(this, "_mutationObserver", null);
       /** @type {ResizeObserver | null} */
@@ -12186,7 +12199,7 @@ ${iframeContent}
       this._setupResizeObserver();
     }
     /**
-     * Set up MutationObserver to watch for style/class attribute changes on html and body.
+     * Set up MutationObserver to watch for style/class/content changes on html and body.
      */
     _setupMutationObserver() {
       if (this._mutationObserver) {
@@ -12253,10 +12266,10 @@ ${iframeContent}
       try {
         const html2 = document.documentElement;
         const body = document.body;
-        if (html2 && this._hasVisibleScrollbar(html2)) {
+        if (html2 && this._hasExplicitlyVisibleScrollbar(html2)) {
           return false;
         }
-        if (body && this._hasVisibleScrollbar(body)) {
+        if (body && this._hasExplicitlyVisibleScrollbar(body)) {
           return false;
         }
         return true;
@@ -12271,10 +12284,11 @@ ${iframeContent}
      * @param {Element} el
      * @returns {boolean}
      */
-    _hasVisibleScrollbar(el) {
+    _hasExplicitlyVisibleScrollbar(el) {
       const style = getComputedStyle(el);
       const overflowY = style.overflowY;
-      return el.scrollHeight > el.clientHeight && overflowY !== "hidden" && overflowY !== "clip";
+      const overflowTypes = this.getFeatureSetting("overflowTypes") ?? ["hidden", "clip", "auto"];
+      return el.scrollHeight > el.clientHeight && !overflowTypes.includes(overflowY);
     }
     /**
      * Notify native if lock state changed

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -514,6 +514,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -3250,7 +3251,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -3648,7 +3649,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.19.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.22.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7b33d8fc6cc05ac083988bcab4a7da618e40e423",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c34ede231536a518f3a6da41f3aa1836c41f9ede",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.19.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.22.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled content-scope scripts that affect in-page protections/compat behavior; small logic changes (element hiding rule selection and UI lock scrollbar detection) could cause site-specific regressions.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `13.19.0` to `13.22.0` and updates the prebuilt Android bundles under `node_modules/@duckduckgo/content-scope-scripts/build/android/*`.
> 
> The updated bundles add `webDetection` to the platform-specific feature set, harden element-hiding domain rule handling when `rules` are missing, tweak Duck Player proxy event validation/typing, and adjust `BrowserUiLock` to always emit an initial lock-state notification and make scrollbar detection configurable via `overflowTypes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ebc3a811bac44b3d22a47556040be0133c52399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->