### PR TITLE
Fix: Crash in the tab switcher adapter

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -442,13 +442,15 @@ class TabSwitcherAdapter(
         if (holder is TabSwitcherViewHolder) {
             holder.cancelLoadJobs()
         }
+
+        val glide = Glide.with(holder.itemView.context.applicationContext)
         when (holder) {
             is TabSwitcherViewHolder.GridTabViewHolder -> {
-                Glide.with(holder.rootView).clear(holder.tabPreview)
-                Glide.with(holder.rootView).clear(holder.favicon)
+                glide.clear(holder.tabPreview)
+                glide.clear(holder.favicon)
             }
             is TabSwitcherViewHolder.ListTabViewHolder -> {
-                Glide.with(holder.rootView).clear(holder.favicon)
+                glide.clear(holder.favicon)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213538329536536?focus=true

### Description

Fixes a crash in the tab switcher caused by Glide being called with an Activity/View context while that Activity is already being destroyed.

In `TabSwitcherAdapter.onViewRecycled`, Glide is now initialized with `holder.itemView.context.applicationContext` before clearing image requests. This avoids Glide’s destroyed-activity guard (You cannot start a load for a destroyed activity) during `RecyclerView` recycle events triggered by teardown animations.

### Steps to test this PR

- [x] Change the animations speed on the emulator before testing by running the following:
```
adb shell settings put global animator_duration_scale 10
adb shell settings put global transition_animation_scale 10
adb shell settings put global window_animation_scale 10
adb shell settings put global always_finish_activities 1
```
- [x] Open the app with only a single tab, then open the tab switcher
- [x] Close the only tab -> this will automatically close the tab switcher
- [x] Confirm the app does not crash and adb logcat shows no _You cannot start a load for a destroyed activity_ errors from `TabSwitcherAdapter.onViewRecycled`
- [x] Restore the animations speed:
```
adb shell settings put global animator_duration_scale 1
adb shell settings put global transition_animation_scale 1
adb shell settings put global window_animation_scale 1
adb shell settings put global always_finish_activities 0
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to `TabSwitcherAdapter.onViewRecycled` that only affects how Glide requests are cleared during RecyclerView teardown; behavior change is limited to using the application context to avoid destroyed-activity crashes.
> 
> **Overview**
> Prevents a tab switcher crash during teardown/recycle by switching `TabSwitcherAdapter.onViewRecycled` to clear Glide requests via a single `Glide.with(holder.itemView.context.applicationContext)` `RequestManager` instead of using the view/activity context.
> 
> This ensures image request cleanup for tab previews/favicons doesn’t trip Glide’s *destroyed activity* guard when the RecyclerView is recycling items while the hosting UI is being destroyed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8846d95a3fbeb88cd8ab120e2c935b466686a0ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->