### PR TITLE
Add SyncAutoRestore API and SyncRecovery key

### DIFF
--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncAutoRestore.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncAutoRestore.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.api
+
+interface SyncAutoRestore {
+
+    /**
+     * Whether Sync auto-restore can be offered to the user.
+     *
+     * Returns true only when ALL of the following are met:
+     * - The auto-restore feature flag is enabled
+     * - An auto-restore token exists
+     */
+    suspend fun canRestore(): Boolean
+
+    /**
+     * Kicks off a headless sync account restore using the
+     * stored auto-restore token.
+     *
+     * This is fire-and-forget: the restore
+     * is best-effort and offers no user-facing results.
+     */
+    fun restoreSyncAccount()
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -77,4 +77,7 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun syncAutoRecoveryCapabilityDetectionRead(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun syncAutoRestore(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.sync.api.SyncAutoRestore
+import com.duckduckgo.sync.impl.SyncFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSyncAutoRestore @Inject constructor(
+    private val persistentStorage: PersistentStorage,
+    private val syncFeature: SyncFeature,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : SyncAutoRestore {
+
+    override suspend fun canRestore(): Boolean {
+        return withContext(dispatcherProvider.io()) {
+            if (!syncFeature.syncAutoRestore().isEnabled()) return@withContext false
+            persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull() != null
+        }
+    }
+
+    override fun restoreSyncAccount() {
+        appScope.launch(dispatcherProvider.io()) {
+            logcat { "Sync-Recovery: restoreSyncAccount called, not yet implemented" }
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncRecoveryPersistentStorageKey.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncRecoveryPersistentStorageKey.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import com.duckduckgo.persistentstorage.api.PersistentStorageKey
+
+object SyncRecoveryPersistentStorageKey : PersistentStorageKey(
+    key = "com.duckduckgo.sync.recovery_code",
+    shouldBackupToCloud = true,
+)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
@@ -101,6 +101,8 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
         binding.clearHistoryPasswordScreenPromo.setOnClickListener { viewModel.onClearHistoryPasswordScreenPromoClicked() }
+        binding.blockStoreWriteButton.setOnClickListener { viewModel.onBlockStoreWriteClicked(binding.blockStoreInput.text) }
+        binding.blockStoreClearButton.setOnClickListener { viewModel.onBlockStoreClearClicked() }
     }
 
     private fun observeUiEvents() {
@@ -168,6 +170,29 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.primaryKeyTextView.text = viewState.primaryKey
         binding.secretKeyTextView.text = viewState.secretKey
         binding.connectedDevicesList.removeAllViews()
+        binding.blockStoreFeatureFlag.text = if (viewState.syncAutoRestoreEnabled) {
+            "✅ syncAutoRestore flag enabled"
+        } else {
+            "❌ syncAutoRestore flag disabled"
+        }
+        binding.blockStoreAvailability.text = when (viewState.blockStoreAvailable) {
+            null -> "Checking..."
+            true -> "✅ Available"
+            false -> "❌ Unavailable (Play Services missing)"
+        }
+        binding.blockStoreE2eStatus.text = when {
+            viewState.blockStoreAvailable == null -> ""
+            viewState.blockStoreAvailable == false -> ""
+            viewState.blockStoreE2ESupported == true -> "✅ E2E encryption supported"
+            else -> "❌ E2E encryption not supported"
+        }
+        binding.blockStoreCurrentValue.text = when (val value = viewState.blockStoreCurrentValue) {
+            is SyncInternalSettingsViewModel.BlockStoreValue.Loading -> "Loading..."
+            is SyncInternalSettingsViewModel.BlockStoreValue.NotSet -> "(key not set)"
+            is SyncInternalSettingsViewModel.BlockStoreValue.HasValue -> {
+                if (value.value.isEmpty()) "(empty string)" else value.value
+            }
+        }
 
         binding.syncInternalEnvironment.quietlySetIsChecked(viewState.useDevEnvironment) { _, enabled ->
             viewModel.onEnvironmentChanged(enabled)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
@@ -21,12 +21,16 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore
@@ -45,6 +49,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
@@ -59,6 +64,8 @@ constructor(
     private val syncFaviconFetchingStore: FaviconsFetchingStore,
     private val dispatchers: DispatcherProvider,
     private val syncPromotionDataStore: SyncPromotionDataStore,
+    private val persistentStorage: PersistentStorage,
+    private val syncFeature: SyncFeature,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
@@ -79,7 +86,17 @@ constructor(
         val connectedDevices: List<ConnectedDevice> = emptyList(),
         val useDevEnvironment: Boolean = false,
         val environment: String = "",
+        val syncAutoRestoreEnabled: Boolean = false,
+        val blockStoreAvailable: Boolean? = null,
+        val blockStoreE2ESupported: Boolean? = null,
+        val blockStoreCurrentValue: BlockStoreValue = BlockStoreValue.Loading,
     )
+
+    sealed class BlockStoreValue {
+        data object Loading : BlockStoreValue()
+        data object NotSet : BlockStoreValue()
+        data class HasValue(val value: String) : BlockStoreValue()
+    }
 
     sealed class Command {
         data class ShowMessage(val message: String) : Command()
@@ -92,6 +109,9 @@ constructor(
     init {
         viewModelScope.launch(dispatchers.io()) {
             updateViewState()
+            checkSyncAutoRestoreFlag()
+            checkBlockStoreAvailability()
+            refreshBlockStoreValue()
         }
     }
 
@@ -324,6 +344,57 @@ constructor(
         viewModelScope.launch {
             syncPromotionDataStore.clearPromoHistory(PasswordsScreen)
             command.send(ShowMessage("'Password screen' promo history cleared"))
+        }
+    }
+
+    private fun checkSyncAutoRestoreFlag() {
+        val enabled = syncFeature.syncAutoRestore().isEnabled()
+        viewState.update { it.copy(syncAutoRestoreEnabled = enabled) }
+    }
+
+    private suspend fun checkBlockStoreAvailability() {
+        when (val availability = persistentStorage.checkAvailability()) {
+            is PersistentStorageAvailability.Unavailable -> {
+                viewState.update { it.copy(blockStoreAvailable = false, blockStoreE2ESupported = false) }
+            }
+            is PersistentStorageAvailability.Available -> {
+                viewState.update { it.copy(blockStoreAvailable = true, blockStoreE2ESupported = availability.isEndToEndEncryptionSupported) }
+            }
+        }
+    }
+
+    private suspend fun refreshBlockStoreValue() {
+        val result = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull()
+        val blockStoreValue = when {
+            result == null -> BlockStoreValue.NotSet
+            else -> BlockStoreValue.HasValue(String(result))
+        }
+        viewState.update { it.copy(blockStoreCurrentValue = blockStoreValue) }
+    }
+
+    fun onBlockStoreWriteClicked(data: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            persistentStorage.store(SyncRecoveryPersistentStorageKey, data.toByteArray())
+                .onSuccess {
+                    refreshBlockStoreValue()
+                    command.send(ShowMessage("Stored successfully"))
+                }
+                .onFailure { error ->
+                    command.send(ShowMessage("Store failed: ${error.message}"))
+                }
+        }
+    }
+
+    fun onBlockStoreClearClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            persistentStorage.clear(SyncRecoveryPersistentStorageKey)
+                .onSuccess {
+                    refreshBlockStoreValue()
+                    command.send(ShowMessage("Cleared successfully"))
+                }
+                .onFailure { error ->
+                    command.send(ShowMessage("Clear failed: ${error.message}"))
+                }
         }
     }
 }

--- a/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
@@ -66,6 +66,91 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
+        <LinearLayout
+            android:id="@+id/blockStoreSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/sync_internal_block_store_header" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreFeatureFlag"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreAvailability"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreE2eStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/sync_internal_block_store_current_value_label" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreCurrentValue"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/blockStoreInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/keyline_4"
+                android:hint="@string/sync_internal_block_store_input_hint"
+                app:editable="true"
+                app:type="single_line" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginEnd="10dp"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/blockStoreWriteButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="@string/sync_internal_block_store_write" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/blockStoreClearButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:text="@string/sync_internal_block_store_clear" />
+
+            </LinearLayout>
+        </LinearLayout>
+
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -34,4 +34,11 @@
     <string name="sync_internal_promotions_clear_history_bookmark_screen_promo">Clear history (bookmark screen)</string>
     <string name="sync_internal_promotions_clear_history_password_screen_promo">Clear history (password screen)</string>
 
+    <!-- Block Store -->
+    <string name="sync_internal_block_store_header">Persistent Storage / Block Store</string>
+    <string name="sync_internal_block_store_current_value_label">Current stored value (SyncRecovery key)</string>
+    <string name="sync_internal_block_store_input_hint">Data to store</string>
+    <string name="sync_internal_block_store_write">Write</string>
+    <string name="sync_internal_block_store_clear">Clear</string>
+
 </resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import android.annotation.SuppressLint
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.sync.impl.SyncFeature
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class RealSyncAutoRestoreTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val persistentStorage: PersistentStorage = mock()
+
+    private lateinit var testee: RealSyncAutoRestore
+
+    @Before
+    fun setup() {
+        testee = RealSyncAutoRestore(
+            persistentStorage = persistentStorage,
+            syncFeature = syncFeature,
+            appScope = coroutineTestRule.testScope,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenFeatureFlagDisabledThenCanRestoreReturnsFalse() = runTest {
+        configureAutoRestoreEnabled(false)
+
+        assertFalse(testee.canRestore())
+    }
+
+    @Test
+    fun whenFeatureFlagEnabledButNoStoredKeyThenCanRestoreReturnsFalse() = runTest {
+        configureAutoRestoreEnabled(true)
+        configureRetrieveSuccess(value = null)
+
+        assertFalse(testee.canRestore())
+    }
+
+    @Test
+    fun whenFeatureFlagEnabledAndKeyExistsThenCanRestoreReturnsTrue() = runTest {
+        configureAutoRestoreEnabled(true)
+        configureRetrieveSuccess(value = "recovery_key_bytes")
+
+        assertTrue(testee.canRestore())
+    }
+
+    @Test
+    fun whenStorageRetrievalFailsThenCanRestoreReturnsFalse() = runTest {
+        configureAutoRestoreEnabled(true)
+        configureRetrieveFailure()
+
+        assertFalse(testee.canRestore())
+    }
+
+    private fun configureAutoRestoreEnabled(enabled: Boolean) {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = enabled))
+    }
+
+    private suspend fun configureRetrieveSuccess(value: String?) {
+        val bytes = value?.toByteArray(Charsets.UTF_8)
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(bytes))
+    }
+
+    private suspend fun configureRetrieveFailure() {
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.failure(RuntimeException("Retrieve failed")))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213488933349586/task/1213232213875729?focus=true

### Description

Adds the `SyncAutoRestore` API and internal dev tooling for validating Block Store integration.

**What's in this PR** (stacked on persistent-storage module)
- `SyncAutoRestore` interface in `sync-api` with `canRestore()` and `restoreSyncAccount()`
- `RealSyncAutoRestore` implementation, gated behind `syncAutoRestore` feature flag (defaults FALSE)
- `SyncRecoveryPersistentStorageKey` — the key that will store the sync recovery code in Block Store (`shouldBackupToCloud = true`)
- Internal settings Block Store section showing: feature flag status, availability, E2E encryption support, current stored value, write/clear controls
- Unit tests for `RealSyncAutoRestore`

**API proposal:** https://app.asana.com/1/137249556945/project/1202552961248957/task/1213554376592121

### Steps to test this PR
**QA optional**

_Block Store dev tooling_
- [x] Install `internalRelease` on a device with Google Play Services
- [x] Open App Settings → Internal Settings → Sync Internal Settings
- [x] Verify Block Store section shows: feature flag status (disabled), availability, E2E status, current value "(key not set)"
- [x] Enter text in input → tap Write → confirm toast "Stored successfully" and value updates
- [x] Tap Clear → confirm toast "Cleared successfully" and value returns to "(key not set)"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new cloud-backup persistent storage key for sync recovery data and wires it into a new auto-restore capability check; misconfiguration could impact sensitive data handling. Functional impact is limited by a default-off feature flag and restore being unimplemented.
> 
> **Overview**
> Adds a new `SyncAutoRestore` API plus `RealSyncAutoRestore` implementation, gated behind a new `syncAutoRestore` feature flag (default **off**), where `canRestore()` checks for a stored recovery token in persistent storage and `restoreSyncAccount()` is currently a stub.
> 
> Introduces `SyncRecoveryPersistentStorageKey` (configured with `shouldBackupToCloud = true`) and expands Sync Internal Settings with a **Block Store** section to display flag/availability/E2E support and to read/write/clear the stored value for validation. Includes unit tests covering `canRestore()` behavior under flag and storage success/failure conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e112155d6733a66444b608fee3b93904ffb8708f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->