### PR TITLE
Implement COUNT_ALWAYS metric type and MetricsPixelNumericValue lint rule

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
@@ -54,7 +54,7 @@ class RealMetricsPixelSender @Inject constructor(
                 when (metricsPixel.type) {
                     MetricType.NORMAL -> sendNormal(definition)
                     MetricType.COUNT_WHEN_IN_WINDOW -> sendCount(definition, metricsPixel.value.toInt())
-                    MetricType.COUNT_ALWAYS -> Unit // TODO: not implemented yet
+                    MetricType.COUNT_ALWAYS -> sendCountAlways(definition, metricsPixel.value.toInt())
                 }
             }
         }
@@ -74,6 +74,18 @@ class RealMetricsPixelSender @Inject constructor(
         if (count >= threshold) return
         val newCount = store.increaseMetricForPixelDefinition(definition)
         if (newCount != threshold) return
+        val tag = tagFor(definition)
+        if (store.wasPixelFired(tag)) return
+        pixel.fire(definition.pixelName, definition.params)
+        store.storePixelTag(tag)
+    }
+
+    private suspend fun sendCountAlways(definition: PixelDefinition, threshold: Int) {
+        val count = store.getMetricForPixelDefinition(definition)
+        if (count >= threshold) return
+        val newCount = store.increaseMetricForPixelDefinition(definition)
+        if (newCount != threshold) return
+        if (!isInConversionWindow(definition)) return
         val tag = tagFor(definition)
         if (store.wasPixelFired(tag)) return
         pixel.fire(definition.pixelName, definition.params)

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
@@ -193,6 +193,54 @@ class RealMetricsPixelSenderTest {
         assertTrue(fakePixel.firedPixels.isEmpty())
     }
 
+    // COUNT_ALWAYS type tests
+
+    @Test
+    fun `COUNT_ALWAYS - pixel not fired before threshold reached`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "3", lowerWindow = 0, upperWindow = 1)
+        sender.send(pixel)
+        sender.send(pixel)
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - pixel fired when threshold reached in window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(3) { sender.send(pixel) }
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - pixel not fired again after threshold`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "3", lowerWindow = 0, upperWindow = 1)
+        repeat(5) { sender.send(pixel) }
+        assertEquals(1, fakePixel.firedPixels.size)
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - count incremented even when outside window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "3", lowerWindow = 5, upperWindow = 7)
+        repeat(2) { sender.send(pixel) }
+        val definition = pixel.getPixelDefinitions().first()
+        assertEquals(2, store.getMetricForPixelDefinition(definition))
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - pixel not fired when threshold reached outside window`() = runTest {
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "3", lowerWindow = 5, upperWindow = 7)
+        repeat(3) { sender.send(pixel) }
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - pixel not fired when no cohort assigned`() = runTest {
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(remoteEnableState = true, enable = true, assignedCohort = null),
+        )
+        sender.send(metricsPixel(type = MetricType.COUNT_ALWAYS, value = "1", lowerWindow = 0, upperWindow = 1))
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
     private fun metricsPixel(
         type: MetricType = MetricType.NORMAL,
         value: String = "1",

--- a/lint-rules/src/main/java/com/duckduckgo/lint/MetricsPixelNumericValueDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/MetricsPixelNumericValueDetector.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class MetricsPixelNumericValueDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableConstructorTypes() =
+        listOf("com.duckduckgo.feature.toggles.api.MetricsPixel")
+
+    override fun visitConstructor(context: JavaContext, node: UCallExpression, constructor: PsiMethod) {
+        val typeArg = findArgument(node, constructor, "type") ?: return
+        val typeText = typeArg.sourcePsi?.text ?: return
+        if (!typeText.contains("COUNT_WHEN_IN_WINDOW") && !typeText.contains("COUNT_ALWAYS")) return
+
+        val valueArg = findArgument(node, constructor, "value") ?: return
+        val valueStr = valueArg.evaluate() as? String ?: return
+
+        if (valueStr.toIntOrNull() == null) {
+            context.report(
+                NUMERIC_VALUE_REQUIRED,
+                valueArg,
+                context.getLocation(valueArg),
+                "`value` must be a valid integer string for COUNT_WHEN_IN_WINDOW/COUNT_ALWAYS pixel types (got \"$valueStr\")",
+            )
+        }
+    }
+
+    private fun findArgument(node: UCallExpression, constructor: PsiMethod, paramName: String): UExpression? {
+        val params = constructor.parameterList.parameters
+        val idx = params.indexOfFirst { it.name == paramName }
+        return if (idx >= 0 && idx < node.valueArguments.size) node.valueArguments[idx] else null
+    }
+
+    companion object {
+        val NUMERIC_VALUE_REQUIRED = Issue.create(
+            "MetricsPixelNumericValue",
+            "MetricsPixel value must be a numeric string for counting types",
+            "When MetricType is COUNT_WHEN_IN_WINDOW or COUNT_ALWAYS, the `value` field is " +
+                "called with `.toInt()` at runtime. Providing a non-integer string will crash.",
+            Category.CORRECTNESS,
+            10,
+            Severity.ERROR,
+            Implementation(
+                MetricsPixelNumericValueDetector::class.java,
+                EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+            ),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.lint.NoDispatcherComputation.Companion.ISSUE_AVOID_COMPUTA
 import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
 import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
 import com.duckduckgo.lint.NoImplImportsInAppModuleDetector.Companion.NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE
+import com.duckduckgo.lint.MetricsPixelNumericValueDetector.Companion.NUMERIC_VALUE_REQUIRED
 import com.duckduckgo.lint.NoMetricsPixelExtensionUsageDetector.Companion.NO_METRICS_PIXEL_EXTENSION_USAGE
 import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoLifecycleScopeInFragmentDetector.Companion.NO_LIFECYCLE_SCOPE_IN_FRAGMENT
@@ -70,6 +71,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_HARCODED_COROUTINE_DISPATCHER,
             NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE,
             NO_METRICS_PIXEL_EXTENSION_USAGE,
+            NUMERIC_VALUE_REQUIRED,
             MISSING_SMARTLING_REQUIRED_DIRECTIVES,
             MISSING_INSTRUCTION,
             PLACEHOLDER_MISSING_POSITION,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/MetricsPixelNumericValueDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/MetricsPixelNumericValueDetectorTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.MetricsPixelNumericValueDetector.Companion.NUMERIC_VALUE_REQUIRED
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class MetricsPixelNumericValueDetectorTest {
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW with valid integer value - no error`() {
+        lint()
+            .files(
+                metricsPixelStub(),
+                kt("""
+                    package com.duckduckgo.somefeature.impl
+
+                    import com.duckduckgo.feature.toggles.api.MetricsPixel
+                    import com.duckduckgo.feature.toggles.api.MetricType
+                    import com.duckduckgo.feature.toggles.api.ConversionWindow
+
+                    class SomeFeature {
+                        fun doSomething(toggle: Any) {
+                            MetricsPixel(
+                                metric = "some_metric",
+                                value = "3",
+                                toggle = toggle as com.duckduckgo.feature.toggles.api.Toggle,
+                                conversionWindow = listOf(ConversionWindow(0, 1)),
+                                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                            )
+                        }
+                    }
+                """).indented(),
+            )
+            .allowCompilationErrors()
+            .issues(NUMERIC_VALUE_REQUIRED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `COUNT_ALWAYS with valid integer value - no error`() {
+        lint()
+            .files(
+                metricsPixelStub(),
+                kt("""
+                    package com.duckduckgo.somefeature.impl
+
+                    import com.duckduckgo.feature.toggles.api.MetricsPixel
+                    import com.duckduckgo.feature.toggles.api.MetricType
+                    import com.duckduckgo.feature.toggles.api.ConversionWindow
+
+                    class SomeFeature {
+                        fun doSomething(toggle: Any) {
+                            MetricsPixel(
+                                metric = "some_metric",
+                                value = "5",
+                                toggle = toggle as com.duckduckgo.feature.toggles.api.Toggle,
+                                conversionWindow = listOf(ConversionWindow(0, 1)),
+                                type = MetricType.COUNT_ALWAYS,
+                            )
+                        }
+                    }
+                """).indented(),
+            )
+            .allowCompilationErrors()
+            .issues(NUMERIC_VALUE_REQUIRED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `NORMAL with non-integer value - no error`() {
+        lint()
+            .files(
+                metricsPixelStub(),
+                kt("""
+                    package com.duckduckgo.somefeature.impl
+
+                    import com.duckduckgo.feature.toggles.api.MetricsPixel
+                    import com.duckduckgo.feature.toggles.api.MetricType
+                    import com.duckduckgo.feature.toggles.api.ConversionWindow
+
+                    class SomeFeature {
+                        fun doSomething(toggle: Any) {
+                            MetricsPixel(
+                                metric = "some_metric",
+                                value = "not_a_number",
+                                toggle = toggle as com.duckduckgo.feature.toggles.api.Toggle,
+                                conversionWindow = listOf(ConversionWindow(0, 1)),
+                                type = MetricType.NORMAL,
+                            )
+                        }
+                    }
+                """).indented(),
+            )
+            .allowCompilationErrors()
+            .issues(NUMERIC_VALUE_REQUIRED)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW with non-integer value - error reported`() {
+        lint()
+            .files(
+                metricsPixelStub(),
+                kt("""
+                    package com.duckduckgo.somefeature.impl
+
+                    import com.duckduckgo.feature.toggles.api.MetricsPixel
+                    import com.duckduckgo.feature.toggles.api.MetricType
+                    import com.duckduckgo.feature.toggles.api.ConversionWindow
+
+                    class SomeFeature {
+                        fun doSomething(toggle: Any) {
+                            MetricsPixel(
+                                metric = "some_metric",
+                                value = "not_a_number",
+                                toggle = toggle as com.duckduckgo.feature.toggles.api.Toggle,
+                                conversionWindow = listOf(ConversionWindow(0, 1)),
+                                type = MetricType.COUNT_WHEN_IN_WINDOW,
+                            )
+                        }
+                    }
+                """).indented(),
+            )
+            .allowCompilationErrors()
+            .issues(NUMERIC_VALUE_REQUIRED)
+            .run()
+            .expectContains("MetricsPixelNumericValue")
+    }
+
+    @Test
+    fun `COUNT_ALWAYS with non-integer value - error reported`() {
+        lint()
+            .files(
+                metricsPixelStub(),
+                kt("""
+                    package com.duckduckgo.somefeature.impl
+
+                    import com.duckduckgo.feature.toggles.api.MetricsPixel
+                    import com.duckduckgo.feature.toggles.api.MetricType
+                    import com.duckduckgo.feature.toggles.api.ConversionWindow
+
+                    class SomeFeature {
+                        fun doSomething(toggle: Any) {
+                            MetricsPixel(
+                                metric = "some_metric",
+                                value = "not_a_number",
+                                toggle = toggle as com.duckduckgo.feature.toggles.api.Toggle,
+                                conversionWindow = listOf(ConversionWindow(0, 1)),
+                                type = MetricType.COUNT_ALWAYS,
+                            )
+                        }
+                    }
+                """).indented(),
+            )
+            .allowCompilationErrors()
+            .issues(NUMERIC_VALUE_REQUIRED)
+            .run()
+            .expectContains("MetricsPixelNumericValue")
+    }
+
+    private fun metricsPixelStub() = kt("""
+        package com.duckduckgo.feature.toggles.api
+
+        interface Toggle
+        enum class MetricType { NORMAL, COUNT_WHEN_IN_WINDOW, COUNT_ALWAYS }
+        data class ConversionWindow(val lowerWindow: Int, val upperWindow: Int)
+        data class MetricsPixel(
+            val metric: String,
+            val value: String,
+            val toggle: Toggle,
+            val conversionWindow: List<ConversionWindow>,
+            val type: MetricType,
+        )
+    """).indented()
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213579405769655

### Description

Implements `MetricType.COUNT_ALWAYS` in `RealMetricsPixelSender`, which was previously a no-op `TODO`. Unlike `COUNT_WHEN_IN_WINDOW`, this type always increments the counter regardless of whether the user is in the conversion window — but only fires the pixel when the threshold is reached AND the user is in the window at that moment.

Also adds a new `MetricsPixelNumericValue` lint rule that detects at compile time when a `MetricsPixel` with a counting type (`COUNT_WHEN_IN_WINDOW` or `COUNT_ALWAYS`) is constructed with a non-integer `value` string, which would crash at runtime due to `.toInt()`.

### Steps to test this PR

_COUNT_ALWAYS behaviour_
- [x] Verify counter increments even when the user is outside the conversion window
- [x] Verify the pixel is NOT fired when the threshold is reached outside the conversion window
- [x] Verify the pixel IS fired when the threshold is reached while inside the conversion window
- [x] Verify the pixel is not fired a second time after the threshold has been reached

_Lint rule_
- [ ] Confirm that `MetricsPixel(value = "not_a_number", type = MetricType.COUNT_ALWAYS, ...)` produces a lint error
- [x] Confirm that `MetricsPixel(value = "3", type = MetricType.COUNT_ALWAYS, ...)` is clean
- [x] Confirm that `MetricsPixel(value = "not_a_number", type = MetricType.NORMAL, ...)` is clean

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metrics pixel counting/firing behavior by implementing `MetricType.COUNT_ALWAYS`, which can affect analytics reporting if thresholds/windows are misconfigured. Adds a new lint error that may fail builds where counting pixels are constructed with non-integer `value` strings.
> 
> **Overview**
> Implements `MetricType.COUNT_ALWAYS` in `RealMetricsPixelSender`: counts are incremented regardless of conversion window, but the pixel is only fired once when the threshold is reached *and* the user is in the conversion window at that moment.
> 
> Adds a new lint check `MetricsPixelNumericValue` (registered in `DuckDuckGoIssueRegistry`) that raises an error when `MetricsPixel` is constructed with `COUNT_WHEN_IN_WINDOW`/`COUNT_ALWAYS` and a non-integer `value`, and expands unit/lint tests to cover the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4487fae498e5e392227c611fad333f56acaa0d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->