### PR TITLE
Add send() extension function for metrics

### DIFF
--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/MetricsPixelPlugin.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/MetricsPixelPlugin.kt
@@ -36,11 +36,23 @@ data class ConversionWindow(val lowerWindow: Int, val upperWindow: Int)
 
 data class PixelDefinition(val pixelName: String, val params: Map<String, String>)
 
+enum class MetricType {
+    /** Fire the pixel once per conversion window. */
+    NORMAL,
+
+    /** Increment the count only while within the conversion window; fire when count reaches [MetricsPixel.value]. */
+    COUNT_WHEN_IN_WINDOW,
+
+    /** Increment the count unconditionally (regardless of conversion window); fire when count reaches [MetricsPixel.value]. */
+    COUNT_ALWAYS,
+}
+
 data class MetricsPixel(
     val metric: String,
     val value: String,
     val conversionWindow: List<ConversionWindow>,
     val toggle: Toggle,
+    val type: MetricType = MetricType.NORMAL,
 ) {
 
     fun getPixelDefinitions(): List<PixelDefinition> {
@@ -73,3 +85,26 @@ data class MetricsPixel(
 }
 
 const val METRICS_PIXEL_PREFIX = "experiment_metrics"
+
+/**
+ * Internal extension interface for sending metric pixels. Should NEVER be used publicly.
+ * Use [MetricsPixel.send] instead.
+ */
+interface MetricsPixelExtension {
+    suspend fun send(metricsPixel: MetricsPixel): Boolean
+}
+
+/**
+ * Provider for [MetricsPixelExtension]. Initialised by the impl module at process start.
+ * Should NEVER be used publicly — call [MetricsPixel.send] instead.
+ */
+object MetricsPixelExtensionProvider {
+    lateinit var instance: MetricsPixelExtension
+}
+
+/**
+ * Sends this metric pixel, handling conversion window checks, deduplication and count thresholds.
+ * @return true if the pixel was fired, false if no cohort is assigned, the conversion window has
+ * passed, the pixel was already sent, or the count threshold has not been reached yet.
+ */
+suspend fun MetricsPixel.send(): Boolean = MetricsPixelExtensionProvider.instance.send(this)

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelExtension
+import com.duckduckgo.feature.toggles.api.MetricsPixelExtensionProvider
+import com.duckduckgo.feature.toggles.api.PixelDefinition
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import okio.ByteString.Companion.encode
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealMetricsPixelSender @Inject constructor(
+    private val pixel: Pixel,
+    private val store: MetricsPixelStore,
+    private val dispatcherProvider: DispatcherProvider,
+) : MetricsPixelExtension {
+
+    override suspend fun send(metricsPixel: MetricsPixel): Boolean {
+        val definitions = metricsPixel.getPixelDefinitions()
+        if (definitions.isEmpty()) return false
+        return withContext(dispatcherProvider.io()) {
+            definitions.any { definition ->
+                when (metricsPixel.type) {
+                    MetricType.NORMAL -> sendNormal(definition)
+                    MetricType.COUNT_WHEN_IN_WINDOW -> sendCount(definition, metricsPixel.value.toInt())
+                    MetricType.COUNT_ALWAYS -> false // TODO: not implemented yet
+                }
+            }
+        }
+    }
+
+    private suspend fun sendNormal(definition: PixelDefinition): Boolean {
+        if (!isInConversionWindow(definition)) return false
+        val tag = tagFor(definition)
+        if (store.wasPixelFired(tag)) return false
+        pixel.fire(definition.pixelName, definition.params)
+        store.storePixelTag(tag)
+        return true
+    }
+
+    private suspend fun sendCount(definition: PixelDefinition, threshold: Int): Boolean {
+        if (!isInConversionWindow(definition)) return false
+        val count = store.getMetricForPixelDefinition(definition)
+        if (count >= threshold) return false
+        val newCount = store.increaseMetricForPixelDefinition(definition)
+        if (newCount != threshold) return false
+        val tag = tagFor(definition)
+        if (store.wasPixelFired(tag)) return false
+        pixel.fire(definition.pixelName, definition.params)
+        store.storePixelTag(tag)
+        return true
+    }
+
+    private fun tagFor(definition: PixelDefinition): String {
+        return (
+            "${definition.pixelName}{metric=${definition.params["metric"]}" +
+                "value=${definition.params["value"]}" +
+                "conversionWindow=${definition.params["conversionWindowDays"]}" +
+                "enrollmentDate=${definition.params["enrollmentDate"]}}"
+            ).encode().md5().hex()
+    }
+
+    private fun isInConversionWindow(definition: PixelDefinition): Boolean {
+        val enrollmentDate = definition.params["enrollmentDate"] ?: return false
+        val lowerWindow = definition.params["conversionWindowDays"]?.split("-")?.first()?.toInt() ?: return false
+        val upperWindow = definition.params["conversionWindowDays"]?.split("-")?.last()?.toInt() ?: return false
+        return daysBetweenTodayAnd(enrollmentDate) in lowerWindow..upperWindow
+    }
+
+    private fun daysBetweenTodayAnd(date: String): Long {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York"))
+        val localDate = LocalDate.parse(date)
+        val zoneDateTime = localDate.atStartOfDay(ZoneId.of("America/New_York"))
+        return ChronoUnit.DAYS.between(zoneDateTime, today)
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@PriorityKey(1)
+class MetricsPixelExtensionProviderObserver @Inject constructor(
+    private val metricsPixelExtension: MetricsPixelExtension,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        MetricsPixelExtensionProvider.instance = metricsPixelExtension
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@SuppressLint("DenyListedApi")
+class RealMetricsPixelSenderTest {
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val store = FakeStore()
+    private val fakePixel = FakeSenderPixel()
+    private lateinit var testFeature: TestTriggerFeature
+    private lateinit var sender: RealMetricsPixelSender
+
+    @Before
+    fun setup() {
+        testFeature = FeatureToggles.Builder(
+            FakeToggleStore(),
+            featureName = "testFeature",
+        ).build().create(TestTriggerFeature::class.java)
+
+        sender = RealMetricsPixelSender(fakePixel, store, coroutineRule.testDispatcherProvider)
+
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+    }
+
+    // NORMAL type tests
+
+    @Test
+    fun `NORMAL - pixel fired when in conversion window`() = runTest {
+        sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1))
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `NORMAL - pixel not fired when outside conversion window`() = runTest {
+        sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 5, upperWindow = 7))
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `NORMAL - pixel not fired twice`() = runTest {
+        val pixel = metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1)
+        sender.send(pixel)
+        sender.send(pixel)
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `NORMAL - returns false when no cohort assigned`() = runTest {
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(remoteEnableState = true, enable = true, assignedCohort = null),
+        )
+        val result = sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1))
+        assertFalse(result)
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `NORMAL - returns false when outside conversion window`() = runTest {
+        val result = sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 5, upperWindow = 7))
+        assertFalse(result)
+    }
+
+    @Test
+    fun `NORMAL - returns true when pixel fired`() = runTest {
+        val result = sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1))
+        assertTrue(result)
+    }
+
+    @Test
+    fun `NORMAL - returns false when pixel already sent`() = runTest {
+        val pixel = metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1)
+        sender.send(pixel)
+        val result = sender.send(pixel)
+        assertFalse(result)
+    }
+
+    // COUNT_WHEN_IN_WINDOW type tests
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - pixel not fired before threshold reached`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        sender.send(pixel)
+        sender.send(pixel)
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - pixel fired when threshold reached`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(3) { sender.send(pixel) }
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - pixel not fired again after threshold`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(5) { sender.send(pixel) }
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - pixel not fired when outside conversion window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "1", lowerWindow = 5, upperWindow = 7)
+        sender.send(pixel)
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - count not incremented when outside conversion window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "1", lowerWindow = 5, upperWindow = 7)
+        repeat(3) { sender.send(pixel) }
+        val definition = pixel.getPixelDefinitions().first()
+        assertEquals(0, store.getMetricForPixelDefinition(definition))
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - returns false when not yet at threshold`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        val result = sender.send(pixel)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - returns true when threshold reached`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(2) { sender.send(pixel) }
+        val result = sender.send(pixel)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - returns false when pixel already fired`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(3) { sender.send(pixel) }
+        val result = sender.send(pixel)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - returns false when outside conversion window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "1", lowerWindow = 5, upperWindow = 7)
+        val result = sender.send(pixel)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - returns false when no cohort assigned`() = runTest {
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(remoteEnableState = true, enable = true, assignedCohort = null),
+        )
+        val result = sender.send(metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "1", lowerWindow = 0, upperWindow = 1))
+        assertFalse(result)
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    private fun metricsPixel(
+        type: MetricType = MetricType.NORMAL,
+        value: String = "1",
+        lowerWindow: Int = 0,
+        upperWindow: Int = 1,
+    ) = MetricsPixel(
+        metric = "test_metric",
+        value = value,
+        toggle = testFeature.experimentFooFeature(),
+        conversionWindow = listOf(ConversionWindow(lowerWindow, upperWindow)),
+        type = type,
+    )
+}
+
+private class FakeSenderPixel : Pixel {
+    val firedPixels = mutableListOf<String>()
+
+    override fun fire(pixel: PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>, type: PixelType) {
+        firedPixels.add(pixel.pixelName)
+    }
+
+    override fun fire(pixelName: String, parameters: Map<String, String>, encodedParameters: Map<String, String>, type: PixelType) {
+        firedPixels.add(pixelName)
+    }
+
+    override fun enqueueFire(pixel: PixelName, parameters: Map<String, String>, encodedParameters: Map<String, String>, type: PixelType) = Unit
+    override fun enqueueFire(pixelName: String, parameters: Map<String, String>, encodedParameters: Map<String, String>, type: PixelType) = Unit
+}

--- a/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeMetricsPixelExtension.kt
+++ b/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeMetricsPixelExtension.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+class FakeMetricsPixelExtension : MetricsPixelExtension {
+
+    val sentMetrics = mutableListOf<MetricsPixel>()
+
+    override suspend fun send(metricsPixel: MetricsPixel): Boolean {
+        sentMetrics.add(metricsPixel)
+        return true
+    }
+
+    fun register() {
+        MetricsPixelExtensionProvider.instance = this
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NoMetricsPixelExtensionUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NoMetricsPixelExtensionUsageDetector.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UImportStatement
+import java.util.EnumSet
+
+/**
+ * Detector that prevents direct usage of [MetricsPixelExtension] and [MetricsPixelExtensionProvider].
+ * These are internal implementation details — callers should use [MetricsPixel.send()] instead.
+ */
+@Suppress("UnstableApiUsage")
+class NoMetricsPixelExtensionUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UImportStatement::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return NoMetricsPixelExtensionImportHandler(context)
+    }
+
+    internal class NoMetricsPixelExtensionImportHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitImportStatement(node: UImportStatement) {
+            val importPath = node.importReference?.asSourceString() ?: return
+
+            if (!isBannedImport(importPath)) return
+
+            // feature-toggles-impl is the only module allowed to reference these internals
+            val packageName = context.uastFile?.packageName.orEmpty()
+            if (packageName.startsWith("com.duckduckgo.feature.toggles.impl")) return
+
+            val typeName = importPath.substringAfterLast('.')
+            context.report(
+                NO_METRICS_PIXEL_EXTENSION_USAGE,
+                node,
+                context.getLocation(node),
+                "`$typeName` is an internal implementation detail. Use `MetricsPixel.send()` instead.",
+            )
+        }
+
+        private fun isBannedImport(importPath: String): Boolean {
+            return importPath.endsWith("MetricsPixelExtension") || importPath.endsWith("MetricsPixelExtensionProvider")
+        }
+    }
+
+    companion object {
+        val NO_METRICS_PIXEL_EXTENSION_USAGE = Issue.create(
+            "NoMetricsPixelExtensionUsage",
+            "Do not use MetricsPixelExtension or MetricsPixelExtensionProvider directly",
+            """
+                `MetricsPixelExtension` and `MetricsPixelExtensionProvider` are internal
+                implementation details and must not be used outside `feature-toggles-impl`.
+
+                Use the public API instead:
+
+                    myMetricsPixel.send()
+            """.trimIndent(),
+            Category.CORRECTNESS,
+            10,
+            Severity.ERROR,
+            Implementation(
+                NoMetricsPixelExtensionUsageDetector::class.java,
+                EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+            ),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.lint.NoDispatcherComputation.Companion.ISSUE_AVOID_COMPUTA
 import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
 import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
 import com.duckduckgo.lint.NoImplImportsInAppModuleDetector.Companion.NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE
+import com.duckduckgo.lint.NoMetricsPixelExtensionUsageDetector.Companion.NO_METRICS_PIXEL_EXTENSION_USAGE
 import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoLifecycleScopeInFragmentDetector.Companion.NO_LIFECYCLE_SCOPE_IN_FRAGMENT
 import com.duckduckgo.lint.NoRetrofitCreateMethodCallDetector.Companion.NO_RETROFIT_CREATE_CALL
@@ -68,6 +69,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_SYSTEM_LOAD_LIBRARY,
             NO_HARCODED_COROUTINE_DISPATCHER,
             NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE,
+            NO_METRICS_PIXEL_EXTENSION_USAGE,
             MISSING_SMARTLING_REQUIRED_DIRECTIVES,
             MISSING_INSTRUCTION,
             PLACEHOLDER_MISSING_POSITION,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoMetricsPixelExtensionUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoMetricsPixelExtensionUsageDetectorTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.NoMetricsPixelExtensionUsageDetector.Companion.NO_METRICS_PIXEL_EXTENSION_USAGE
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoMetricsPixelExtensionUsageDetectorTest {
+
+    @Test
+    fun whenImportingMetricsPixelExtensionOutsideImplThenFailWithError() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.somefeature.api
+
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtension
+
+                class SomeFeature {
+                    fun doSomething() {}
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NO_METRICS_PIXEL_EXTENSION_USAGE)
+            .run()
+            .expectContains("NoMetricsPixelExtensionUsage")
+    }
+
+    @Test
+    fun whenImportingMetricsPixelExtensionProviderOutsideImplThenFailWithError() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.somefeature.api
+
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtensionProvider
+
+                class SomeFeature {
+                    fun doSomething() {}
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NO_METRICS_PIXEL_EXTENSION_USAGE)
+            .run()
+            .expectContains("NoMetricsPixelExtensionUsage")
+    }
+
+    @Test
+    fun whenImportingBothBannedTypesOutsideImplThenFailWithTwoErrors() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.somefeature.impl
+
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtension
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtensionProvider
+
+                class SomeImplementation {
+                    fun doSomething() {}
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NO_METRICS_PIXEL_EXTENSION_USAGE)
+            .run()
+            .expectContains("NoMetricsPixelExtensionUsage")
+    }
+
+    @Test
+    fun whenImportingBannedTypesInsideFeatureTogglesImplThenSucceed() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.feature.toggles.impl
+
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtension
+                import com.duckduckgo.feature.toggles.api.MetricsPixelExtensionProvider
+
+                class RealMetricsPixelSender {
+                    fun doSomething() {}
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NO_METRICS_PIXEL_EXTENSION_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenImportingPublicMetricsPixelApiThenSucceed() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.somefeature.api
+
+                import com.duckduckgo.feature.toggles.api.MetricsPixel
+                import com.duckduckgo.feature.toggles.api.ConversionWindow
+                import com.duckduckgo.feature.toggles.api.MetricType
+
+                class SomeFeature {
+                    fun doSomething() {}
+                }
+            """).indented())
+            .allowCompilationErrors()
+            .issues(NO_METRICS_PIXEL_EXTENSION_USAGE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1208889145294658/task/1213475480534053?focus=true 

### Description
Part 2 of 3 in the experiment metrics pixel refactor.                                                                                                                                          
                                                            
Introduces a public `MetricsPixel.send()` extension function so callers no longer need to iterate over pixel definitions, check conversion windows, or handle deduplication themselves. All that logic now lives in `feature-toggles-impl`.

This PR just introduces the new extension function, migrating to using it will happen in the final PR.

  Changes:
  - **`MetricType` enum** — `NORMAL` (fire once per window), `COUNT_WHEN_IN_WINDOW` (increment count only while in window, fire at threshold), `COUNT_ALWAYS` (increment unconditionally, fire at
   threshold — not yet implemented)
  - **`MetricsPixel.type`** — new field on the data class, defaults to `NORMAL` (non-breaking)
  - **`MetricsPixel.send()`** — public extension function; the only API callers should use
  - **`MetricsPixelExtension` / `MetricsPixelExtensionProvider`** — internal service-locator wiring that connects the public API to the impl module; initialised via a
  `MainProcessLifecycleObserver` at process start
  - **`RealMetricsPixelSender`** — implementation handling conversion-window checks, deduplication, and count thresholds
  - **Lint rule** — `NoMetricsPixelExtensionUsage` prevents direct use of `MetricsPixelExtension` or `MetricsPixelExtensionProvider` outside `feature-toggles-impl`

### Steps to test this PR
_Lint rule_
- [x] Importing `MetricsPixelExtension` or `MetricsPixelExtensionProvider` outside `feature-toggles-impl` produces a lint error pointing to `MetricsPixel.send()`

_Unit tests_
- [x] `./gradlew :feature-toggles-impl:testDebugUnitTest` — all tests pass
- [ ] `./gradlew :lint-rules:test` — all tests pass

### UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new runtime wiring (a `lateinit` service-locator set at process start) and new pixel-firing logic for conversion windows and count thresholds, which could crash or change reporting if invoked before initialization or if thresholds/window parsing are wrong.
> 
> **Overview**
> Adds `MetricType` and a new `MetricsPixel.type` field (defaulting to `NORMAL`), plus a public `MetricsPixel.send()` extension that hides pixel-definition iteration from callers.
> 
> Implements sending in `feature-toggles-impl` via `RealMetricsPixelSender`, including conversion-window checks, deduplication via stored tags, and a `COUNT_WHEN_IN_WINDOW` thresholded counter (with `COUNT_ALWAYS` stubbed).
> 
> Adds `MetricsPixelExtension`/`MetricsPixelExtensionProvider` wiring initialized on main-process startup, a `FakeMetricsPixelExtension` for tests, and a new lint rule (`NoMetricsPixelExtensionUsage`) to forbid direct use of the internal extension/provider outside `feature-toggles-impl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbc2770d7e1d6ebb652b07fab2b2de3669a68190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->