### PR TITLE
Pixel: Custom tab tracker animations click pixel

### DIFF
--- a/PixelDefinitions/pixels/custom_tabs.json5
+++ b/PixelDefinitions/pixels/custom_tabs.json5
@@ -1,19 +1,27 @@
 // See https://app.asana.com/1/137249556945/project/488551667048375/task/1212210662052777?focus=true
 {
     "m_custom_tabs_address_bar_clicked": {
-        "description": "When a user clicks the 'address bar' part of the custom tab, the pixel is fired.",
+        "description": "When a user clicks on the 'address bar' part of the custom tab, the pixel is fired.",
         "owners": ["0nko"],
         "triggers": ["other"],
         "suffixes": [["form_factor"], ["first_daily_count", "form_factor"]],
         "parameters": ["appVersion"],
-        "expires": "2026-02-27"
+        "expires": "2026-03-30"
     },
     "m_custom_tabs_dax_clicked": {
-        "description": "When a user clicks the 'Dax logo' on the custom tab, the pixel is fired.",
+        "description": "When a user clicks on the 'Dax logo' on the custom tab, the pixel is fired.",
         "owners": ["0nko"],
         "triggers": ["other"],
         "suffixes": [["form_factor"], ["first_daily_count", "form_factor"]],
         "parameters": ["appVersion"],
-        "expires": "2026-02-27"
+        "expires": "2026-03-30"
+    },
+    "m_custom_tabs_tracker_animation_clicked": {
+        "description": "When a user clicks on the tracker animation on the custom tab, the pixel is fired.",
+        "owners": ["0nko"],
+        "triggers": ["other"],
+        "suffixes": [["form_factor"], ["first_daily_count", "form_factor"]],
+        "parameters": ["appVersion"],
+        "expires": "2026-03-30"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabPixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabPixelNames.kt
@@ -30,4 +30,6 @@ enum class CustomTabPixelNames(override val pixelName: String) : Pixel.PixelName
     CUSTOM_TABS_ADDRESS_BAR_CLICKED_DAILY("m_custom_tabs_address_bar_clicked_daily"),
     CUSTOM_TABS_DAX_CLICKED("m_custom_tabs_dax_clicked"),
     CUSTOM_TABS_DAX_CLICKED_DAILY("m_custom_tabs_dax_clicked_daily"),
+    CUSTOM_TABS_TRACKER_ANIMATION_CLICKED("m_custom_tabs_tracker_animation_clicked"),
+    CUSTOM_TABS_TRACKER_ANIMATION_CLICKED_DAILY("m_custom_tabs_tracker_animation_clicked_daily"),
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -1183,6 +1183,11 @@ class OmnibarLayout @JvmOverloads constructor(
                         pixel.fire(CustomTabPixelNames.CUSTOM_TABS_DAX_CLICKED)
                         pixel.fire(CustomTabPixelNames.CUSTOM_TABS_DAX_CLICKED_DAILY, type = PixelType.Daily())
                     }
+
+                    customTabSceneRoot.setOnClickListener {
+                        pixel.fire(CustomTabPixelNames.CUSTOM_TABS_TRACKER_ANIMATION_CLICKED)
+                        pixel.fire(CustomTabPixelNames.CUSTOM_TABS_TRACKER_ANIMATION_CLICKED_DAILY, type = PixelType.Daily())
+                    }
                 }
             }
         } else {

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -159,6 +159,8 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             CustomTabPixelNames.CUSTOM_TABS_ADDRESS_BAR_CLICKED_DAILY.pixelName to PixelParameter.removeAtb(),
             CustomTabPixelNames.CUSTOM_TABS_DAX_CLICKED.pixelName to PixelParameter.removeAtb(),
             CustomTabPixelNames.CUSTOM_TABS_DAX_CLICKED_DAILY.pixelName to PixelParameter.removeAtb(),
+            CustomTabPixelNames.CUSTOM_TABS_TRACKER_ANIMATION_CLICKED.pixelName to PixelParameter.removeAtb(),
+            CustomTabPixelNames.CUSTOM_TABS_TRACKER_ANIMATION_CLICKED_DAILY.pixelName to PixelParameter.removeAtb(),
             AppPixelName.FIRE_DIALOG_SHOWN.pixelName to PixelParameter.removeAtb(),
             AppPixelName.DATA_CLEARING_AUTOMATIC_OPTIONS_UPDATED.pixelName to PixelParameter.removeAtb(),
             RemoteMessagingPixelName.REMOTE_MESSAGE_IMAGE_LOAD_SUCCESS.pixelName to PixelParameter.removeAtb(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1213487690353471?focus=true

### Description

This PR adds a new temporary pixel for the tracker animation clicks in the custom tabs.

### Steps to test this PR

- [x] Go to Settings -> Developer Settings -> Custom tabs
- [x] Load a new custom tab (cnn.com)
- [x] When the tracker animation starts, tap on it
- [x] Verify that that `m_custom_tabs_tracker_animation_clicked` is fired
- [x] Verify that that `m_custom_tabs_tracker_animation_clicked_daily` is fired

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds telemetry-only pixels for a new click target and updates metadata/parameter stripping without changing core browsing or security logic.
> 
> **Overview**
> Adds a new temporary custom tabs pixel, `m_custom_tabs_tracker_animation_clicked` (and daily variant), fired when the tracker animation area is tapped in the *new custom tab* UI.
> 
> Updates pixel definitions (new entry + copy tweaks and extended expiry for existing custom tab click pixels) and ensures the new pixel has ATB removed via `PixelParamRemovalInterceptor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8590613ad97456643f36e610b655062350dc50aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->