### PR TITLE
Move recent chats from NativeInputManager to NativeInputWidget

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -12071,36 +12071,9 @@
 
     <issue
         id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
-    </issue>
-
-    <issue
-        id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.NativeInputWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.ui.NativeInputWidget"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
     </issue>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1277,7 +1277,7 @@ class BrowserTabFragment :
             onMenuTapped = {
                 launchBrowserMenu(addExtraDelay = omnibarRepository.omnibarType == OmnibarType.SPLIT)
             },
-            onStopClicked = {
+            onStopTapped = {
                 contentScopeScripts.sendSubscriptionEvent(
                     SubscriptionEventData(
                         featureName = "aiChat",

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -24,7 +24,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.net.toUri
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -42,19 +41,13 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
-import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
-import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 interface NativeInputManager {
@@ -76,7 +69,7 @@ interface NativeInputManager {
         onFireButtonTapped: () -> Unit,
         onTabSwitcherTapped: () -> Unit,
         onMenuTapped: () -> Unit,
-        onStopClicked: () -> Unit,
+        onStopTapped: () -> Unit,
     )
     fun hideNativeInput(
         rootView: ViewGroup,
@@ -92,22 +85,15 @@ interface NativeInputManager {
 @ContributesBinding(AppScope::class, boundType = NativeInputManager::class)
 class RealNativeInputManager @Inject constructor(
     private val duckChat: DuckChat,
-    private val chatSuggestionsReader: ChatSuggestionsReader,
 ) : NativeInputManager {
     private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
 
     private var isNativeInputFieldEnabled: Boolean = false
 
-    private var autoCompleteAdapter: RecyclerView.Adapter<*>? = null
-
-    private var chatSuggestionsUserEnabled: Boolean = true
-    private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
-    private var chatSuggestionsJob: Job? = null
-
     private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
 
-    private fun widgetFrom(widgetView: View): NativeInputModeWidget? {
-        return widgetView.findViewById(R.id.inputModeWidget)
+    private fun widgetFrom(widgetView: View): NativeInputWidget? {
+        return widgetView.findViewById<View?>(R.id.inputModeWidget) as? NativeInputWidget
     }
 
     override fun start(lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit) {
@@ -115,12 +101,6 @@ class RealNativeInputManager @Inject constructor(
             .onEach { isEnabled ->
                 if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
                 isNativeInputFieldEnabled = isEnabled
-            }
-            .launchIn(lifecycleOwner.lifecycleScope)
-
-        duckChat.observeChatSuggestionsUserSettingEnabled()
-            .onEach { enabled ->
-                chatSuggestionsUserEnabled = enabled
             }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
@@ -139,7 +119,7 @@ class RealNativeInputManager @Inject constructor(
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
         if (omnibar.viewMode is Omnibar.ViewMode.Browser) {
-            rootView.findViewById<View?>(R.id.webViewContainer)?.show()
+            hideNtp(rootView)
         }
         restoreOmnibar(omnibar, rootView)
         omnibar.show()
@@ -168,7 +148,7 @@ class RealNativeInputManager @Inject constructor(
 
         val widget = widgetFrom(rootView) ?: return
         val focusedView = rootView.findFocus()
-        val focusWithinWidget = focusedView?.let { isDescendantOf(widget, it) } ?: false
+        val focusWithinWidget = focusedView?.let { isDescendantOf(widget.asView(), it) } ?: false
         if (widget.hasInputFocus() || !focusWithinWidget) {
             widget.clearInputFocus()
         } else {
@@ -192,7 +172,7 @@ class RealNativeInputManager @Inject constructor(
         onFireButtonTapped: () -> Unit,
         onTabSwitcherTapped: () -> Unit,
         onMenuTapped: () -> Unit,
-        onStopClicked: () -> Unit,
+        onStopTapped: () -> Unit,
     ) {
         if (!isNativeInputFieldEnabled) return
 
@@ -221,7 +201,7 @@ class RealNativeInputManager @Inject constructor(
             onFireButtonTapped = onFireButtonTapped,
             onTabSwitcherTapped = onTabSwitcherTapped,
             onMenuTapped = onMenuTapped,
-            onStopClicked = onStopClicked,
+            onStopTapped = onStopTapped,
         )
         if (omnibar.viewMode != DuckAI && prefillText.isNotEmpty()) {
             widgetFrom(widgetView)?.text = prefillText
@@ -229,7 +209,7 @@ class RealNativeInputManager @Inject constructor(
         attachWidget(widgetView, rootView, omnibar)
         if (omnibar.viewMode != DuckAI) {
             omnibar.hide()
-            rootView.findViewById<View?>(R.id.webViewContainer)?.gone()
+            showNtp(rootView)
         }
     }
 
@@ -267,7 +247,7 @@ class RealNativeInputManager @Inject constructor(
         onDuckAiChatSubmitted: (String) -> Unit,
     ) {
         val widget = widgetFrom(widgetView) ?: return
-        widget.bindSearchCallbacks(
+        widget.bindInputEvents(
             onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
                 if (omnibar.viewMode == DuckAI) {
@@ -281,7 +261,7 @@ class RealNativeInputManager @Inject constructor(
             },
             onChatSubmitted = { query ->
                 if (omnibar.viewMode == DuckAI) {
-                    (widget.context as? Activity)?.hideKeyboard(widget.inputField)
+                    widget.hideKeyboard()
                     onDuckAiChatSubmitted(query)
                 } else {
                     hideNativeInput(rootView, omnibar)
@@ -301,6 +281,19 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
+    private fun showNtp(rootView: ViewGroup) {
+        rootView.findViewById<View?>(R.id.browserLayout)?.gone()
+        rootView.findViewById<View?>(R.id.includeNewBrowserTab)?.show()
+        rootView.findViewById<View?>(R.id.newTabContainerLayout)?.show()
+    }
+
+    private fun hideNtp(rootView: ViewGroup) {
+        rootView.findViewById<View?>(R.id.includeNewBrowserTab)?.gone()
+        rootView.findViewById<View?>(R.id.newTabContainerLayout)?.gone()
+        rootView.findViewById<View?>(R.id.browserLayout)?.show()
+        rootView.findViewById<View?>(R.id.webViewContainer)?.show()
+    }
+
     private fun removeWidget(rootView: ViewGroup): Boolean {
         var removed = false
         rootView.findViewById<View?>(R.id.inputModeTopRoot)?.let {
@@ -311,9 +304,6 @@ class RealNativeInputManager @Inject constructor(
             rootView.removeView(it)
             removed = true
         }
-        restoreAutoCompleteAdapter(rootView)
-        chatSuggestionsAdapter = null
-        autoCompleteAdapter = null
         return removed
     }
 
@@ -454,10 +444,10 @@ class RealNativeInputManager @Inject constructor(
         onFireButtonTapped: () -> Unit,
         onTabSwitcherTapped: () -> Unit,
         onMenuTapped: () -> Unit,
-        onStopClicked: () -> Unit,
+        onStopTapped: () -> Unit,
     ) {
         bindMainButtons(widgetView, onFireButtonTapped, onTabSwitcherTapped, onMenuTapped)
-        widgetFrom(widgetView)?.onStopClicked = onStopClicked
+        widgetFrom(widgetView)?.onStopTapped = onStopTapped
         bindTabCount(widgetView, lifecycleOwner, tabs)
         bindSearchCallbacks(
             widgetView,
@@ -527,7 +517,7 @@ class RealNativeInputManager @Inject constructor(
         widgetView: View,
         omnibar: Omnibar,
     ) {
-        widgetFrom(widgetView)?.setMainButtonsAllowed(omnibar.viewMode != DuckAI)
+        widgetFrom(widgetView)?.setMainButtonsVisibility(omnibar.viewMode != DuckAI)
     }
 
     private fun attachWidget(
@@ -580,111 +570,30 @@ class RealNativeInputManager @Inject constructor(
         val autoCompleteList =
             rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
         val focusedView = rootView.findViewById<View?>(R.id.focusedView)
-        val adapter = ChatSuggestionsAdapter { suggestion ->
-            onChatSuggestionSelected(buildChatUrl(suggestion))
-        }.also { chatSuggestionsAdapter = it }
-
-        fun showChatSuggestions(query: String) {
-            if (!chatSuggestionsUserEnabled) {
-                hideChatSuggestions(autoCompleteList, focusedView, hideList = true)
-                return
-            }
-            autoCompleteAdapter = autoCompleteAdapter ?: autoCompleteList.adapter
-            autoCompleteList.adapter = adapter
-            autoCompleteList.itemAnimator = null
-            fetchChatSuggestions(
-                lifecycleOwner = lifecycleOwner,
-                query = query,
-                autoCompleteList = autoCompleteList,
-                focusedView = focusedView,
-                adapter = adapter,
-            )
-        }
-
-        fun clearChatSuggestions(hideList: Boolean) {
-            hideChatSuggestions(autoCompleteList, focusedView, hideList = hideList)
-            if (!hideList) {
-                restoreAutoCompleteAdapter(rootView)
-            }
-        }
-
-        val previousOnSearchSelected = widget.onSearchSelected
-        widget.onSearchSelected = {
-            clearChatSuggestions(hideList = false)
-            previousOnSearchSelected?.invoke()
-        }
-
-        val previousOnChatSelected = widget.onChatSelected
-        widget.onChatSelected = {
-            previousOnChatSelected?.invoke()
-            omnibar.hide()
-            showChatSuggestions(widget.text)
-        }
-
-        widget.onChatTextChanged = { text ->
-            if (autoCompleteList.adapter == adapter) {
-                fetchChatSuggestions(
-                    lifecycleOwner = lifecycleOwner,
-                    query = text,
-                    autoCompleteList = autoCompleteList,
-                    focusedView = focusedView,
-                    adapter = adapter,
-                )
-            }
-        }
-    }
-
-    private fun fetchChatSuggestions(
-        lifecycleOwner: LifecycleOwner,
-        query: String,
-        autoCompleteList: RecyclerView,
-        focusedView: View?,
-        adapter: ChatSuggestionsAdapter,
-    ) {
-        chatSuggestionsJob?.cancel()
-        chatSuggestionsJob =
-            lifecycleOwner.lifecycleScope.launch {
-                val suggestions = runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
-                adapter.submitList(suggestions)
-                if (suggestions.isNotEmpty()) {
-                    autoCompleteList.show()
-                    focusedView?.gone()
-                } else {
-                    autoCompleteList.gone()
+        var adapter: RecyclerView.Adapter<*>? = null
+        widget.bindChatSuggestions(
+            lifecycleOwner = lifecycleOwner,
+            onChatSuggestionSelected = onChatSuggestionSelected,
+            onChatTabSelected = { omnibar.hide() },
+            onShowSuggestions = { chatAdapter ->
+                adapter = adapter ?: autoCompleteList.adapter
+                autoCompleteList.adapter = chatAdapter
+                autoCompleteList.itemAnimator = null
+                autoCompleteList.show()
+                focusedView?.gone()
+            },
+            onClearSuggestions = { hideList ->
+                adapter?.let { adapter ->
+                    if (autoCompleteList.adapter != adapter) {
+                        autoCompleteList.adapter = adapter
+                    }
                 }
-            }
-    }
-
-    private fun hideChatSuggestions(
-        autoCompleteList: RecyclerView,
-        focusedView: View?,
-        hideList: Boolean,
-    ) {
-        chatSuggestionsJob?.cancel()
-        chatSuggestionsAdapter?.submitList(emptyList())
-        if (hideList) {
-            autoCompleteList.gone()
-            focusedView?.gone()
-        }
-        chatSuggestionsReader.tearDown()
-    }
-
-    private fun restoreAutoCompleteAdapter(rootView: ViewGroup) {
-        val autoCompleteList = rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
-        autoCompleteAdapter?.let { adapter ->
-            if (autoCompleteList.adapter != adapter) {
-                autoCompleteList.adapter = adapter
-            }
-        }
-    }
-
-    private fun buildChatUrl(suggestion: ChatSuggestion): String {
-        return duckChat.getDuckChatUrl("", false)
-            .toUri()
-            .buildUpon()
-            .appendQueryParameter(CHAT_ID_PARAM, suggestion.chatId)
-            .build()
-            .toString()
+                if (hideList) {
+                    autoCompleteList.gone()
+                    focusedView?.gone()
+                }
+            },
+        )
     }
 
     private fun configureAutocompleteLayout(
@@ -871,9 +780,5 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
         )
-    }
-
-    companion object {
-        private const val CHAT_ID_PARAM = "chatID"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -22,6 +22,7 @@ import android.graphics.Color
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
+import androidx.core.net.toUri
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.LifecycleOwner
@@ -36,6 +37,9 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.google.android.material.card.MaterialCardView
@@ -44,35 +48,93 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+interface NativeInputWidget {
+
+    var text: String
+    var onSearchSelected: (() -> Unit)?
+    var onChatSelected: (() -> Unit)?
+    var onClearTextTapped: (() -> Unit)?
+    var onStopTapped: (() -> Unit)?
+
+    fun focusInput(activity: Activity?)
+    fun hasInputFocus(): Boolean
+    fun clearInputFocus()
+    fun requestInputFocus()
+    fun hideKeyboard()
+    fun selectChatTab()
+    fun isChatTabSelected(): Boolean
+    fun setMainButtonsVisibility(isVisible: Boolean)
+
+    fun bindMainButtons(
+        onFireButtonTapped: () -> Unit,
+        onTabSwitcherTapped: () -> Unit,
+        onMenuTapped: () -> Unit,
+    )
+
+    fun bindInputEvents(
+        onSearchTextChanged: (String) -> Unit,
+        onSearchSubmitted: (String) -> Unit,
+        onChatSubmitted: (String) -> Unit,
+    )
+
+    fun bindTabCount(
+        lifecycleOwner: LifecycleOwner,
+        tabCount: LiveData<Int>,
+    )
+
+    fun bindChatSuggestions(
+        lifecycleOwner: LifecycleOwner,
+        onChatSuggestionSelected: (String) -> Unit,
+        onChatTabSelected: () -> Unit,
+        onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
+        onClearSuggestions: (Boolean) -> Unit,
+    )
+
+    fun asView(): View
+}
 
 @InjectWith(ViewScope::class)
 class NativeInputModeWidget @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
-) : InputModeWidget(context, attrs, defStyle) {
+) : InputModeWidget(context, attrs, defStyle), NativeInputWidget {
 
     @Inject
     lateinit var duckChatInternal: DuckChatInternal
 
+    @Inject
+    lateinit var chatSuggestionsReader: ChatSuggestionsReader
+
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
-    private var allowMainButtons: Boolean = true
+    private var showMainButtons: Boolean = true
     private var submitButtons: InputScreenButtons? = null
     private var chatStateJob: Job? = null
-    var onStopClicked: (() -> Unit)? = null
+    private var chatSuggestionsSettingJob: Job? = null
+    private var chatSuggestionsJob: Job? = null
+    private var chatSuggestionsUserEnabled: Boolean = true
+    private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
+    private var onClearSuggestions: ((Boolean) -> Unit)? = null
+    override var onStopTapped: (() -> Unit)? = null
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         applyNativeStyling()
         observeChatState()
+        observeChatSuggestionsEnabled()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         chatStateJob?.cancel()
         chatStateJob = null
+        chatSuggestionsSettingJob?.cancel()
+        chatSuggestionsSettingJob = null
+        tearDownChatSuggestions()
     }
 
     private fun observeChatState() {
@@ -190,7 +252,36 @@ class NativeInputModeWidget @JvmOverloads constructor(
         inputField.doAfterTextChanged { updateMainButtonsVisibility() }
     }
 
-    fun bindMainButtons(
+    override fun focusInput(activity: Activity?) {
+        inputField.requestFocus()
+        activity?.showKeyboard(inputField)
+    }
+
+    override fun hasInputFocus(): Boolean = inputField.hasFocus()
+
+    override fun requestInputFocus() {
+        if (!inputField.hasFocus()) {
+            inputField.requestFocus()
+        }
+    }
+
+    override fun hideKeyboard() {
+        (context as? Activity)?.hideKeyboard(inputField)
+    }
+
+    override fun selectChatTab() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        if (toggle.selectedTabPosition != 1) {
+            toggle.getTabAt(1)?.select()
+        }
+    }
+
+    override fun setMainButtonsVisibility(isVisible: Boolean) {
+        showMainButtons = isVisible
+        updateMainButtonsVisibility()
+    }
+
+    override fun bindMainButtons(
         onFireButtonTapped: () -> Unit,
         onTabSwitcherTapped: () -> Unit,
         onMenuTapped: () -> Unit,
@@ -209,7 +300,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    fun bindSearchCallbacks(
+    override fun bindInputEvents(
         onSearchTextChanged: (String) -> Unit,
         onSearchSubmitted: (String) -> Unit,
         onChatSubmitted: (String) -> Unit,
@@ -222,16 +313,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         this.onChatSent = onChatSubmitted
     }
 
-    fun setTabCount(count: Int) {
-        tabSwitcherButton.count = count
-    }
-
-    fun setMainButtonsAllowed(allowed: Boolean) {
-        allowMainButtons = allowed
-        updateMainButtonsVisibility()
-    }
-
-    fun bindTabCount(
+    override fun bindTabCount(
         lifecycleOwner: LifecycleOwner,
         tabCount: LiveData<Int>,
     ) {
@@ -247,18 +329,110 @@ class NativeInputModeWidget @JvmOverloads constructor(
         setTabCount(tabCount.value ?: 0)
     }
 
-    fun focusInput(activity: Activity?) {
-        inputField.requestFocus()
-        activity?.showKeyboard(inputField)
+    override fun bindChatSuggestions(
+        lifecycleOwner: LifecycleOwner,
+        onChatSuggestionSelected: (String) -> Unit,
+        onChatTabSelected: () -> Unit,
+        onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
+        onClearSuggestions: (Boolean) -> Unit,
+    ) {
+        this.onClearSuggestions = onClearSuggestions
+
+        val adapter = ChatSuggestionsAdapter { suggestion ->
+            onChatSuggestionSelected(buildChatUrl(suggestion))
+        }.also { chatSuggestionsAdapter = it }
+
+        fun showSuggestions(query: String) {
+            if (!chatSuggestionsUserEnabled) {
+                hideChatSuggestions(hideList = true)
+                return
+            }
+            onShowSuggestions(adapter)
+            fetchChatSuggestions(lifecycleOwner, query, adapter)
+        }
+
+        val previousOnSearchSelected = this.onSearchSelected
+        this.onSearchSelected = {
+            hideChatSuggestions(hideList = false)
+            previousOnSearchSelected?.invoke()
+        }
+
+        val previousOnChatSelected = this.onChatSelected
+        this.onChatSelected = {
+            previousOnChatSelected?.invoke()
+            onChatTabSelected()
+            showSuggestions(text)
+        }
+
+        this.onChatTextChanged = { text ->
+            showSuggestions(text)
+        }
     }
 
-    fun hasInputFocus(): Boolean = inputField.hasFocus()
+    private fun tearDownChatSuggestions() {
+        hideChatSuggestions(hideList = true)
+        chatSuggestionsAdapter = null
+        onClearSuggestions = null
+    }
+
+    override fun asView(): View = this
+
+    fun setTabCount(count: Int) {
+        tabSwitcherButton.count = count
+    }
+
+    private fun observeChatSuggestionsEnabled() {
+        chatSuggestionsSettingJob?.cancel()
+        chatSuggestionsSettingJob = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
+            .onEach { enabled -> chatSuggestionsUserEnabled = enabled }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    private fun fetchChatSuggestions(
+        lifecycleOwner: LifecycleOwner,
+        query: String,
+        adapter: ChatSuggestionsAdapter,
+    ) {
+        chatSuggestionsJob?.cancel()
+        chatSuggestionsJob = lifecycleOwner.lifecycleScope.launch {
+            val suggestions = runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+            adapter.submitList(suggestions)
+            if (suggestions.isEmpty()) {
+                onClearSuggestions?.invoke(true)
+            }
+        }
+    }
+
+    private fun hideChatSuggestions(hideList: Boolean) {
+        chatSuggestionsJob?.cancel()
+        chatSuggestionsAdapter?.submitList(emptyList())
+        chatSuggestionsReader.tearDown()
+        onClearSuggestions?.invoke(hideList)
+    }
+
+    private fun buildChatUrl(suggestion: ChatSuggestion): String {
+        return duckChatInternal.getDuckChatUrl("", false)
+            .toUri()
+            .buildUpon()
+            .appendQueryParameter(CHAT_ID_PARAM, suggestion.chatId)
+            .build()
+            .toString()
+    }
+
+    private fun setChatStreaming(streaming: Boolean) {
+        ensureSubmitButtons()
+        if (streaming) {
+            submitButtons?.setStopButton()
+        } else {
+            submitButtons?.clearStopButton(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+        }
+    }
 
     private fun updateMainButtonsVisibility() {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isSearchTab = toggle.selectedTabPosition == 0
         val hasText = inputField.text?.isNotBlank() == true
-        setMainButtonsVisible(allowMainButtons && isSearchTab && !hasText)
+        setMainButtonsVisible(showMainButtons && isSearchTab && !hasText)
     }
 
     private fun updateDuckAiSubmitButton() {
@@ -284,7 +458,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val container = findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer) ?: return
         val buttons = InputScreenButtons(context, useTopBar = false).apply {
             onSendClick = { submitMessage() }
-            onStopClick = { this@NativeInputModeWidget.onStopClicked?.invoke() }
+            onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
             setSendButtonVisible(false)
             setNewLineButtonVisible(false)
             setVoiceButtonVisible(false)
@@ -301,25 +475,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    fun requestInputFocus() {
-        if (!inputField.hasFocus()) {
-            inputField.requestFocus()
-        }
-    }
-
-    fun selectChatTab() {
-        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        if (toggle.selectedTabPosition != 1) {
-            toggle.getTabAt(1)?.select()
-        }
-    }
-
-    fun setChatStreaming(streaming: Boolean) {
-        ensureSubmitButtons()
-        if (streaming) {
-            submitButtons?.setStopButton()
-        } else {
-            submitButtons?.clearStopButton(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
-        }
+    companion object {
+        private const val CHAT_ID_PARAM = "chatID"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213566799053014?focus=true

### Description

- Interfaces out the native input widget
- Moves recent chats to the native input widget
- Additional: Shows NTP when the input is cleared

### Steps to test this PR

Enable feature flag > “nativeInputField", AI Features > “Native Input Field”

- [ ] Test that recent chats work correctly


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI refactor that shifts chat-suggestions fetching/teardown and stop-button wiring into the widget and changes NTP/browser visibility toggling, which could introduce regressions in focus/keyboard, suggestion list swapping, or view state transitions.
> 
> **Overview**
> **Refactors native input ownership** by introducing a `NativeInputWidget` interface and updating `NativeInputManager` to interact with the widget via that interface (including renaming `onStopClicked`  `onStopTapped`).
> 
> **Moves chat suggestions/recent chats behavior into the widget** (`NativeInputModeWidget`) by relocating suggestion fetching, settings observation, URL building, and teardown from the app module into `duckchat-impl`, with `NativeInputManager` now only swapping the RecyclerView adapter and reacting to widget callbacks.
> 
> **Adjusts browser/NTP visibility when native input is shown/hidden**, adding explicit `showNtp`/`hideNtp` helpers so clearing/hiding native input restores the appropriate container views instead of directly toggling just the WebView container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e269fc5f0e1a2032f46a575b2b099d4e7776ce82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->