### PR TITLE
ANR fix: move app install timestamp access to io dispatcher

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/install/AppInstallSharedPreferencesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/install/AppInstallSharedPreferencesTest.kt
@@ -19,11 +19,18 @@ package com.duckduckgo.app.global.install
 import android.content.Context
 import androidx.core.content.edit
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class AppInstallSharedPreferencesTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     private lateinit var testee: AppInstallSharedPreferences
 
@@ -32,25 +39,49 @@ class AppInstallSharedPreferencesTest {
     @Before
     fun setup() {
         context.getSharedPreferences(AppInstallSharedPreferences.FILENAME, Context.MODE_PRIVATE).edit { clear() }
-        testee = AppInstallSharedPreferences(context)
+        testee = AppInstallSharedPreferences(
+            context = context,
+            appCoroutineScope = coroutineTestRule.testScope,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        )
     }
 
     @Test
-    fun whenInitializedThenInstallTimestampNotYetRecorded() {
+    fun whenInitializedThenInstallTimestampNotYetRecorded() = runTest {
         assertFalse(testee.hasInstallTimestampRecorded())
     }
 
     @Test
-    fun whenInstallTimestampRecordedThenTimestampMarkedAsAvailable() {
+    fun whenInstallTimestampRecordedThenTimestampMarkedAsAvailable() = runTest {
         val timestamp = 1L
         testee.installTimestamp = timestamp
         assertTrue(testee.hasInstallTimestampRecorded())
     }
 
     @Test
-    fun whenTimestampRecordedThenSameTimestampRetrieved() {
+    fun whenTimestampRecordedThenSameTimestampRetrieved() = runTest {
         val timestamp = 1L
         testee.installTimestamp = timestamp
         assertEquals(timestamp, testee.installTimestamp)
+    }
+
+    @Test
+    fun whenOnCreateCalledAndNoTimestampThenTimestampIsRecorded() = runTest {
+        assertFalse(testee.hasInstallTimestampRecorded())
+
+        testee.onCreate(mock())
+
+        assertTrue(testee.hasInstallTimestampRecorded())
+        assertTrue(testee.installTimestamp > 0)
+    }
+
+    @Test
+    fun whenOnCreateCalledAndTimestampExistsThenTimestampIsNotOverwritten() = runTest {
+        val existingTimestamp = 12345L
+        testee.installTimestamp = existingTimestamp
+
+        testee.onCreate(mock())
+
+        assertEquals(existingTimestamp, testee.installTimestamp)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -22,8 +22,12 @@ import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import logcat.LogPriority.INFO
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.LogPriority
 import logcat.logcat
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -44,7 +48,11 @@ fun AppInstallStore.daysInstalled(): Long {
     return TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - installTimestamp)
 }
 
-class AppInstallSharedPreferences @Inject constructor(private val context: Context) : AppInstallStore {
+class AppInstallSharedPreferences @Inject constructor(
+    private val context: Context,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : AppInstallStore {
     override var installTimestamp: Long
         get() = preferences.getLong(KEY_TIMESTAMP_UTC, 0L)
         set(timestamp) = preferences.edit { putLong(KEY_TIMESTAMP_UTC, timestamp) }
@@ -67,9 +75,11 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
 
     @UiThread
     override fun onCreate(owner: LifecycleOwner) {
-        logcat(INFO) { "recording installation timestamp" }
-        if (!hasInstallTimestampRecorded()) {
-            installTimestamp = System.currentTimeMillis()
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            logcat(LogPriority.INFO) { "recording installation timestamp" }
+            if (!hasInstallTimestampRecorded()) {
+                installTimestamp = System.currentTimeMillis()
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213372241993254?focus=true 

### Description
Addresses an ANR caused by reading/writing app install timestamp on main thread

### Steps to test this PR
qa optional 

1. Uninstall app or clear data
2. Start logcat filter
3. Cold launch app
4. Before fix: Look for StrictMode policy violation: android.os.strictmode.DiskReadViolation with com.duckduckgo.app.install.settings in the stack
5. After fix: No violation for that file


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves install timestamp recording off the UI thread and makes it asynchronous, which could affect any code that assumes the timestamp is available immediately at startup. Overall scope is small and limited to install SharedPreferences access.
> 
> **Overview**
> Prevents potential startup ANRs by moving `AppInstallSharedPreferences.onCreate` install-timestamp read/write work into an `IO` coroutine launched from the app scope.
> 
> Updates `AppInstallSharedPreferences` construction to accept `@AppCoroutineScope` and a `DispatcherProvider`, and expands instrumentation tests to run with coroutine test infrastructure and to verify `onCreate` records a timestamp only when missing (and does not overwrite an existing value).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5be422e21e96c2a97e6f07711b8c4b0a95eb849e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->