### PR TITLE
Add develocity test retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,18 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
+// Develocity test retry configuration to detect flaky tests
+def isCI = System.getenv('CI') != null
+subprojects {
+    tasks.withType(Test).configureEach {
+        develocity.testRetry {
+            maxRetries = isCI ? 1 : 0
+            maxFailures = 5
+            failOnPassedAfterRetry = true
+        }
+    }
+}
+
 fladle {
     configs {
         serviceAccountCredentials.set(project.layout.projectDirectory.file("flank.json"))
@@ -193,6 +205,8 @@ fladle {
                     ["model": "Pixel2.arm", "version": "28"]
             ])
             localResultsDir.set("fladleResults")
+            // retry once, if it succeeds it will be reported as a flaky test
+            flakyTestAttempts.set(1)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1213191170200739?focus=true

### Description
Enables test retry to detect flaky tests.

### Steps to test this PR
N/A

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test behavior by retrying failed tests and failing builds when tests only pass after a retry, which could increase pipeline failures/noise if flakiness is present.
> 
> **Overview**
> Adds Develocity test-retry configuration for all Gradle `Test` tasks, enabling a single retry on CI (none locally), capping total failures, and marking *passed-after-retry* as a build failure to surface flaky tests.
> 
> Updates Firebase Test Lab (Fladle) `androidTests` to retry each flaky test once via `flakyTestAttempts`, so intermittent Android test failures are reported as flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88af2379e5b61a3f95da86d4e803c082da2f04a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->