### PR TITLE
Fix/exhaustive when

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
@@ -85,7 +85,6 @@ enum class Size {
             return when (size) {
                 Small -> R.dimen.buttonSmallHeight
                 Large -> R.dimen.buttonLargeHeight
-                else -> R.dimen.buttonSmallHeight
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -189,7 +189,6 @@ class AutofillManagementActivity : DuckDuckGoActivity(), PasswordsScreenPromotio
     }
 
     private fun processCommand(command: AutofillPasswordsManagementViewModel.Command) {
-        var processed = true
         when (command) {
             is ShowCredentialMode -> showCredentialMode()
             is ShowUserUsernameCopied -> showCopiedToClipboardSnackbar(CopiedToClipboardDataType.Username)
@@ -206,12 +205,9 @@ class AutofillManagementActivity : DuckDuckGoActivity(), PasswordsScreenPromotio
             is ExitLockedMode -> exitLockedMode()
             is ExitDisabledMode -> exitDisabledMode()
             is ExitListMode -> exitListMode()
-            else -> processed = false
         }
-        if (processed) {
-            logcat(VERBOSE) { "Processed command $command" }
-            viewModel.commandProcessed(command)
-        }
+        logcat(VERBOSE) { "Processed command $command" }
+        viewModel.commandProcessed(command)
     }
 
     private fun showCopiedToClipboardSnackbar(dataType: CopiedToClipboardDataType) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -491,16 +491,12 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
     }
 
     private fun processCommand(command: CredentialModeCommand) {
-        var processed = true
         when (command) {
             is ShowEditCredentialMode -> showEditMode()
             is ShowManualCredentialMode -> showEditMode()
-            else -> processed = false
         }
-        if (processed) {
-            logcat(VERBOSE) { "Processed command $command" }
-            viewModel.commandProcessed(command)
-        }
+        logcat(VERBOSE) { "Processed command $command" }
+        viewModel.commandProcessed(command)
     }
 
     private fun disableSystemAutofillServiceOnPasswordField() {

--- a/buildSrc/src/main/java/com/duckduckgo/gradle/ModuleType.kt
+++ b/buildSrc/src/main/java/com/duckduckgo/gradle/ModuleType.kt
@@ -55,7 +55,6 @@ sealed class ModuleType {
                 ApiPureKotlin -> "api"
                 Impl -> "impl"
                 Internal -> "internal"
-                else -> throw IllegalArgumentException("Module type [${javaClass.simpleName} does not have a destination directory")
             }
         }
 
@@ -65,7 +64,6 @@ sealed class ModuleType {
                 ApiPureKotlin -> "api"
                 Impl -> "impl"
                 Internal -> "internal"
-                else -> throw IllegalArgumentException("Module type [${javaClass.simpleName} does not have a template")
             }
         }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
@@ -241,9 +241,6 @@ class NetpAppExclusionListActivity :
             is Command.ShowSystemAppsExclusionWarning -> showSystemAppsWarning(command.category)
 
             is Command.ShowAutoExcludePrompt -> showAutoExcludePrompt(command.apps)
-            else -> {
-                /* noop */
-            }
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
@@ -205,10 +205,6 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                     ),
                 )
             }
-
-            else -> {
-                // No op
-            }
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteNextBrokerStepEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteNextBrokerStepEventHandler.kt
@@ -146,10 +146,6 @@ class ExecuteNextBrokerStepEventHandler @Inject constructor(
                     ),
                 )
             }
-
-            else -> {
-                // No-op
-            }
         }
     }
 

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/RxBasedPixel.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/RxBasedPixel.kt
@@ -55,7 +55,7 @@ class RxBasedPixel @Inject constructor(
             .sendPixel(pixelName, parameters, encodedParameters, type)
             .subscribeOn(Schedulers.io())
             .subscribe(
-                { result ->
+                { result: PixelSender.SendPixelResult ->
                     when (result) {
                         PIXEL_SENT -> logcat(VERBOSE) { "Pixel sent: $pixelName with params: $parameters $encodedParameters" }
                         PIXEL_IGNORED -> logcat(VERBOSE) { "Pixel ignored: $pixelName with params: $parameters $encodedParameters" }
@@ -93,7 +93,7 @@ class RxBasedPixel @Inject constructor(
             .enqueuePixel(pixelName, parameters, encodedParameters, type)
             .subscribeOn(Schedulers.io())
             .subscribe(
-                { result ->
+                { result: EnqueuePixelResult ->
                     when (result) {
                         EnqueuePixelResult.PIXEL_ENQUEUED -> logcat(VERBOSE) {
                             "Pixel enqueued: $pixelName with params: $parameters $encodedParameters"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/SubscriptionFeedbackActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/SubscriptionFeedbackActivity.kt
@@ -182,8 +182,6 @@ class SubscriptionFeedbackActivity :
                     ),
                 )
             }
-
-            else -> {} // Do nothing
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: /

### Description

Optimize when-clauses by removing cases that can never happen (sealed classes - else cases as well as java - null interop type)

### Steps to test this PR

- Compile the app

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup to make `when` expressions exhaustive and remove dead/default branches; behavior should be unchanged aside from always acknowledging processed commands in Autofill screens.
> 
> **Overview**
> Cleans up multiple `when` statements (design system, Autofill, VPN exclusions, PIR state handlers, subscriptions feedback, and Gradle `ModuleType`) by removing unreachable `else`/no-op branches and relying on Kotlin exhaustiveness.
> 
> In Autofill command handling (`AutofillManagementActivity` and `AutofillManagementCredentialsMode`), the processed-command logging and `viewModel.commandProcessed` call are now unconditional after the `when`, aligning with the assumption that commands are fully covered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbb3a28a14136b6bd9b97beebe7f6f25a0697ad1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->