### PR TITLE
Adjust maestro tests after updating onboarding copy

### DIFF
--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -11,8 +11,8 @@ tags:
           stopApp: true
 
       - assertVisible:
-          text: ".*Ready for a faster browser that keeps you protected?.*"
-      - tapOn: "let's do it!"
+          text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
+      - tapOn: "let's get started!"
       - assertVisible:
           text: "Protections activated!"
       - tapOn: "choose your browser"

--- a/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
@@ -11,8 +11,8 @@ tags:
           stopApp: true
 
       - assertVisible:
-          text: ".*Ready for a faster browser that keeps you protected?.*"
-      - tapOn: "let's do it!"
+          text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
+      - tapOn: "let's get started!"
       - assertVisible:
           text: "Protections activated!"
       - tapOn: "choose your browser"

--- a/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
@@ -11,8 +11,8 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*Ready for a faster browser that keeps you protected?.*"
-- assertVisible: "let's do it!"
+    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
+- assertVisible: "let's get started!"
 - tapOn: "I've been here before"
 - assertVisible:
     text: "Got it! I'll skip the other tips."

--- a/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
@@ -11,8 +11,8 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*Ready for a faster browser that keeps you protected?.*"
-- assertVisible: "let's do it!"
+    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
+- assertVisible: "let's get started!"
 - tapOn: "I've been here before"
 - assertVisible:
     text: "Got it! I'll skip the other tips."

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -1,8 +1,8 @@
 appId: com.duckduckgo.mobile.android
 ---
 - assertVisible:
-    text: ".*Ready for a faster browser that keeps you protected?.*"
-- tapOn: "let's do it!"
+    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
+- tapOn: "let's get started!"
 - assertVisible:
     text: "Protections activated!"
 - scrollUntilVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1213507088418855?focus=true

### Description

### Steps to test this PR

n/a

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Maestro UI test expectations for new onboarding copy and button label changes; no production logic is modified.
> 
> **Overview**
> Updates Maestro onboarding/pre-onboarding flows to match new onboarding copy.
> 
> Replaces the initial welcome-screen `assertVisible` regex and updates the CTA from `let's do it!` to `let's get started!` across custom tabs navigation tests and returning-user preonboarding scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc6b57870d066d318b8b1f48e76fb58998ca6315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->