### PR TITLE
Fix native input keyboard issues

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4501,6 +4501,7 @@ class BrowserTabFragment :
 
     fun onBackPressed(isCustomTab: Boolean = false): Boolean {
         if (!isAdded) return false
+        if (nativeInputManager.hideNativeInput(binding.rootView, omnibar)) return true
         return viewModel.onUserPressedBack(isCustomTab)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -131,13 +131,16 @@ class RealNativeInputManager @Inject constructor(
         rootView: ViewGroup,
         omnibar: Omnibar,
     ): Boolean {
-        if (!isNativeInputFieldEnabled) return true
+        if (!isNativeInputFieldEnabled) return false
 
         if (omnibar.viewMode == DuckAI) return false
         val removed = removeWidget(rootView)
         if (!removed) return false
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
+        if (omnibar.viewMode is Omnibar.ViewMode.Browser) {
+            rootView.findViewById<View?>(R.id.webViewContainer)?.show()
+        }
         restoreOmnibar(omnibar, rootView)
         omnibar.show()
         return true
@@ -163,16 +166,11 @@ class RealNativeInputManager @Inject constructor(
 
         if (!isNativeInputFieldEnabled || isVisible) return
 
-        if (omnibar.viewMode == DuckAI) {
-            widgetFrom(rootView)?.requestInputFocus()
-            return
-        }
         val widget = widgetFrom(rootView) ?: return
         val focusedView = rootView.findFocus()
         val focusWithinWidget = focusedView?.let { isDescendantOf(widget, it) } ?: false
         if (widget.hasInputFocus() || !focusWithinWidget) {
             widget.clearInputFocus()
-            hideNativeInput(rootView, omnibar)
         } else {
             widget.requestInputFocus()
         }
@@ -231,6 +229,7 @@ class RealNativeInputManager @Inject constructor(
         attachWidget(widgetView, rootView, omnibar)
         if (omnibar.viewMode != DuckAI) {
             omnibar.hide()
+            rootView.findViewById<View?>(R.id.webViewContainer)?.gone()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -76,6 +76,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun observeChatState() {
+        var isFocussed = false
+
         chatStateJob?.cancel()
         chatStateJob = duckChatInternal.chatState
             .drop(1)
@@ -83,18 +85,20 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 setChatStreaming(state == ChatState.STREAMING)
                 when (state) {
                     ChatState.HIDE -> {
+                        isFocussed = hasInputFocus()
                         (context as? Activity)?.hideKeyboard()
                         clearInputFocus()
                         widgetRoot?.visibility = GONE
                     }
                     ChatState.SHOW -> {
                         widgetRoot?.visibility = VISIBLE
-                        requestInputFocus()
-                        (context as? Activity)?.showKeyboard(inputField)
+                        if (isFocussed) {
+                            requestInputFocus()
+                            (context as? Activity)?.showKeyboard(inputField)
+                        }
                     }
                     ChatState.READY -> {
                         widgetRoot?.visibility = VISIBLE
-                        requestInputFocus()
                     }
                     else -> {}
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213538329536544?focus=true

### Description

Fixes these issues:

- [Bug: Keyboard opens after opening sidebar](https://app.asana.com/1/137249556945/project/1200204095367872/task/1213531090780201?focus=true)
- Only dismiss widget `onBackPressed`
- When keyboard is dismissed and widget is visible, hide `WebView`
- Fixes an issue where the native input would stay focussed when keyboard was not visible

### Steps to test this PR

Enable feature flag > “nativeInputField", AI Features > “Native Input Field”

_Browser keyboard behavior_
- [ ] Visit a site
- [ ] Focus the omnibar
- [ ] Clear the input and dismiss the keyboard
- [ ] Verify that WebView is not shown
- [ ] Swipe back
- [ ] Verify that the ominbar and WebView are shown

_Duck.ai keyboard behavior_
- [ ] Go to Duck.ai (don’t focus the widget)
- [ ] Open the side bar
- [ ] Verify that the widget is hidden
- [ ] Close the side bar
- [ ] Verify that the widget is shown (without the keyboard)
- [ ] Focus the widget
- [ ] Open the side bar
- [ ] Verify that the widget and keyboard are hidden
- [ ] Close the side bar
- [ ] Verify that the widget and keyboard are shown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes back-press handling, keyboard visibility reactions, and view visibility (including `webViewContainer`) in core browsing/AI input flows, which can cause regressions in navigation and focus behavior.
> 
> **Overview**
> Improves native input dismissal and keyboard/focus behavior to reduce UI glitches when switching between browser and Duck AI modes.
> 
> Back-press now first attempts to dismiss the native input widget; `hideNativeInput` no longer consumes the event when native input is disabled, and it restores `webViewContainer` visibility when returning to normal browsing.
> 
> Keyboard visibility handling and Duck AI widget state updates were adjusted to avoid forcing focus/keyboard on state transitions (only restoring it when the widget was previously focused).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit accdbfc8387464482306054f3118b435841dc0ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->