### PR TITLE
Add native omnibar controller and layout coordinator

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -139,6 +139,7 @@ import com.duckduckgo.app.browser.menu.VpnMenuStore
 import com.duckduckgo.app.browser.model.BasicAuthenticationCredentials
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
+import com.duckduckgo.app.browser.nativeinput.NativeInputCallbacks
 import com.duckduckgo.app.browser.nativeinput.NativeInputManager
 import com.duckduckgo.app.browser.navigation.bar.BrowserNavigationBarViewIntegration
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarObserver
@@ -1058,8 +1059,8 @@ class BrowserTabFragment :
             omnibarType = settingsDataStore.omnibarType,
             binding = binding,
         )
-        nativeInputManager.start(viewLifecycleOwner) {
-            nativeInputManager.hideNativeInput(binding.rootView, omnibar)
+        nativeInputManager.init(omnibar, binding.rootView, viewLifecycleOwner) {
+            nativeInputManager.hideNativeInput()
         }
 
         webViewContainer = binding.webViewContainer
@@ -1233,59 +1234,59 @@ class BrowserTabFragment :
 
     private fun showNativeInput(query: String = "") {
         nativeInputManager.showNativeInput(
-            omnibar = omnibar,
             layoutInflater = layoutInflater,
-            rootView = binding.rootView,
             lifecycleOwner = viewLifecycleOwner,
             tabs = viewModel.tabs,
             query = query,
-            onSearchTextChanged = { text -> onUserEnteredText(text) },
-            onClearAutocomplete = {
-                if (binding.autoCompleteSuggestionsList.isVisible) {
-                    viewModel.autoCompleteSuggestionsGone()
-                }
-                viewModel.triggerAutocomplete("", hasFocus = false, hasQueryChanged = true)
-                binding.autoCompleteSuggestionsList.gone()
-                binding.focusedView.gone()
-            },
-            onSearchSubmitted = { query -> onUserSubmittedText(query) },
-            onChatSubmitted = { query ->
-                val url = duckChat.getDuckChatUrl(query, true)
-                browserActivity?.launchNewTab(query = url, skipHome = true)
-            },
-            onDuckAiChatSubmitted = { query ->
-                contentScopeScripts.sendSubscriptionEvent(
-                    SubscriptionEventData(
-                        featureName = "aiChat",
-                        subscriptionName = "submitAIChatNativePrompt",
-                        params = JSONObject().apply {
-                            put("platform", "android")
-                            put(
-                                "query",
-                                JSONObject().apply {
-                                    put("prompt", query)
-                                    put("autoSubmit", true)
-                                },
-                            )
-                        },
-                    ),
-                )
-            },
-            onChatSuggestionSelected = { query -> userEnteredQuery(query) },
-            onFireButtonTapped = { onFireButtonPressed() },
-            onTabSwitcherTapped = { launchTabSwitcher() },
-            onMenuTapped = {
-                launchBrowserMenu(addExtraDelay = omnibarRepository.omnibarType == OmnibarType.SPLIT)
-            },
-            onStopTapped = {
-                contentScopeScripts.sendSubscriptionEvent(
-                    SubscriptionEventData(
-                        featureName = "aiChat",
-                        subscriptionName = "submitPromptInterruption",
-                        params = JSONObject("{}"),
-                    ),
-                )
-            },
+            callbacks = NativeInputCallbacks(
+                onSearchTextChanged = { text -> onUserEnteredText(text) },
+                onClearAutocomplete = {
+                    if (binding.autoCompleteSuggestionsList.isVisible) {
+                        viewModel.autoCompleteSuggestionsGone()
+                    }
+                    viewModel.triggerAutocomplete("", hasFocus = false, hasQueryChanged = true)
+                    binding.autoCompleteSuggestionsList.gone()
+                    binding.focusedView.gone()
+                },
+                onSearchSubmitted = { query -> onUserSubmittedText(query) },
+                onBrowserChatSubmitted = { query ->
+                    val url = duckChat.getDuckChatUrl(query, true)
+                    browserActivity?.launchNewTab(query = url, skipHome = true)
+                },
+                onDuckAiChatSubmitted = { query ->
+                    contentScopeScripts.sendSubscriptionEvent(
+                        SubscriptionEventData(
+                            featureName = "aiChat",
+                            subscriptionName = "submitAIChatNativePrompt",
+                            params = JSONObject().apply {
+                                put("platform", "android")
+                                put(
+                                    "query",
+                                    JSONObject().apply {
+                                        put("prompt", query)
+                                        put("autoSubmit", true)
+                                    },
+                                )
+                            },
+                        ),
+                    )
+                },
+                onChatSuggestionSelected = { query -> userEnteredQuery(query) },
+                onFireButtonTapped = { onFireButtonPressed() },
+                onTabSwitcherTapped = { launchTabSwitcher() },
+                onMenuTapped = {
+                    launchBrowserMenu(addExtraDelay = omnibarRepository.omnibarType == OmnibarType.SPLIT)
+                },
+                onStopTapped = {
+                    contentScopeScripts.sendSubscriptionEvent(
+                        SubscriptionEventData(
+                            featureName = "aiChat",
+                            subscriptionName = "submitPromptInterruption",
+                            params = JSONObject("{}"),
+                        ),
+                    )
+                },
+            ),
         )
     }
 
@@ -2765,7 +2766,7 @@ class BrowserTabFragment :
             is Command.EnableDuckAIFullScreen -> showDuckAI(it.browserViewState)
             is Command.DisableDuckAIFullScreen -> {
                 omnibar.setViewMode(Browser(it.url))
-                nativeInputManager.hideNativeInput(binding.rootView, omnibar)
+                nativeInputManager.hideNativeInput()
             }
             is Command.ShowDuckAIContextualMode -> showDuckChatContextualSheet(it.tabId)
             is Command.StartAddressBarTrackersAnimation -> {
@@ -4501,7 +4502,7 @@ class BrowserTabFragment :
 
     fun onBackPressed(isCustomTab: Boolean = false): Boolean {
         if (!isAdded) return false
-        if (nativeInputManager.hideNativeInput(binding.rootView, omnibar)) return true
+        if (nativeInputManager.hideNativeInput()) return true
         return viewModel.onUserPressedBack(isCustomTab)
     }
 
@@ -5480,7 +5481,7 @@ class BrowserTabFragment :
                 if (isVisible) {
                     viewModel.sendKeyboardFocusedPixel()
                 }
-                nativeInputManager.onKeyboardVisibilityChanged(isVisible, binding.rootView, omnibar)
+                nativeInputManager.onKeyboardVisibilityChanged(isVisible)
             }
             .launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.duckduckgo.app.browser.R
+import com.google.android.material.card.MaterialCardView
+
+class NativeInputLayoutCoordinator(
+    private val rootView: ViewGroup,
+    private val omnibarState: OmnibarState,
+) {
+    fun isWidgetBottom(): Boolean = omnibarState.isDuckAiMode() || omnibarState.isOmnibarBottom()
+
+    private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+    private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+
+    fun buildWidgetLayoutParams(): ViewGroup.LayoutParams {
+        return CoordinatorLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            gravity = if (isWidgetBottom()) Gravity.BOTTOM else Gravity.TOP
+        }
+    }
+
+    fun applyBottomCardShape(widgetView: View) {
+        if (!isWidgetBottom()) return
+        val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
+        val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
+        card.shapeAppearanceModel =
+            card.shapeAppearanceModel
+                .toBuilder()
+                .setTopLeftCornerSize(radius)
+                .setTopRightCornerSize(radius)
+                .setBottomLeftCornerSize(0f)
+                .setBottomRightCornerSize(0f)
+                .build()
+    }
+
+    fun configureAutocompleteLayout(widgetView: View) {
+        val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
+        val focusedView = rootView.findViewById<View?>(R.id.focusedView)
+        val baseElevation = maxOf(autoCompleteList.elevation, focusedView?.elevation ?: 0f)
+        val targetElevation = baseElevation + widgetView.resources.displayMetrics.density
+        widgetView.elevation = maxOf(widgetView.elevation, targetElevation)
+        widgetView.bringToFront()
+
+        val targets =
+            buildList {
+                add(autoCompleteList to autoCompleteList.snapshotPadding())
+                focusedView?.let { add(it to it.snapshotPadding()) }
+            }
+        fun applyPadding(deltaTop: Int, deltaBottom: Int) {
+            targets.forEach { (view, padding) ->
+                view.setPadding(
+                    padding.left,
+                    padding.top + deltaTop,
+                    padding.right,
+                    padding.bottom + deltaBottom,
+                )
+            }
+        }
+
+        fun applyForWidgetPosition() {
+            val isBottom = isWidgetBottom()
+            val topOffset = if (isBottom) 0 else maxOf(0, widgetView.bottom - autoCompleteList.top)
+            val bottomOffset = if (isBottom) maxOf(0, autoCompleteList.bottom - widgetView.top) else 0
+            applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
+        }
+
+        widgetView.post { applyForWidgetPosition() }
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyForWidgetPosition()
+            }
+        widgetView.addOnLayoutChangeListener(layoutListener)
+        autoCompleteList.addOnLayoutChangeListener(layoutListener)
+        focusedView?.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    applyPadding(deltaTop = 0, deltaBottom = 0)
+                    v.removeOnLayoutChangeListener(layoutListener)
+                    autoCompleteList.removeOnLayoutChangeListener(layoutListener)
+                    focusedView?.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    fun configureContentOffset(widgetView: View) {
+        data class Target(val view: View, val basePadding: Padding)
+        val newTabContent =
+            rootView.findViewById<View?>(R.id.newTabPage)
+                ?: rootView.findViewById(R.id.includeNewBrowserTab)
+        val targets =
+            listOfNotNull(
+                rootView.findViewById(R.id.browserLayout),
+                newTabContent,
+            ).map { Target(it, it.snapshotPadding()) }
+        if (targets.isEmpty()) return
+        val anchor = widgetView.findViewById(R.id.inputModeWidgetCard) ?: widgetView
+
+        val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
+
+        fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
+            view.setPadding(
+                padding.left,
+                padding.top + deltaTop,
+                padding.right,
+                padding.bottom + deltaBottom,
+            )
+        }
+
+        fun applyOffset() {
+            if (!widgetView.isShown) {
+                targets.forEach { target ->
+                    applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
+                }
+                return
+            }
+            val isBottom = isWidgetBottom()
+            val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
+            val anchorBottomInWindow = anchorLocation[1] + anchor.height
+            targets.forEach { target ->
+                val view = target.view
+                val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
+                val deltaTop = if (isBottom) 0 else maxOf(0, anchorBottomInWindow - viewLocation[1])
+                val deltaBottom =
+                    if (isBottom) {
+                        if (omnibarState.isOmnibarBottom()) {
+                            maxOf(0, overlap)
+                        } else {
+                            maxOf(0, anchor.height - overlap)
+                        }
+                    } else {
+                        0
+                    }
+                applyPadding(view, target.basePadding, deltaTop, deltaBottom)
+            }
+        }
+
+        widgetView.post { applyOffset() }
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyOffset()
+            }
+        widgetView.addOnLayoutChangeListener(layoutListener)
+        rootView.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    targets.forEach { target ->
+                        applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
+                    }
+                    v.removeOnLayoutChangeListener(layoutListener)
+                    rootView.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    fun applyForcedBottomTranslation(widgetView: View) {
+        val shouldForce = isWidgetBottom() && !omnibarState.isOmnibarBottom()
+        if (!shouldForce) {
+            widgetView.translationY = 0f
+            return
+        }
+        fun applyOffset() {
+            val gap = maxOf(0, rootView.height - widgetView.bottom)
+            if (widgetView.translationY != gap.toFloat()) {
+                widgetView.translationY = gap.toFloat()
+            }
+        }
+        applyOffset()
+        val layoutListener =
+            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                applyOffset()
+            }
+        rootView.addOnLayoutChangeListener(layoutListener)
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+
+                override fun onViewDetachedFromWindow(v: View) {
+                    rootView.removeOnLayoutChangeListener(layoutListener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -17,14 +17,9 @@
 package com.duckduckgo.app.browser.nativeinput
 
 import android.app.Activity
-import android.graphics.Color
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.lifecycleScope
@@ -32,71 +27,61 @@ import androidx.lifecycle.map
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.Omnibar
-import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.DuckAI
-import com.duckduckgo.app.browser.omnibar.OmnibarType
-import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
-import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.app.tabs.model.TabEntity
-import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
-import com.duckduckgo.common.ui.view.toPx
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
-import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
+class NativeInputCallbacks(
+    val onSearchTextChanged: (String) -> Unit,
+    val onSearchSubmitted: (String) -> Unit,
+    val onBrowserChatSubmitted: (String) -> Unit,
+    val onDuckAiChatSubmitted: (String) -> Unit,
+    val onChatSuggestionSelected: (String) -> Unit,
+    val onClearAutocomplete: () -> Unit,
+    val onFireButtonTapped: () -> Unit,
+    val onTabSwitcherTapped: () -> Unit,
+    val onMenuTapped: () -> Unit,
+    val onStopTapped: () -> Unit,
+)
+
 interface NativeInputManager {
-    fun start(lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit = {})
+    fun init(omnibar: Omnibar, rootView: ViewGroup, lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit = {})
     fun isNativeInputEnabled(): Boolean
     fun showNativeInput(
-        omnibar: Omnibar,
         layoutInflater: LayoutInflater,
-        rootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
         query: String = "",
-        onSearchTextChanged: (String) -> Unit,
-        onClearAutocomplete: () -> Unit,
-        onSearchSubmitted: (String) -> Unit,
-        onChatSubmitted: (String) -> Unit,
-        onDuckAiChatSubmitted: (String) -> Unit,
-        onChatSuggestionSelected: (String) -> Unit,
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-        onStopTapped: () -> Unit,
+        callbacks: NativeInputCallbacks,
     )
-    fun hideNativeInput(
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ): Boolean
-    fun onKeyboardVisibilityChanged(
-        isVisible: Boolean,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    )
+    fun hideNativeInput(): Boolean
+    fun onKeyboardVisibilityChanged(isVisible: Boolean)
 }
 
-@ContributesBinding(AppScope::class, boundType = NativeInputManager::class)
+@ContributesBinding(FragmentScope::class)
 class RealNativeInputManager @Inject constructor(
     private val duckChat: DuckChat,
 ) : NativeInputManager {
-    private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
-
+    private lateinit var omnibarController: NativeInputOmnibarController
+    private lateinit var rootView: ViewGroup
+    private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
-
-    private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
 
     private fun widgetFrom(widgetView: View): NativeInputWidget? {
         return widgetView.findViewById<View?>(R.id.inputModeWidget) as? NativeInputWidget
     }
 
-    override fun start(lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit) {
+    override fun init(omnibar: Omnibar, rootView: ViewGroup, lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit) {
+        this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView)
+        this.rootView = rootView
+        this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
         duckChat.observeNativeInputFieldUserSettingEnabled()
             .onEach { isEnabled ->
                 if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
@@ -107,30 +92,23 @@ class RealNativeInputManager @Inject constructor(
 
     override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
 
-    override fun hideNativeInput(
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ): Boolean {
+    override fun hideNativeInput(): Boolean {
         if (!isNativeInputFieldEnabled) return false
 
-        if (omnibar.viewMode == DuckAI) return false
-        val removed = removeWidget(rootView)
+        if (omnibarController.isDuckAiMode()) return false
+        val removed = removeWidget()
         if (!removed) return false
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
-        if (omnibar.viewMode is Omnibar.ViewMode.Browser) {
-            hideNtp(rootView)
+        if (omnibarController.isBrowserMode()) {
+            hideNtp()
         }
-        restoreOmnibar(omnibar, rootView)
-        omnibar.show()
+        omnibarController.restore()
+        omnibarController.show()
         return true
     }
 
-    override fun onKeyboardVisibilityChanged(
-        isVisible: Boolean,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
+    override fun onKeyboardVisibilityChanged(isVisible: Boolean) {
         fun isDescendantOf(
             ancestor: View,
             view: View,
@@ -157,144 +135,88 @@ class RealNativeInputManager @Inject constructor(
     }
 
     override fun showNativeInput(
-        omnibar: Omnibar,
         layoutInflater: LayoutInflater,
-        rootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
         query: String,
-        onSearchTextChanged: (String) -> Unit,
-        onClearAutocomplete: () -> Unit,
-        onSearchSubmitted: (String) -> Unit,
-        onChatSubmitted: (String) -> Unit,
-        onDuckAiChatSubmitted: (String) -> Unit,
-        onChatSuggestionSelected: (String) -> Unit,
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-        onStopTapped: () -> Unit,
+        callbacks: NativeInputCallbacks,
     ) {
         if (!isNativeInputFieldEnabled) return
 
-        if (omnibar.viewMode == DuckAI) {
-            forceOmnibarTop(omnibar, rootView)
+        if (omnibarController.isDuckAiMode()) {
+            omnibarController.forceToTop()
         }
-        removeWidget(rootView)
-        if (omnibar.viewMode == DuckAI) {
-            omnibar.show()
-            hideOmnibarBackground(omnibar, rootView)
+        removeWidget()
+        if (omnibarController.isDuckAiMode()) {
+            omnibarController.show()
+            omnibarController.hideBackground()
         }
-        val widgetView = createWidgetView(layoutInflater, rootView, omnibar)
-        val prefillText = query.ifEmpty { omnibar.getText() }
-        bindWidget(
-            widgetView = widgetView,
-            rootView = rootView,
-            omnibar = omnibar,
-            lifecycleOwner = lifecycleOwner,
-            tabs = tabs,
-            onSearchTextChanged = onSearchTextChanged,
-            onClearAutocomplete = onClearAutocomplete,
-            onSearchSubmitted = onSearchSubmitted,
-            onChatSubmitted = onChatSubmitted,
-            onDuckAiChatSubmitted = onDuckAiChatSubmitted,
-            onChatSuggestionSelected = onChatSuggestionSelected,
-            onFireButtonTapped = onFireButtonTapped,
-            onTabSwitcherTapped = onTabSwitcherTapped,
-            onMenuTapped = onMenuTapped,
-            onStopTapped = onStopTapped,
-        )
-        if (omnibar.viewMode != DuckAI && prefillText.isNotEmpty()) {
+        val widgetView = createWidgetView(layoutInflater)
+        val prefillText = query.ifEmpty { omnibarController.getText() }
+        bindWidget(widgetView, lifecycleOwner, tabs, callbacks)
+        if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             widgetFrom(widgetView)?.text = prefillText
         }
-        attachWidget(widgetView, rootView, omnibar)
-        if (omnibar.viewMode != DuckAI) {
-            omnibar.hide()
-            showNtp(rootView)
+        attachWidget(widgetView)
+        if (!omnibarController.isDuckAiMode()) {
+            omnibarController.hide()
+            showNtp()
         }
-    }
-
-    private fun bindMainButtons(
-        widgetView: View,
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-    ) {
-        widgetFrom(widgetView)?.bindMainButtons(
-            onFireButtonTapped = onFireButtonTapped,
-            onTabSwitcherTapped = onTabSwitcherTapped,
-            onMenuTapped = onMenuTapped,
-        )
-    }
-
-    private fun bindTabCount(
-        widgetView: View,
-        lifecycleOwner: LifecycleOwner,
-        tabs: LiveData<List<TabEntity>>,
-    ) {
-        val widget = widgetFrom(widgetView) ?: return
-        val tabCount = tabs.map { it.size }
-        widget.bindTabCount(lifecycleOwner, tabCount)
     }
 
     private fun bindSearchCallbacks(
         widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-        onSearchTextChanged: (String) -> Unit,
-        onClearAutocomplete: () -> Unit,
-        onSearchSubmitted: (String) -> Unit,
-        onChatSubmitted: (String) -> Unit,
-        onDuckAiChatSubmitted: (String) -> Unit,
+        callbacks: NativeInputCallbacks,
     ) {
         val widget = widgetFrom(widgetView) ?: return
         widget.bindInputEvents(
-            onSearchTextChanged = onSearchTextChanged,
+            onSearchTextChanged = callbacks.onSearchTextChanged,
             onSearchSubmitted = { query ->
-                if (omnibar.viewMode == DuckAI) {
-                    removeWidget(rootView)
-                    restoreOmnibar(omnibar, rootView)
-                    omnibar.show()
+                if (omnibarController.isDuckAiMode()) {
+                    removeWidget()
+                    omnibarController.restore()
+                    omnibarController.show()
                 } else {
-                    hideNativeInput(rootView, omnibar)
+                    hideNativeInput()
                 }
-                onSearchSubmitted(query)
+                callbacks.onSearchSubmitted(query)
             },
             onChatSubmitted = { query ->
-                if (omnibar.viewMode == DuckAI) {
+                if (omnibarController.isDuckAiMode()) {
                     widget.hideKeyboard()
-                    onDuckAiChatSubmitted(query)
+                    callbacks.onDuckAiChatSubmitted(query)
                 } else {
-                    hideNativeInput(rootView, omnibar)
-                    onChatSubmitted(query)
+                    hideNativeInput()
+                    callbacks.onBrowserChatSubmitted(query)
                 }
             },
         )
         val previousOnChatSelected = widget.onChatSelected
         widget.onChatSelected = {
-            onClearAutocomplete()
+            callbacks.onClearAutocomplete()
             previousOnChatSelected?.invoke()
         }
         widget.onClearTextTapped = {
             if (!widget.isChatTabSelected()) {
-                onClearAutocomplete()
+                callbacks.onClearAutocomplete()
             }
         }
     }
 
-    private fun showNtp(rootView: ViewGroup) {
+    private fun showNtp() {
         rootView.findViewById<View?>(R.id.browserLayout)?.gone()
         rootView.findViewById<View?>(R.id.includeNewBrowserTab)?.show()
         rootView.findViewById<View?>(R.id.newTabContainerLayout)?.show()
     }
 
-    private fun hideNtp(rootView: ViewGroup) {
+    private fun hideNtp() {
         rootView.findViewById<View?>(R.id.includeNewBrowserTab)?.gone()
         rootView.findViewById<View?>(R.id.newTabContainerLayout)?.gone()
         rootView.findViewById<View?>(R.id.browserLayout)?.show()
         rootView.findViewById<View?>(R.id.webViewContainer)?.show()
     }
 
-    private fun removeWidget(rootView: ViewGroup): Boolean {
+    private fun removeWidget(): Boolean {
         var removed = false
         rootView.findViewById<View?>(R.id.inputModeTopRoot)?.let {
             rootView.removeView(it)
@@ -307,121 +229,9 @@ class RealNativeInputManager @Inject constructor(
         return removed
     }
 
-    private fun hideOmnibarBackground(omnibar: Omnibar, rootView: ViewGroup) {
-        val omnibarView = omnibar.omnibarView as? View ?: return
-
-        val toolbarContainer = omnibarView.findViewById<View?>(R.id.toolbarContainer)
-        val cardShadow = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)
-        val innerCard = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
-        val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
-        val aiIcon = omnibarView.findViewById<View?>(R.id.aiIcon)
-        val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
-        val leadingIconContainer = omnibarView.findViewById<View?>(R.id.omnibarIconContainer)
-        val shieldIcon = omnibarView.findViewById<View?>(R.id.shieldIcon)
-        val omnibarTextInput = omnibarView.findViewById<View?>(R.id.omnibarTextInput)
-        val pageLoadingIndicator = omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)
-        val fireIconMenu = omnibarView.findViewById<View?>(R.id.fireIconMenu)
-        val tabsMenu = omnibarView.findViewById<View?>(R.id.tabsMenu)
-        val browserMenu = omnibarView.findViewById<View?>(R.id.browserMenu)
-
-        fun apply() {
-            if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
-            toolbarContainer?.setBackgroundColor(Color.TRANSPARENT)
-            cardShadow?.setCardBackgroundColor(Color.TRANSPARENT)
-            cardShadow?.cardElevation = 0f
-            innerCard?.setCardBackgroundColor(Color.TRANSPARENT)
-            leadingIconContainer?.gone()
-            shieldIcon?.gone()
-            omnibarTextInput?.gone()
-            pageLoadingIndicator?.gone()
-            fireIconMenu?.show()
-            tabsMenu?.show()
-            browserMenu?.show()
-            header?.show()
-            header?.gravity = Gravity.CENTER_VERTICAL or Gravity.START
-            header?.setBackgroundColor(Color.TRANSPARENT)
-            aiIcon?.gone()
-            aiTitle?.show()
-            aiTitle?.setTextAppearance(com.google.android.material.R.style.TextAppearance_MaterialComponents_Headline6)
-        }
-
-        apply()
-        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
-        omnibarView.addOnLayoutChangeListener(listener)
-        omnibarView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-                override fun onViewDetachedFromWindow(v: View) {
-                    omnibarView.removeOnLayoutChangeListener(listener)
-                    v.removeOnAttachStateChangeListener(this)
-                }
-            },
-        )
-    }
-
-    private fun restoreOmnibar(omnibar: Omnibar, rootView: ViewGroup) {
-        val omnibarView = omnibar.omnibarView as? View
-        if (omnibarView != null) {
-            val ctx = omnibarView.context
-            omnibarView.findViewById<View?>(R.id.toolbarContainer)
-                ?.setBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar))
-            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
-                setCardBackgroundColor(ctx.getColorFromAttr(com.google.android.material.R.attr.colorSurface))
-                cardElevation = 1f.toPx()
-            }
-            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
-                ?.setCardBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorWindow))
-        }
-
-        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
-            val params = omnibarView?.layoutParams as? CoordinatorLayout.LayoutParams
-            if (params?.gravity == Gravity.TOP) {
-                omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> { gravity = Gravity.BOTTOM }
-                val parent = omnibarView.parent as? ViewGroup
-                parent?.removeView(omnibarView)
-                parent?.addView(omnibarView)
-                omnibarView.elevation = 0f
-                rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                    behavior = BottomOmnibarBrowserContainerLayoutBehavior()
-                }
-            }
-        }
-
-        if (omnibar.omnibarType == OmnibarType.SPLIT) {
-            rootView.findViewById<View?>(R.id.navigationBar)?.show()
-        }
-
-        omnibar.isScrollingEnabled = true
-    }
-
-    private fun forceOmnibarTop(omnibar: Omnibar, rootView: ViewGroup) {
-        val omnibarView = omnibar.omnibarView as? View ?: return
-        val parent = omnibarView.parent as? ViewGroup ?: return
-
-        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
-            omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                gravity = Gravity.TOP
-            }
-            parent.removeView(omnibarView)
-            parent.addView(omnibarView, 0)
-            omnibarView.elevation = 1f.toPx()
-
-            val topBehavior = TopOmnibarBrowserContainerLayoutBehavior(rootView.context, null)
-            rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                behavior = topBehavior
-            }
-        }
-        omnibar.isScrollingEnabled = false
-        omnibar.setExpanded(true)
-    }
-
-    private fun createWidgetView(
-        layoutInflater: LayoutInflater,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ): View {
+    private fun createWidgetView(layoutInflater: LayoutInflater): View {
         val layoutRes =
-            if (isWidgetBottom(omnibar)) {
+            if (layoutCoordinator.isWidgetBottom()) {
                 R.layout.input_mode_widget_card_view_bottom
             } else {
                 R.layout.input_mode_widget_card_view
@@ -431,46 +241,26 @@ class RealNativeInputManager @Inject constructor(
 
     private fun bindWidget(
         widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
-        onSearchTextChanged: (String) -> Unit,
-        onClearAutocomplete: () -> Unit,
-        onSearchSubmitted: (String) -> Unit,
-        onChatSubmitted: (String) -> Unit,
-        onDuckAiChatSubmitted: (String) -> Unit,
-        onChatSuggestionSelected: (String) -> Unit,
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-        onStopTapped: () -> Unit,
+        callbacks: NativeInputCallbacks,
     ) {
-        bindMainButtons(widgetView, onFireButtonTapped, onTabSwitcherTapped, onMenuTapped)
-        widgetFrom(widgetView)?.onStopTapped = onStopTapped
-        bindTabCount(widgetView, lifecycleOwner, tabs)
-        bindSearchCallbacks(
-            widgetView,
-            rootView,
-            omnibar,
-            onSearchTextChanged,
-            onClearAutocomplete,
-            onSearchSubmitted,
-            onChatSubmitted,
-            onDuckAiChatSubmitted,
-        )
-        bindAutocompleteVisibility(widgetView, rootView, omnibar)
-        bindChatSuggestions(
-            widgetView = widgetView,
-            rootView = rootView,
-            omnibar = omnibar,
-            lifecycleOwner = lifecycleOwner,
-            onChatSuggestionSelected = onChatSuggestionSelected,
-        )
-        bindSearchTabAutocompleteClearing(widgetView, onClearAutocomplete)
-        applyInitialTabSelection(widgetView, omnibar)
-        applyMainButtonsVisibility(widgetView, omnibar)
-        applyBottomCardShape(widgetView, omnibar)
+        widgetFrom(widgetView)?.apply {
+            bindMainButtons(
+                onFireButtonTapped = callbacks.onFireButtonTapped,
+                onTabSwitcherTapped = callbacks.onTabSwitcherTapped,
+                onMenuTapped = callbacks.onMenuTapped,
+            )
+            onStopTapped = callbacks.onStopTapped
+            bindTabCount(lifecycleOwner, tabs.map { it.size })
+        }
+        bindSearchCallbacks(widgetView, callbacks)
+        bindAutocompleteVisibility(widgetView)
+        bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
+        bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
+        applyInitialTabSelection(widgetView)
+        applyMainButtonsVisibility(widgetView)
+        layoutCoordinator.applyBottomCardShape(widgetView)
     }
 
     private fun bindSearchTabAutocompleteClearing(
@@ -487,20 +277,13 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyInitialTabSelection(
-        widgetView: View,
-        omnibar: Omnibar,
-    ) {
-        if (omnibar.viewMode != DuckAI) return
+    private fun applyInitialTabSelection(widgetView: View) {
+        if (!omnibarController.isDuckAiMode()) return
         widgetFrom(widgetView)?.selectChatTab()
     }
 
-    private fun bindAutocompleteVisibility(
-        widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
-        if (omnibar.viewMode != DuckAI) return
+    private fun bindAutocompleteVisibility(widgetView: View) {
+        if (!omnibarController.isDuckAiMode()) return
         val widget = widgetFrom(widgetView) ?: return
         val autoCompleteList =
             rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
@@ -513,58 +296,32 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyMainButtonsVisibility(
-        widgetView: View,
-        omnibar: Omnibar,
-    ) {
-        widgetFrom(widgetView)?.setMainButtonsVisibility(omnibar.viewMode != DuckAI)
+    private fun applyMainButtonsVisibility(widgetView: View) {
+        widgetFrom(widgetView)?.setMainButtonsVisibility(!omnibarController.isDuckAiMode())
     }
 
-    private fun attachWidget(
-        widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
-        rootView.addView(widgetView, buildWidgetLayoutParams(omnibar))
-        if (isWidgetBottom(omnibar)) {
+    private fun attachWidget(widgetView: View) {
+        rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams())
+        if (layoutCoordinator.isWidgetBottom()) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
             rootView.findViewById<View?>(R.id.browserLayout)?.let {
                 it.setPadding(it.paddingLeft, it.paddingTop, it.paddingRight, 0)
             }
         }
-        configureAutocompleteLayout(widgetView, rootView, omnibar)
-        configureContentOffset(widgetView, rootView, omnibar)
-        widgetView.post { applyForcedBottomTranslation(widgetView, rootView, omnibar) }
-        if (omnibar.viewMode != DuckAI) {
+        layoutCoordinator.configureAutocompleteLayout(widgetView)
+        layoutCoordinator.configureContentOffset(widgetView)
+        widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView) }
+        if (!omnibarController.isDuckAiMode()) {
             widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
         }
     }
 
-    private fun applyBottomCardShape(
-        widgetView: View,
-        omnibar: Omnibar,
-    ) {
-        if (!isWidgetBottom(omnibar)) return
-        val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
-        val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
-        card.shapeAppearanceModel =
-            card.shapeAppearanceModel
-                .toBuilder()
-                .setTopLeftCornerSize(radius)
-                .setTopRightCornerSize(radius)
-                .setBottomLeftCornerSize(0f)
-                .setBottomRightCornerSize(0f)
-                .build()
-    }
-
     private fun bindChatSuggestions(
         widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
         lifecycleOwner: LifecycleOwner,
         onChatSuggestionSelected: (String) -> Unit,
     ) {
-        if (omnibar.viewMode == DuckAI) return
+        if (omnibarController.isDuckAiMode()) return
         if (!duckChat.isChatSuggestionsFeatureAvailable()) return
         val widget = widgetFrom(widgetView) ?: return
         val autoCompleteList =
@@ -574,7 +331,7 @@ class RealNativeInputManager @Inject constructor(
         widget.bindChatSuggestions(
             lifecycleOwner = lifecycleOwner,
             onChatSuggestionSelected = onChatSuggestionSelected,
-            onChatTabSelected = { omnibar.hide() },
+            onChatTabSelected = { omnibarController.hide() },
             onShowSuggestions = { chatAdapter ->
                 adapter = adapter ?: autoCompleteList.adapter
                 autoCompleteList.adapter = chatAdapter
@@ -591,192 +348,6 @@ class RealNativeInputManager @Inject constructor(
                 if (hideList) {
                     autoCompleteList.gone()
                     focusedView?.gone()
-                }
-            },
-        )
-    }
-
-    private fun configureAutocompleteLayout(
-        widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
-        val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
-        val focusedView = rootView.findViewById<View?>(R.id.focusedView)
-        val baseElevation = maxOf(autoCompleteList.elevation, focusedView?.elevation ?: 0f)
-        val targetElevation = baseElevation + widgetView.resources.displayMetrics.density
-        widgetView.elevation = maxOf(widgetView.elevation, targetElevation)
-        widgetView.bringToFront()
-
-        val targets =
-            buildList {
-                add(autoCompleteList to autoCompleteList.snapshotPadding())
-                focusedView?.let { add(it to it.snapshotPadding()) }
-            }
-        fun applyPadding(deltaTop: Int, deltaBottom: Int) {
-            targets.forEach { (view, padding) ->
-                view.setPadding(
-                    padding.left,
-                    padding.top + deltaTop,
-                    padding.right,
-                    padding.bottom + deltaBottom,
-                )
-            }
-        }
-
-        fun applyForWidgetPosition() {
-            val isBottom = isWidgetBottom(omnibar)
-            val topOffset = if (isBottom) 0 else maxOf(0, widgetView.bottom - autoCompleteList.top)
-            val bottomOffset = if (isBottom) maxOf(0, autoCompleteList.bottom - widgetView.top) else 0
-            applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
-        }
-
-        widgetView.post { applyForWidgetPosition() }
-        val layoutListener =
-            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                applyForWidgetPosition()
-            }
-        widgetView.addOnLayoutChangeListener(layoutListener)
-        autoCompleteList.addOnLayoutChangeListener(layoutListener)
-        focusedView?.addOnLayoutChangeListener(layoutListener)
-        widgetView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-
-                override fun onViewDetachedFromWindow(v: View) {
-                    applyPadding(deltaTop = 0, deltaBottom = 0)
-                    v.removeOnLayoutChangeListener(layoutListener)
-                    autoCompleteList.removeOnLayoutChangeListener(layoutListener)
-                    focusedView?.removeOnLayoutChangeListener(layoutListener)
-                    v.removeOnAttachStateChangeListener(this)
-                }
-            },
-        )
-    }
-
-    private fun configureContentOffset(
-        widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
-        data class Target(val view: View, val basePadding: Padding)
-        val newTabContent =
-            rootView.findViewById<View?>(R.id.newTabPage)
-                ?: rootView.findViewById(R.id.includeNewBrowserTab)
-        val targets =
-            listOfNotNull(
-                rootView.findViewById(R.id.browserLayout),
-                newTabContent,
-            ).map { Target(it, it.snapshotPadding()) }
-        if (targets.isEmpty()) return
-        val anchor = widgetView.findViewById(R.id.inputModeWidgetCard) ?: widgetView
-
-        val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
-
-        fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
-            view.setPadding(
-                padding.left,
-                padding.top + deltaTop,
-                padding.right,
-                padding.bottom + deltaBottom,
-            )
-        }
-
-        fun applyOffset() {
-            if (!widgetView.isShown) {
-                targets.forEach { target ->
-                    applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
-                }
-                return
-            }
-            val isBottom = isWidgetBottom(omnibar)
-            val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
-            val anchorBottomInWindow = anchorLocation[1] + anchor.height
-            targets.forEach { target ->
-                val view = target.view
-                val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
-                val deltaTop = if (isBottom) 0 else maxOf(0, anchorBottomInWindow - viewLocation[1])
-                val deltaBottom =
-                    if (isBottom) {
-                        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
-                            maxOf(0, overlap)
-                        } else {
-                            maxOf(0, anchor.height - overlap)
-                        }
-                    } else {
-                        0
-                    }
-                applyPadding(view, target.basePadding, deltaTop, deltaBottom)
-            }
-        }
-
-        widgetView.post { applyOffset() }
-        val layoutListener =
-            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                applyOffset()
-            }
-        widgetView.addOnLayoutChangeListener(layoutListener)
-        rootView.addOnLayoutChangeListener(layoutListener)
-        widgetView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-
-                override fun onViewDetachedFromWindow(v: View) {
-                    targets.forEach { target ->
-                        applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
-                    }
-                    v.removeOnLayoutChangeListener(layoutListener)
-                    rootView.removeOnLayoutChangeListener(layoutListener)
-                    v.removeOnAttachStateChangeListener(this)
-                }
-            },
-        )
-    }
-
-    private fun buildWidgetLayoutParams(
-        omnibar: Omnibar,
-    ): ViewGroup.LayoutParams {
-        return CoordinatorLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-        ).apply {
-            gravity = if (isWidgetBottom(omnibar)) Gravity.BOTTOM else Gravity.TOP
-        }
-    }
-
-    private fun isWidgetBottom(omnibar: Omnibar): Boolean {
-        return omnibar.viewMode == DuckAI || omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM
-    }
-
-    private fun applyForcedBottomTranslation(
-        widgetView: View,
-        rootView: ViewGroup,
-        omnibar: Omnibar,
-    ) {
-        val shouldForce = isWidgetBottom(omnibar) && omnibar.omnibarType != OmnibarType.SINGLE_BOTTOM
-        if (!shouldForce) {
-            widgetView.translationY = 0f
-            return
-        }
-        fun applyOffset() {
-            val gap = maxOf(0, rootView.height - widgetView.bottom)
-            if (widgetView.translationY != gap.toFloat()) {
-                widgetView.translationY = gap.toFloat()
-            }
-        }
-        applyOffset()
-        val layoutListener =
-            View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                applyOffset()
-            }
-        rootView.addOnLayoutChangeListener(layoutListener)
-        widgetView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-
-                override fun onViewDetachedFromWindow(v: View) {
-                    rootView.removeOnLayoutChangeListener(layoutListener)
-                    v.removeOnAttachStateChangeListener(this)
                 }
             },
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.graphics.Color
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.omnibar.Omnibar
+import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.DuckAI
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
+import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
+import com.google.android.material.card.MaterialCardView
+
+interface OmnibarState {
+    fun isDuckAiMode(): Boolean
+    fun isBrowserMode(): Boolean
+    fun isOmnibarBottom(): Boolean
+}
+
+interface NativeInputOmnibarController : OmnibarState {
+    fun show()
+    fun hide()
+    fun getText(): String
+    fun hideBackground()
+    fun restore()
+    fun forceToTop()
+}
+
+class RealNativeInputOmnibarController(
+    private val omnibar: Omnibar,
+    private val rootView: ViewGroup,
+) : NativeInputOmnibarController {
+
+    override fun isDuckAiMode(): Boolean = omnibar.viewMode == DuckAI
+
+    override fun isBrowserMode(): Boolean = omnibar.viewMode is Omnibar.ViewMode.Browser
+
+    override fun isOmnibarBottom(): Boolean =
+        omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM
+
+    override fun show() = omnibar.show()
+
+    override fun hide() = omnibar.hide()
+
+    override fun getText(): String = omnibar.getText()
+
+    override fun hideBackground() {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+
+        val toolbarContainer = omnibarView.findViewById<View?>(R.id.toolbarContainer)
+        val cardShadow = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)
+        val innerCard = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+        val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
+        val aiIcon = omnibarView.findViewById<View?>(R.id.aiIcon)
+        val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
+        val leadingIconContainer = omnibarView.findViewById<View?>(R.id.omnibarIconContainer)
+        val shieldIcon = omnibarView.findViewById<View?>(R.id.shieldIcon)
+        val omnibarTextInput = omnibarView.findViewById<View?>(R.id.omnibarTextInput)
+        val pageLoadingIndicator = omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)
+        val fireIconMenu = omnibarView.findViewById<View?>(R.id.fireIconMenu)
+        val tabsMenu = omnibarView.findViewById<View?>(R.id.tabsMenu)
+        val browserMenu = omnibarView.findViewById<View?>(R.id.browserMenu)
+
+        fun apply() {
+            if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
+            toolbarContainer?.setBackgroundColor(Color.TRANSPARENT)
+            cardShadow?.setCardBackgroundColor(Color.TRANSPARENT)
+            cardShadow?.cardElevation = 0f
+            innerCard?.setCardBackgroundColor(Color.TRANSPARENT)
+            leadingIconContainer?.gone()
+            shieldIcon?.gone()
+            omnibarTextInput?.gone()
+            pageLoadingIndicator?.gone()
+            fireIconMenu?.show()
+            tabsMenu?.show()
+            browserMenu?.show()
+            header?.show()
+            header?.gravity = Gravity.CENTER_VERTICAL or Gravity.START
+            header?.setBackgroundColor(Color.TRANSPARENT)
+            aiIcon?.gone()
+            aiTitle?.show()
+            aiTitle?.setTextAppearance(com.google.android.material.R.style.TextAppearance_MaterialComponents_Headline6)
+        }
+
+        apply()
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
+        omnibarView.addOnLayoutChangeListener(listener)
+        omnibarView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+                override fun onViewDetachedFromWindow(v: View) {
+                    omnibarView.removeOnLayoutChangeListener(listener)
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+    }
+
+    override fun restore() {
+        val omnibarView = omnibar.omnibarView as? View
+        if (omnibarView != null) {
+            val ctx = omnibarView.context
+            omnibarView.findViewById<View?>(R.id.toolbarContainer)
+                ?.setBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar))
+            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
+                setCardBackgroundColor(ctx.getColorFromAttr(com.google.android.material.R.attr.colorSurface))
+                cardElevation = 1f.toPx()
+            }
+            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+                ?.setCardBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorWindow))
+        }
+
+        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
+            val params = omnibarView?.layoutParams as? CoordinatorLayout.LayoutParams
+            if (params?.gravity == Gravity.TOP) {
+                omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> { gravity = Gravity.BOTTOM }
+                val parent = omnibarView.parent as? ViewGroup
+                parent?.removeView(omnibarView)
+                parent?.addView(omnibarView)
+                omnibarView.elevation = 0f
+                rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                    behavior = BottomOmnibarBrowserContainerLayoutBehavior()
+                }
+            }
+        }
+
+        if (omnibar.omnibarType == OmnibarType.SPLIT) {
+            rootView.findViewById<View?>(R.id.navigationBar)?.show()
+        }
+
+        omnibar.isScrollingEnabled = true
+    }
+
+    override fun forceToTop() {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        val parent = omnibarView.parent as? ViewGroup ?: return
+
+        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
+            omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                gravity = Gravity.TOP
+            }
+            parent.removeView(omnibarView)
+            parent.addView(omnibarView, 0)
+            omnibarView.elevation = 1f.toPx()
+
+            val topBehavior = TopOmnibarBrowserContainerLayoutBehavior(rootView.context, null)
+            rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                behavior = topBehavior
+            }
+        }
+        omnibar.isScrollingEnabled = false
+        omnibar.setExpanded(true)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213566799053025?focus=true

### Description

- Extracts layout coordination into `NativeInputLayoutCoordinator`
- Extracts omnibar related code into `NativeInputOmnibarController`
- Also cleans up interfaces

### Steps to test this PR

- [ ] Smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how the native input widget integrates with the omnibar and page layout, which can subtly affect view positioning, padding, focus/keyboard behavior, and DuckAI mode transitions. Risk is localized to browser UI but could cause regressions in layout or back/keyboard handling.
> 
> **Overview**
> Refactors native input integration by introducing `NativeInputOmnibarController` (omnibar show/hide, background/position forcing, restore) and `NativeInputLayoutCoordinator` (widget gravity, padding/elevation offsets, forced bottom translation), moving UI-manipulation logic out of `RealNativeInputManager`.
> 
> Updates `NativeInputManager` to be fragment-scoped, requires `init(omnibar, rootView, lifecycleOwner)`, and consolidates the many event lambdas into a single `NativeInputCallbacks` object; `BrowserTabFragment` is updated accordingly and now calls `hideNativeInput()`/`onKeyboardVisibilityChanged()` without passing views/omnibar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aad64c7aa5381074a667f7fe3ddf01034f42567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->