### PR TITLE
Add KDoc for SecureStorageKeyStore.updateKey and getKey

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -49,11 +49,19 @@ import okio.ByteString.Companion.toByteString
  */
 interface SecureStorageKeyStore {
 
+    /**
+     * Stores or removes a key entry by name.
+     *
+     * Pass `null` for [keyValue] to remove the key.
+     */
     suspend fun updateKey(
         keyName: String,
         keyValue: ByteArray?,
     )
 
+    /**
+     * Retrieves a key entry by name, or `null` if not found.
+     */
     suspend fun getKey(keyName: String): ByteArray?
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213555043338969

### Description

Adds missing KDoc comments to the `updateKey()` and `getKey()` methods in the `SecureStorageKeyStore` interface. Documents the null-removal behaviour of `updateKey` and the nullable return value of `getKey`, making the API contract clearer for callers.

### Steps to test this PR

_KDoc change — no runtime behaviour changed_
- [ ] Verify the project builds cleanly (`./gradlew :autofill-impl:testDebugUnitTest`)
- [ ] Confirm no new lint warnings introduced
- [ ] Review the updated KDoc renders correctly in the IDE

### UI changes
| Before  | After |
| ------ | ----- |
|(no UI changes)|(no UI changes)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime logic, storage, or encryption behavior is modified.
> 
> **Overview**
> Clarifies the `SecureStorageKeyStore` API contract by adding KDoc to `updateKey` and `getKey`.
> 
> `updateKey` now explicitly documents that passing a `null` value removes the stored key, and `getKey` documents that it returns `null` when the key is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8833b8d0c231c273f63e90325c2c251d92969189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->