### PR TITLE
Onboarding widget prompt installs the "wrong" widget

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2536,6 +2536,7 @@ class BrowserTabFragment :
             is Command.LaunchPlayStore -> launchPlayStore(it.appPackage)
             is Command.SubmitUrl -> submitQuery(it.url)
             is Command.LaunchAddWidget -> addWidgetLauncher.launchAddWidget(activity)
+            is Command.LaunchAddWidgetOnboardingExperiment -> addWidgetLauncher.launchAddWidget(activity, simpleWidgetPrompt = true)
             is Command.LaunchDefaultBrowser -> launchDefaultBrowser()
             is Command.LaunchAppTPOnboarding -> launchAppTPOnboardingScreen()
             is Command.RequiresAuthentication -> showAuthenticationDialog(it.request)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -105,6 +105,7 @@ import com.duckduckgo.app.browser.commands.Command.HideWarningMaliciousSite
 import com.duckduckgo.app.browser.commands.Command.HideWebContent
 import com.duckduckgo.app.browser.commands.Command.InjectEmailAddress
 import com.duckduckgo.app.browser.commands.Command.LaunchAddWidget
+import com.duckduckgo.app.browser.commands.Command.LaunchAddWidgetOnboardingExperiment
 import com.duckduckgo.app.browser.commands.Command.LaunchAutofillSettings
 import com.duckduckgo.app.browser.commands.Command.LaunchBookmarksActivity
 import com.duckduckgo.app.browser.commands.Command.LaunchFireDialogFromOnboardingDialog
@@ -3209,7 +3210,8 @@ class BrowserTabViewModel @Inject constructor(
         }
         val onboardingCommand =
             when (cta) {
-                is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddWidgetAutoOnboardingExperiment, is HomePanelCta.AddWidgetInstructions -> {
+                is HomePanelCta.AddWidgetAutoOnboardingExperiment -> LaunchAddWidgetOnboardingExperiment
+                is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddWidgetInstructions -> {
                     LaunchAddWidget
                 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -252,6 +252,7 @@ sealed class Command {
     data object LaunchAppTPOnboarding : Command()
 
     data object LaunchAddWidget : Command()
+    data object LaunchAddWidgetOnboardingExperiment : Command()
 
     class RequiresAuthentication(
         val request: BasicAuthenticationRequest,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3130,6 +3130,14 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserClickedAddWidgetOnboardingExperimentCtaButtonThenLaunchAddWidgetOnboardingExperimentCommand() {
+        val cta = HomePanelCta.AddWidgetAutoOnboardingExperiment
+        setCta(cta)
+        testee.onUserClickCtaOkButton(cta)
+        assertCommandIssued<Command.LaunchAddWidgetOnboardingExperiment>()
+    }
+
+    @Test
     fun whenUserClickedLegacyAddWidgetCtaButtonThenLaunchAddWidgetCommand() {
         val cta = HomePanelCta.AddWidgetInstructions
         setCta(cta)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213483937703418?focus=true

### Description

Added `LaunchAddWidgetOnboardingExperiment` command and used it to launch the add widget flow with a simple widget prompt enabled

### Steps to test this PR

- [ ] Install from this branch
- [ ] Go through onboarding and at the end open a new tab to trigger the Add widget bottomsheet.
- [ ] Tap on the primary CTA to add the widget.
- [ ] Confirm that the simple search widget is added, and not the search and favorites one.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to CTA command routing and widget-launch parameters; main risk is accidentally altering which widget gets pinned during onboarding flows.
> 
> **Overview**
> Fixes the onboarding add-widget experiment so its CTA launches the add-widget flow with the *simple search widget* prompt enabled.
> 
> This introduces a new `Command.LaunchAddWidgetOnboardingExperiment`, routes `HomePanelCta.AddWidgetAutoOnboardingExperiment` to it in `BrowserTabViewModel`, handles it in `BrowserTabFragment` by calling `AddWidgetLauncher.launchAddWidget(..., simpleWidgetPrompt = true)`, and adds a unit test asserting the new command is issued.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1df8a2c341003e23273abf742acfc6315309a97f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->