### PR TITLE
PIR: Update broker etags only when they are successfully stored

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerJsonUpdater.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerJsonUpdater.kt
@@ -110,13 +110,13 @@ class RealBrokerJsonUpdater @Inject constructor(
 
         val updatedJsons = jsonEtagsFromConfig.toSet() - existingEtags.toSet()
 
-        pirRepository.updateBrokerJsons(jsonEtagsFromConfig)
-
         if (updatedJsons.isNotEmpty()) {
             logcat { "PIR-update: Downloading updated broker json files: $updatedJsons" }
             brokerDataDownloader.downloadBrokerData(updatedJsons.map { it.fileName })
         } else {
             logcat { "PIR-update: No broker json files to update." }
         }
+
+        pirRepository.updateBrokerJsons(jsonEtagsFromConfig)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/brokers/RealBrokerJsonUpdaterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/brokers/RealBrokerJsonUpdaterTest.kt
@@ -273,4 +273,24 @@ class RealBrokerJsonUpdaterTest {
         verify(mockPirRepository, never()).updateMainEtag(any())
         verify(mockPirRepository, never()).updateBrokerJsons(any())
     }
+
+    @Test
+    fun whenDownloadBrokerDataThrowsExceptionThenBrokerJsonsNotUpdated() = runTest {
+        // Given
+        val successResponse = Response.success(testMainConfig)
+        whenever(mockPirRepository.getCurrentMainEtag()).thenReturn("old-etag")
+        whenever(mockPirRepository.getStoredBrokersCount()).thenReturn(2)
+        whenever(mockDbpService.getMainConfig("old-etag")).thenReturn(successResponse)
+        whenever(mockPirRepository.getAllLocalBrokerJsons()).thenReturn(testExistingBrokerJsons)
+        whenever(mockBrokerDataDownloader.downloadBrokerData(any())).thenThrow(RuntimeException("Download failed"))
+
+        // When
+        val result = testee.update()
+
+        // Then - etags should NOT be saved when download fails
+        assertFalse(result)
+        verify(mockBrokerDataDownloader).downloadBrokerData(listOf(testFileName2, testFileName3))
+        verify(mockPirRepository, never()).updateBrokerJsons(any())
+        verify(mockPirRepository, never()).updateMainEtag(any())
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213537623549113?focus=true 

### Description
See attached task description

### Steps to test this PR
https://app.asana.com/1/137249556945/project/488551667048375/task/1213537623549120?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR update state persistence order, so failures during broker data download now keep etags/main etag unchanged and return failure, which could affect update retry behavior. Scope is small and covered by a new regression test.
> 
> **Overview**
> Prevents PIR from saving updated broker JSON etags before the corresponding broker data has been downloaded.
> 
> `RealBrokerJsonUpdater.checkUpdatesFromMainConfig` now updates `PirRepository.updateBrokerJsons` *after* `downloadBrokerData` completes, so a download exception leaves both broker etags and the main etag untouched. Adds a unit test asserting etags are not persisted when `downloadBrokerData` throws.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1eb26b87d646a40ac2f4dca2a4950313f9186dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->