### PR TITLE
Move rescope token request to IO thread

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandler.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandler.kt
@@ -16,7 +16,9 @@
 
 package com.duckduckgo.sync.impl.messaging
 
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.AppUrl
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -31,6 +33,8 @@ import com.duckduckgo.sync.impl.SyncApi
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import logcat.LogPriority
 import logcat.logcat
 import org.json.JSONObject
@@ -42,6 +46,8 @@ class GetScopedSyncAuthTokenHandler @Inject constructor(
     private val syncStore: SyncStore,
     private val deviceSyncState: DeviceSyncState,
     private val syncPixels: SyncPixels,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
 ) : ContentScopeJsMessageHandlersPlugin {
     override fun getJsMessageHandler(): JsMessageHandler =
         object : JsMessageHandler {
@@ -70,14 +76,16 @@ class GetScopedSyncAuthTokenHandler @Inject constructor(
                         return
                     }
 
-                val jsonPayload = runCatching {
-                    handleRescopeTokenResult(syncApi.rescopeToken(token, SCOPE))
-                }.getOrElse { e ->
-                    logcat(LogPriority.ERROR) { "DuckChat-Sync: exception during rescope token: ${e.message}" }
-                    createErrorPayload("internal error")
-                }
+                appCoroutineScope.launch(dispatcherProvider.io()) {
+                    val jsonPayload = runCatching {
+                        handleRescopeTokenResult(syncApi.rescopeToken(token, SCOPE))
+                    }.getOrElse { e ->
+                        logcat(LogPriority.ERROR) { "DuckChat-Sync: exception during rescope token: ${e.message}" }
+                        createErrorPayload("internal error")
+                    }
 
-                sendResponse(jsMessaging, jsMessage, jsonPayload)
+                    sendResponse(jsMessaging, jsMessage, jsonPayload)
+                }
             }
 
             private fun handleRescopeTokenResult(result: Result<String>): JSONObject {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandlerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/messaging/GetScopedSyncAuthTokenHandlerTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.messaging
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -30,6 +31,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argumentCaptor
@@ -40,6 +42,9 @@ import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class GetScopedSyncAuthTokenHandlerTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val mockSyncApi: SyncApi = mock()
     private val mockSyncStore: SyncStore = mock()
@@ -58,6 +63,8 @@ class GetScopedSyncAuthTokenHandlerTest {
             syncStore = mockSyncStore,
             deviceSyncState = mockDeviceSyncState,
             syncPixels = mockSyncPixels,
+            appCoroutineScope = coroutineTestRule.testScope,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213530835574684?focus=true 

### Description
Moves the network request that happens in `GetScopedSyncAuthTokenHandler` to an `io` thread instead of trying to do it on the `java bridge` thread (which is for JS->Native comms). 

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves token rescoping into an injected app-level coroutine on the IO dispatcher, introducing async behavior that could affect response timing/cancellation and test determinism if dispatchers/scopes are misconfigured.
> 
> **Overview**
> `GetScopedSyncAuthTokenHandler` now performs `syncApi.rescopeToken` asynchronously by launching on an injected `@AppCoroutineScope` with `dispatcherProvider.io()`, instead of executing inline on the message handler thread.
> 
> Tests are updated to inject a `CoroutineTestRule` test scope/dispatcher provider so the new coroutine-based behavior remains verifiable while keeping the existing success/error response and pixel assertions intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389af649987c60f3205ed7815d652ee618c47e6d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->