### PR TITLE
PIR: Reset PIR only when coming from canRunPIR state

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
@@ -30,10 +30,12 @@ class FakePirDataStore : PirDataStore {
     override var weeklyStatLastSentMs: Long = 0L
     override var hasBrokerConfigBeenManuallyUpdated: Boolean = false
     override var latestBackgroundScanRunInMs: Long = 0L
+    override var featureReceivedMs: Long = 0L
 
     override fun reset() {
         mainConfigEtag = null
         hasBrokerConfigBeenManuallyUpdated = false
+        featureReceivedMs = 0L
         resetUserData()
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
@@ -19,10 +19,12 @@ package com.duckduckgo.pir.impl.brokers
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
@@ -40,6 +42,8 @@ class PirDataUpdateObserver @Inject constructor(
     private val brokerJsonUpdater: BrokerJsonUpdater,
     private val pirWorkHandler: PirWorkHandler,
     private val pirFeatureDataCleaner: PirFeatureDataCleaner,
+    private val pirRepository: PirRepository,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : MainProcessLifecycleObserver {
     override fun onCreate(owner: LifecycleOwner) {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -47,7 +51,13 @@ class PirDataUpdateObserver @Inject constructor(
             pirWorkHandler
                 .canRunPir()
                 .collectLatest { enabled ->
+                    val featureReceiveMs = pirRepository.getFeatureReceivedMs()
                     if (enabled) {
+                        // We only set the value if it was not set previously
+                        if (featureReceiveMs == 0L) {
+                            pirRepository.setFeatureReceivedMs(currentTimeProvider.currentTimeMillis())
+                        }
+
                         logcat { "PIR-update: Attempting to update all broker data" }
                         if (brokerJsonUpdater.update()) {
                             logcat { "PIR-update: Update successfully completed." }
@@ -56,9 +66,14 @@ class PirDataUpdateObserver @Inject constructor(
                         }
                     } else {
                         logcat { "PIR-update: PIR not enabled" }
-                        // This will also cancel any ongoing work that is currently running if PIR is not enabled
-                        pirWorkHandler.cancelWork()
-                        pirFeatureDataCleaner.removeAllData()
+                        // We also check the etag to handle scenarios where featureReceiveMs was not yet available
+                        if (featureReceiveMs != 0L || pirRepository.getCurrentMainEtag() != null) {
+                            logcat { "PIR-update: resetting feature" }
+                            // This will also cancel any ongoing work that is currently running if PIR is not enabled
+                            // This will also clear the featureReceivedMs
+                            pirWorkHandler.cancelWork()
+                            pirFeatureDataCleaner.removeAllData()
+                        }
                     }
                 }
         }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
@@ -29,6 +29,7 @@ interface PirDataStore {
     var weeklyStatLastSentMs: Long
     var hasBrokerConfigBeenManuallyUpdated: Boolean
     var latestBackgroundScanRunInMs: Long
+    var featureReceivedMs: Long
 
     fun reset()
     fun resetUserData()
@@ -108,9 +109,18 @@ internal class RealPirDataStore(
             }
         }
 
+    override var featureReceivedMs: Long
+        get() = preferences.getLong(KEY_FEATURE_RECEIVED_MS, 0L)
+        set(value) {
+            preferences.edit {
+                putLong(KEY_FEATURE_RECEIVED_MS, value)
+            }
+        }
+
     override fun reset() {
         mainConfigEtag = null
         hasBrokerConfigBeenManuallyUpdated = false
+        featureReceivedMs = 0L
         resetUserData()
     }
 
@@ -133,5 +143,6 @@ internal class RealPirDataStore(
         private const val KEY_WEEKLY_STATS_LAST_SENT_MS = "KEY_WEEKLY_STATS_LAST_SENT_MS"
         private const val KEY_BROKER_CONFIG_MANUALLY_UPDATED = "KEY_BROKER_CONFIG_MANUALLY_UPDATED"
         private const val KEY_LAST_BG_SCAN_RUN = "KEY_LAST_BG_SCAN_RUN_MS"
+        private const val KEY_FEATURE_RECEIVED_MS = "KEY_FEATURE_RECEIVED_MS"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -69,6 +69,16 @@ interface PirRepository {
      */
     suspend fun isRepositoryAvailable(): Boolean
 
+    /**
+     * Returns the time in ms when the feature was first allowed to be run on the user's device. If the feature is not allowed to be run, we get 0L.
+     */
+    suspend fun getFeatureReceivedMs(): Long
+
+    /**
+     * Set the time in ms when the feature was first allowed to be run on the user's device
+     */
+    suspend fun setFeatureReceivedMs(long: Long)
+
     suspend fun getCurrentMainEtag(): String?
 
     suspend fun updateMainEtag(etag: String?)
@@ -293,6 +303,16 @@ class RealPirRepository(
     private val addressCityStateAdapter by lazy { Moshi.Builder().build().adapter(AddressCityState::class.java) }
 
     override suspend fun isRepositoryAvailable(): Boolean = database.await() != null
+
+    override suspend fun getFeatureReceivedMs(): Long = withContext(dispatcherProvider.io()) {
+        pirDataStore.featureReceivedMs
+    }
+
+    override suspend fun setFeatureReceivedMs(long: Long) {
+        withContext(dispatcherProvider.io()) {
+            pirDataStore.featureReceivedMs = long
+        }
+    }
 
     override suspend fun getCurrentMainEtag(): String? = pirDataStore.mainConfigEtag
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
@@ -19,13 +19,16 @@ package com.duckduckgo.pir.impl.brokers
 import androidx.lifecycle.Lifecycle.State.INITIALIZED
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.store.PirRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -42,6 +45,8 @@ class PirDataUpdateObserverTest {
     private val brokerJsonUpdater: BrokerJsonUpdater = mock()
     private val pirWorkHandler: PirWorkHandler = mock()
     private val pirFeatureDataCleaner: PirFeatureDataCleaner = mock()
+    private val pirRepository: PirRepository = mock()
+    private val currentTimeProvider: CurrentTimeProvider = mock()
     private val canRunPirFlow = MutableStateFlow(false)
 
     private lateinit var pirDataUpdateObserver: PirDataUpdateObserver
@@ -49,6 +54,8 @@ class PirDataUpdateObserverTest {
     @Before
     fun setUp() = runTest {
         whenever(pirWorkHandler.canRunPir()).thenReturn(canRunPirFlow)
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
 
         pirDataUpdateObserver = PirDataUpdateObserver(
             coroutineScope = coroutineRule.testScope,
@@ -56,29 +63,31 @@ class PirDataUpdateObserverTest {
             brokerJsonUpdater = brokerJsonUpdater,
             pirWorkHandler = pirWorkHandler,
             pirFeatureDataCleaner = pirFeatureDataCleaner,
+            pirRepository = pirRepository,
+            currentTimeProvider = currentTimeProvider,
         )
     }
 
     @Test
-    fun whenOnCreateAndPIRIsNotEnabledThenCancelsWork() = runTest {
+    fun whenOnCreateAndPIRWasNeverEnabledAndIsNotEnabledThenDoNotCancelWork() = runTest {
         pirDataUpdateObserver.onCreate(lifecycleOwner)
         canRunPirFlow.value = false
 
-        verify(pirWorkHandler).cancelWork()
-        verify(pirFeatureDataCleaner).removeAllData()
+        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirFeatureDataCleaner, never()).removeAllData()
         verify(brokerJsonUpdater, never()).update()
     }
 
     @Test
     fun whenOnCreateAndPIRStateChangesFromEnabledToDisabledThenCancelsWork() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
+        // First call (enabled): 0L so featureReceivedMs gets set; second call (disabled): non-zero to trigger cleanup
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L, 1000L)
 
-        // First enable PIR
         canRunPirFlow.value = true
         pirDataUpdateObserver.onCreate(lifecycleOwner)
         verify(brokerJsonUpdater).update()
 
-        // Then disable PIR
         canRunPirFlow.value = false
         verify(pirWorkHandler).cancelWork()
         verify(pirFeatureDataCleaner).removeAllData()
@@ -90,10 +99,10 @@ class PirDataUpdateObserverTest {
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        // First PIR is disabled
+        // PIR starts disabled — featureReceivedMs is 0L so no cleanup should happen
         canRunPirFlow.value = false
-        verify(pirWorkHandler).cancelWork()
-        verify(pirFeatureDataCleaner).removeAllData()
+        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirFeatureDataCleaner, never()).removeAllData()
 
         // Then enable PIR
         canRunPirFlow.value = true
@@ -107,23 +116,22 @@ class PirDataUpdateObserverTest {
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        // Enable PIR multiple times
+        // MutableStateFlow deduplicates same values, so no additional emissions
         canRunPirFlow.value = true
         canRunPirFlow.value = true
         canRunPirFlow.value = true
 
-        // Should call update only once
         verify(brokerJsonUpdater, times(1)).update()
         verifyNoInteractions(pirFeatureDataCleaner)
     }
 
     @Test
-    fun whenOnCreateWithPIRDisabledThenCancelWork() = runTest {
+    fun whenOnCreateWithPIRNeverEnabledAndDisabledThenDoNotCancelWork() = runTest {
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        verify(pirWorkHandler).cancelWork()
+        verify(pirWorkHandler, never()).cancelWork()
         verify(brokerJsonUpdater, never()).update()
-        verify(pirFeatureDataCleaner).removeAllData()
+        verify(pirFeatureDataCleaner, never()).removeAllData()
     }
 
     @Test
@@ -136,5 +144,54 @@ class PirDataUpdateObserverTest {
         verify(brokerJsonUpdater).update()
         verify(pirWorkHandler, never()).cancelWork()
         verifyNoInteractions(pirFeatureDataCleaner)
+    }
+
+    @Test
+    fun whenPirEnabledForFirstTimeThenSetsFeatureReceivedMs() = runTest {
+        whenever(brokerJsonUpdater.update()).thenReturn(true)
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(12345L)
+
+        canRunPirFlow.value = true
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirRepository).setFeatureReceivedMs(12345L)
+    }
+
+    @Test
+    fun whenPirAlreadyEnabledPreviouslyThenDoesNotOverwriteFeatureReceivedMs() = runTest {
+        whenever(brokerJsonUpdater.update()).thenReturn(true)
+        // featureReceivedMs already set from a previous session
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(5000L)
+
+        canRunPirFlow.value = true
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirRepository, never()).setFeatureReceivedMs(any())
+    }
+
+    @Test
+    fun whenPirDisabledAndFeatureReceivedMsIsZeroButEtagPresentThenCleansUp() = runTest {
+        // Existing user upgrading from a version before featureReceivedMs was introduced:
+        // featureReceivedMs is 0L but an etag exists, meaning broker data was previously downloaded
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
+        whenever(pirRepository.getCurrentMainEtag()).thenReturn("some-etag")
+
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirWorkHandler).cancelWork()
+        verify(pirFeatureDataCleaner).removeAllData()
+    }
+
+    @Test
+    fun whenPirDisabledAndBothFeatureReceivedMsAndEtagAreUnsetThenDoesNotCleanUp() = runTest {
+        // Fresh install: no featureReceivedMs and no etag — nothing to clean up
+        whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
+        whenever(pirRepository.getCurrentMainEtag()).thenReturn(null)
+
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirFeatureDataCleaner, never()).removeAllData()
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
@@ -866,6 +866,22 @@ class RealPirRepositoryTest {
     }
 
     @Test
+    fun whenGetFeatureReceivedMsThenReturnValueFromDataStore() = runTest {
+        whenever(mockPirDataStore.featureReceivedMs).thenReturn(12345L)
+
+        val result = testee.getFeatureReceivedMs()
+
+        assertEquals(12345L, result)
+    }
+
+    @Test
+    fun whenSetFeatureReceivedMsThenDelegateToDataStore() = runTest {
+        testee.setFeatureReceivedMs(12345L)
+
+        verify(mockPirDataStore).featureReceivedMs = 12345L
+    }
+
+    @Test
     fun whenClearAllDataThenDeleteAllTables() = runTest {
         testee.clearAllData()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1213123233787087?focus=true 

### Description
This change ensures that:
- We store when the feature was first allowed on the device
- We clear when the feature was disallowed from the device
- We only reset the db and kill features when coming from a previously allowed state. Succeeding attempts to reset are not necessary after that

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1213569229601723?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR enable/disable lifecycle behavior and data cleanup conditions, which could affect when broker data/work is purged for existing users. Risk is mitigated by added unit tests but edge cases around state persistence/migration (etag vs `featureReceivedMs`) could still cause unexpected cleanup or stale data.
> 
> **Overview**
> **Tracks when PIR first becomes runnable and avoids redundant resets.** A new persisted `featureReceivedMs` timestamp is added to `PirDataStore`/`PirRepository` and is set once when `canRunPir()` first emits `true`.
> 
> **Tightens cleanup logic when PIR is disabled.** `PirDataUpdateObserver` now only cancels work and clears PIR data if the feature was previously enabled (`featureReceivedMs != 0`) *or* legacy broker data is detected via an existing main etag, preventing repeated/pointless resets on fresh installs.
> 
> Tests are updated/added to cover timestamp setting, non-overwrite behavior, and the new cleanup gating (including the migration etag fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ba226efff147ea0d1b6d72edfc77ba365ad3dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->