### PR TITLE
Notify duck.ai refresh token after upgrades/downgrades

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -944,6 +944,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun observeSubscriptionChangesForDuckChat() {
         subscriptions.getSubscriptionStatusFlow()
+            .map { status -> Pair(status, subscriptions.getAccessToken()) }
             .distinctUntilChanged()
             .onEach { _ ->
                 if (!androidBrowserConfig.refreshDuckAiOnSubscriptionChanges().isEnabled()) return@onEach

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -9079,6 +9079,27 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenSubscriptionStatusSameButAccessTokenChangesOnDuckAiThenAuthUpdateEventSent() = runTest {
+        val duckAiUrl = "https://duck.ai/chat"
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        loadUrl(duckAiUrl, title = "Duck.ai")
+
+        whenever(subscriptions.getAccessToken()).thenReturn("token_plus")
+        testee.subscriptionEventDataFlow.test {
+            subscriptionStatusFlow.emit(SubscriptionStatus.AUTO_RENEWABLE)
+            val firstEvent = awaitItem()
+            assertEquals("authUpdate", firstEvent.subscriptionName)
+
+            whenever(subscriptions.getAccessToken()).thenReturn("token_pro")
+            subscriptionStatusFlow.emit(SubscriptionStatus.AUTO_RENEWABLE)
+            val secondEvent = awaitItem()
+            assertEquals("authUpdate", secondEvent.subscriptionName)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenLoadDataWithInitialUrlThenPreviousUrlIsSetToSkipFirstTrackerAnimation() {
         givenDisableTrackerAnimationOnRestartFeature(true)
         val initialUrl = "https://example.com"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.withContext
@@ -81,6 +82,7 @@ class DuckChatWebViewViewModel @Inject constructor(
 
     private fun observeSubscriptionChanges() {
         subscriptions.getSubscriptionStatusFlow()
+            .map { status -> Pair(status, subscriptions.getAccessToken()) }
             .distinctUntilChanged()
             .onEach { _ ->
                 commandChannel.trySend(Command.SendSubscriptionAuthUpdateEvent)

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewViewModelTest.kt
@@ -125,6 +125,21 @@ class DuckChatWebViewViewModelTest {
     }
 
     @Test
+    fun whenSubscriptionStatusSameButAccessTokenChangesThenCommandSent() = runTest {
+        viewModel.commands.test {
+            whenever(subscriptions.getAccessToken()).thenReturn("token_plus")
+            subscriptionStatusFlow.emit(AUTO_RENEWABLE)
+            val firstCommand = awaitItem()
+            assertTrue(firstCommand is Command.SendSubscriptionAuthUpdateEvent)
+
+            whenever(subscriptions.getAccessToken()).thenReturn("token_pro")
+            subscriptionStatusFlow.emit(AUTO_RENEWABLE)
+            val secondCommand = awaitItem()
+            assertTrue(secondCommand is Command.SendSubscriptionAuthUpdateEvent)
+        }
+    }
+
+    @Test
     fun whenSubscriptionStatusChangesTwiceToDifferentValuesThenTwoCommandsSent() = runTest {
         viewModel.commands.test {
             subscriptionStatusFlow.emit(AUTO_RENEWABLE)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213538447440690?focus=true 

### Description
Improves signaling auth updates in duck.ai after subscription changes.
problem is we were not signaling if something changes but subscription is still active (no actual change).
We need to also signal if token has changed.

### Steps to test this PR
(This can be tested as part of https://app.asana.com/1/137249556945/task/1213403613657648?focus=true, using the attached build)

_Feature 1_
- [x] Apply patch in https://app.asana.com/1/137249556945/project/72649045549333/task/1213538447440690?focus=true
- [x] fresh install
- [x] Visit https://abrown.duck.ai/ and login with your DDG account
- [x] Restart the app (don't use fire button → this will remove you from being logged in on alistair sandbox)
- [x] From duck.ai upgrade from free to plus monthly
- [x] Go back to duck.ai, check your subscription is plus
- [x] Open side bar menu
- [x] click on upgrade to pro
- [x] upgrade to monthly pro (if this fails due to short time, restart the app)
- [x] After upgrade go back to duck.ai
- [x] Check your subscription is pro

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when subscription auth-update events are emitted by including the access token in `distinctUntilChanged`, which could increase event frequency or cause unexpected refreshes in duck.ai flows. Covered by new unit tests but still impacts subscription-related behavior.
> 
> **Overview**
> Improves duck.ai subscription auth signaling by treating *(subscription status, access token)* as the change key instead of status alone, so upgrades/downgrades that rotate tokens still trigger an `authUpdate`/`SendSubscriptionAuthUpdateEvent` refresh.
> 
> Adds targeted tests in `BrowserTabViewModelTest` and `DuckChatWebViewViewModelTest` to verify a new auth update is emitted when only the access token changes while the status remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4c86bac220b3812386a99cadd3fa2a53e4330c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->