### PR TITLE
Update content scope scripts to version 13.27.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -4213,7 +4213,10 @@
         filteredChats = filteredChats.filter((chat) => this.isNotOlderThan(chat, since));
       }
       const matchingChats = query ? filteredChats.filter((chat) => this.chatMatchesQuery(chat, query)) : filteredChats;
-      for (const chat of matchingChats) {
+      const sortedChats = [...matchingChats].sort((a2, b2) => {
+        return (this.getLastEditTime(b2) ?? 0) - (this.getLastEditTime(a2) ?? 0);
+      });
+      for (const chat of sortedChats) {
         const formattedChat = this.formatChat(chat);
         if (chat.pinned) {
           pinnedChats.push(formattedChat);
@@ -4222,6 +4225,18 @@
         }
       }
       return { pinnedChats, chats };
+    }
+    /**
+     * @param {object} chat - Chat object
+     * @returns {string|null} The first user message content, or null if not found
+     */
+    extractFirstUserMessageContent(chat) {
+      const messages = chat?.messages;
+      if (!Array.isArray(messages)) {
+        return null;
+      }
+      const firstUserMessage = messages.find((msg) => msg?.role === "user");
+      return typeof firstUserMessage?.content === "string" ? firstUserMessage.content : null;
     }
     /**
      * Formats a chat object for sending to native, extracting only needed keys
@@ -4242,15 +4257,17 @@
       };
     }
     /**
-     * Checks if a chat matches the search query by checking if all query words appear in title
+     * Checks if a chat matches the search query by checking if all query words appear in title or first user message
      * @param {object} chat - Chat object
      * @param {string} query - Lowercase search query
-     * @returns {boolean} True if chat title contains all query words
+     * @returns {boolean} True if chat title or first user message contains all query words
      */
     chatMatchesQuery(chat, query) {
       const title = typeof chat.title === "string" ? chat.title.toLowerCase() : "";
+      const firstUserQuery = this.extractFirstUserMessageContent(chat);
+      const formattedUserQuery = typeof firstUserQuery === "string" ? firstUserQuery.toLowerCase() : "";
       const words = query.split(/\s+/).filter((w2) => w2);
-      return words.every((word) => title.includes(word));
+      return words.every((word) => title.includes(word) || formattedUserQuery.includes(word));
     }
     /**
      * Checks if a chat's lastEdit is not older than the given timestamp
@@ -4259,15 +4276,20 @@
      * @returns {boolean} True if chat is not older than the timestamp
      */
     isNotOlderThan(chat, since) {
+      const time = this.getLastEditTime(chat);
+      return time === null || time >= since;
+    }
+    /**
+     * Parses a chat's lastEdit into a numeric timestamp.
+     * Returns null if lastEdit is missing or malformed.
+     * @param {object} chat - Chat object
+     * @returns {number | null} Timestamp in milliseconds, or null
+     */
+    getLastEditTime(chat) {
       const lastEdit = chat.lastEdit;
-      if (!lastEdit) {
-        return true;
-      }
-      const timestamp = new Date(lastEdit).getTime();
-      if (Number.isNaN(timestamp)) {
-        return true;
-      }
-      return timestamp >= since;
+      if (!lastEdit) return null;
+      const time = new Date(lastEdit).getTime();
+      return Number.isNaN(time) ? null : time;
     }
   };
   /** @type {number} Default maximum number of chats to return */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.26.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.27.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#663ffb5d22f961575aff0e611aaf0ca1c5f23b3c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#307fe6d8a17d12539c44ba98b2d703c38cfe45de",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.26.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.27.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213563821717521/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled `content-scope-scripts` logic that changes chat history ordering, search matching, and `since` filtering behavior, which could affect what chats users see. Risk is limited to client-side history/query logic and dependency lockfile updates.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `13.26.0` to `13.27.0` (with corresponding `package-lock.json` resolved SHA updates).
> 
> In the bundled `duckAiChatHistory` script, chat history processing now **sorts results by most recent `lastEdit`**, expands search to match query words in the *title or the first user message*, and centralizes `lastEdit` parsing via `getLastEditTime()` (treating missing/malformed timestamps as `null` and allowing them through `since` filtering).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56240bca93a18ac0fdef12e774b99e7e67710cdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->