### PR TITLE
PIR: Send details of broker json download failures

### DIFF
--- a/PixelDefinitions/pixels/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/personal_information_removal.json5
@@ -998,7 +998,14 @@
         "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "error_details",
+                "description": "Sanitized exception message from client",
+                "type": "string"
+            }
+        ]
     },
     "m_dbp_data_broker_action-failed_error": {
         "description": "Fired when a scan or opt-out action fails while processing a data broker.",

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerJsonUpdater.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerJsonUpdater.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.pir.impl.store.PirRepository.BrokerJson
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
+import logcat.asLog
 import logcat.logcat
 import javax.inject.Inject
 
@@ -83,7 +84,8 @@ class RealBrokerJsonUpdater @Inject constructor(
             true
         }.getOrElse {
             logcat(ERROR) { "PIR-update: Json update failed to complete due to: $it" }
-            pixelSender.reportDownloadMainConfigFailure()
+            val message = it.asLog().sanitize() ?: it.message ?: "Unknown error"
+            pixelSender.reportDownloadMainConfigFailure(message)
             false
         }
     }
@@ -118,5 +120,25 @@ class RealBrokerJsonUpdater @Inject constructor(
         }
 
         pirRepository.updateBrokerJsons(jsonEtagsFromConfig)
+    }
+
+    private fun String.sanitize(): String? {
+        // if we fail for whatever reason, we don't include the stack trace
+        return runCatching {
+            val emailRegex = Regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}")
+            val phoneRegex = Regex("\\b(?:\\d[\\s()-]?){6,14}\\b") // This regex matches common phone number formats
+            val phoneRegex2 = Regex("\\b\\+?\\d[- (]*\\d{3}[- )]*\\d{3}[- ]*\\d{4}\\b") // enhanced to redact also other phone number formats
+            val urlRegex = Regex("\\b(?:https?://|www\\.)\\S+\\b")
+            val ipv4Regex = Regex("\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b")
+
+            var sanitizedStackTrace = this
+            sanitizedStackTrace = sanitizedStackTrace.replace(urlRegex, "[REDACTED_URL]")
+            sanitizedStackTrace = sanitizedStackTrace.replace(emailRegex, "[REDACTED_EMAIL]")
+            sanitizedStackTrace = sanitizedStackTrace.replace(phoneRegex2, "[REDACTED_PHONE]")
+            sanitizedStackTrace = sanitizedStackTrace.replace(phoneRegex, "[REDACTED_PHONE]")
+            sanitizedStackTrace = sanitizedStackTrace.replace(ipv4Regex, "[REDACTED_IPV4]")
+
+            return sanitizedStackTrace
+        }.getOrNull()
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -543,7 +543,9 @@ interface PirPixelSender {
         errorCode: String,
     )
 
-    fun reportDownloadMainConfigFailure()
+    fun reportDownloadMainConfigFailure(
+        message: String,
+    )
 
     fun reportBrokerActionFailure(
         brokerUrl: String,
@@ -1291,8 +1293,11 @@ class RealPirPixelSender @Inject constructor(
         fire(PIR_DOWNLOAD_MAINCONFIG_BE_FAILURE, params)
     }
 
-    override fun reportDownloadMainConfigFailure() {
-        fire(PIR_DOWNLOAD_MAINCONFIG_FAILURE)
+    override fun reportDownloadMainConfigFailure(message: String) {
+        val params = mapOf(
+            PARAM_KEY_ERROR_DETAILS to message,
+        )
+        fire(PIR_DOWNLOAD_MAINCONFIG_FAILURE, params)
     }
 
     override fun reportBrokerActionFailure(

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -874,7 +874,7 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportDownloadMainConfigFailureThenFiresCorrectPixel() = runTest {
-        testee.reportDownloadMainConfigFailure()
+        testee.reportDownloadMainConfigFailure("test")
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender).fire(
@@ -884,7 +884,8 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue.isEmpty())
+        val params = paramsCaptor.allValues.first()
+        assert(params["error_details"] == "test")
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213537623549132?focus=true 

### Description
See attached task description

### Steps to test this PR
QA-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes pixel schema and the `PirPixelSender.reportDownloadMainConfigFailure` API, which can break callers or analytics pipelines if not updated in lockstep. Added sanitization logic must avoid leaking PII and could be incomplete or over-redact.
> 
> **Overview**
> Adds an `error_details` parameter to the `m_dbp_download_mainconfig_failure` pixel and updates `PirPixelSender.reportDownloadMainConfigFailure` to require a message and send it as a parameter.
> 
> Updates `BrokerJsonUpdater` to capture exception details on main-config download/update failures, sanitize them (redacting emails/phones/URLs/IPv4), and emit the failure pixel with the sanitized message; associated unit test assertions are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afccb05f52d3255f99d472eebdc123196c81d0c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->