### PR TITLE
Approval stuck condition

### DIFF
--- a/0001-fix-review-approval-stuck-condition.patch
+++ b/0001-fix-review-approval-stuck-condition.patch
@@ -1,0 +1,58 @@
+From 80bbb9cc6b0b1d9be98103489bf7fa67a07da458 Mon Sep 17 00:00:00 2001
+From: Cursor Agent <cursoragent@cursor.com>
+Date: Sat, 28 Feb 2026 12:49:46 +0000
+Subject: [PATCH] fix(review): prevent approval-stuck condition when COMMENTED
+ reviews shadow APPROVED
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Two issues caused findAuthorizedApproval to miss valid, non-stale approvals:
+
+1. The latestByUser map tracked ALL review states, so a COMMENTED review
+   (e.g. replying to a thread after approving) would overwrite the user's
+   APPROVED review. GitHub still considers the approval valid, but this
+   code dropped it — leaving the check stuck at 'Waiting for approval'
+   with no event to re-trigger it.
+
+2. listReviews was not paginated, so PRs with 30+ review events could
+   silently miss approvals on later pages.
+
+Fix: only track decision states (APPROVED, CHANGES_REQUESTED, DISMISSED)
+in the per-user map, and use github.paginate for full review history.
+---
+ .github/scripts/review-helpers.mjs | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/.github/scripts/review-helpers.mjs b/.github/scripts/review-helpers.mjs
+index 5d20d9887..df6c6431b 100644
+--- a/.github/scripts/review-helpers.mjs
++++ b/.github/scripts/review-helpers.mjs
+@@ -75,17 +75,20 @@ export async function findTeamForUser(github, orgToken, org, teams, username) {
+  *                        If not provided, team membership checks are skipped.
+  */
+ export async function findAuthorizedApproval(github, { owner, repo, prNumber, org, teams, orgToken }) {
+-    const { data: reviews } = await github.rest.pulls.listReviews({
++    const reviews = await github.paginate(github.rest.pulls.listReviews, {
+         owner,
+         repo,
+         pull_number: prNumber,
+     });
+ 
+-    const latestByUser = new Map();
++    const DECISION_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
++    const latestDecisionByUser = new Map();
+     for (const r of reviews) {
+-        if (r.user?.login) latestByUser.set(r.user.login, r);
++        if (r.user?.login && DECISION_STATES.has(r.state)) {
++            latestDecisionByUser.set(r.user.login, r);
++        }
+     }
+-    const approved = [...latestByUser.values()].filter((r) => r.state === 'APPROVED');
++    const approved = [...latestDecisionByUser.values()].filter((r) => r.state === 'APPROVED');
+     if (approved.length === 0) return null;
+ 
+     if (approved.some((r) => r.user.login === DAX_USERNAME)) {
+-- 
+2.43.0
+


### PR DESCRIPTION
Task/Issue URL: Investigate and fix `review_validation` check getting stuck.

### Description
The `review_validation` GitHub Action check in `duckduckgo/content-scope-scripts` can get stuck in an "in_progress" state, even when a valid approval exists. This occurs because the `findAuthorizedApproval` function in `.github/scripts/review-helpers.mjs` incorrectly:
1. Overwrites an `APPROVED` review with a `COMMENTED` review if a reviewer comments after approving.
2. Fails to paginate review history, potentially missing approvals on PRs with many reviews.

When an approval is dropped, subsequent `pull_request_target` events cause the check to transition to "Waiting for approval" and become permanently stuck.

This PR provides a patch file to address this by:
- Modifying `findAuthorizedApproval` to only consider decision states (`APPROVED`, `CHANGES_REQUESTED`, `DISMISSED`) when determining the latest review per user.
- Utilizing `github.paginate()` to ensure all review history is fetched.

### Steps to test this PR
This PR contains a patch for `duckduckgo/content-scope-scripts`. To test the fix:
1. Apply the changes from `0001-fix-review-approval-stuck-condition.patch` to `.github/scripts/review-helpers.mjs` in the `duckduckgo/content-scope-scripts` repository.
2. In a test PR in `duckduckgo/content-scope-scripts`:
    - Get an approval.
    - Have the approving user add a new comment to the PR (not a review comment, but a general PR comment).
    - Push a new commit to the PR.
    - Verify that the `review_validation` check remains in a `success` state and does not get stuck in "Waiting for approval".
3. (Optional, for pagination) Create a PR with more than 30 reviews (e.g., by having multiple users submit multiple reviews/comments). Ensure approvals are correctly identified.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
N/A

---
<p><a href="https://cursor.com/agents/bc-b9ad4cea-6efa-4341-a7bc-e18be68f04ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ad4cea-6efa-4341-a7bc-e18be68f04ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI review-gating logic; incorrect handling could allow or block merges if GitHub review states differ from assumptions.
> 
> **Overview**
> Prevents the `review_validation` check from getting stuck by updating `findAuthorizedApproval` to fetch the *full* PR review history via `github.paginate` (avoiding the 30-review page limit).
> 
> Adjusts per-user “latest review” tracking to consider only decision states (`APPROVED`, `CHANGES_REQUESTED`, `DISMISSED`), so a later `COMMENTED` review no longer overwrites a valid approval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f41d3aa53db98c137bf5dbf9ad716549ecf779dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->