### PR TITLE
Fix "Sign in with Google" flow

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
@@ -150,6 +150,23 @@ class AppThirdPartyCookieManagerTest {
         assertNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
 
+    @UiThreadTest
+    @Test
+    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthWithAppDomainAndNoSsDomainThenDomainAddedToTheList() = runTest {
+        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_APP_DOMAIN_URI)
+
+        assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthWithBothSsDomainAndAppDomainThenSsDomainUsed() = runTest {
+        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_BOTH_DOMAINS_URI)
+
+        assertNotNull(authCookiesAllowedDomainsRepository.getDomain("ss.com"))
+        assertNull(authCookiesAllowedDomainsRepository.getDomain("app.com"))
+    }
+
     @Test
     fun whenClearAllDataThenDomainDeletedFromDatabase() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
@@ -194,6 +211,10 @@ class AppThirdPartyCookieManagerTest {
             "https://accounts.google.com/o/oauth2/auth/identifier?response_type=permission%20id_token&ss_domain=https%3A%2F%2Fexample.com".toUri()
         val NON_THIRD_PARTY_AUTH_URI =
             "https://accounts.google.com/o/oauth2/auth/identifier?response_type=code&ss_domain=https%3A%2F%2Fexample.com".toUri()
+        val THIRD_PARTY_AUTH_APP_DOMAIN_URI =
+            "https://accounts.google.com/v3/signin/identifier?response_type=permission%20id_token&app_domain=https%3A%2F%2Fexample.com".toUri()
+        val THIRD_PARTY_AUTH_BOTH_DOMAINS_URI =
+            "https://accounts.google.com?response_type=permission%20id_token&ss_domain=https%3A%2F%2Fss.com&app_domain=https%3A%2F%2Fapp.com".toUri()
         const val USER_ID_COOKIE = "user_id"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
@@ -84,7 +84,7 @@ class AppThirdPartyCookieManager(
     }
 
     private suspend fun addHostToList(uri: Uri) {
-        val ssDomain = uri.getQueryParameter(SS_DOMAIN)
+        val ssDomain = uri.getQueryParameter(SS_DOMAIN_PARAM) ?: uri.getQueryParameter(APP_DOMAIN_PARAM)
         val accessType = uri.getQueryParameter(RESPONSE_TYPE)
         ssDomain?.let {
             if (accessType?.contains(CODE) == false) {
@@ -103,7 +103,8 @@ class AppThirdPartyCookieManager(
 
     // See https://app.asana.com/0/1125189844152671/1200029737431978 for mor context about the below values
     companion object {
-        private const val SS_DOMAIN = "ss_domain"
+        private const val SS_DOMAIN_PARAM = "ss_domain"
+        private const val APP_DOMAIN_PARAM = "app_domain"
         private const val RESPONSE_TYPE = "response_type"
         private const val CODE = "code"
         const val GOOGLE_ACCOUNTS_URL = "https://accounts.google.com"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200776578798655/task/1213538197575561?focus=true

### Description

When a user clicks "Sign in with Google" on a third-party website, we must
temporarily allow third-party cookies for that website's domain. That way, the
Google auth cookie can be written when the user returns to the website.

So far, we determine the website's domain by looking at the `ss_domain` query
parameter, but it seems that on initial sign-in the URL structure differs and
the `app_domain` parameter is used instead. It's only on the second
attempt (after the user already logged into their Google account) that the
`ss_domain` parameter is used, which results in the user having to click the
"Sign in to Google" button twice for it to work.

Let's fall back to `app_domain` when `ss_domain` isn't available therefore,
which should fix the problem.

### Steps to test this PR

1. Burn with Fire button
2. Navigate to https://poshmark.com/
2. Click the `Continue with Google` button to sign in using a Google account.
3. Sign in to your Google account and approve Poshmark's access.
4. When you are taken back to poshmark.com, confirm that you are then logged in (or taken to the next stage in account creation if you don't already have an account).

In other words, make sure that clicking the `Continue with Google` button a second time after step 4 isn't required. But note that sometimes there's a few second delay after you're taken back to poshmark.com before the login process continues.