### PR TITLE
Clean up metrics

### DIFF
--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/MetricsPixelPlugin.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/MetricsPixelPlugin.kt
@@ -16,10 +16,6 @@
 
 package com.duckduckgo.feature.toggles.api
 
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-
 /**
  * Experiment pixels that want to be fired should implement this plugin. The associated plugin point
  * will call the plugins before the pixels that match the [MetricsPixel] spec are fired.
@@ -33,8 +29,6 @@ interface MetricsPixelPlugin {
 }
 
 data class ConversionWindow(val lowerWindow: Int, val upperWindow: Int)
-
-data class PixelDefinition(val pixelName: String, val params: Map<String, String>)
 
 enum class MetricType {
     /** Fire the pixel once per conversion window. */
@@ -53,38 +47,7 @@ data class MetricsPixel(
     val conversionWindow: List<ConversionWindow>,
     val toggle: Toggle,
     val type: MetricType = MetricType.NORMAL,
-) {
-
-    fun getPixelDefinitions(): List<PixelDefinition> {
-        val cohort = toggle.getRawStoredState()?.assignedCohort?.name.orEmpty()
-        val enrollmentDateET = toggle.getRawStoredState()?.assignedCohort?.enrollmentDateET?.let {
-            ZonedDateTime.parse(it).truncatedTo(ChronoUnit.DAYS).format(DateTimeFormatter.ISO_LOCAL_DATE)
-        }.orEmpty()
-        if (cohort.isEmpty() || enrollmentDateET.isEmpty()) {
-            return emptyList()
-        }
-
-        val pixelName = "${METRICS_PIXEL_PREFIX}_${toggle.featureName().name}_$cohort"
-
-        return conversionWindow.map { window ->
-            val params = mutableMapOf<String, String>()
-            val conversionWindowDays = if (window.lowerWindow == window.upperWindow) {
-                "${window.lowerWindow}"
-            } else {
-                "${window.lowerWindow}-${window.upperWindow}"
-            }
-
-            params["metric"] = metric
-            params["value"] = value
-            params["enrollmentDate"] = enrollmentDateET
-            params["conversionWindowDays"] = conversionWindowDays
-
-            PixelDefinition(pixelName = pixelName, params = params)
-        }
-    }
-}
-
-const val METRICS_PIXEL_PREFIX = "experiment_metrics"
+)
 
 /**
  * Internal extension interface for sending metric pixels. Should NEVER be used publicly.

--- a/feature-toggles/feature-toggles-impl/lint-baseline.xml
+++ b/feature-toggles/feature-toggles-impl/lint-baseline.xml
@@ -4,111 +4,23 @@
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="                val cohortName = metric.toggle.getRawStoredState()?.assignedCohort?.name"
-        errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    val cohort = toggle.getRawStoredState()?.assignedCohort?.name.orEmpty()"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptor.kt"
-            line="71"
-            column="34"/>
+            file="src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt"
+            line="110"
+            column="18"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
+        errorLine1="    val enrollmentDateET = toggle.getRawStoredState()?.assignedCohort?.enrollmentDateET?.let {"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="48"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="74"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="100"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="126"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="152"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="182"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="208"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="234"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="260"
-            column="9"/>
+            file="src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt"
+            line="111"
+            column="28"/>
     </issue>
 
     <issue

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelRemovalInterceptor.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelRemovalInterceptor.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.feature.toggles.impl
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.METRICS_PIXEL_PREFIX
 import com.duckduckgo.feature.toggles.impl.FeatureTogglesPixelName.EXPERIMENT_ENROLLMENT
 import com.squareup.anvil.annotations.ContributesMultibinding
 

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricsPixelStore.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricsPixelStore.kt
@@ -22,12 +22,13 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+
+data class PixelDefinition(val pixelName: String, val params: Map<String, String>)
 
 interface MetricsPixelStore {
     /**

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.feature.toggles.api.MetricType
 import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.MetricsPixelExtension
 import com.duckduckgo.feature.toggles.api.MetricsPixelExtensionProvider
-import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -35,6 +34,7 @@ import okio.ByteString.Companion.encode
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
@@ -101,6 +101,36 @@ class RealMetricsPixelSender @Inject constructor(
         val localDate = LocalDate.parse(date)
         val zoneDateTime = localDate.atStartOfDay(ZoneId.of("America/New_York"))
         return ChronoUnit.DAYS.between(zoneDateTime, today)
+    }
+}
+
+internal const val METRICS_PIXEL_PREFIX = "experiment_metrics"
+
+internal fun MetricsPixel.getPixelDefinitions(): List<PixelDefinition> {
+    val cohort = toggle.getRawStoredState()?.assignedCohort?.name.orEmpty()
+    val enrollmentDateET = toggle.getRawStoredState()?.assignedCohort?.enrollmentDateET?.let {
+        ZonedDateTime.parse(it).truncatedTo(ChronoUnit.DAYS).format(DateTimeFormatter.ISO_LOCAL_DATE)
+    }.orEmpty()
+    if (cohort.isEmpty() || enrollmentDateET.isEmpty()) {
+        return emptyList()
+    }
+
+    val pixelName = "${METRICS_PIXEL_PREFIX}_${toggle.featureName().name}_$cohort"
+
+    return conversionWindow.map { window ->
+        val params = mutableMapOf<String, String>()
+        val conversionWindowDays = if (window.lowerWindow == window.upperWindow) {
+            "${window.lowerWindow}"
+        } else {
+            "${window.lowerWindow}-${window.upperWindow}"
+        }
+
+        params["metric"] = metric
+        params["value"] = value
+        params["enrollmentDate"] = enrollmentDateET
+        params["conversionWindowDays"] = conversionWindowDays
+
+        PixelDefinition(pixelName = pixelName, params = params)
     }
 }
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/MetricsPixelDefinitionsTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/MetricsPixelDefinitionsTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl
+
+import android.annotation.SuppressLint
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@SuppressLint("DenyListedApi")
+class MetricsPixelDefinitionsTest {
+
+    private lateinit var testFeature: TestTriggerFeature
+
+    @Before
+    fun setup() {
+        testFeature = FeatureToggles.Builder(
+            FakeToggleStore(),
+            featureName = "testFeature",
+        ).build().create(TestTriggerFeature::class.java)
+
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns empty list when no cohort assigned`() {
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(remoteEnableState = true, enable = true, assignedCohort = null),
+        )
+        assertTrue(metricsPixel().getPixelDefinitions().isEmpty())
+    }
+
+    @Test
+    fun `returns empty list when cohort name is empty`() {
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+        assertTrue(metricsPixel().getPixelDefinitions().isEmpty())
+    }
+
+    @Test
+    fun `returns empty list when enrollment date is null`() {
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = null),
+            ),
+        )
+        assertTrue(metricsPixel().getPixelDefinitions().isEmpty())
+    }
+
+    @Test
+    fun `pixel name contains feature name and cohort name`() {
+        val definitions = metricsPixel().getPixelDefinitions()
+        assertEquals("experiment_metrics_experimentFooFeature_control", definitions.first().pixelName)
+    }
+
+    @Test
+    fun `params contain correct metric and value`() {
+        val params = metricsPixel(metric = "my_metric", value = "42").getPixelDefinitions().first().params
+        assertEquals("my_metric", params["metric"])
+        assertEquals("42", params["value"])
+    }
+
+    @Test
+    fun `params contain enrollment date formatted as ISO local date`() {
+        val params = metricsPixel().getPixelDefinitions().first().params
+        assertTrue(params["enrollmentDate"]!!.matches(Regex("\\d{4}-\\d{2}-\\d{2}")))
+    }
+
+    @Test
+    fun `conversionWindowDays is single value when lower equals upper`() {
+        val params = metricsPixel(lowerWindow = 5, upperWindow = 5).getPixelDefinitions().first().params
+        assertEquals("5", params["conversionWindowDays"])
+    }
+
+    @Test
+    fun `conversionWindowDays is range when lower differs from upper`() {
+        val params = metricsPixel(lowerWindow = 3, upperWindow = 7).getPixelDefinitions().first().params
+        assertEquals("3-7", params["conversionWindowDays"])
+    }
+
+    @Test
+    fun `returns one definition per conversion window`() {
+        val pixel = MetricsPixel(
+            metric = "m",
+            value = "1",
+            toggle = testFeature.experimentFooFeature(),
+            conversionWindow = listOf(ConversionWindow(0, 1), ConversionWindow(2, 3), ConversionWindow(4, 5)),
+        )
+        assertEquals(3, pixel.getPixelDefinitions().size)
+    }
+
+    @Test
+    fun `each definition has correct conversionWindowDays for its window`() {
+        val pixel = MetricsPixel(
+            metric = "m",
+            value = "1",
+            toggle = testFeature.experimentFooFeature(),
+            conversionWindow = listOf(ConversionWindow(0, 1), ConversionWindow(7, 7)),
+        )
+        val definitions = pixel.getPixelDefinitions()
+        assertEquals("0-1", definitions[0].params["conversionWindowDays"])
+        assertEquals("7", definitions[1].params["conversionWindowDays"])
+    }
+
+    private fun metricsPixel(
+        metric: String = "test_metric",
+        value: String = "1",
+        lowerWindow: Int = 0,
+        upperWindow: Int = 1,
+    ) = MetricsPixel(
+        metric = metric,
+        value = value,
+        toggle = testFeature.experimentFooFeature(),
+        conversionWindow = listOf(ConversionWindow(lowerWindow, upperWindow)),
+    )
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.MetricType
 import com.duckduckgo.feature.toggles.api.MetricsPixel
-import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208889145294658/task/1213552278141625?focus=true 

### Description
Moves implementation details out of the -api module and into -impl to better respect the module boundary.

  - PixelDefinition data class moved from feature-toggles-api to feature-toggles-impl (it's an internal type only used by the impl)
  - getPixelDefinitions() moved from MetricsPixel (api) to an internal extension function in RealMetricsPixelSender.kt (impl), along with METRICS_PIXEL_PREFIX
  - Adds MetricsPixelDefinitionsTest to cover getPixelDefinitions() logic (pixel name format, params, conversion window formatting, empty cases)

### Steps to test this PR

- [x] App builds
- [x] Tests Pass
- [x] Code check


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experiment metrics pixel naming/parameter generation and removes previously-public API types, so any subtle behavior change or downstream usage could impact analytics firing and compilation.
> 
> **Overview**
> **Refactors metrics pixel internals to respect module boundaries.** `PixelDefinition`, `METRICS_PIXEL_PREFIX`, and `getPixelDefinitions()` are removed from `feature-toggles-api` and reintroduced as `internal` impl-only code (an extension on `MetricsPixel` in `RealMetricsPixelSender` and a `PixelDefinition` model in `MetricsPixelStore`).
> 
> Adds `MetricsPixelDefinitionsTest` to validate pixel name/params/conversion-window formatting and updates existing tests/lint baseline and interceptors to reference the impl-scoped constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db28c63ec418adb887ca85155b85e810b460307. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->