### PR TITLE
Update content scope scripts to version 13.23.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -532,6 +532,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -2122,7 +2123,7 @@
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
       this._queue.forEach((subscription) => subscription(response));
@@ -3327,7 +3328,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -3725,7 +3726,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -3906,7 +3907,7 @@
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {
@@ -3914,7 +3915,7 @@
       return processAttr(configSetting, defaultValue);
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args2) {
     }
@@ -3953,7 +3954,7 @@
       this.platform = args.platform;
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     load(_args2) {
     }
@@ -4032,7 +4033,7 @@
     /**
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
@@ -4063,7 +4064,7 @@
     }
     /**
      * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
      * @param {string} propertyName
      * @param {Partial<PropertyDescriptor>} descriptor
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -4073,7 +4074,7 @@
     }
     /**
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
      * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -4330,9 +4331,9 @@
   var WebCompat = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeShareRequest, null);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
       /** @type {Map<string, object>} */
       __privateAdd(this, _webNotifications, /* @__PURE__ */ new Map());

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2038,6 +2038,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -3627,7 +3628,7 @@
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
       this._queue.forEach((subscription) => subscription(response));
@@ -4852,7 +4853,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5250,7 +5251,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -5431,7 +5432,7 @@
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {
@@ -5439,7 +5440,7 @@
       return processAttr(configSetting, defaultValue);
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args2) {
     }
@@ -5478,7 +5479,7 @@
       this.platform = args.platform;
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     load(_args2) {
     }
@@ -5557,7 +5558,7 @@
     /**
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
@@ -5588,7 +5589,7 @@
     }
     /**
      * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
      * @param {string} propertyName
      * @param {Partial<PropertyDescriptor>} descriptor
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -5598,7 +5599,7 @@
     }
     /**
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
      * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2038,6 +2038,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -3596,7 +3597,7 @@
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
       this._queue.forEach((subscription) => subscription(response));
@@ -4821,7 +4822,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5219,7 +5220,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -5400,7 +5401,7 @@
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {
@@ -5408,7 +5409,7 @@
       return processAttr(configSetting, defaultValue);
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args2) {
     }
@@ -5447,7 +5448,7 @@
       this.platform = args.platform;
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     load(_args2) {
     }
@@ -5526,7 +5527,7 @@
     /**
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
@@ -5557,7 +5558,7 @@
     }
     /**
      * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
      * @param {string} propertyName
      * @param {Partial<PropertyDescriptor>} descriptor
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -5567,7 +5568,7 @@
     }
     /**
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
      * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1387,6 +1387,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -3534,7 +3535,7 @@
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
       this._queue.forEach((subscription) => subscription(response));
@@ -4759,7 +4760,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -5157,7 +5158,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -5338,7 +5339,7 @@
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {
@@ -5346,7 +5347,7 @@
       return processAttr(configSetting, defaultValue);
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args2) {
     }
@@ -5385,7 +5386,7 @@
       this.platform = args.platform;
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     load(_args2) {
     }
@@ -5464,7 +5465,7 @@
     /**
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
@@ -5495,7 +5496,7 @@
     }
     /**
      * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
      * @param {string} propertyName
      * @param {Partial<PropertyDescriptor>} descriptor
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -5505,7 +5506,7 @@
     }
     /**
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
      * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -6533,7 +6534,7 @@
       },
       /**
        * @param {string} name
-       * @param {(d: any) => void} callback
+       * @param {(d: unknown) => void} callback
        * @returns {() => void}
        */
       subscribe(name, callback) {
@@ -6836,7 +6837,12 @@
       if (shouldInjectStyleTag) {
         shouldInjectStyleTag = this.matchConditionalFeatureSetting("styleTagExceptions").length === 0;
       }
-      const activeDomainRules = this.matchConditionalFeatureSetting("domains").flatMap((item) => item.rules);
+      const activeDomainRules = this.matchConditionalFeatureSetting("domains").flatMap((item) => {
+        return (
+          /** @type {ElementHidingRule[]} */
+          item.rules || []
+        );
+      });
       const overrideRules = activeDomainRules.filter((rule) => {
         return rule.type === "override";
       });
@@ -7139,9 +7145,9 @@
   var WebCompat = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeShareRequest, null);
-      /** @type {Promise<any> | null} */
+      /** @type {Promise<{failure?: {name: string, message: string}}> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
       /** @type {Map<string, object>} */
       __privateAdd(this, _webNotifications, /* @__PURE__ */ new Map());
@@ -9440,7 +9446,10 @@
         try {
           assertCustomEvent(evt);
           if (evt.detail.kind === MSG_NAME_SET_VALUES) {
-            return this.setUserValues(evt.detail.data).then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
+            return this.setUserValues(
+              /** @type {import("../duck-player.js").UserValues} */
+              evt.detail.data
+            ).then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
           }
           if (evt.detail.kind === MSG_NAME_READ_VALUES_SERP) {
             return this.getUserValues().then((updated) => respond(MSG_NAME_PUSH_DATA, updated)).catch(console.error);
@@ -9457,7 +9466,11 @@
   };
   function assertCustomEvent(event) {
     if (!("detail" in event)) throw new Error("none-custom event");
-    if (typeof event.detail.kind !== "string") throw new Error("custom event requires detail.kind to be a string");
+    const detail = (
+      /** @type {{kind: unknown}} */
+      event.detail
+    );
+    if (typeof detail.kind !== "string") throw new Error("custom event requires detail.kind to be a string");
   }
   var Pixel = class {
     /**
@@ -12148,8 +12161,8 @@ ${iframeContent}
   var BrowserUiLock = class extends ContentFeature {
     constructor() {
       super(...arguments);
-      /** @type {boolean} */
-      __publicField(this, "_currentLockState", false);
+      /** @type {boolean | null} Null ensures the first evaluation always sends a notification */
+      __publicField(this, "_currentLockState", null);
       /** @type {MutationObserver | null} */
       __publicField(this, "_mutationObserver", null);
       /** @type {ResizeObserver | null} */
@@ -12186,7 +12199,7 @@ ${iframeContent}
       this._setupResizeObserver();
     }
     /**
-     * Set up MutationObserver to watch for style/class attribute changes on html and body.
+     * Set up MutationObserver to watch for style/class/content changes on html and body.
      */
     _setupMutationObserver() {
       if (this._mutationObserver) {
@@ -12253,10 +12266,10 @@ ${iframeContent}
       try {
         const html2 = document.documentElement;
         const body = document.body;
-        if (html2 && this._hasVisibleScrollbar(html2)) {
+        if (html2 && this._hasExplicitlyVisibleScrollbar(html2)) {
           return false;
         }
-        if (body && this._hasVisibleScrollbar(body)) {
+        if (body && this._hasExplicitlyVisibleScrollbar(body)) {
           return false;
         }
         return true;
@@ -12271,10 +12284,11 @@ ${iframeContent}
      * @param {Element} el
      * @returns {boolean}
      */
-    _hasVisibleScrollbar(el) {
+    _hasExplicitlyVisibleScrollbar(el) {
       const style = getComputedStyle(el);
       const overflowY = style.overflowY;
-      return el.scrollHeight > el.clientHeight && overflowY !== "hidden" && overflowY !== "clip";
+      const overflowTypes = this.getFeatureSetting("overflowTypes") ?? ["hidden", "clip", "auto"];
+      return el.scrollHeight > el.clientHeight && !overflowTypes.includes(overflowY);
     }
     /**
      * Notify native if lock state changed

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -514,6 +514,7 @@
     "breakageReporting",
     "print",
     "webInterferenceDetection",
+    "webDetection",
     "pageObserver",
     "hover"
   ];
@@ -2045,7 +2046,7 @@
     /**
      * Callback for update() handler. This connects messages sent from the Platform
      * with callback functions in the _queue.
-     * @param {any} response
+     * @param {unknown} response
      */
     onResponse(response) {
       this._queue.forEach((subscription) => subscription(response));
@@ -3250,7 +3251,7 @@
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
-     * @return {any[]}
+     * @return {ConditionalSettingEntry[]}
      * @protected
      */
     matchConditionalFeatureSetting(featureKeyName) {
@@ -3648,7 +3649,7 @@
        *
        * Use `this._declareExposeMethods([...names])` to declare which methods are exposed.
        *
-       * @type {ExposeMethods<any> | undefined}
+       * @type {ExposeMethods<string> | undefined}
        */
       __publicField(this, "_exposedMethods");
       this.setArgs(this.args);
@@ -3829,7 +3830,7 @@
      * If the value is not an object, return the value.
      * If the value is an object, check its type property.
      * @param {string} attrName
-     * @param {any} defaultValue - The default value to use if the config setting is not set
+     * @param {unknown} defaultValue - The default value to use if the config setting is not set
      * @returns The value of the config setting or the default value
      */
     getFeatureAttr(attrName, defaultValue) {
@@ -3837,7 +3838,7 @@
       return processAttr(configSetting, defaultValue);
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     init(_args2) {
     }
@@ -3876,7 +3877,7 @@
       this.platform = args.platform;
     }
     /**
-     * @param {any} [_args]
+     * @param {unknown} [_args]
      */
     load(_args2) {
     }
@@ -3955,7 +3956,7 @@
     /**
      * Define a property descriptor with debug flags.
      * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string | symbol} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
@@ -3986,7 +3987,7 @@
     }
     /**
      * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
      * @param {string} propertyName
      * @param {Partial<PropertyDescriptor>} descriptor
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
@@ -3996,7 +3997,7 @@
     }
     /**
      * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {object} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
      * @param {string} propertyName
      * @param {(originalFn: any, ...args: any[]) => any } wrapperFn - wrapper function receives the original function as the first argument
      * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.19.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7b33d8fc6cc05ac083988bcab4a7da618e40e423",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4c512828248f52c530cc2668e422ce5091a2ceb7",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
-      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.19.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run