### PR TITLE
Add invalid page context diagnostic pixels

### DIFF
--- a/PixelDefinitions/pixels/duck_chat.json5
+++ b/PixelDefinitions/pixels/duck_chat.json5
@@ -141,6 +141,27 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_aichat_contextual_page_context_invalid_empty": {
+        "description": "User attempted to attach page context but the context string was empty",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_contextual_page_context_invalid_no_title": {
+        "description": "User attempted to attach page context but the extracted title was missing or blank",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_contextual_page_context_invalid_no_content": {
+        "description": "User attempted to attach page context but the extracted content body was missing or blank",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_contextual_page_context_auto_attached_count": {
         "description": "The page context has been automatically attached to the Contextual sheet",
         "owners": ["malmstein"],

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -346,7 +346,7 @@ class DuckChatContextualViewModel @Inject constructor(
         logcat { "Duck.ai Contextual: addPageContext" }
         duckChatPixels.reportContextualPlaceholderContextTapped()
         viewModelScope.launch {
-            val isContextValid = isContextValid(updatedPageContext)
+            val isContextValid = isContextValid(updatedPageContext, reportInvalidPixels = true)
             if (isContextValid) {
                 duckChatPixels.reportContextualPageContextManuallyAttachedNative()
                 _viewState.update { current ->
@@ -360,12 +360,18 @@ class DuckChatContextualViewModel @Inject constructor(
         }
     }
 
-    private fun isContextValid(pageContext: String): Boolean {
-        if (pageContext.isEmpty()) return false
+    private fun isContextValid(pageContext: String, reportInvalidPixels: Boolean = false): Boolean {
+        if (pageContext.isEmpty()) {
+            if (reportInvalidPixels) duckChatPixels.reportContextualPageContextInvalidEmpty()
+            return false
+        }
         val json = JSONObject(pageContext)
         val title = json.optString("title").takeIf { it.isNotBlank() }
         val content = json.optString("content").takeIf { it.isNotBlank() }
-
+        if (reportInvalidPixels) {
+            if (title == null) duckChatPixels.reportContextualPageContextInvalidNoTitle()
+            if (content == null) duckChatPixels.reportContextualPageContextInvalidNoContent()
+        }
         return title != null && content != null
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -131,6 +131,9 @@ interface DuckChatPixels {
     fun reportContextualSummarizePromptSelected()
     fun reportContextualPlaceholderContextTapped()
     fun reportContextualPlaceholderContextShown()
+    fun reportContextualPageContextInvalidEmpty()
+    fun reportContextualPageContextInvalidNoTitle()
+    fun reportContextualPageContextInvalidNoContent()
 
     fun reportChatSyncActive()
 }
@@ -310,6 +313,27 @@ class RealDuckChatPixels @Inject constructor(
         }
     }
 
+    override fun reportContextualPageContextInvalidEmpty() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualPageContextInvalidNoTitle() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualPageContextInvalidNoContent() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
     override fun reportChatSyncActive() {
         pixel.fire(DuckChatPixelName.SYNC_AI_CHAT_ACTIVE, type = Pixel.PixelType.Daily())
     }
@@ -409,6 +433,12 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY("m_aichat_contextual_page_context_placeholder_shown_daily"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT("m_aichat_contextual_page_context_placeholder_tapped_count"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY("m_aichat_contextual_page_context_placeholder_tapped_daily"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT("m_aichat_contextual_page_context_invalid_empty_c"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY("m_aichat_contextual_page_context_invalid_empty_d"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT("m_aichat_contextual_page_context_invalid_no_title_c"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_DAILY("m_aichat_contextual_page_context_invalid_no_title_d"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_COUNT("m_aichat_contextual_page_context_invalid_no_content_c"),
+    DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_DAILY("m_aichat_contextual_page_context_invalid_no_content_d"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_AUTO_ATTACHED_COUNT("m_aichat_contextual_page_context_auto_attached_count"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_AUTO_ATTACHED_DAILY("m_aichat_contextual_page_context_auto_attached_daily"),
     DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_MANUALLY_ATTACHED_NATIVE_COUNT("m_aichat_contextual_page_context_manually_attached_native_count"),
@@ -535,6 +565,12 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_AUTO_ATTACHED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_AUTO_ATTACHED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_MANUALLY_ATTACHED_NATIVE_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -436,6 +436,52 @@ class DuckChatContextualViewModelTest {
             assertFalse(state.showContext)
             assertFalse(state.userRemovedContext)
             verify(duckChatPixels).reportContextualPlaceholderContextTapped()
+            verify(duckChatPixels).reportContextualPageContextInvalidNoContent()
+        }
+
+    @Test
+    fun `when addPageContext with empty context then invalid empty pixel fired`() =
+        runTest {
+            testee.updatedPageContext = ""
+
+            testee.addPageContext()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(duckChatPixels).reportContextualPageContextInvalidEmpty()
+        }
+
+    @Test
+    fun `when addPageContext with missing title then invalid no title pixel fired`() =
+        runTest {
+            testee.updatedPageContext =
+                """
+                {
+                    "url": "https://ctx.com",
+                    "content": "some content"
+                }
+                """.trimIndent()
+
+            testee.addPageContext()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(duckChatPixels).reportContextualPageContextInvalidNoTitle()
+        }
+
+    @Test
+    fun `when addPageContext with both title and content missing then both invalid pixels fired`() =
+        runTest {
+            testee.updatedPageContext =
+                """
+                {
+                    "url": "https://ctx.com"
+                }
+                """.trimIndent()
+
+            testee.addPageContext()
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(duckChatPixels).reportContextualPageContextInvalidNoTitle()
+            verify(duckChatPixels).reportContextualPageContextInvalidNoContent()
         }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -336,4 +336,34 @@ class RealDuckChatPixelsTest {
 
         verify(mockPixel).fire(DuckChatPixelName.SYNC_AI_CHAT_ACTIVE, emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
+
+    @Test
+    fun `when reportContextualPageContextInvalidEmpty then fires count and daily`() = runTest {
+        testee.reportContextualPageContextInvalidEmpty()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_EMPTY_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualPageContextInvalidNoTitle then fires count and daily`() = runTest {
+        testee.reportContextualPageContextInvalidNoTitle()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_TITLE_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualPageContextInvalidNoContent then fires count and daily`() = runTest {
+        testee.reportContextualPageContextInvalidNoContent()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_INVALID_NO_CONTENT_DAILY, type = Pixel.PixelType.Daily())
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1198194956794324/task/1213492015096541

### Description

The ratio of `m_aichat_contextual_page_context_placeholder_tapped` to `m_aichat_contextual_page_context_manually_attached_native` is ~30%, meaning ~70% of manual attachment attempts fail `isContextValid()`. Without per-reason breakdowns we can't tell whether extraction is failing, validity criteria are too strict, or certain page types systematically fail.

This PR adds three diagnostic pixels that fire when `addPageContext()` finds the page context invalid, one per failure reason:

- `m_aichat_contextual_page_context_invalid_empty_c/d` — context string was empty
- `m_aichat_contextual_page_context_invalid_no_title_c/d` — extracted title was missing or blank
- `m_aichat_contextual_page_context_invalid_no_content_c/d` — extracted content body was missing or blank

The pixels only fire from the user-initiated path (`addPageContext()`), not from auto-attach or `replacePrompt()`. This is done via a `reportInvalidPixels: Boolean = false` parameter on `isContextValid()`.

### Steps to test this PR

_Diagnostic pixels_
- [ ] Open the contextual sheet on a page where context extraction fails (e.g. a blank/loading page) and tap the placeholder — verify `m_aichat_contextual_page_context_invalid_empty` fires
- [ ] Open on a page that produces context without a title — verify `m_aichat_contextual_page_context_invalid_no_title` fires
- [ ] Open on a page that produces context without body content — verify `m_aichat_contextual_page_context_invalid_no_content` fires
- [ ] Open on a valid page and tap the placeholder — verify none of the invalid pixels fire and `m_aichat_contextual_page_context_manually_attached_native` fires as before

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to additional pixel firing and a small, gated tweak to `isContextValid` used during manual context attachment. Main risk is incorrect/over-firing telemetry if the new pixel names or call sites are miswired.
> 
> **Overview**
> Adds three new **diagnostic contextual pixels** to break down why manual page-context attachment fails: empty context, missing title, and missing content.
> 
> Updates `DuckChatContextualViewModel.addPageContext()` to call `isContextValid(..., reportInvalidPixels = true)` so these pixels only fire on the user-initiated attach path, and extends `DuckChatPixels`/`RealDuckChatPixels` (plus pixel name definitions and param-removal mapping) to support firing count+daily variants. Unit tests were expanded to assert the new pixels fire for each invalid case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1af41c98f8eae20833cc3f285a33183a17bbdc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->