### PR TITLE
PIR: Use provided user agent

### DIFF
--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation project(':remote-messaging-api')
     implementation project(':subscriptions-api')
     implementation project(':statistics-api')
+    implementation project(':user-agent-api')
     implementation "com.squareup.logcat:logcat:_"
     implementation "com.squareup.moshi:moshi-adapters:_"
     implementation "com.squareup.moshi:moshi-kotlin:_"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
@@ -28,6 +28,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.common.PirJobConstants.DBP_INITIAL_URL
+import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import logcat.logcat
 import javax.inject.Inject
@@ -64,7 +65,9 @@ interface PirDetachedWebViewProvider {
 }
 
 @ContributesBinding(AppScope::class)
-class RealPirDetachedWebViewProvider @Inject constructor() :
+class RealPirDetachedWebViewProvider @Inject constructor(
+    private val userAgentProvider: UserAgentProvider,
+) :
     PirDetachedWebViewProvider {
     @SuppressLint("SetJavaScriptEnabled")
     override fun createInstance(
@@ -155,7 +158,7 @@ class RealPirDetachedWebViewProvider @Inject constructor() :
                 }
             }
             settings.apply {
-                userAgentString = CUSTOM_UA
+                userAgentString = userAgentProvider.userAgent()
                 javaScriptEnabled = true
                 domStorageEnabled = true
                 loadWithOverviewMode = true
@@ -164,10 +167,5 @@ class RealPirDetachedWebViewProvider @Inject constructor() :
                 cacheMode = WebSettings.LOAD_NO_CACHE
             }
         }
-    }
-
-    companion object {
-        private const val CUSTOM_UA =
-            "Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213555408650056?focus=true

### Description
Uses the provided user agent instead of our hardcoded one.

### Steps to test this PR

_Smoke test PIR_
- [ ] Run a scan or two and confirm same number of results is found after the change

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the user agent used by PIR’s scanning WebView, which can alter broker site behavior and scan/opt-out results even though the code change is small.
> 
> **Overview**
> Updates PIR’s detached WebView configuration to **stop using a hardcoded user agent** and instead set `WebSettings.userAgentString` via an injected `UserAgentProvider`.
> 
> Adds the `:user-agent-api` dependency and removes the local UA constant, making PIR’s WebView UA consistent with the app-provided UA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f368b1d49ca3c56ea03514c2b14faf6bb75830db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->