### PR TITLE
Add Duck.ai native input

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -12075,4 +12075,40 @@
             column="9"/>
     </issue>
 
+    <issue
+        id="NoImplImportsInAppModule"
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
+    </issue>
+
+    <issue
+        id="NoImplImportsInAppModule"
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
+    </issue>
+
+    <issue
+        id="NoImplImportsInAppModule"
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
+    </issue>
+
+    <issue
+        id="NoImplImportsInAppModule"
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
+    </issue>
+
 </issues>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -139,6 +139,7 @@ import com.duckduckgo.app.browser.menu.VpnMenuStore
 import com.duckduckgo.app.browser.model.BasicAuthenticationCredentials
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
+import com.duckduckgo.app.browser.nativeinput.NativeInputManager
 import com.duckduckgo.app.browser.navigation.bar.BrowserNavigationBarViewIntegration
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarObserver
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
@@ -383,6 +384,9 @@ class BrowserTabFragment :
     private var duckAiContextualFragment: DuckChatContextualFragment? = null
     private var contextualSheetLayoutChangeListener: View.OnLayoutChangeListener? = null
     private var contextualSheetBottomSheetCallback: BottomSheetBehavior.BottomSheetCallback? = null
+
+    @Inject
+    lateinit var nativeInputManager: NativeInputManager
 
     override val coroutineContext: CoroutineContext
         get() = supervisorJob + dispatchers.main()
@@ -1054,6 +1058,9 @@ class BrowserTabFragment :
             omnibarType = settingsDataStore.omnibarType,
             binding = binding,
         )
+        nativeInputManager.start(viewLifecycleOwner) {
+            nativeInputManager.hideNativeInput(binding.rootView, omnibar)
+        }
 
         webViewContainer = binding.webViewContainer
         configureObservers()
@@ -1216,8 +1223,70 @@ class BrowserTabFragment :
 
     private fun configureInputScreenLauncher() {
         omnibar.configureInputScreenLaunchListener { query ->
-            launchInputScreen(query)
+            if (!nativeInputManager.isNativeInputEnabled()) {
+                launchInputScreen(query)
+            } else {
+                showNativeInput(query)
+            }
         }
+    }
+
+    private fun showNativeInput(query: String = "") {
+        nativeInputManager.showNativeInput(
+            omnibar = omnibar,
+            layoutInflater = layoutInflater,
+            rootView = binding.rootView,
+            lifecycleOwner = viewLifecycleOwner,
+            tabs = viewModel.tabs,
+            query = query,
+            onSearchTextChanged = { text -> onUserEnteredText(text) },
+            onClearAutocomplete = {
+                if (binding.autoCompleteSuggestionsList.isVisible) {
+                    viewModel.autoCompleteSuggestionsGone()
+                }
+                viewModel.triggerAutocomplete("", hasFocus = false, hasQueryChanged = true)
+                binding.autoCompleteSuggestionsList.gone()
+                binding.focusedView.gone()
+            },
+            onSearchSubmitted = { query -> onUserSubmittedText(query) },
+            onChatSubmitted = { query ->
+                val url = duckChat.getDuckChatUrl(query, true)
+                browserActivity?.launchNewTab(query = url, skipHome = true)
+            },
+            onDuckAiChatSubmitted = { query ->
+                contentScopeScripts.sendSubscriptionEvent(
+                    SubscriptionEventData(
+                        featureName = "aiChat",
+                        subscriptionName = "submitAIChatNativePrompt",
+                        params = JSONObject().apply {
+                            put("platform", "android")
+                            put(
+                                "query",
+                                JSONObject().apply {
+                                    put("prompt", query)
+                                    put("autoSubmit", true)
+                                },
+                            )
+                        },
+                    ),
+                )
+            },
+            onChatSuggestionSelected = { query -> userEnteredQuery(query) },
+            onFireButtonTapped = { onFireButtonPressed() },
+            onTabSwitcherTapped = { launchTabSwitcher() },
+            onMenuTapped = {
+                launchBrowserMenu(addExtraDelay = omnibarRepository.omnibarType == OmnibarType.SPLIT)
+            },
+            onStopClicked = {
+                contentScopeScripts.sendSubscriptionEvent(
+                    SubscriptionEventData(
+                        featureName = "aiChat",
+                        subscriptionName = "submitPromptInterruption",
+                        params = JSONObject("{}"),
+                    ),
+                )
+            },
+        )
     }
 
     private fun launchInputScreen(query: String) {
@@ -2098,6 +2167,7 @@ class BrowserTabFragment :
     private fun showDuckAI(browserViewState: BrowserViewState) {
         renderBrowserMenu(viewState = browserViewState, omnibarViewMode = ViewMode.DuckAI)
         omnibar.setViewMode(ViewMode.DuckAI)
+        showNativeInput()
     }
 
     private fun showMaliciousWarning(
@@ -2459,7 +2529,9 @@ class BrowserTabFragment :
             }
 
             is Command.ShowKeyboard -> {
-                showKeyboard()
+                if (!nativeInputManager.isNativeInputEnabled()) {
+                    showKeyboard()
+                }
             }
 
             is Command.HideKeyboard -> {
@@ -2690,9 +2762,11 @@ class BrowserTabFragment :
             is Command.EnqueueCookiesAnimation -> enqueueCookiesAnimation(it.isCosmetic)
             is Command.PageStarted -> onPageStarted()
             is Command.EnableDuckAIFullScreen -> showDuckAI(it.browserViewState)
-            is Command.DisableDuckAIFullScreen -> omnibar.setViewMode(ViewMode.Browser(it.url))
+            is Command.DisableDuckAIFullScreen -> {
+                omnibar.setViewMode(Browser(it.url))
+                nativeInputManager.hideNativeInput(binding.rootView, omnibar)
+            }
             is Command.ShowDuckAIContextualMode -> showDuckChatContextualSheet(it.tabId)
-            is Command.DisableDuckAIFullScreen -> omnibar.setViewMode(Browser(it.url))
             is Command.StartAddressBarTrackersAnimation -> {
                 omnibar.startTrackersAnimation(it.trackerEntities)
             }
@@ -5404,6 +5478,7 @@ class BrowserTabFragment :
                 if (isVisible) {
                     viewModel.sendKeyboardFocusedPixel()
                 }
+                nativeInputManager.onKeyboardVisibilityChanged(isVisible, binding.rootView, omnibar)
             }
             .launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -1,0 +1,880 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.app.Activity
+import android.graphics.Color
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.net.toUri
+import androidx.core.view.updateLayoutParams
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.map
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.omnibar.Omnibar
+import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.DuckAI
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
+import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+import com.google.android.material.card.MaterialCardView
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+interface NativeInputManager {
+    fun start(lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit = {})
+    fun isNativeInputEnabled(): Boolean
+    fun showNativeInput(
+        omnibar: Omnibar,
+        layoutInflater: LayoutInflater,
+        rootView: ViewGroup,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+        query: String = "",
+        onSearchTextChanged: (String) -> Unit,
+        onClearAutocomplete: () -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+        onDuckAiChatSubmitted: (String) -> Unit,
+        onChatSuggestionSelected: (String) -> Unit,
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+        onStopClicked: () -> Unit,
+    )
+    fun hideNativeInput(
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ): Boolean
+    fun onKeyboardVisibilityChanged(
+        isVisible: Boolean,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    )
+}
+
+@ContributesBinding(AppScope::class, boundType = NativeInputManager::class)
+class RealNativeInputManager @Inject constructor(
+    private val duckChat: DuckChat,
+    private val chatSuggestionsReader: ChatSuggestionsReader,
+) : NativeInputManager {
+    private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+    private var isNativeInputFieldEnabled: Boolean = false
+
+    private var autoCompleteAdapter: RecyclerView.Adapter<*>? = null
+
+    private var chatSuggestionsUserEnabled: Boolean = true
+    private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
+    private var chatSuggestionsJob: Job? = null
+
+    private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+
+    private fun widgetFrom(widgetView: View): NativeInputModeWidget? {
+        return widgetView.findViewById(R.id.inputModeWidget)
+    }
+
+    override fun start(lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit) {
+        duckChat.observeNativeInputFieldUserSettingEnabled()
+            .onEach { isEnabled ->
+                if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
+                isNativeInputFieldEnabled = isEnabled
+            }
+            .launchIn(lifecycleOwner.lifecycleScope)
+
+        duckChat.observeChatSuggestionsUserSettingEnabled()
+            .onEach { enabled ->
+                chatSuggestionsUserEnabled = enabled
+            }
+            .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
+
+    override fun hideNativeInput(
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ): Boolean {
+        if (!isNativeInputFieldEnabled) return true
+
+        if (omnibar.viewMode == DuckAI) return false
+        val removed = removeWidget(rootView)
+        if (!removed) return false
+        rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
+        rootView.findViewById<View?>(R.id.focusedView)?.gone()
+        restoreOmnibar(omnibar, rootView)
+        omnibar.show()
+        return true
+    }
+
+    override fun onKeyboardVisibilityChanged(
+        isVisible: Boolean,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        fun isDescendantOf(
+            ancestor: View,
+            view: View,
+        ): Boolean {
+            var current: View? = view
+            while (current != null) {
+                if (current === ancestor) return true
+                val parent = current.parent
+                current = parent as? View
+            }
+            return false
+        }
+
+        if (!isNativeInputFieldEnabled || isVisible) return
+
+        if (omnibar.viewMode == DuckAI) {
+            widgetFrom(rootView)?.requestInputFocus()
+            return
+        }
+        val widget = widgetFrom(rootView) ?: return
+        val focusedView = rootView.findFocus()
+        val focusWithinWidget = focusedView?.let { isDescendantOf(widget, it) } ?: false
+        if (widget.hasInputFocus() || !focusWithinWidget) {
+            widget.clearInputFocus()
+            hideNativeInput(rootView, omnibar)
+        } else {
+            widget.requestInputFocus()
+        }
+    }
+
+    override fun showNativeInput(
+        omnibar: Omnibar,
+        layoutInflater: LayoutInflater,
+        rootView: ViewGroup,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+        query: String,
+        onSearchTextChanged: (String) -> Unit,
+        onClearAutocomplete: () -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+        onDuckAiChatSubmitted: (String) -> Unit,
+        onChatSuggestionSelected: (String) -> Unit,
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+        onStopClicked: () -> Unit,
+    ) {
+        if (!isNativeInputFieldEnabled) return
+
+        if (omnibar.viewMode == DuckAI) {
+            forceOmnibarTop(omnibar, rootView)
+        }
+        removeWidget(rootView)
+        if (omnibar.viewMode == DuckAI) {
+            omnibar.show()
+            hideOmnibarBackground(omnibar, rootView)
+        }
+        val widgetView = createWidgetView(layoutInflater, rootView, omnibar)
+        val prefillText = query.ifEmpty { omnibar.getText() }
+        bindWidget(
+            widgetView = widgetView,
+            rootView = rootView,
+            omnibar = omnibar,
+            lifecycleOwner = lifecycleOwner,
+            tabs = tabs,
+            onSearchTextChanged = onSearchTextChanged,
+            onClearAutocomplete = onClearAutocomplete,
+            onSearchSubmitted = onSearchSubmitted,
+            onChatSubmitted = onChatSubmitted,
+            onDuckAiChatSubmitted = onDuckAiChatSubmitted,
+            onChatSuggestionSelected = onChatSuggestionSelected,
+            onFireButtonTapped = onFireButtonTapped,
+            onTabSwitcherTapped = onTabSwitcherTapped,
+            onMenuTapped = onMenuTapped,
+            onStopClicked = onStopClicked,
+        )
+        if (omnibar.viewMode != DuckAI && prefillText.isNotEmpty()) {
+            widgetFrom(widgetView)?.text = prefillText
+        }
+        attachWidget(widgetView, rootView, omnibar)
+        if (omnibar.viewMode != DuckAI) {
+            omnibar.hide()
+        }
+    }
+
+    private fun bindMainButtons(
+        widgetView: View,
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+    ) {
+        widgetFrom(widgetView)?.bindMainButtons(
+            onFireButtonTapped = onFireButtonTapped,
+            onTabSwitcherTapped = onTabSwitcherTapped,
+            onMenuTapped = onMenuTapped,
+        )
+    }
+
+    private fun bindTabCount(
+        widgetView: View,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+    ) {
+        val widget = widgetFrom(widgetView) ?: return
+        val tabCount = tabs.map { it.size }
+        widget.bindTabCount(lifecycleOwner, tabCount)
+    }
+
+    private fun bindSearchCallbacks(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+        onSearchTextChanged: (String) -> Unit,
+        onClearAutocomplete: () -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+        onDuckAiChatSubmitted: (String) -> Unit,
+    ) {
+        val widget = widgetFrom(widgetView) ?: return
+        widget.bindSearchCallbacks(
+            onSearchTextChanged = onSearchTextChanged,
+            onSearchSubmitted = { query ->
+                if (omnibar.viewMode == DuckAI) {
+                    removeWidget(rootView)
+                    restoreOmnibar(omnibar, rootView)
+                    omnibar.show()
+                } else {
+                    hideNativeInput(rootView, omnibar)
+                }
+                onSearchSubmitted(query)
+            },
+            onChatSubmitted = { query ->
+                if (omnibar.viewMode == DuckAI) {
+                    (widget.context as? Activity)?.hideKeyboard(widget.inputField)
+                    onDuckAiChatSubmitted(query)
+                } else {
+                    hideNativeInput(rootView, omnibar)
+                    onChatSubmitted(query)
+                }
+            },
+        )
+        val previousOnChatSelected = widget.onChatSelected
+        widget.onChatSelected = {
+            onClearAutocomplete()
+            previousOnChatSelected?.invoke()
+        }
+        widget.onClearTextTapped = {
+            if (!widget.isChatTabSelected()) {
+                onClearAutocomplete()
+            }
+        }
+    }
+
+    private fun removeWidget(rootView: ViewGroup): Boolean {
+        var removed = false
+        rootView.findViewById<View?>(R.id.inputModeTopRoot)?.let {
+            rootView.removeView(it)
+            removed = true
+        }
+        rootView.findViewById<View?>(R.id.inputModeBottomRoot)?.let {
+            rootView.removeView(it)
+            removed = true
+        }
+        restoreAutoCompleteAdapter(rootView)
+        chatSuggestionsAdapter = null
+        autoCompleteAdapter = null
+        return removed
+    }
+
+    private fun hideOmnibarBackground(omnibar: Omnibar, rootView: ViewGroup) {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+
+        val toolbarContainer = omnibarView.findViewById<View?>(R.id.toolbarContainer)
+        val cardShadow = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)
+        val innerCard = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+        val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
+        val aiIcon = omnibarView.findViewById<View?>(R.id.aiIcon)
+        val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
+        val leadingIconContainer = omnibarView.findViewById<View?>(R.id.omnibarIconContainer)
+        val shieldIcon = omnibarView.findViewById<View?>(R.id.shieldIcon)
+        val omnibarTextInput = omnibarView.findViewById<View?>(R.id.omnibarTextInput)
+        val pageLoadingIndicator = omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)
+        val fireIconMenu = omnibarView.findViewById<View?>(R.id.fireIconMenu)
+        val tabsMenu = omnibarView.findViewById<View?>(R.id.tabsMenu)
+        val browserMenu = omnibarView.findViewById<View?>(R.id.browserMenu)
+
+        fun apply() {
+            if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
+            toolbarContainer?.setBackgroundColor(Color.TRANSPARENT)
+            cardShadow?.setCardBackgroundColor(Color.TRANSPARENT)
+            cardShadow?.cardElevation = 0f
+            innerCard?.setCardBackgroundColor(Color.TRANSPARENT)
+            leadingIconContainer?.gone()
+            shieldIcon?.gone()
+            omnibarTextInput?.gone()
+            pageLoadingIndicator?.gone()
+            fireIconMenu?.show()
+            tabsMenu?.show()
+            browserMenu?.show()
+            header?.show()
+            header?.gravity = Gravity.CENTER_VERTICAL or Gravity.START
+            header?.setBackgroundColor(Color.TRANSPARENT)
+            aiIcon?.gone()
+            aiTitle?.show()
+            aiTitle?.setTextAppearance(com.google.android.material.R.style.TextAppearance_MaterialComponents_Headline6)
+        }
+
+        apply()
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
+        omnibarView.addOnLayoutChangeListener(listener)
+        omnibarView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+                override fun onViewDetachedFromWindow(v: View) {
+                    omnibarView.removeOnLayoutChangeListener(listener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    private fun restoreOmnibar(omnibar: Omnibar, rootView: ViewGroup) {
+        val omnibarView = omnibar.omnibarView as? View
+        if (omnibarView != null) {
+            val ctx = omnibarView.context
+            omnibarView.findViewById<View?>(R.id.toolbarContainer)
+                ?.setBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar))
+            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
+                setCardBackgroundColor(ctx.getColorFromAttr(com.google.android.material.R.attr.colorSurface))
+                cardElevation = 1f.toPx()
+            }
+            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+                ?.setCardBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorWindow))
+        }
+
+        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
+            val params = omnibarView?.layoutParams as? CoordinatorLayout.LayoutParams
+            if (params?.gravity == Gravity.TOP) {
+                omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> { gravity = Gravity.BOTTOM }
+                val parent = omnibarView.parent as? ViewGroup
+                parent?.removeView(omnibarView)
+                parent?.addView(omnibarView)
+                omnibarView.elevation = 0f
+                rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                    behavior = BottomOmnibarBrowserContainerLayoutBehavior()
+                }
+            }
+        }
+
+        if (omnibar.omnibarType == OmnibarType.SPLIT) {
+            rootView.findViewById<View?>(R.id.navigationBar)?.show()
+        }
+
+        omnibar.isScrollingEnabled = true
+    }
+
+    private fun forceOmnibarTop(omnibar: Omnibar, rootView: ViewGroup) {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        val parent = omnibarView.parent as? ViewGroup ?: return
+
+        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
+            omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                gravity = Gravity.TOP
+            }
+            parent.removeView(omnibarView)
+            parent.addView(omnibarView, 0)
+            omnibarView.elevation = 1f.toPx()
+
+            val topBehavior = TopOmnibarBrowserContainerLayoutBehavior(rootView.context, null)
+            rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                behavior = topBehavior
+            }
+        }
+        omnibar.isScrollingEnabled = false
+        omnibar.setExpanded(true)
+    }
+
+    private fun createWidgetView(
+        layoutInflater: LayoutInflater,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ): View {
+        val layoutRes =
+            if (isWidgetBottom(omnibar)) {
+                R.layout.input_mode_widget_card_view_bottom
+            } else {
+                R.layout.input_mode_widget_card_view
+            }
+        return layoutInflater.inflate(layoutRes, rootView, false)
+    }
+
+    private fun bindWidget(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+        onSearchTextChanged: (String) -> Unit,
+        onClearAutocomplete: () -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+        onDuckAiChatSubmitted: (String) -> Unit,
+        onChatSuggestionSelected: (String) -> Unit,
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+        onStopClicked: () -> Unit,
+    ) {
+        bindMainButtons(widgetView, onFireButtonTapped, onTabSwitcherTapped, onMenuTapped)
+        widgetFrom(widgetView)?.onStopClicked = onStopClicked
+        bindTabCount(widgetView, lifecycleOwner, tabs)
+        bindSearchCallbacks(
+            widgetView,
+            rootView,
+            omnibar,
+            onSearchTextChanged,
+            onClearAutocomplete,
+            onSearchSubmitted,
+            onChatSubmitted,
+            onDuckAiChatSubmitted,
+        )
+        bindAutocompleteVisibility(widgetView, rootView, omnibar)
+        bindChatSuggestions(
+            widgetView = widgetView,
+            rootView = rootView,
+            omnibar = omnibar,
+            lifecycleOwner = lifecycleOwner,
+            onChatSuggestionSelected = onChatSuggestionSelected,
+        )
+        bindSearchTabAutocompleteClearing(widgetView, onClearAutocomplete)
+        applyInitialTabSelection(widgetView, omnibar)
+        applyMainButtonsVisibility(widgetView, omnibar)
+        applyBottomCardShape(widgetView, omnibar)
+    }
+
+    private fun bindSearchTabAutocompleteClearing(
+        widgetView: View,
+        onClearAutocomplete: () -> Unit,
+    ) {
+        val widget = widgetFrom(widgetView) ?: return
+        val previousOnSearchSelected = widget.onSearchSelected
+        widget.onSearchSelected = {
+            if (widget.text.isBlank()) {
+                onClearAutocomplete()
+            }
+            previousOnSearchSelected?.invoke()
+        }
+    }
+
+    private fun applyInitialTabSelection(
+        widgetView: View,
+        omnibar: Omnibar,
+    ) {
+        if (omnibar.viewMode != DuckAI) return
+        widgetFrom(widgetView)?.selectChatTab()
+    }
+
+    private fun bindAutocompleteVisibility(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        if (omnibar.viewMode != DuckAI) return
+        val widget = widgetFrom(widgetView) ?: return
+        val autoCompleteList =
+            rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
+        val focusedView = rootView.findViewById<View?>(R.id.focusedView)
+        val previousOnChatSelected = widget.onChatSelected
+        widget.onChatSelected = {
+            previousOnChatSelected?.invoke()
+            autoCompleteList.gone()
+            focusedView?.gone()
+        }
+    }
+
+    private fun applyMainButtonsVisibility(
+        widgetView: View,
+        omnibar: Omnibar,
+    ) {
+        widgetFrom(widgetView)?.setMainButtonsAllowed(omnibar.viewMode != DuckAI)
+    }
+
+    private fun attachWidget(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        rootView.addView(widgetView, buildWidgetLayoutParams(omnibar))
+        if (isWidgetBottom(omnibar)) {
+            rootView.findViewById<View?>(R.id.navigationBar)?.gone()
+            rootView.findViewById<View?>(R.id.browserLayout)?.let {
+                it.setPadding(it.paddingLeft, it.paddingTop, it.paddingRight, 0)
+            }
+        }
+        configureAutocompleteLayout(widgetView, rootView, omnibar)
+        configureContentOffset(widgetView, rootView, omnibar)
+        widgetView.post { applyForcedBottomTranslation(widgetView, rootView, omnibar) }
+        if (omnibar.viewMode != DuckAI) {
+            widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
+        }
+    }
+
+    private fun applyBottomCardShape(
+        widgetView: View,
+        omnibar: Omnibar,
+    ) {
+        if (!isWidgetBottom(omnibar)) return
+        val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
+        val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
+        card.shapeAppearanceModel =
+            card.shapeAppearanceModel
+                .toBuilder()
+                .setTopLeftCornerSize(radius)
+                .setTopRightCornerSize(radius)
+                .setBottomLeftCornerSize(0f)
+                .setBottomRightCornerSize(0f)
+                .build()
+    }
+
+    private fun bindChatSuggestions(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+        lifecycleOwner: LifecycleOwner,
+        onChatSuggestionSelected: (String) -> Unit,
+    ) {
+        if (omnibar.viewMode == DuckAI) return
+        if (!duckChat.isChatSuggestionsFeatureAvailable()) return
+        val widget = widgetFrom(widgetView) ?: return
+        val autoCompleteList =
+            rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
+        val focusedView = rootView.findViewById<View?>(R.id.focusedView)
+        val adapter = ChatSuggestionsAdapter { suggestion ->
+            onChatSuggestionSelected(buildChatUrl(suggestion))
+        }.also { chatSuggestionsAdapter = it }
+
+        fun showChatSuggestions(query: String) {
+            if (!chatSuggestionsUserEnabled) {
+                hideChatSuggestions(autoCompleteList, focusedView, hideList = true)
+                return
+            }
+            autoCompleteAdapter = autoCompleteAdapter ?: autoCompleteList.adapter
+            autoCompleteList.adapter = adapter
+            autoCompleteList.itemAnimator = null
+            fetchChatSuggestions(
+                lifecycleOwner = lifecycleOwner,
+                query = query,
+                autoCompleteList = autoCompleteList,
+                focusedView = focusedView,
+                adapter = adapter,
+            )
+        }
+
+        fun clearChatSuggestions(hideList: Boolean) {
+            hideChatSuggestions(autoCompleteList, focusedView, hideList = hideList)
+            if (!hideList) {
+                restoreAutoCompleteAdapter(rootView)
+            }
+        }
+
+        val previousOnSearchSelected = widget.onSearchSelected
+        widget.onSearchSelected = {
+            clearChatSuggestions(hideList = false)
+            previousOnSearchSelected?.invoke()
+        }
+
+        val previousOnChatSelected = widget.onChatSelected
+        widget.onChatSelected = {
+            previousOnChatSelected?.invoke()
+            omnibar.hide()
+            showChatSuggestions(widget.text)
+        }
+
+        widget.onChatTextChanged = { text ->
+            if (autoCompleteList.adapter == adapter) {
+                fetchChatSuggestions(
+                    lifecycleOwner = lifecycleOwner,
+                    query = text,
+                    autoCompleteList = autoCompleteList,
+                    focusedView = focusedView,
+                    adapter = adapter,
+                )
+            }
+        }
+    }
+
+    private fun fetchChatSuggestions(
+        lifecycleOwner: LifecycleOwner,
+        query: String,
+        autoCompleteList: RecyclerView,
+        focusedView: View?,
+        adapter: ChatSuggestionsAdapter,
+    ) {
+        chatSuggestionsJob?.cancel()
+        chatSuggestionsJob =
+            lifecycleOwner.lifecycleScope.launch {
+                val suggestions = runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+                adapter.submitList(suggestions)
+                if (suggestions.isNotEmpty()) {
+                    autoCompleteList.show()
+                    focusedView?.gone()
+                } else {
+                    autoCompleteList.gone()
+                }
+            }
+    }
+
+    private fun hideChatSuggestions(
+        autoCompleteList: RecyclerView,
+        focusedView: View?,
+        hideList: Boolean,
+    ) {
+        chatSuggestionsJob?.cancel()
+        chatSuggestionsAdapter?.submitList(emptyList())
+        if (hideList) {
+            autoCompleteList.gone()
+            focusedView?.gone()
+        }
+        chatSuggestionsReader.tearDown()
+    }
+
+    private fun restoreAutoCompleteAdapter(rootView: ViewGroup) {
+        val autoCompleteList = rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
+        autoCompleteAdapter?.let { adapter ->
+            if (autoCompleteList.adapter != adapter) {
+                autoCompleteList.adapter = adapter
+            }
+        }
+    }
+
+    private fun buildChatUrl(suggestion: ChatSuggestion): String {
+        return duckChat.getDuckChatUrl("", false)
+            .toUri()
+            .buildUpon()
+            .appendQueryParameter(CHAT_ID_PARAM, suggestion.chatId)
+            .build()
+            .toString()
+    }
+
+    private fun configureAutocompleteLayout(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
+        val focusedView = rootView.findViewById<View?>(R.id.focusedView)
+        val baseElevation = maxOf(autoCompleteList.elevation, focusedView?.elevation ?: 0f)
+        val targetElevation = baseElevation + widgetView.resources.displayMetrics.density
+        widgetView.elevation = maxOf(widgetView.elevation, targetElevation)
+        widgetView.bringToFront()
+
+        val targets =
+            buildList {
+                add(autoCompleteList to autoCompleteList.snapshotPadding())
+                focusedView?.let { add(it to it.snapshotPadding()) }
+            }
+        fun applyPadding(deltaTop: Int, deltaBottom: Int) {
+            targets.forEach { (view, padding) ->
+                view.setPadding(
+                    padding.left,
+                    padding.top + deltaTop,
+                    padding.right,
+                    padding.bottom + deltaBottom,
+                )
+            }
+        }
+
+        fun applyForWidgetPosition() {
+            val isBottom = isWidgetBottom(omnibar)
+            val topOffset = if (isBottom) 0 else maxOf(0, widgetView.bottom - autoCompleteList.top)
+            val bottomOffset = if (isBottom) maxOf(0, autoCompleteList.bottom - widgetView.top) else 0
+            applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
+        }
+
+        widgetView.post { applyForWidgetPosition() }
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyForWidgetPosition()
+            }
+        widgetView.addOnLayoutChangeListener(layoutListener)
+        autoCompleteList.addOnLayoutChangeListener(layoutListener)
+        focusedView?.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    applyPadding(deltaTop = 0, deltaBottom = 0)
+                    v.removeOnLayoutChangeListener(layoutListener)
+                    autoCompleteList.removeOnLayoutChangeListener(layoutListener)
+                    focusedView?.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    private fun configureContentOffset(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        data class Target(val view: View, val basePadding: Padding)
+        val newTabContent =
+            rootView.findViewById<View?>(R.id.newTabPage)
+                ?: rootView.findViewById(R.id.includeNewBrowserTab)
+        val targets =
+            listOfNotNull(
+                rootView.findViewById(R.id.browserLayout),
+                newTabContent,
+            ).map { Target(it, it.snapshotPadding()) }
+        if (targets.isEmpty()) return
+        val anchor = widgetView.findViewById(R.id.inputModeWidgetCard) ?: widgetView
+
+        val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
+
+        fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
+            view.setPadding(
+                padding.left,
+                padding.top + deltaTop,
+                padding.right,
+                padding.bottom + deltaBottom,
+            )
+        }
+
+        fun applyOffset() {
+            if (!widgetView.isShown) {
+                targets.forEach { target ->
+                    applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
+                }
+                return
+            }
+            val isBottom = isWidgetBottom(omnibar)
+            val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
+            val anchorBottomInWindow = anchorLocation[1] + anchor.height
+            targets.forEach { target ->
+                val view = target.view
+                val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
+                val deltaTop = if (isBottom) 0 else maxOf(0, anchorBottomInWindow - viewLocation[1])
+                val deltaBottom =
+                    if (isBottom) {
+                        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
+                            maxOf(0, overlap)
+                        } else {
+                            maxOf(0, anchor.height - overlap)
+                        }
+                    } else {
+                        0
+                    }
+                applyPadding(view, target.basePadding, deltaTop, deltaBottom)
+            }
+        }
+
+        widgetView.post { applyOffset() }
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyOffset()
+            }
+        widgetView.addOnLayoutChangeListener(layoutListener)
+        rootView.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    targets.forEach { target ->
+                        applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
+                    }
+                    v.removeOnLayoutChangeListener(layoutListener)
+                    rootView.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    private fun buildWidgetLayoutParams(
+        omnibar: Omnibar,
+    ): ViewGroup.LayoutParams {
+        return CoordinatorLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            gravity = if (isWidgetBottom(omnibar)) Gravity.BOTTOM else Gravity.TOP
+        }
+    }
+
+    private fun isWidgetBottom(omnibar: Omnibar): Boolean {
+        return omnibar.viewMode == DuckAI || omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM
+    }
+
+    private fun applyForcedBottomTranslation(
+        widgetView: View,
+        rootView: ViewGroup,
+        omnibar: Omnibar,
+    ) {
+        val shouldForce = isWidgetBottom(omnibar) && omnibar.omnibarType != OmnibarType.SINGLE_BOTTOM
+        if (!shouldForce) {
+            widgetView.translationY = 0f
+            return
+        }
+        fun applyOffset() {
+            val gap = maxOf(0, rootView.height - widgetView.bottom)
+            if (widgetView.translationY != gap.toFloat()) {
+                widgetView.translationY = gap.toFloat()
+            }
+        }
+        applyOffset()
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyOffset()
+            }
+        rootView.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    rootView.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    companion object {
+        private const val CHAT_ID_PARAM = "chatID"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -55,6 +55,7 @@ class BottomAppBarBehavior<V : View>(
         R.id.webViewFullScreenContainer,
         R.id.browserLayout,
         R.id.includeNewBrowserTab,
+        R.id.inputModeBottomRoot,
     )
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -266,10 +266,15 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     init {
         logVoiceSearchAvailability()
-        duckAiFeatureState.showInputScreen.onEach { inputScreenEnabled ->
+        combine(
+            duckAiFeatureState.showInputScreen,
+            duckChat.observeNativeInputFieldUserSettingEnabled(),
+        ) { inputScreenEnabled, nativeInputEnabled ->
+            inputScreenEnabled || nativeInputEnabled
+        }.onEach { showClickCatcher ->
             _viewState.update {
                 it.copy(
-                    showTextInputClickCatcher = inputScreenEnabled,
+                    showTextInputClickCatcher = showClickCatcher,
                 )
             }
         }.launchIn(viewModelScope)
@@ -1074,7 +1079,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     }
 
     fun onDuckAiHeaderClicked() {
-        if (duckAiFeatureState.showInputScreen.value) {
+        if (viewState.value.showTextInputClickCatcher) {
             onTextInputClickCatcherClicked()
         } else {
             _viewState.update {

--- a/app/src/main/res/layout/input_mode_widget_card_view.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/inputModeTopRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/inputModeWidgetCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="?attr/daxColorSurface"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="4dp"
+        app:cardUseCompatPadding="true">
+
+        <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+            android:id="@+id/inputModeWidget"
+            android:paddingHorizontal="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.card.MaterialCardView>
+</FrameLayout>

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/inputModeBottomRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/inputModeWidgetCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="?attr/daxColorSurface"
+        app:cardElevation="4dp"
+        app:cardUseCompatPadding="false">
+
+        <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+            android:id="@+id/inputModeWidget"
+            android:paddingHorizontal="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.card.MaterialCardView>
+</FrameLayout>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -406,6 +406,7 @@ class RealDuckChat @Inject constructor(
     override suspend fun setNativeInputFieldUserSetting(isEnabled: Boolean) {
         withContext(dispatchers.io()) {
             duckChatFeatureRepository.setNativeInputFieldUserSetting(isEnabled)
+            cacheUserSettings()
         }
     }
 
@@ -771,9 +772,10 @@ class RealDuckChat @Inject constructor(
         withContext(dispatchers.io()) {
             isDuckChatUserEnabled = duckChatFeatureRepository.isDuckChatUserEnabled()
 
+            val isNativeInputFieldEnabled = duckChatFeatureRepository.isNativeInputFieldUserSettingEnabled()
             val showInputScreen =
                 isInputScreenFeatureAvailable() && isDuckChatFeatureEnabled && isDuckChatUserEnabled &&
-                    duckChatFeatureRepository.isInputScreenUserSettingEnabled()
+                    duckChatFeatureRepository.isInputScreenUserSettingEnabled() && !isNativeInputFieldEnabled
             _showInputScreen.emit(showInputScreen)
 
             _showInputScreenAutomaticallyOnNewTab.value = showInputScreen && duckAiInputScreenOpenAutomaticallyEnabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -224,7 +224,7 @@ class RealDuckChatJSHelper @Inject constructor(
         return JsCallbackData(jsonPayload, featureName, method, id)
     }
 
-    private fun getAIChatNativeConfigValues(
+    private suspend fun getAIChatNativeConfigValues(
         featureName: String,
         method: String,
         id: String,
@@ -236,7 +236,7 @@ class RealDuckChatJSHelper @Inject constructor(
                 put(IS_HANDOFF_ENABLED, duckChat.isDuckChatFeatureEnabled())
                 put(SUPPORTS_CLOSING_AI_CHAT, true)
                 put(SUPPORTS_OPENING_SETTINGS, true)
-                put(SUPPORTS_NATIVE_CHAT_INPUT, false)
+                put(SUPPORTS_NATIVE_CHAT_INPUT, dataStore.isNativeInputFieldUserSettingEnabled())
                 put(SUPPORTS_CHAT_ID_RESTORATION, duckChat.isDuckChatFullScreenModeEnabled())
                 put(SUPPORTS_IMAGE_UPLOAD, duckChat.isImageUploadEnabled())
                 put(SUPPORTS_STANDALONE_MIGRATION, duckChat.isStandaloneMigrationEnabled())

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -64,7 +64,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 
 @InjectWith(ViewScope::class)
-class InputModeWidget @JvmOverloads constructor(
+open class InputModeWidget @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -45,6 +45,8 @@ class InputScreenButtons @JvmOverloads constructor(
             binding.actionSend.setOnClickListener { value?.invoke() }
         }
 
+    var onStopClick: (() -> Unit)? = null
+
     var onNewLineClick: (() -> Unit)? = null
         set(value) {
             field = value
@@ -69,6 +71,25 @@ class InputScreenButtons @JvmOverloads constructor(
 
     fun setSendButtonIcon(iconResId: Int) {
         binding.actionSend.setImageResource(iconResId)
+    }
+
+    fun setStopButton() {
+        binding.actionSend.setImageResource(R.drawable.ic_stop_16)
+        binding.actionSend.backgroundTintList = resolveThemeColorStateList(CommonR.attr.daxColorButtonDestructiveContainer)
+        binding.actionSend.setOnClickListener { onStopClick?.invoke() }
+    }
+
+    fun clearStopButton(iconResId: Int) {
+        binding.actionSend.setImageResource(iconResId)
+        binding.actionSend.backgroundTintList = resolveThemeColorStateList(CommonR.attr.daxColorButtonPrimaryContainer)
+        binding.actionSend.setOnClickListener { onSendClick?.invoke() }
+    }
+
+    private fun resolveThemeColorStateList(attr: Int): android.content.res.ColorStateList? {
+        val attributes = context.obtainStyledAttributes(intArrayOf(attr))
+        val colorStateList = attributes.getColorStateList(0)
+        attributes.recycle()
+        return colorStateList
     }
 
     fun setSendButtonVisible(visible: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.updateLayoutParams
+import androidx.core.widget.doAfterTextChanged
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.common.utils.extensions.showKeyboard
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.ChatState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
+import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.tabs.TabLayout
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class NativeInputModeWidget @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : InputModeWidget(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var duckChatInternal: DuckChatInternal
+
+    private var tabCountLiveData: LiveData<Int>? = null
+    private var tabCountObserver: Observer<Int>? = null
+    private var allowMainButtons: Boolean = true
+    private var submitButtons: InputScreenButtons? = null
+    private var chatStateJob: Job? = null
+    var onStopClicked: (() -> Unit)? = null
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        applyNativeStyling()
+        observeChatState()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        chatStateJob?.cancel()
+        chatStateJob = null
+    }
+
+    private fun observeChatState() {
+        chatStateJob?.cancel()
+        chatStateJob = duckChatInternal.chatState
+            .drop(1)
+            .onEach { state ->
+                setChatStreaming(state == ChatState.STREAMING)
+                when (state) {
+                    ChatState.HIDE -> {
+                        (context as? Activity)?.hideKeyboard()
+                        clearInputFocus()
+                        widgetRoot?.visibility = GONE
+                    }
+                    ChatState.SHOW -> {
+                        widgetRoot?.visibility = VISIBLE
+                        requestInputFocus()
+                        (context as? Activity)?.showKeyboard(inputField)
+                    }
+                    ChatState.READY -> {
+                        widgetRoot?.visibility = VISIBLE
+                        requestInputFocus()
+                    }
+                    else -> {}
+                }
+            }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    private val widgetRoot: View?
+        get() {
+            var v: View? = this
+            while (v != null) {
+                val p = v.parent
+                if (p is androidx.coordinatorlayout.widget.CoordinatorLayout) return v
+                v = p as? View
+            }
+            return null
+        }
+
+    private fun applyNativeStyling() {
+        setBackgroundColor(Color.TRANSPARENT)
+        hideBackArrow()
+        hideInputFieldBackground()
+        if (duckChatInternal.isEnabled()) {
+            setToggleMatchParent()
+        } else {
+            hideToggle()
+        }
+        prepareSubmitButtons()
+        configureMainButtonsVisibility()
+    }
+
+    private fun prepareSubmitButtons() {
+        ensureSubmitButtons()
+        submitButtons?.setSendButtonVisible(false)
+        findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer)?.visibility = VISIBLE
+    }
+
+    private fun hideBackArrow() {
+        findViewById<View?>(R.id.InputModeWidgetBack)?.visibility = GONE
+    }
+
+    private fun hideInputFieldBackground() {
+        findViewById<View?>(R.id.backgroundLayer)?.setBackgroundColor(Color.TRANSPARENT)
+        findViewById<MaterialCardView?>(R.id.inputModeWidgetCard)?.apply {
+            setCardBackgroundColor(Color.TRANSPARENT)
+            strokeWidth = 0
+            cardElevation = 0f
+            elevation = 0f
+            outlineProvider = null
+        }
+    }
+
+    private fun hideToggle() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        toggle.getTabAt(0)?.select()
+        toggle.visibility = GONE
+    }
+
+    private fun setToggleMatchParent() {
+        findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
+            toggle.updateLayoutParams<LayoutParams> {
+                width = 0
+                matchConstraintDefaultWidth = LayoutParams.MATCH_CONSTRAINT_SPREAD
+                constrainedWidth = false
+            }
+            toggle.tabMode = TabLayout.MODE_FIXED
+            toggle.tabGravity = TabLayout.GRAVITY_FILL
+            toggle.requestLayout()
+        }
+    }
+
+    private fun configureMainButtonsVisibility() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        updateMainButtonsVisibility()
+        updateDuckAiSubmitButton()
+        toggle.addOnTabSelectedListener(
+            object : TabLayout.OnTabSelectedListener {
+                override fun onTabSelected(tab: TabLayout.Tab) {
+                    updateMainButtonsVisibility()
+                    updateDuckAiSubmitButton()
+                }
+                override fun onTabUnselected(tab: TabLayout.Tab) {}
+                override fun onTabReselected(tab: TabLayout.Tab) {
+                    updateMainButtonsVisibility()
+                    updateDuckAiSubmitButton()
+                }
+            },
+        )
+        inputField.doAfterTextChanged { updateMainButtonsVisibility() }
+    }
+
+    fun bindMainButtons(
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+    ) {
+        this.onFireButtonTapped = {
+            focusMainButton(R.id.inputFieldFireButton)
+            onFireButtonTapped()
+        }
+        this.onTabSwitcherTapped = {
+            focusMainButton(R.id.inputFieldTabsMenu)
+            onTabSwitcherTapped()
+        }
+        this.onMenuTapped = {
+            focusMainButton(R.id.inputFieldBrowserMenu)
+            onMenuTapped()
+        }
+    }
+
+    fun bindSearchCallbacks(
+        onSearchTextChanged: (String) -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+    ) {
+        this.onSearchTextChanged = onSearchTextChanged
+        this.onSearchSelected = {
+            onSearchTextChanged(text)
+        }
+        this.onSearchSent = onSearchSubmitted
+        this.onChatSent = onChatSubmitted
+    }
+
+    fun setTabCount(count: Int) {
+        tabSwitcherButton.count = count
+    }
+
+    fun setMainButtonsAllowed(allowed: Boolean) {
+        allowMainButtons = allowed
+        updateMainButtonsVisibility()
+    }
+
+    fun bindTabCount(
+        lifecycleOwner: LifecycleOwner,
+        tabCount: LiveData<Int>,
+    ) {
+        tabCountObserver?.let { existing ->
+            tabCountLiveData?.removeObserver(existing)
+        }
+        val observer = Observer<Int> { count ->
+            setTabCount(count)
+        }
+        tabCountLiveData = tabCount
+        tabCountObserver = observer
+        tabCount.observe(lifecycleOwner, observer)
+        setTabCount(tabCount.value ?: 0)
+    }
+
+    fun focusInput(activity: Activity?) {
+        inputField.requestFocus()
+        activity?.showKeyboard(inputField)
+    }
+
+    fun hasInputFocus(): Boolean = inputField.hasFocus()
+
+    private fun updateMainButtonsVisibility() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        val isSearchTab = toggle.selectedTabPosition == 0
+        val hasText = inputField.text?.isNotBlank() == true
+        setMainButtonsVisible(allowMainButtons && isSearchTab && !hasText)
+    }
+
+    private fun updateDuckAiSubmitButton() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        val isChatTab = toggle.selectedTabPosition == 1
+        if (isChatTab) {
+            submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+            submitButtons?.setSendButtonVisible(true)
+            if (!canExpand) {
+                inputField.minLines = 1
+                inputField.maxLines = 1
+            } else {
+                inputField.minLines = 1
+            }
+        } else {
+            submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_find_search_24)
+            submitButtons?.setSendButtonVisible(false)
+        }
+    }
+
+    private fun ensureSubmitButtons() {
+        if (submitButtons != null) return
+        val container = findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer) ?: return
+        val buttons = InputScreenButtons(context, useTopBar = false).apply {
+            onSendClick = { submitMessage() }
+            onStopClick = { this@NativeInputModeWidget.onStopClicked?.invoke() }
+            setSendButtonVisible(false)
+            setNewLineButtonVisible(false)
+            setVoiceButtonVisible(false)
+        }
+        container.addView(buttons)
+        submitButtons = buttons
+    }
+
+    private fun focusMainButton(id: Int) {
+        findViewById<View?>(id)?.let { button ->
+            button.isFocusableInTouchMode = true
+            button.requestFocus()
+            button.isFocusableInTouchMode = false
+        }
+    }
+
+    fun requestInputFocus() {
+        if (!inputField.hasFocus()) {
+            inputField.requestFocus()
+        }
+    }
+
+    fun selectChatTab() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        if (toggle.selectedTabPosition != 1) {
+            toggle.getTabAt(1)?.select()
+        }
+    }
+
+    fun setChatStreaming(streaming: Boolean) {
+        ensureSubmitButtons()
+        if (streaming) {
+            submitButtons?.setStopButton()
+        } else {
+            submitButtons?.clearStopButton(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_stop_16.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_stop_16.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.25,2c0.966,0 1.75,0.784 1.75,1.75v8.5A1.75,1.75 0,0 1,12.25 14h-8.5A1.75,1.75 0,0 1,2 12.25v-8.5C2,2.784 2.784,2 3.75,2z"
+      android:fillColor="#FDFBFC"/>
+</vector>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -853,6 +853,15 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `input screen feature - when native input enabled then emit disabled`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isNativeInputFieldUserSettingEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showInputScreen.value)
+    }
+
+    @Test
     fun `input screen feature - when global feature flag disabled then emit disabled`() = runTest {
         duckChatFeature.self().setRawStoredState(State(false))
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -229,6 +229,7 @@ class RealDuckChatJSHelperTest {
 
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(false)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -478,6 +479,7 @@ class RealDuckChatJSHelperTest {
 
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(false)
         whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(false)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -518,6 +520,7 @@ class RealDuckChatJSHelperTest {
 
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(true)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -662,6 +665,7 @@ class RealDuckChatJSHelperTest {
 
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isDuckChatContextualModeEnabled()).thenReturn(true)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -702,6 +706,7 @@ class RealDuckChatJSHelperTest {
         val id = "123"
 
         whenever(mockDuckChat.isStandaloneMigrationEnabled()).thenReturn(true)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -963,6 +968,7 @@ class RealDuckChatJSHelperTest {
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isImageUploadEnabled()).thenReturn(true)
         whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(false)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,
@@ -991,6 +997,42 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenGetAIChatNativeConfigValuesAndNativeInputEnabledThenReturnSupportsNativeChatInputEnabled() = runTest {
+        val featureName = "aiChat"
+        val method = "getAIChatNativeConfigValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(false)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(true)
+
+        val result = testee.processJsCallbackMessage(
+            featureName,
+            method,
+            id,
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        val expectedPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", true)
+            put("supportsClosingAIChat", true)
+            put("supportsOpeningSettings", true)
+            put("supportsNativeChatInput", true)
+            put("supportsURLChatIDRestoration", false)
+            put("supportsImageUpload", false)
+            put("supportsStandaloneMigration", false)
+            put("supportsAIChatFullMode", false)
+            put("supportsAIChatContextualMode", false)
+            put("supportsAIChatSync", false)
+            put("supportsPageContext", false)
+        }
+
+        assertEquals(expectedPayload.toString(), result!!.params.toString())
+    }
+
+    @Test
     fun whenGetAIChatNativeConfigValuesAndChatSyncEnabledThenReturnJsCallbackDataWithSupportsAIChatSyncEnabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeConfigValues"
@@ -999,6 +1041,7 @@ class RealDuckChatJSHelperTest {
         whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isDuckChatFullScreenModeEnabled()).thenReturn(false)
         whenever(mockDuckChat.isChatSyncFeatureEnabled()).thenReturn(true)
+        whenever(mockDataStore.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(
             featureName,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213449606836061?focus=true

### Description

- Adds a native input field to Duck.ai and uses the same input field on the browser.
- The field is activated when the “Native Input Field” setting is enabled in “AI features”.

### Steps to test this PR

- [ ] Enable `nativeInput` in feature flag inventory
- [ ] Go to “AI Features” and enable “Native Input Field"
- [ ] Focus the omnibar
- [ ] Verify that the native input field is shown
- [ ] Swipe back
- [ ] Verify that the omnibar is shown
- [ ] Focus the omnibar and make a search
- [ ] Verify that a search is completed and the omnibar is shown
- [ ] Focus the omnibar and tap the Duck.ai selector
- [ ] Submit a prompt
- [ ] Verify that Duck.ai is open with the prompt
- [ ] Generate a long response
- [ ] Verify that the stop button is visible in the input when generating
- [ ] Push the stop button to interrupt the query
- [ ] With the keyboard up, go to Duck.ai menu
- [ ] Verify that the keyboard is hidden
- [ ] Hide the menu
- [ ] Verify that the keyboard is shown
- [ ] Tap the Search selector and make a search
- [ ] Verify that a search is completed

Complete these steps for top, bottom and split omnibar

### UI changes
See: https://app.asana.com/1/137249556945/task/1213076064203080/comment/1213477674567634?focus=true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new omnibar/keyboard behavior and swaps between native input and the existing input screen based on user settings, which can cause UI/layout and focus regressions across top/bottom/split omnibar modes. Also adds direct app-module imports from `duckchat-impl` (captured in the lint baseline), increasing coupling risk.
> 
> **Overview**
> Adds a new **native Duck.ai input field** that can replace the existing input-screen launcher when the “Native Input Field” setting is enabled, including show/hide and focus handling driven by keyboard visibility.
> 
> Introduces `NativeInputManager` (used by `BrowserTabFragment`) to render a `NativeInputModeWidget` overlay, manage omnibar positioning/background (including Duck.ai fullscreen), and optionally swap autocomplete list contents to Duck.ai chat suggestions.
> 
> Updates DuckChat feature plumbing so enabling native input disables `showInputScreen`, caches the native-input setting, and reports `supportsNativeChatInput` via the JS config callback; adds a streaming **Stop** button UI and related tests. Separately, updates `BottomAppBarBehavior` exemptions and adds lint-baseline entries for `NoImplImportsInAppModule` due to `duckchat-impl` imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 887aaf55317dfb43569271b22f8e84cba90f7d04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->