### PR TITLE
PIR: Increase API read timeout when fetching jsons

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/DbpService.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/DbpService.kt
@@ -37,6 +37,7 @@ interface DbpService {
     ): Response<PirMainConfig>
 
     @PirAuthRequired
+    @PirExtendedReadTimeout
     @GET("$BASE_URL/remote/v0?name=all.zip&type=spec")
     @Streaming
     suspend fun getBrokerJsonFiles(): ResponseBody

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/PirAuthInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/service/PirAuthInterceptor.kt
@@ -41,9 +41,21 @@ class PirAuthInterceptor @Inject constructor(
     override fun intercept(chain: Chain): Response {
         val request = chain.request()
 
-        val authRequired = request.tag(Invocation::class.java)
+        val invocation = request.tag(Invocation::class.java)
+
+        val authRequired = invocation
             ?.method()
             ?.isAnnotationPresent(PirAuthRequired::class.java) == true
+
+        val hasExtendedTimeout = invocation
+            ?.method()
+            ?.isAnnotationPresent(PirExtendedReadTimeout::class.java) == true
+
+        val timeoutAdjustedChain = if (hasExtendedTimeout) {
+            chain.withReadTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } else {
+            chain
+        }
 
         return if (authRequired) {
             val accessToken = runBlocking { subscriptions.getAccessToken() }
@@ -53,9 +65,9 @@ class PirAuthInterceptor @Inject constructor(
                 .header("Authorization", "bearer $accessToken")
                 .build()
 
-            chain.withReadTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS).proceed(authenticatedRequest)
+            timeoutAdjustedChain.proceed(authenticatedRequest)
         } else {
-            chain.proceed(request)
+            timeoutAdjustedChain.proceed(request)
         }
     }
 
@@ -67,3 +79,7 @@ class PirAuthInterceptor @Inject constructor(
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class PirAuthRequired
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PirExtendedReadTimeout

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/service/PirAuthInterceptorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/service/PirAuthInterceptorTest.kt
@@ -77,6 +77,30 @@ class PirAuthInterceptorTest {
             .build()
 
         whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        assertNotNull(capturedRequest.header("Authorization"))
+        assertEquals("bearer $testToken", capturedRequest.header("Authorization"))
+    }
+
+    @Test
+    fun whenRequestWithExtendedReadTimeoutAnnotationThenUsesExtendedTimeout() = runTest {
+        val testToken = "test-access-token"
+        whenever(mockSubscriptions.getAccessToken()).thenReturn(testToken)
+
+        val mockMethod = TestInterface::class.java.getMethod("authRequiredWithExtendedTimeout")
+        val invocation = Invocation.of(mockMethod, emptyList<Any>())
+        val request = Request.Builder()
+            .url("https://example.com")
+            .tag(Invocation::class.java, invocation)
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
         val timeoutChain: Interceptor.Chain = mock()
         whenever(mockChain.withReadTimeout(30, TimeUnit.SECONDS)).thenReturn(timeoutChain)
         whenever(timeoutChain.proceed(any())).thenReturn(mockResponse)
@@ -147,6 +171,10 @@ class PirAuthInterceptorTest {
     interface TestInterface {
         @PirAuthRequired
         fun authRequiredMethod()
+
+        @PirAuthRequired
+        @PirExtendedReadTimeout
+        fun authRequiredWithExtendedTimeout()
 
         fun nonAuthRequiredMethod()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213531646709005?focus=true

### Description
Increases read timeout from default 10 seconds to 30 seconds since the broker json files are a bit larger.
Only applies to the json files fetch request. 

### Steps to test this PR

_PIR smoke test_
- [x] Clean install from this branch
- [x] Gain subscription
- [x] Do a smoke test of PIR

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to applying a longer OkHttp read timeout (30s) for a single annotated PIR endpoint, with a unit test to verify behavior.
> 
> **Overview**
> **Improves reliability when downloading PIR broker JSON/spec zip files** by allowing a longer read timeout.
> 
> Adds a new Retrofit method annotation `@PirExtendedReadTimeout` and updates `PirAuthInterceptor` to apply a 30s `withReadTimeout` when present, while keeping existing auth-header behavior unchanged for other requests. `DbpService.getBrokerJsonFiles()` is now annotated to use the extended timeout, and tests cover the new timeout path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88df0848825c6a7e35dddfd0f7ce34008d9666b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->