### PR TITLE
Use a double for sampling in the app startup metrics settings

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/startup/SamplingDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/startup/SamplingDecider.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.startup
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -45,7 +46,10 @@ class RealSamplingDecider @Inject constructor(
 ) : SamplingDecider {
 
     private val jsonAdapter by lazy {
-        moshi.adapter(AppStartupMetricsJson::class.java)
+        moshi.newBuilder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+            .adapter(AppStartupMetricsJson::class.java)
     }
 
     override fun shouldSample(settingsJson: String?): Boolean {

--- a/app/src/test/java/com/duckduckgo/app/startup/SamplingDeciderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/startup/SamplingDeciderTest.kt
@@ -94,4 +94,12 @@ class SamplingDeciderTest {
         assertTrue(decider.shouldSample("not-valid-json"))
         verify(mockRandom).nextDouble()
     }
+
+    @Test
+    fun `when sampling key is missing then falls back to default 1 percent sampling`() {
+        whenever(mockRandom.nextDouble()).thenReturn(0.005)
+
+        assertTrue(decider.shouldSample("{}"))
+        verify(mockRandom).nextDouble()
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213548603472775?focus=true 

### Description

Use a double for sampling in the app startup metrics settings

### Steps to test this PR

If unit tests pass, it is enough

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote settings JSON is parsed for startup-metrics sampling, which could alter sampling behavior if configs still send the value as a string and now fall back to the default rate. Impact is limited to metrics collection volume (no security-sensitive logic).
> 
> **Overview**
> Updates `RealSamplingDecider` to parse feature-flag settings into a typed `AppStartupMetricsJson` (with `sampling: Double`) using Moshi’s `KotlinJsonAdapterFactory`, instead of reading `sampling` from a `Map<String, String>`.
> 
> Tests are updated to use numeric JSON values and add coverage for the case where the `sampling` key is missing (defaulting to 1% sampling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7259b121cb36772c7275230a8a4c12b847a96761. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->