### PR TITLE
Restore ability to run adhoc maestro cloud release tests for hotfixes

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -1,35 +1,30 @@
-name: Release - Run E2E Maestro Tests
+name: Ad-hoc Release Tests - Maestro Cloud
 
 on:
   workflow_dispatch:
     inputs:
-      app-version:
-        description: 'App Version for Testing'
+      commit-ref:
+        description: 'Branch name, tag, or commit SHA to build and test'
         required: true
         default: 'PLACEHOLDER'
         type: string
-      test-tag:
-        description: 'Maestro Tests tag to include'
-        required: true
-        default: 'releaseTest'
-        type: string
-
-env:
-  ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
-  emoji_info: ":information_source:" # ℹ️
-  emoji_success: ":white_check_mark:" # ✅
-  emoji_failure: ":x:" # ❌
 
 jobs:
   run-release-tests:
     name: Create release APK and run E2E Maestro tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          submodules: recursive
+
       - name: Checkout and Assemble
         id: assemble
         uses: ./.github/actions/checkout-and-assemble
         with:
-          commit: ${{ inputs.app-version }}
+          commit: ${{ inputs.commit-ref }}
           flavours: 'play'
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
@@ -47,7 +42,7 @@ jobs:
           app-file: ${{ steps.assemble.outputs.play_apk_path }}
           android-api-level: 30
           workspace: .maestro
-          include-tags: ${{ inputs.test-tag }}
+          include-tags: releaseTest
 
       - name: Analyze Maestro Flow Results
         if: always()
@@ -67,15 +62,3 @@ jobs:
           echo "Release Tests Step Conclusion: ${{ steps.release-tests.conclusion }}" # From Maestro action itself
           echo "Analyzed Flow Summary Status: ${{ steps.analyze-flow-results.outputs.flow_summary_status }}" # From analyzer action
           printf "Analyzed Flow Summary Message:\n%s\n" "${{ steps.analyze-flow-results.outputs.flow_summary_message }}"
-
-      - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
-        id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: GH Workflow Failure - Tag Android Release (Robin)
-          asana-task-description: Run Release Tests in Maestro has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
-          action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1213422200354215?focus=true

### Description
Restores `release_tests.yml` to allow it to trigger release tests to run on Maestro Cloud from CI from an arbitrary commit hash

### Changes:                                                                                               
  - Add initial `develop` checkout so composite actions resolve correctly for hotfix refs                  
  - Remove `test-tag` input — always run `releaseTest`                                                       
  - Rename `app-version` input to `commit-ref` (accepts branches, tags, or SHAs)                             
  - Rename workflow to "Ad-hoc Release Tests - Maestro Cloud"
  - Remove Asana task creation on failure 


### Steps to test this PR
- QA optional
- Tested in runs https://github.com/duckduckgo/Android/actions/runs/22862027726 and https://github.com/duckduckgo/Android/actions/runs/22861749518 to run against a tag and a branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a manually-triggered CI workflow, though it affects how release-test runs are checked out and could break ad-hoc testing if refs/actions resolution is wrong.
> 
> **Overview**
> Restores/streamlines the ad-hoc Maestro Cloud release testing workflow so it can be run against an arbitrary branch/tag/SHA via a renamed `commit-ref` input.
> 
> The workflow now checks out `develop` first to ensure local composite actions resolve, always runs the `releaseTest` Maestro tag (removing the configurable `test-tag` input), and removes the Asana task creation and related env vars on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76c55454d09b7060886739c9d94bc72f2db17b4d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->