### PR TITLE
Failing pixel report

### DIFF
--- a/PixelDefinitions/pixels/browser_menu.json5
+++ b/PixelDefinitions/pixels/browser_menu.json5
@@ -20,6 +20,6 @@
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "atb", "vpnMenuItemStatus"]
+        "parameters": ["appVersion", "vpnMenuItemStatus"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -192,6 +192,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.GET_DESKTOP_BROWSER_DISMISSED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.GET_DESKTOP_BROWSER_SHARE_DOWNLOAD_LINK_CLICK.pixelName to PixelParameter.removeAtb(),
             AppPixelName.GET_DESKTOP_BROWSER_LINK_CLICK.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.MENU_ACTION_VPN_PRESSED.pixelName to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213478675582883?focus=true

### Description
Added missing params to pixel definition

### Steps to test this PR
- [ ] N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to pixel metadata and query-param stripping for a single pixel, with no user-facing behavior changes.
> 
> **Overview**
> Fixes browser menu pixel definitions by adding missing `appVersion`/`atb` parameters to `m_nav_pm_o` and adding `appVersion` to `m_nav_vpn_menu_item_pressed`.
> 
> Updates `PixelParamRemovalInterceptor` to also strip `atb` from `AppPixelName.MENU_ACTION_VPN_PRESSED`, keeping emitted parameters consistent with expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eda628a876c2f4299ba180a0fad218e0c021ecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->