### PR TITLE
Enable PIR to internal always

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 import com.duckduckgo.pir.api.PirFeature
 import com.duckduckgo.pir.api.dashboard.PirFeatureState
 import com.duckduckgo.pir.impl.store.PirRepository
@@ -38,7 +39,8 @@ interface PirRemoteFeatures {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @DefaultValue(DefaultFeatureValue.INTERNAL)
+    @DefaultValue(DefaultFeatureValue.FALSE)
+    @InternalAlwaysEnabled
     fun pirBeta(): Toggle
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213488638646835?focus=true

### Description
See attached task description

### Steps to test this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR gating behavior by making `pirBeta` always enabled for internal builds while defaulting remote config to false, which could unintentionally expose PIR flows to internal users if downstream assumptions rely on the previous toggle semantics.
> 
> **Overview**
> Updates the `pir` remote feature toggle definition so `pirBeta` is **internal-always-enabled**.
> 
> Specifically, `pirBeta` now defaults to `FALSE` and is annotated with `@InternalAlwaysEnabled`, changing how `PirRemoteFeatureImpl` evaluates `getPirFeatureState()` for internal users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b46425c470896db49d93ecc6d49c77b0418eadd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->