### PR TITLE
Update content scope scripts to version 13.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.27.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.28.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.56.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.56.0.tgz",
-      "integrity": "sha512-0gImNtILoEb4LtQkCXJ7pjwqV3lY4IG7sm9y+cbB218MqKKoMJ/zht9UEI0bJ2J2IZZ0GEcLQE9TsQ3AISFZ5Q==",
+      "version": "14.57.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.57.0.tgz",
+      "integrity": "sha512-0fsdgEpX/wO2VwnpnhlYB4JSdgMn0ivTZKJL1ABCcsDcDq3jwiIi7NlWOVR1f6oxVQ5oqWRhN2ekU+kxeVB52g==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#307fe6d8a17d12539c44ba98b2d703c38cfe45de",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dd2d1a2f2a2b601d1f3854f645efe561f494a7d2",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
-      "integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.24.tgz",
-      "integrity": "sha512-olfx1b3BeWaOVAtrEhsvxdl0hbQE0+16mnV7CEi6z3qmrv2271F45OZvld1mXJ0Xoaw8TstkF7HRvGwVjIQqjw==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.25.tgz",
+      "integrity": "sha512-rFB8lPWHAf4II9+Zdlc6dwcJLIe6sqEzndcjfbcv9PdsFTlNYBgRI4y9aJzo7VMHvg/GRaUlFK+qZUyKpcE6zA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.24"
+        "tldts-core": "^7.0.25"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.27.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.28.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213581099981692/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `@duckduckgo/content-scope-scripts` (and associated lockfile transitive versions like `@duckduckgo/autoconsent` and `tldts-*`), which can change in-page privacy/consent behavior at runtime. Risk is moderate because it’s a dependency-only change but affects core content-scoping logic.
> 
> **Overview**
> Updates the `@duckduckgo/content-scope-scripts` dependency from `13.27.0` to `13.28.0` in `package.json`, with the lockfile updated to the new git commit.
> 
> Refreshes `package-lock.json` accordingly, including bumped resolved versions for `@duckduckgo/autoconsent` (`14.56.0` → `14.57.0`) and `tldts-core`/`tldts-experimental` (`7.0.24` → `7.0.25`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf9c8be455635eb84c1d1b99adbe77148640829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->