### PR TITLE
Add test integration with Block Store

### DIFF
--- a/PixelDefinitions/pixels/blockstore_temp.json5
+++ b/PixelDefinitions/pixels/blockstore_temp.json5
@@ -1,0 +1,65 @@
+{
+    "sync_auto_recovery_blockstore_available_encrypted_daily": {
+        "description": "Fired daily when Block Store is available with E2E encryption support.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_available_unencrypted_daily": {
+        "description": "Fired daily when Block Store is available but without E2E encryption support.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_unavailable_daily": {
+        "description": "Fired daily when Block Store is determined to be unavailable (e.g., no Google Play Services).",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_check_error_daily": {
+        "description": "Fired daily when Block Store availability check throws an exception.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_write_success_daily": {
+        "description": "Fired daily when successfully writing to Block Store.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_write_error_daily": {
+        "description": "Fired daily when writing to Block Store fails.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_read_success_daily": {
+        "description": "Fired daily when successfully reading from Block Store (regardless of whether data was found).",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_read_error_daily": {
+        "description": "Fired daily when reading from Block Store fails.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "sync_auto_recovery_blockstore_read_mismatch_daily": {
+        "description": "Fired daily when reading from Block Store returns a different value than was written.",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -377,6 +377,12 @@ dependencies {
     implementation project(':sync-settings-api')
     implementation project(':sync-settings-impl')
 
+    // temporary inclusion to ensure blockstore integration
+    implementation project(':persistent-storage-api')
+    internalImplementation project(':persistent-storage-impl')
+    playImplementation project(':persistent-storage-impl')
+    fdroidImplementation project(':persistent-storage-dummy-impl')
+
     implementation project(':request-filterer-api')
     implementation project(':request-filterer-impl')
     implementation project(':request-filterer-store')

--- a/persistent-storage/persistent-storage-api/build.gradle
+++ b/persistent-storage/persistent-storage-api/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace 'com.duckduckgo.persistent.storage.api'
+}
+
+dependencies {
+    // Pure API module - no dependencies needed
+}

--- a/persistent-storage/persistent-storage-api/src/main/java/com/duckduckgo/persistent/storage/api/PersistentStorage.kt
+++ b/persistent-storage/persistent-storage-api/src/main/java/com/duckduckgo/persistent/storage/api/PersistentStorage.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.persistent.storage.api
+
+/**
+ * Abstraction for persistent storage that survives app uninstall/reinstall.
+ *
+ * On Android, this is backed by Google's Block Store API on play/internal builds,
+ * with a no-op implementation for F-Droid builds (no Google Play Services).
+ */
+interface PersistentStorage {
+    /**
+     * Check if persistent storage is available and what encryption level is supported.
+     */
+    suspend fun checkAvailability(): PersistentStorageAvailability
+
+    /**
+     * Write a value to persistent storage.
+     * @param key The key to store the value under
+     * @param value The value to write
+     * @return Result.success if write succeeded, Result.failure with exception otherwise
+     */
+    suspend fun write(key: String, value: String): Result<Unit>
+
+    /**
+     * Read a value from persistent storage.
+     * @param key The key to read
+     * @return Result.success with the value (or null if not found), Result.failure with exception otherwise
+     */
+    suspend fun read(key: String): Result<String?>
+}
+
+/**
+ * Availability status of persistent storage.
+ */
+sealed class PersistentStorageAvailability {
+    /** Persistent storage is available with end-to-end encryption */
+    object AvailableEncrypted : PersistentStorageAvailability()
+
+    /** Persistent storage is available but without end-to-end encryption */
+    object AvailableUnencrypted : PersistentStorageAvailability()
+
+    /** Persistent storage is not available at runtime (e.g., no Google Play Services on device) */
+    object Unavailable : PersistentStorageAvailability()
+
+    /** Build type does not support persistent storage (e.g., F-Droid has no GMS) */
+    object BuildTypeUnsupported : PersistentStorageAvailability()
+}

--- a/persistent-storage/persistent-storage-dummy-impl/build.gradle
+++ b/persistent-storage/persistent-storage-dummy-impl/build.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace 'com.duckduckgo.persistent.storage.dummy.impl'
+    anvil {
+        generateDaggerFactories = true
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+        abortOnError = !project.hasProperty("abortOnError") || project.property("abortOnError") != "false"
+    }
+}
+
+dependencies {
+    implementation project(path: ':persistent-storage-api')
+    implementation project(path: ':di')
+    implementation project(path: ':anvil-annotations')
+
+    anvil project(path: ':anvil-compiler')
+
+    implementation Google.dagger
+}

--- a/persistent-storage/persistent-storage-dummy-impl/lint-baseline.xml
+++ b/persistent-storage/persistent-storage-dummy-impl/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.5.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.1)" variant="all" version="8.5.1">
+
+</issues>

--- a/persistent-storage/persistent-storage-dummy-impl/src/main/java/com/duckduckgo/persistent/storage/dummy/impl/DummyPersistentStorage.kt
+++ b/persistent-storage/persistent-storage-dummy-impl/src/main/java/com/duckduckgo/persistent/storage/dummy/impl/DummyPersistentStorage.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.persistent.storage.dummy.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.persistent.storage.api.PersistentStorage
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Dummy implementation of [PersistentStorage] for F-Droid builds.
+ *
+ * F-Droid builds don't have Google Play Services, so persistent storage
+ * that survives reinstall is not available.
+ */
+@ContributesBinding(AppScope::class)
+class DummyPersistentStorage @Inject constructor() : PersistentStorage {
+
+    override suspend fun checkAvailability(): PersistentStorageAvailability {
+        return PersistentStorageAvailability.BuildTypeUnsupported
+    }
+
+    override suspend fun write(key: String, value: String): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun read(key: String): Result<String?> {
+        return Result.success(null)
+    }
+}

--- a/persistent-storage/persistent-storage-impl/build.gradle
+++ b/persistent-storage/persistent-storage-impl/build.gradle
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace 'com.duckduckgo.persistent.storage.impl'
+    anvil {
+        generateDaggerFactories = true
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+        abortOnError = !project.hasProperty("abortOnError") || project.property("abortOnError") != "false"
+    }
+}
+
+dependencies {
+    implementation project(path: ':di')
+    implementation project(path: ':common-utils')
+    implementation project(path: ':anvil-annotations')
+    implementation project(path: ':persistent-storage-api')
+
+    anvil project(path: ':anvil-compiler')
+
+    implementation Google.dagger
+    implementation "com.squareup.logcat:logcat:_"
+    implementation KotlinX.coroutines.core
+    implementation KotlinX.coroutines.playServices
+
+    // Block Store API
+    implementation "com.google.android.gms:play-services-auth-blockstore:_"
+
+    // Testing dependencies
+    testImplementation Testing.junit4
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation project(path: ':common-test')
+    testImplementation (KotlinX.coroutines.test) {
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+    testImplementation Testing.robolectric
+    testImplementation AndroidX.test.ext.junit
+}

--- a/persistent-storage/persistent-storage-impl/lint-baseline.xml
+++ b/persistent-storage/persistent-storage-impl/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.5.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.1)" variant="all" version="8.5.1">
+
+</issues>

--- a/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistent/storage/impl/BlockstoreClientProvider.kt
+++ b/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistent/storage/impl/BlockstoreClientProvider.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.persistent.storage.impl
+
+import android.content.Context
+import com.duckduckgo.di.scopes.AppScope
+import com.google.android.gms.auth.blockstore.Blockstore
+import com.google.android.gms.auth.blockstore.BlockstoreClient
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Provider for [BlockstoreClient] and Play Services availability.
+ * Extracted to enable unit testing of [RealPersistentStorage].
+ */
+interface BlockstoreClientProvider {
+    val client: BlockstoreClient
+    val isPlayServicesAvailable: Boolean
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealBlockstoreClientProvider @Inject constructor(
+    private val context: Context,
+) : BlockstoreClientProvider {
+
+    override val client: BlockstoreClient by lazy {
+        Blockstore.getClient(context)
+    }
+
+    override val isPlayServicesAvailable: Boolean by lazy {
+        val result = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+        val available = result == ConnectionResult.SUCCESS
+        logcat { "PersistentStorage: Play Services available = $available (result code: $result)" }
+        available
+    }
+}

--- a/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistent/storage/impl/RealPersistentStorage.kt
+++ b/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistent/storage/impl/RealPersistentStorage.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.persistent.storage.impl
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.persistent.storage.api.PersistentStorage
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability
+import com.google.android.gms.auth.blockstore.RetrieveBytesRequest
+import com.google.android.gms.auth.blockstore.StoreBytesData
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Real implementation of [PersistentStorage] that uses Google's Block Store API.
+ *
+ * This implementation is only included in play and internal builds (not fdroid).
+ */
+@ContributesBinding(AppScope::class)
+class RealPersistentStorage @Inject constructor(
+    private val clientProvider: BlockstoreClientProvider,
+    private val dispatcherProvider: DispatcherProvider,
+) : PersistentStorage {
+
+    private val client get() = clientProvider.client
+    private val isPlayServicesAvailable get() = clientProvider.isPlayServicesAvailable
+
+    override suspend fun checkAvailability(): PersistentStorageAvailability = withContext(dispatcherProvider.io()) {
+        logcat { "PersistentStorage: checking availability..." }
+
+        if (!isPlayServicesAvailable) {
+            logcat { "PersistentStorage: Play Services not available" }
+            return@withContext PersistentStorageAvailability.Unavailable
+        }
+
+        val isE2EAvailable = try {
+            client.isEndToEndEncryptionAvailable.await().also {
+                logcat { "PersistentStorage: E2E encryption available = $it" }
+            }
+        } catch (e: Throwable) {
+            ensureActive()
+            logcat(LogPriority.WARN) { "PersistentStorage: E2E check failed - ${e.message}" }
+            false
+        }
+
+        if (isE2EAvailable) {
+            logcat { "PersistentStorage: available with E2E encryption" }
+            PersistentStorageAvailability.AvailableEncrypted
+        } else {
+            logcat { "PersistentStorage: available without E2E encryption" }
+            PersistentStorageAvailability.AvailableUnencrypted
+        }
+    }
+
+    override suspend fun write(key: String, value: String): Result<Unit> = withContext(dispatcherProvider.io()) {
+        logcat { "PersistentStorage: attempting to write key '$key' (${value.length} chars)..." }
+
+        if (!isPlayServicesAvailable) {
+            logcat(LogPriority.WARN) { "PersistentStorage: cannot write - Play Services not available" }
+            return@withContext Result.failure(IllegalStateException("Play Services not available"))
+        }
+
+        try {
+            val data = StoreBytesData.Builder()
+                .setKey(key)
+                .setBytes(value.toByteArray(Charsets.UTF_8))
+                .build()
+
+            client.storeBytes(data).await()
+            logcat { "PersistentStorage: write success for key '$key'" }
+            Result.success(Unit)
+        } catch (e: Throwable) {
+            ensureActive()
+            logcat(LogPriority.WARN) { "PersistentStorage: write failed - ${e.message}" }
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun read(key: String): Result<String?> = withContext(dispatcherProvider.io()) {
+        logcat { "PersistentStorage: attempting to read key '$key'..." }
+
+        if (!isPlayServicesAvailable) {
+            logcat(LogPriority.WARN) { "PersistentStorage: cannot read - Play Services not available" }
+            return@withContext Result.failure(IllegalStateException("Play Services not available"))
+        }
+
+        try {
+            val request = RetrieveBytesRequest.Builder()
+                .setKeys(listOf(key))
+                .build()
+
+            val response = client.retrieveBytes(request).await()
+            val blockstoreData = response.blockstoreDataMap[key]
+            val result = if (blockstoreData != null) {
+                String(blockstoreData.bytes, Charsets.UTF_8).also {
+                    logcat { "PersistentStorage: read success for key '$key' - data found (${it.length} chars)" }
+                }
+            } else {
+                logcat { "PersistentStorage: read success for key '$key' - no data found" }
+                null
+            }
+            Result.success(result)
+        } catch (e: Throwable) {
+            ensureActive()
+            logcat(LogPriority.WARN) { "PersistentStorage: read failed - ${e.message}" }
+            Result.failure(e)
+        }
+    }
+}

--- a/persistent-storage/persistent-storage-impl/src/test/java/com/duckduckgo/persistent/storage/impl/RealPersistentStorageTest.kt
+++ b/persistent-storage/persistent-storage-impl/src/test/java/com/duckduckgo/persistent/storage/impl/RealPersistentStorageTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.persistent.storage.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability
+import com.google.android.gms.auth.blockstore.BlockstoreClient
+import com.google.android.gms.auth.blockstore.RetrieveBytesRequest
+import com.google.android.gms.auth.blockstore.RetrieveBytesResponse
+import com.google.android.gms.auth.blockstore.RetrieveBytesResponse.BlockstoreData
+import com.google.android.gms.auth.blockstore.StoreBytesData
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealPersistentStorageTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val blockstoreClient: BlockstoreClient = mock()
+    private val clientProvider: BlockstoreClientProvider = mock()
+
+    private lateinit var testee: RealPersistentStorage
+
+    @Before
+    fun setup() {
+        whenever(clientProvider.client).thenReturn(blockstoreClient)
+        testee = RealPersistentStorage(
+            clientProvider = clientProvider,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenPlayServicesNotAvailableThenReturnsUnavailable() = runTest {
+        configurePlayServicesAvailable(false)
+
+        val result = testee.checkAvailability()
+
+        assertEquals(PersistentStorageAvailability.Unavailable, result)
+    }
+
+    @Test
+    fun whenE2EEncryptionAvailableThenReturnsAvailableEncrypted() = runTest {
+        configurePlayServicesAvailable(true)
+        configureE2EAvailable(true)
+
+        val result = testee.checkAvailability()
+
+        assertEquals(PersistentStorageAvailability.AvailableEncrypted, result)
+    }
+
+    @Test
+    fun whenE2EEncryptionNotAvailableThenReturnsAvailableUnencrypted() = runTest {
+        configurePlayServicesAvailable(true)
+        configureE2EAvailable(false)
+
+        val result = testee.checkAvailability()
+
+        assertEquals(PersistentStorageAvailability.AvailableUnencrypted, result)
+    }
+
+    @Test
+    fun whenE2ECheckFailsThenReturnsAvailableUnencrypted() = runTest {
+        configurePlayServicesAvailable(true)
+        configureE2ECheckFails()
+
+        val result = testee.checkAvailability()
+
+        assertEquals(PersistentStorageAvailability.AvailableUnencrypted, result)
+    }
+
+    @Test
+    fun whenWriteAndPlayServicesNotAvailableThenReturnsFailure() = runTest {
+        configurePlayServicesAvailable(false)
+
+        val result = testee.write("key", "value")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun whenWriteSucceedsThenReturnsSuccess() = runTest {
+        configurePlayServicesAvailable(true)
+        configureWriteSuccess()
+
+        val result = testee.write("key", "value")
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun whenWriteFailsThenReturnsFailure() = runTest {
+        configurePlayServicesAvailable(true)
+        configureWriteFails()
+
+        val result = testee.write("key", "value")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun whenReadAndPlayServicesNotAvailableThenReturnsFailure() = runTest {
+        configurePlayServicesAvailable(false)
+
+        val result = testee.read("key")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun whenReadSucceedsWithDataThenReturnsValue() = runTest {
+        configurePlayServicesAvailable(true)
+        configureReadSuccess("key", "test_value")
+
+        val result = testee.read("key")
+
+        assertTrue(result.isSuccess)
+        assertEquals("test_value", result.getOrNull())
+    }
+
+    @Test
+    fun whenReadSucceedsWithNoDataThenReturnsNull() = runTest {
+        configurePlayServicesAvailable(true)
+        configureReadSuccessNoData("key")
+
+        val result = testee.read("key")
+
+        assertTrue(result.isSuccess)
+        assertEquals(null, result.getOrNull())
+    }
+
+    @Test
+    fun whenReadFailsThenReturnsFailure() = runTest {
+        configurePlayServicesAvailable(true)
+        configureReadFails()
+
+        val result = testee.read("key")
+
+        assertTrue(result.isFailure)
+    }
+
+    private fun configurePlayServicesAvailable(available: Boolean) {
+        whenever(clientProvider.isPlayServicesAvailable).thenReturn(available)
+    }
+
+    private fun configureE2EAvailable(available: Boolean) {
+        whenever(blockstoreClient.isEndToEndEncryptionAvailable).thenReturn(Tasks.forResult(available))
+    }
+
+    private fun configureE2ECheckFails() {
+        whenever(blockstoreClient.isEndToEndEncryptionAvailable).thenReturn(Tasks.forException(RuntimeException("E2E check failed")))
+    }
+
+    private fun configureWriteSuccess() {
+        whenever(blockstoreClient.storeBytes(any<StoreBytesData>())).thenReturn(Tasks.forResult(0))
+    }
+
+    private fun configureWriteFails() {
+        whenever(blockstoreClient.storeBytes(any<StoreBytesData>())).thenReturn(Tasks.forException(RuntimeException("Write failed")))
+    }
+
+    private fun configureReadSuccess(key: String, value: String) {
+        val blockstoreData: BlockstoreData = mock()
+        whenever(blockstoreData.bytes).thenReturn(value.toByteArray(Charsets.UTF_8))
+
+        val response: RetrieveBytesResponse = mock()
+        whenever(response.blockstoreDataMap).thenReturn(mapOf(key to blockstoreData))
+
+        whenever(blockstoreClient.retrieveBytes(any<RetrieveBytesRequest>())).thenReturn(Tasks.forResult(response))
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun configureReadSuccessNoData(key: String) {
+        val response: RetrieveBytesResponse = mock()
+        whenever(response.blockstoreDataMap).thenReturn(emptyMap())
+
+        whenever(blockstoreClient.retrieveBytes(any<RetrieveBytesRequest>())).thenReturn(Tasks.forResult(response))
+    }
+
+    private fun configureReadFails() {
+        whenever(blockstoreClient.retrieveBytes(any<RetrieveBytesRequest>())).thenReturn(Tasks.forException(RuntimeException("Read failed")))
+    }
+}

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation project(':statistics-api')
     implementation project(':content-scope-scripts-api')
     implementation project(':js-messaging-api')
+    implementation project(':persistent-storage-api')
 
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -71,4 +71,10 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun useExpandableBarcodeConnectSyncLayout(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun syncAutoRecoveryCapabilityDetectionWrite(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun syncAutoRecoveryCapabilityDetectionRead(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorecovery/SyncAutoRecoveryCapabilityObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorecovery/SyncAutoRecoveryCapabilityObserver.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorecovery
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.persistent.storage.api.PersistentStorage
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability.AvailableEncrypted
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability.AvailableUnencrypted
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability.BuildTypeUnsupported
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability.Unavailable
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixelName
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Observes privacy config download to validate persistent storage integration stability.
+ *
+ * This is part of de-risking strategy and will be later removed:
+ * - Feature flagged capability detection
+ * - Fires pixels on success/error to validate Block Store works reliably
+ */
+@SingleInstanceIn(AppScope::class)
+@ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+class SyncAutoRecoveryCapabilityObserver @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+    private val persistentStorage: PersistentStorage,
+    private val pixel: Pixel,
+) : PrivacyConfigCallbackPlugin {
+
+    override fun onPrivacyConfigDownloaded() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            runCapabilityDetection()
+        }
+    }
+
+    private suspend fun runCapabilityDetection() {
+        // Check feature flags first - don't touch Block Store API if both disabled
+        val writeEnabled = syncFeature.syncAutoRecoveryCapabilityDetectionWrite().isEnabled()
+        val readEnabled = syncFeature.syncAutoRecoveryCapabilityDetectionRead().isEnabled()
+
+        if (!writeEnabled && !readEnabled) {
+            logcat { "Sync-Recovery: both write and read FFs disabled, skipping" }
+            return
+        }
+
+        logcat { "Sync-Recovery: capability detection enabled (write=$writeEnabled, read=$readEnabled)" }
+
+        // Now check availability (this touches Block Store API)
+        val availability = checkAvailability() ?: return
+
+        // For unsupported build types (e.g., F-Droid), exit without any pixels
+        if (availability is BuildTypeUnsupported) {
+            logcat { "Sync-Recovery: build type does not support persistent storage, skipping" }
+            return
+        }
+
+        // Fire the availability pixel
+        fireAvailabilityPixel(availability)
+
+        if (availability is Unavailable) {
+            return
+        }
+
+        // Read first to validate previous session's write persisted
+        if (readEnabled) {
+            read()
+        } else {
+            logcat { "Sync-Recovery: read FF disabled, skipping read test" }
+        }
+
+        // Write new value for next session to read
+        if (writeEnabled) {
+            write()
+        } else {
+            logcat { "Sync-Recovery: write FF disabled, skipping write test" }
+        }
+    }
+
+    /**
+     * Returns null if exception occurred (error pixel fired), otherwise returns the availability.
+     */
+    private suspend fun checkAvailability(): PersistentStorageAvailability? {
+        return try {
+            persistentStorage.checkAvailability()
+        } catch (t: Throwable) {
+            currentCoroutineContext().ensureActive()
+            logcat(LogPriority.WARN) { "Sync-Recovery: availability check failed - ${t.message}" }
+            pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_CHECK_ERROR_DAILY, type = Daily())
+            null
+        }
+    }
+
+    private fun fireAvailabilityPixel(availability: PersistentStorageAvailability) {
+        when (availability) {
+            is AvailableEncrypted -> {
+                logcat { "Sync-Recovery: persistent storage available with E2E encryption" }
+                pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY, type = Daily())
+            }
+            is AvailableUnencrypted -> {
+                logcat { "Sync-Recovery: persistent storage available without E2E encryption" }
+                pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_UNENCRYPTED_DAILY, type = Daily())
+            }
+            is Unavailable -> {
+                logcat { "Sync-Recovery: persistent storage unavailable" }
+                pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_UNAVAILABLE_DAILY, type = Daily())
+            }
+            is BuildTypeUnsupported -> {
+                // No pixel for unsupported build type - this code path shouldn't be reached
+                // as we return early in runCapabilityDetection()
+            }
+        }
+    }
+
+    private suspend fun write() {
+        try {
+            logcat { "Sync-Recovery: attempting to write to persistent storage..." }
+            val testValue = "${TEST_VALUE_PREFIX}${System.currentTimeMillis()}"
+
+            persistentStorage.write(TEST_KEY, testValue)
+                .onSuccess {
+                    logcat { "Sync-Recovery: write success" }
+                    pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY, type = Daily())
+                }
+                .onFailure { exception ->
+                    logcat(LogPriority.WARN) { "Sync-Recovery: write failed - ${exception.message}" }
+                    pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY, type = Daily())
+                }
+        } catch (t: Throwable) {
+            currentCoroutineContext().ensureActive()
+            logcat(LogPriority.WARN) { "Sync-Recovery: write failed - ${t.message}" }
+            pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY, type = Daily())
+        }
+    }
+
+    private suspend fun read() {
+        try {
+            logcat { "Sync-Recovery: attempting to read from persistent storage..." }
+
+            persistentStorage.read(TEST_KEY)
+                .onSuccess { readValue ->
+                    val isValid = readValue == null || readValue.startsWith(TEST_VALUE_PREFIX)
+                    if (isValid) {
+                        logcat { "Sync-Recovery: read success (value=${if (readValue != null) "${readValue.length} chars" else "null"})" }
+                        pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY, type = Daily())
+                    } else {
+                        logcat(LogPriority.WARN) { "Sync-Recovery: read returned unexpected value" }
+                        pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_MISMATCH_DAILY, type = Daily())
+                    }
+                }
+                .onFailure { exception ->
+                    logcat(LogPriority.WARN) { "Sync-Recovery: read failed - ${exception.message}" }
+                    pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY, type = Daily())
+                }
+        } catch (t: Throwable) {
+            currentCoroutineContext().ensureActive()
+            logcat(LogPriority.WARN) { "Sync-Recovery: read failed - ${t.message}" }
+            pixel.fire(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY, type = Daily())
+        }
+    }
+
+    companion object {
+        private const val TEST_KEY = "com.duckduckgo.sync.derisk.test"
+        private const val TEST_VALUE_PREFIX = "derisk_test_"
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -57,6 +57,16 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
+
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_UNENCRYPTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_UNAVAILABLE_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_CHECK_ERROR_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_MISMATCH_DAILY.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -494,6 +494,17 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_DISMISSED("sync_setup_promo_bookmark_added_dialog_dismissed"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_CONFIRMED("sync_setup_promo_bookmark_added_dialog_confirmed"),
     SYNC_AI_CHAT_ACTIVE("sync_ai_chat_active"),
+
+    // temporary pixels for testing block store integration
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY("sync_auto_recovery_blockstore_available_encrypted_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_UNENCRYPTED_DAILY("sync_auto_recovery_blockstore_available_unencrypted_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_UNAVAILABLE_DAILY("sync_auto_recovery_blockstore_unavailable_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_CHECK_ERROR_DAILY("sync_auto_recovery_blockstore_check_error_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY("sync_auto_recovery_blockstore_write_success_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY("sync_auto_recovery_blockstore_write_error_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY("sync_auto_recovery_blockstore_read_success_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY("sync_auto_recovery_blockstore_read_error_daily"),
+    SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_MISMATCH_DAILY("sync_auto_recovery_blockstore_read_mismatch_daily"),
 }
 
 object SyncPixelParameters {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorecovery/SyncAutoRecoveryCapabilityObserverTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorecovery/SyncAutoRecoveryCapabilityObserverTest.kt
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorecovery
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.persistent.storage.api.PersistentStorage
+import com.duckduckgo.persistent.storage.api.PersistentStorageAvailability
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixelName
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class SyncAutoRecoveryCapabilityObserverTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val persistentStorage: PersistentStorage = mock()
+    private val pixel: Pixel = mock()
+
+    private lateinit var testee: SyncAutoRecoveryCapabilityObserver
+
+    @Before
+    fun setup() {
+        testee = SyncAutoRecoveryCapabilityObserver(
+            appCoroutineScope = coroutineTestRule.testScope,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+            syncFeature = syncFeature,
+            persistentStorage = persistentStorage,
+            pixel = pixel,
+        )
+    }
+
+    @Test
+    fun whenBuildTypeUnsupportedThenSkipsEverythingAndFiresNoPixels() = runTest {
+        configureAvailability(PersistentStorageAvailability.BuildTypeUnsupported)
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(persistentStorage).checkAvailability()
+        verify(persistentStorage, never()).write(any(), any())
+        verify(persistentStorage, never()).read(any())
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenBothFlagsDisabledThenSkipsEverythingAndFiresNoPixels() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(false)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(persistentStorage)
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenWriteFlagEnabledAndReadDisabledThenChecksAvailabilityAndWritesButSkipsRead() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(persistentStorage).checkAvailability()
+        verify(persistentStorage).write(any(), any())
+        verify(persistentStorage, never()).read(any())
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadFlagEnabledAndWriteDisabledThenChecksAvailabilityAndReadsButSkipsWrite() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadSuccess("derisk_test_123")
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(persistentStorage).checkAvailability()
+        verify(persistentStorage, never()).write(any(), any())
+        verify(persistentStorage).read(any())
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenBothFlagsEnabledThenExecutesFullFlow() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+        configureReadSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(persistentStorage).checkAvailability()
+        verify(persistentStorage).write(any(), any())
+        verify(persistentStorage).read(any())
+    }
+
+    @Test
+    fun whenBlockStoreAvailableEncryptedThenFiresEncryptedPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_ENCRYPTED_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenBlockStoreAvailableUnencryptedThenFiresUnencryptedPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableUnencrypted)
+        configureWriteSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_AVAILABLE_UNENCRYPTED_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenBlockStoreUnavailableThenFiresUnavailablePixelAndSkipsWriteAndRead() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.Unavailable)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_UNAVAILABLE_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(persistentStorage, never()).write(any(), any())
+        verify(persistentStorage, never()).read(any())
+    }
+
+    @Test
+    fun whenAvailabilityCheckThrowsExceptionThenFiresCheckErrorPixelAndSkipsWriteAndRead() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailabilityThrows()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_CHECK_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(persistentStorage, never()).write(any(), any())
+        verify(persistentStorage, never()).read(any())
+    }
+
+    @Test
+    fun whenWriteSucceedsThenFiresWriteSuccessPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenWriteFailsThenFiresWriteErrorPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteFailure()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenWriteThrowsExceptionThenFiresWriteErrorPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(false)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteThrows()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadSucceedsWithInvalidPrefixThenFiresReadMismatchPixel() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+        configureReadSuccess("unexpected_value") // Value without expected prefix
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_MISMATCH_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadSucceedsWithNullValueAndNoWriteThenFiresReadSuccessPixel() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadSucceedsWithValidPrefixThenFiresReadSuccessPixel() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadSuccess("derisk_test_1234567890")
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadFailsThenFiresReadErrorPixel() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadFailure()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadThrowsExceptionThenFiresReadErrorPixel() = runTest {
+        configureWriteFlagEnabled(false)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadThrows()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenWriteSucceedsButReadFailsThenFiresBothWriteSuccessAndReadErrorPixels() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureWriteSuccess()
+        configureReadFailure()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    @Test
+    fun whenReadFailsThenWriteStillAttemptedIfWriteFlagEnabled() = runTest {
+        configureWriteFlagEnabled(true)
+        configureReadFlagEnabled(true)
+        configureAvailability(PersistentStorageAvailability.AvailableEncrypted)
+        configureReadFailure()
+        configureWriteSuccess()
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(persistentStorage).read(any())
+        verify(persistentStorage).write(any(), any())
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_READ_ERROR_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+        verify(pixel).fire(
+            eq(SyncPixelName.SYNC_AUTO_RECOVERY_BLOCKSTORE_WRITE_SUCCESS_DAILY),
+            any(),
+            any(),
+            eq(Pixel.PixelType.Daily()),
+        )
+    }
+
+    private fun configureWriteFlagEnabled(enabled: Boolean) {
+        syncFeature.syncAutoRecoveryCapabilityDetectionWrite().setRawStoredState(State(enable = enabled))
+    }
+
+    private fun configureReadFlagEnabled(enabled: Boolean) {
+        syncFeature.syncAutoRecoveryCapabilityDetectionRead().setRawStoredState(State(enable = enabled))
+    }
+
+    private fun configureAvailability(availability: PersistentStorageAvailability) = runBlocking {
+        whenever(persistentStorage.checkAvailability()).thenReturn(availability)
+    }
+
+    private fun configureAvailabilityThrows() = runBlocking {
+        whenever(persistentStorage.checkAvailability()).thenThrow(RuntimeException("Availability check failed"))
+    }
+
+    private fun configureWriteSuccess() = runBlocking {
+        whenever(persistentStorage.write(any(), any())).thenReturn(Result.success(Unit))
+    }
+
+    private fun configureWriteFailure() = runBlocking {
+        whenever(persistentStorage.write(any(), any())).thenReturn(Result.failure(RuntimeException("Write failed")))
+    }
+
+    private fun configureWriteThrows() = runBlocking {
+        whenever(persistentStorage.write(any(), any())).thenThrow(RuntimeException("Write failed"))
+    }
+
+    private fun configureReadSuccess(value: String? = null) = runBlocking {
+        whenever(persistentStorage.read(any())).thenReturn(Result.success(value))
+    }
+
+    private fun configureReadFailure() = runBlocking {
+        whenever(persistentStorage.read(any())).thenReturn(Result.failure(RuntimeException("Read failed")))
+    }
+
+    private fun configureReadThrows() = runBlocking {
+        whenever(persistentStorage.read(any())).thenThrow(RuntimeException("Read failed"))
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -112,6 +112,8 @@ version.google.android.flexbox=3.0.0
 
 version.google.android.material=1.12.0
 
+version.google.android.play-services-auth-blockstore=16.4.0
+
 version.google.dagger=2.53.1
 
 #Cannot update to 3.1+ because we need at least Kotlin 2.1.0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213490458680904?focus=true

### Description
Adds Block Store capability detection to validate whether the device supports persistent storage that survives app reinstall. This is groundwork for sync auto-recovery.

- Checks Block Store availability and E2E encryption status on privacy config download
- Performs read/write validation with a test value
- Fires daily pixels for availability, write success/error, read success/error/mismatch
- Feature flag gated with separate toggles for write and read operations
- F-Droid build returns noop implementation (no Play Services)

### Steps to test this PR

**Logcat filter:** `PersistentStorage|Sync-Recovery|sync_auto_recovery`

_Play Services available, device lock enabled (E2E encrypted)_
- [x] Fresh install `internalDebug` build on device with Play Services and device lock enabled
- [x] Launch app, verify logs show:
  - `PersistentStorage: E2E encryption available = true`
  - `Sync-Recovery: persistent storage available with E2E encryption`
  - `Pixel sent: sync_auto_recovery_blockstore_available_encrypted_daily`
  - `PersistentStorage: read success for key '...' - no data found`
  - `Sync-Recovery: read success (value=null)`
  - `PersistentStorage: write success for key '...'`
  - `Pixel sent: sync_auto_recovery_blockstore_read_success_daily`
  - `Pixel sent: sync_auto_recovery_blockstore_write_success_daily`
- [x] Force stop app, relaunch, verify:
  - `PersistentStorage: read success for key '...' - data found (25 chars)`
  - Daily pixels are NOT sent again (already fired today)

_Play Services available, device lock disabled (unencrypted)_
- [x] Disable device lock (Settings → Security → Screen lock → None)
- [x] Fresh install, launch app, verify logs show:
  - `PersistentStorage: E2E encryption available = false`
  - `Sync-Recovery: persistent storage available without E2E encryption`
  - `Pixel sent: sync_auto_recovery_blockstore_available_unencrypted_daily`
  - Read/write operations succeed
- [x] Force stop app, relaunch, verify:
  - `PersistentStorage: read success for key '...' - data found (25 chars)`
  - Daily pixels are NOT sent again

_Play Services not available_
- [x] Test on emulator without Google Play Services
- [x] Launch app, verify logs show:
  - `PersistentStorage: Play Services not available`
  - `Sync-Recovery: persistent storage unavailable`
  - `Pixel sent: sync_auto_recovery_blockstore_unavailable_daily`
  - Read/write operations skipped
- [x] Force stop app, relaunch, verify:
  - Same behavior, daily pixel NOT sent again

_F-Droid build_
- [x] Temporarily comment out `setIgnore(true)` in `app/build.gradle` variantFilter to enable `fdroidDebug` variant
- [x] Install `fdroidDebug` build
- [x] Launch app, verify logs show: `Sync-Recovery: build type does not support persistent storage, skipping`
- [x] Force stop app, relaunch, verify same behavior

_Feature Flag Gating (Write toggle disabled)_
- [x] Fresh install `internalDebug` build
- [x] Disable `syncAutoRecoveryCapabilityDetectionWrite` toggle, enable read toggle
- [x] Force stop app, relaunch, verify logs show:
  - `Sync-Recovery: capability detection enabled (write=false, read=true)`
  - Availability check runs, availability pixel fires (or you see is ignored if it fired already today)
  - `Sync-Recovery: attempting to read from persistent storage...`
  - Read operation runs, `read_success` pixel fires  (or you see is ignored if it fired already today)
  - `Sync-Recovery: write FF disabled, skipping write test`
  - NO `write_success` pixel
- [x] Force stop app, relaunch, verify daily pixels NOT sent again

_Feature Flag Gating (Read toggle disabled)_
- [x] Fresh install `internalDebug` build
- [x] Disable `syncAutoRecoveryCapabilityDetectionRead` toggle, enable write toggle
- [x] Force stop app, relaunch, verify logs show:
  - `Sync-Recovery: capability detection enabled (write=true, read=false)`
  - Availability check runs, availability pixel fires (or you see is ignored if it fired already today)
  - `Sync-Recovery: read FF disabled, skipping read test`
  - NO `read_success` pixel
  - `Sync-Recovery: attempting to write to persistent storage...`
  - Write operation runs, `write_success` pixel fires (or you see is ignored if it fired already today)
- [x] Force stop app, relaunch, verify daily pixels NOT sent again

_Feature Flag Gating (Both toggles disabled)_
- [x] Fresh install `internalDebug` build
- [x] Disable both `syncAutoRecoveryCapabilityDetectionWrite` and `syncAutoRecoveryCapabilityDetectionRead` toggles
- [x] Force stop app, relaunch, verify logs show:
  - `Sync-Recovery: both write and read FFs disabled, skipping`
  - NO availability check, NO pixels fired at all
- [x] Force stop app, relaunch, verify same behavior

### UI changes
None - no UI changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Play Services Block Store dependency and runs new capability detection on privacy-config download (with read/write attempts), which could impact startup stability/perf on play/internal builds despite exception handling and feature flags.
> 
> **Overview**
> Adds a new `persistent-storage` module split into `persistent-storage-api` plus two implementations: a Play/internal `RealPersistentStorage` backed by Google Block Store (including Play Services availability and E2E-encryption checks) and an F-Droid `DummyPersistentStorage` no-op.
> 
> Wires the new API into the app and `sync-impl`, introducing a privacy-config callback (`SyncAutoRecoveryCapabilityObserver`) that feature-flag gates Block Store availability checks and optional read/write probe, and emits new daily de-risking pixels for availability and read/write outcomes.
> 
> Updates pixel definitions and sync pixel enums/param-removal lists for the new Block Store telemetry, and adds the `play-services-auth-blockstore` version plus unit tests for both the storage implementation and the observer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 045f8478c2d942ea99d5eb19ae22d65a037f9fb5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->