### PR TITLE
Improve KDoc for SecureStorageKeyStore.canUseEncryption

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -57,9 +57,12 @@ interface SecureStorageKeyStore {
     suspend fun getKey(keyName: String): ByteArray?
 
     /**
-     * This method can be used to check if the keystore implementation has for support for encryption
+     * This method can be used to check if the keystore implementation has support for encryption.
      *
-     * @return `true` if all the crypto dependencies needed by keystore is available and `false` otherwise
+     * When the harmony feature is enabled, checks the harmony-backed preferences; otherwise checks
+     * the legacy EncryptedSharedPreferences.
+     *
+     * @return `true` if all the crypto dependencies needed by keystore are available and `false` otherwise
      */
     suspend fun canUseEncryption(): Boolean
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213555043244384

### Description

Improves the KDoc comment for `SecureStorageKeyStore.canUseEncryption()` to accurately describe its behaviour when the harmony feature toggle is enabled. The previous comment omitted the harmony code path and contained minor grammar issues.

### Steps to test this PR

_KDoc change — no runtime behaviour changed_
- [ ] Verify the project builds cleanly (`./gradlew :autofill-impl:testDebugUnitTest`)
- [ ] Confirm no new lint warnings introduced
- [ ] Review the updated KDoc renders correctly in the IDE

### UI changes
| Before  | After |
| ------ | ----- |
|(no UI changes)|(no UI changes)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates KDoc to match the existing harmony/legacy code path; no runtime behavior is modified.
> 
> **Overview**
> Updates the KDoc for `SecureStorageKeyStore.canUseEncryption()` to fix grammar and explicitly document that, when the harmony feature flag is enabled, encryption availability is determined via harmony-backed preferences rather than legacy `EncryptedSharedPreferences`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 069a8be41c74b4436a8ee97197734fce713aee22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->