### PR TITLE
Update content scope scripts to version 13.29.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -1239,6 +1239,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data = {}) {
@@ -1310,9 +1312,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -1948,19 +1951,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data, e);
       }
     }
     /**
@@ -2046,6 +2049,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data, error);
+    }
+  }
+  function logNotificationError(env, name, data, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**
@@ -4844,7 +4867,7 @@
       });
       this.wrapProperty(globalThis.ScreenOrientation.prototype, "unlock", {
         value: () => {
-          this.messaging.request(MSG_SCREEN_UNLOCK, {});
+          void this.messaging.request(MSG_SCREEN_UNLOCK, {});
         }
       });
     }
@@ -6313,7 +6336,7 @@
           } catch {
           }
         }
-        this._executeFireEvent(detectorConfig, detected);
+        void this._executeFireEvent(detectorConfig, detected);
       } catch (e) {
         if (this.isDebug) {
           this.log.error(`Error running auto-detector ${fullDetectorId}:`, e);
@@ -6370,7 +6393,7 @@
               });
             }
           }
-          this._executeFireEvent(detectorConfig, detected);
+          void this._executeFireEvent(detectorConfig, detected);
         }
       }
       return results;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2779,6 +2779,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data2 = {}) {
@@ -2850,9 +2852,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -3493,19 +3496,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data2 = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data2
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data: data2 });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data2
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data2);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data2, e);
       }
     }
     /**
@@ -3591,6 +3594,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data2) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data2, error);
+    }
+  }
+  function logNotificationError(env, name, data2, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data: data2 });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**
@@ -9499,7 +9522,7 @@
     /**
      * Observes the removal of an element from the DOM.
      * @param {HTMLElement|Element} element
-     * @param {any} onRemoveCallback
+     * @param {() => void} onRemoveCallback
      */
     observeElementRemoval(element, onRemoveCallback) {
       const observer = new MutationObserver((mutations) => {
@@ -9834,7 +9857,7 @@
       return await this.runWithRetry(() => this.findExportId(), maxAttempts, interval, "linear");
     }
     urlChanged() {
-      this.handleLocation(window.location);
+      void this.handleLocation(window.location);
     }
     init() {
       if (isBeingFramed()) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2748,6 +2748,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data2 = {}) {
@@ -2819,9 +2821,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -3462,19 +3465,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data2 = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data2
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data: data2 });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data2
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data2);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data2, e);
       }
     }
     /**
@@ -3560,6 +3563,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data2) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data2, error);
+    }
+  }
+  function logNotificationError(env, name, data2, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data: data2 });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2645,6 +2645,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data = {}) {
@@ -2716,9 +2718,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -3359,19 +3362,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data, e);
       }
     }
     /**
@@ -3457,6 +3460,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data, error);
+    }
+  }
+  function logNotificationError(env, name, data, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**
@@ -7658,7 +7681,7 @@
       });
       this.wrapProperty(globalThis.ScreenOrientation.prototype, "unlock", {
         value: () => {
-          this.messaging.request(MSG_SCREEN_UNLOCK, {});
+          void this.messaging.request(MSG_SCREEN_UNLOCK, {});
         }
       });
     }
@@ -8297,7 +8320,7 @@
           } catch {
           }
         }
-        this._executeFireEvent(detectorConfig, detected);
+        void this._executeFireEvent(detectorConfig, detected);
       } catch (e) {
         if (this.isDebug) {
           this.log.error(`Error running auto-detector ${fullDetectorId}:`, e);
@@ -8354,7 +8377,7 @@
               });
             }
           }
-          this._executeFireEvent(detectorConfig, detected);
+          void this._executeFireEvent(detectorConfig, detected);
         }
       }
       return results;
@@ -11195,7 +11218,7 @@
             document.querySelector(this.settings.selectors.videoElement)
           );
           if (video?.isConnected) {
-            video.play();
+            void video.play();
           }
         };
       });
@@ -11442,7 +11465,7 @@
       });
       const comms = new DuckPlayerOverlayMessages(this.messaging, env);
       if (overlaysEnabled) {
-        initOverlays(overlaySettings.youtube, env, comms);
+        void initOverlays(overlaySettings.youtube, env, comms);
       } else if (serpProxyEnabled) {
         comms.serpProxy();
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -1203,6 +1203,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data = {}) {
@@ -1274,9 +1276,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -1912,19 +1915,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data, e);
       }
     }
     /**
@@ -2010,6 +2013,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data, error);
+    }
+  }
+  function logNotificationError(env, name, data, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -1203,6 +1203,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data = {}) {
@@ -1274,9 +1276,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -1912,19 +1915,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data
-      });
       try {
-        this.transport.notify(message);
-      } catch (e) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e);
-          console.error("[Messaging] Message details:", { name, data });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data);
         }
+      } catch (e) {
+        logNotificationError(this.messagingContext.env, name, data, e);
       }
     }
     /**
@@ -2010,6 +2013,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data, error);
+    }
+  }
+  function logNotificationError(env, name, data, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -430,6 +430,8 @@
      * Sends message to the webkit layer (fire and forget)
      * @param {String} handler
      * @param {*} data
+     * @returns {*}
+     * @throws {MissingHandler}
      * @internal
      */
     wkSend(handler, data = {}) {
@@ -501,9 +503,10 @@
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
+     * @returns {Promise<void>}
      */
-    notify(msg) {
-      this.wkSend(msg.context, msg);
+    async notify(msg) {
+      await this.wkSend(msg.context, msg);
     }
     /**
      * @param {import('../index.js').RequestMessage} msg
@@ -1172,19 +1175,19 @@
      * @param {Record<string, any>} [data]
      */
     notify(name, data = {}) {
-      const message = new NotificationMessage({
-        context: this.messagingContext.context,
-        featureName: this.messagingContext.featureName,
-        method: name,
-        params: data
-      });
       try {
-        this.transport.notify(message);
-      } catch (e3) {
-        if (this.messagingContext.env === "development") {
-          console.error("[Messaging] Failed to send notification:", e3);
-          console.error("[Messaging] Message details:", { name, data });
+        const message = new NotificationMessage({
+          context: this.messagingContext.context,
+          featureName: this.messagingContext.featureName,
+          method: name,
+          params: data
+        });
+        const maybeAsyncResult = this.transport.notify(message);
+        if (isPromiseLike(maybeAsyncResult)) {
+          void handleAsyncNotificationResult(maybeAsyncResult, this.messagingContext.env, name, data);
         }
+      } catch (e3) {
+        logNotificationError(this.messagingContext.env, name, data, e3);
       }
     }
     /**
@@ -1270,6 +1273,26 @@
       return new TestTransport(config, messagingContext);
     }
     throw new Error("unreachable");
+  }
+  function isPromiseLike(value) {
+    return value !== null && value !== void 0 && typeof /** @type {{then?: unknown}} */
+    value.then === "function";
+  }
+  async function handleAsyncNotificationResult(result, env, name, data) {
+    try {
+      await result;
+    } catch (error) {
+      logNotificationError(env, name, data, error);
+    }
+  }
+  function logNotificationError(env, name, data, error) {
+    if (env === "development") {
+      try {
+        console.error("[Messaging] Failed to send notification:", error);
+        console.error("[Messaging] Message details:", { name, data });
+      } catch {
+      }
+    }
   }
   var MissingHandler = class extends Error {
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.28.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.29.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.57.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.57.0.tgz",
-      "integrity": "sha512-0fsdgEpX/wO2VwnpnhlYB4JSdgMn0ivTZKJL1ABCcsDcDq3jwiIi7NlWOVR1f6oxVQ5oqWRhN2ekU+kxeVB52g==",
+      "version": "14.58.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.58.0.tgz",
+      "integrity": "sha512-7Bifmg7CFonMQub51Jve4EfTFD6x6GeEyugwKjKg+IA1wPJwf5gFz4D5Ix4jbJd/a/1nZWwIC6rsU6Sdh33jJA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dd2d1a2f2a2b601d1f3854f645efe561f494a7d2",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#13976e04d81eefac5a9c718d886ce99460a9123b",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
-      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.28.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.29.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213581221530204?focus=true

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the injected messaging bridge behavior to tolerate async `notify` implementations and suppress unhandled promise rejections, which could affect webkit/app communication if regressions slip in. Otherwise changes are largely defensive/error-handling tweaks plus dependency bumps.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` to `13.29.0` (and refreshes lockfile resolutions, e.g. `@duckduckgo/autoconsent` and `@types/node`).
> 
> The bundled Android scripts adjust messaging to **support async/Promise-like `notify` paths**: `WebkitMessagingTransport.notify` becomes `async`, `Messaging.notify` detects/handles promise rejections via centralized logging, and multiple call sites now explicitly discard returned promises with `void` to avoid unhandled rejections. Minor typing/docs tweaks are included (e.g., `wkSend` JSDoc, `observeElementRemoval` callback signature).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a4c181882669d27b9d81ce3119c9b7d51fd41e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->