### PR TITLE
Add isAlwaysTrue test function to SubscriptionsDummy

### DIFF
--- a/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
+++ b/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
@@ -56,4 +56,6 @@ class SubscriptionsDummy @Inject constructor() : Subscriptions {
     override fun isPrivacyProUrl(uri: Uri): Boolean = false
 
     override suspend fun isFreeTrialEligible(): Boolean = false
+
+    internal fun isAlwaysTrue(): Boolean = true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1125189844152671/task/1213556897905477

### Description

Adds a trivial `internal fun isAlwaysTrue(): Boolean = true` function to `SubscriptionsDummy.kt`. This is a test change to validate the `asana-code-flow` skill end-to-end, confirming that the branch creation, commit, Asana task creation, and PR submission all work correctly together with the Asana URL present in the PR body at creation time.

### Steps to test this PR

_Skill validation_
- [ ] Confirm the Asana task URL above appears in the PR body at creation time
- [ ] Confirm GitHub Actions `action-pr-opened.yaml` ran on the `opened` event without errors
- [ ] Confirm the Asana task received a PR link comment from the bot

### UI changes
| Before  | After |
| ------ | ----- |
|(no UI changes)|(no UI changes)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an unused `internal` helper method to a dummy subscriptions implementation; no behavior changes to production subscription flows are expected.
> 
> **Overview**
> Adds a trivial `internal fun isAlwaysTrue(): Boolean = true` method to `SubscriptionsDummy`, without changing any existing `Subscriptions` API behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abd5232fd7e9c8f4ea9e8b0e1abe006f261857e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->