### PR TITLE
Implement unfocussed native input state

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1272,11 +1272,6 @@ class BrowserTabFragment :
                     )
                 },
                 onChatSuggestionSelected = { query -> userEnteredQuery(query) },
-                onFireButtonTapped = { onFireButtonPressed() },
-                onTabSwitcherTapped = { launchTabSwitcher() },
-                onMenuTapped = {
-                    launchBrowserMenu(addExtraDelay = omnibarRepository.omnibarType == OmnibarType.SPLIT)
-                },
                 onStopTapped = {
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -54,6 +54,18 @@ class NativeInputLayoutCoordinator(
                 .setBottomLeftCornerSize(0f)
                 .setBottomRightCornerSize(0f)
                 .build()
+        card.useCompatPadding = false
+    }
+
+    fun applyRoundedCardShape(widgetView: View) {
+        val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
+        val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
+        card.shapeAppearanceModel =
+            card.shapeAppearanceModel
+                .toBuilder()
+                .setAllCornerSizes(radius)
+                .build()
+        card.useCompatPadding = true
     }
 
     fun configureAutocompleteLayout(widgetView: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
@@ -45,9 +46,6 @@ class NativeInputCallbacks(
     val onDuckAiChatSubmitted: (String) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
     val onClearAutocomplete: () -> Unit,
-    val onFireButtonTapped: () -> Unit,
-    val onTabSwitcherTapped: () -> Unit,
-    val onMenuTapped: () -> Unit,
     val onStopTapped: () -> Unit,
 )
 
@@ -109,29 +107,74 @@ class RealNativeInputManager @Inject constructor(
     }
 
     override fun onKeyboardVisibilityChanged(isVisible: Boolean) {
-        fun isDescendantOf(
-            ancestor: View,
-            view: View,
-        ): Boolean {
-            var current: View? = view
-            while (current != null) {
-                if (current === ancestor) return true
-                val parent = current.parent
-                current = parent as? View
-            }
-            return false
-        }
-
-        if (!isNativeInputFieldEnabled || isVisible) return
-
+        if (!isNativeInputFieldEnabled) return
         val widget = widgetFrom(rootView) ?: return
+        val widgetRoot = widget.asView().parent?.parent as? View
+
+        if (isVisible) {
+            onKeyboardShown(widgetRoot)
+        } else {
+            onKeyboardHidden(widget, widgetRoot)
+        }
+    }
+
+    private fun onKeyboardShown(widgetRoot: View?) {
+        if (omnibarController.isDuckAiMode() || omnibarController.isSplitMode()) return
+        omnibarController.hide()
+        setWidgetCardEndMargin(0)
+        widgetRoot?.translationZ = 0f
+        if (layoutCoordinator.isWidgetBottom() && widgetRoot != null) {
+            layoutCoordinator.applyBottomCardShape(widgetRoot)
+        }
+    }
+
+    private fun onKeyboardHidden(widget: NativeInputWidget, widgetRoot: View?) {
+        updateWidgetFocus(widget)
+        if (!omnibarController.isDuckAiMode() && !omnibarController.isSplitMode()) {
+            showTabsAndMenuButtons(widgetRoot)
+        }
+    }
+
+    private fun updateWidgetFocus(widget: NativeInputWidget) {
         val focusedView = rootView.findFocus()
-        val focusWithinWidget = focusedView?.let { isDescendantOf(widget.asView(), it) } ?: false
+        val focusWithinWidget = focusedView != null && isDescendantOf(widget.asView(), focusedView)
         if (widget.hasInputFocus() || !focusWithinWidget) {
             widget.clearInputFocus()
         } else {
             widget.requestInputFocus()
         }
+    }
+
+    private fun showTabsAndMenuButtons(widgetRoot: View?) {
+        omnibarController.showTabsAndMenuButtons()
+        widgetRoot?.let {
+            it.bringToFront()
+            it.translationZ = 8f.toPx()
+        }
+        if (widgetRoot != null) {
+            layoutCoordinator.applyRoundedCardShape(widgetRoot)
+        }
+        rootView.post {
+            if (widgetRoot != null && widgetRoot.translationZ != 0f) {
+                setWidgetCardEndMargin(omnibarController.getButtonsWidth())
+            }
+        }
+    }
+
+    private fun isDescendantOf(ancestor: View, view: View): Boolean {
+        var current: View? = view
+        while (current != null) {
+            if (current === ancestor) return true
+            current = current.parent as? View
+        }
+        return false
+    }
+
+    private fun setWidgetCardEndMargin(margin: Int) {
+        val card = rootView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return
+        val params = card.layoutParams as? ViewGroup.MarginLayoutParams ?: return
+        params.marginEnd = margin
+        card.layoutParams = params
     }
 
     override fun showNativeInput(
@@ -246,20 +289,15 @@ class RealNativeInputManager @Inject constructor(
         callbacks: NativeInputCallbacks,
     ) {
         widgetFrom(widgetView)?.apply {
-            bindMainButtons(
-                onFireButtonTapped = callbacks.onFireButtonTapped,
-                onTabSwitcherTapped = callbacks.onTabSwitcherTapped,
-                onMenuTapped = callbacks.onMenuTapped,
-            )
             onStopTapped = callbacks.onStopTapped
             bindTabCount(lifecycleOwner, tabs.map { it.size })
+            hideMainButtons()
         }
         bindSearchCallbacks(widgetView, callbacks)
         bindAutocompleteVisibility(widgetView)
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         applyInitialTabSelection(widgetView)
-        applyMainButtonsVisibility(widgetView)
         layoutCoordinator.applyBottomCardShape(widgetView)
     }
 
@@ -296,10 +334,6 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyMainButtonsVisibility(widgetView: View) {
-        widgetFrom(widgetView)?.setMainButtonsVisibility(!omnibarController.isDuckAiMode())
-    }
-
     private fun attachWidget(widgetView: View) {
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams())
         if (layoutCoordinator.isWidgetBottom()) {
@@ -331,7 +365,6 @@ class RealNativeInputManager @Inject constructor(
         widget.bindChatSuggestions(
             lifecycleOwner = lifecycleOwner,
             onChatSuggestionSelected = onChatSuggestionSelected,
-            onChatTabSelected = { omnibarController.hide() },
             onShowSuggestions = { chatAdapter ->
                 adapter = adapter ?: autoCompleteList.adapter
                 autoCompleteList.adapter = chatAdapter

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -39,6 +39,7 @@ interface OmnibarState {
     fun isDuckAiMode(): Boolean
     fun isBrowserMode(): Boolean
     fun isOmnibarBottom(): Boolean
+    fun isSplitMode(): Boolean
 }
 
 interface NativeInputOmnibarController : OmnibarState {
@@ -46,6 +47,8 @@ interface NativeInputOmnibarController : OmnibarState {
     fun hide()
     fun getText(): String
     fun hideBackground()
+    fun showTabsAndMenuButtons()
+    fun getButtonsWidth(): Int
     fun restore()
     fun forceToTop()
 }
@@ -55,12 +58,17 @@ class RealNativeInputOmnibarController(
     private val rootView: ViewGroup,
 ) : NativeInputOmnibarController {
 
+    private var layoutListener: View.OnLayoutChangeListener? = null
+
     override fun isDuckAiMode(): Boolean = omnibar.viewMode == DuckAI
 
     override fun isBrowserMode(): Boolean = omnibar.viewMode is Omnibar.ViewMode.Browser
 
     override fun isOmnibarBottom(): Boolean =
         omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM
+
+    override fun isSplitMode(): Boolean =
+        omnibar.omnibarType == OmnibarType.SPLIT
 
     override fun show() = omnibar.show()
 
@@ -70,89 +78,120 @@ class RealNativeInputOmnibarController(
 
     override fun hideBackground() {
         val omnibarView = omnibar.omnibarView as? View ?: return
+        applyOnLayout(omnibarView) {
+            makeOmnibarTransparent(omnibarView)
+            hideOmnibarContent(omnibarView)
+            showDuckAiTitle(omnibarView)
+            omnibarView.findViewById<View?>(R.id.fireIconMenu)?.show()
+            omnibarView.findViewById<View?>(R.id.tabsMenu)?.show()
+            omnibarView.findViewById<View?>(R.id.browserMenu)?.show()
+        }
+    }
 
-        val toolbarContainer = omnibarView.findViewById<View?>(R.id.toolbarContainer)
-        val cardShadow = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)
-        val innerCard = omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+    override fun showTabsAndMenuButtons() {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
+        omnibar.show()
+        omnibar.isScrollingEnabled = false
+        omnibar.setExpanded(true)
+        applyOnLayout(omnibarView) {
+            makeOmnibarTransparent(omnibarView)
+            hideOmnibarContent(omnibarView)
+            omnibarView.findViewById<View?>(R.id.duckAIHeader)?.gone()
+            omnibarView.findViewById<View?>(R.id.endIconsContainer)?.gone()
+            omnibarView.findViewById<View?>(R.id.duckAiSidebar)?.gone()
+            omnibarView.findViewById<View?>(R.id.fireIconMenu)?.gone()
+            omnibarView.findViewById<View?>(R.id.tabsMenu)?.show()
+            omnibarView.findViewById<View?>(R.id.browserMenu)?.show()
+        }
+    }
+
+    private fun makeOmnibarTransparent(omnibarView: View) {
+        omnibarView.findViewById<View?>(R.id.toolbarContainer)?.setBackgroundColor(Color.TRANSPARENT)
+        omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
+            setCardBackgroundColor(Color.TRANSPARENT)
+            cardElevation = 0f
+        }
+        omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)?.setCardBackgroundColor(Color.TRANSPARENT)
+    }
+
+    private fun hideOmnibarContent(omnibarView: View) {
+        omnibarView.findViewById<View?>(R.id.omnibarIconContainer)?.gone()
+        omnibarView.findViewById<View?>(R.id.shieldIcon)?.gone()
+        omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.gone()
+        omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)?.gone()
+    }
+
+    private fun showDuckAiTitle(omnibarView: View) {
         val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
-        val aiIcon = omnibarView.findViewById<View?>(R.id.aiIcon)
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
-        val leadingIconContainer = omnibarView.findViewById<View?>(R.id.omnibarIconContainer)
-        val shieldIcon = omnibarView.findViewById<View?>(R.id.shieldIcon)
-        val omnibarTextInput = omnibarView.findViewById<View?>(R.id.omnibarTextInput)
-        val pageLoadingIndicator = omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)
-        val fireIconMenu = omnibarView.findViewById<View?>(R.id.fireIconMenu)
+        omnibarView.findViewById<View?>(R.id.aiIcon)?.gone()
+        header?.show()
+        header?.gravity = Gravity.CENTER_VERTICAL or Gravity.START
+        header?.setBackgroundColor(Color.TRANSPARENT)
+        aiTitle?.show()
+        aiTitle?.setTextAppearance(com.google.android.material.R.style.TextAppearance_MaterialComponents_Headline6)
+    }
+
+    private fun applyOnLayout(omnibarView: View, block: () -> Unit) {
+        removeLayoutListener(omnibarView)
+        block()
+        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            if (rootView.findViewById<View?>(R.id.inputModeWidget) != null) block()
+        }
+        layoutListener = listener
+        omnibarView.addOnLayoutChangeListener(listener)
+    }
+
+    private fun removeLayoutListener(omnibarView: View) {
+        layoutListener?.let { omnibarView.removeOnLayoutChangeListener(it) }
+        layoutListener = null
+    }
+
+    override fun getButtonsWidth(): Int {
+        val omnibarView = omnibar.omnibarView as? View ?: return 0
         val tabsMenu = omnibarView.findViewById<View?>(R.id.tabsMenu)
         val browserMenu = omnibarView.findViewById<View?>(R.id.browserMenu)
-
-        fun apply() {
-            if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
-            toolbarContainer?.setBackgroundColor(Color.TRANSPARENT)
-            cardShadow?.setCardBackgroundColor(Color.TRANSPARENT)
-            cardShadow?.cardElevation = 0f
-            innerCard?.setCardBackgroundColor(Color.TRANSPARENT)
-            leadingIconContainer?.gone()
-            shieldIcon?.gone()
-            omnibarTextInput?.gone()
-            pageLoadingIndicator?.gone()
-            fireIconMenu?.show()
-            tabsMenu?.show()
-            browserMenu?.show()
-            header?.show()
-            header?.gravity = Gravity.CENTER_VERTICAL or Gravity.START
-            header?.setBackgroundColor(Color.TRANSPARENT)
-            aiIcon?.gone()
-            aiTitle?.show()
-            aiTitle?.setTextAppearance(com.google.android.material.R.style.TextAppearance_MaterialComponents_Headline6)
-        }
-
-        apply()
-        val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ -> apply() }
-        omnibarView.addOnLayoutChangeListener(listener)
-        omnibarView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-                override fun onViewDetachedFromWindow(v: View) {
-                    omnibarView.removeOnLayoutChangeListener(listener)
-                    v.removeOnAttachStateChangeListener(this)
-                }
-            },
-        )
+        return (tabsMenu?.width ?: 0) + (browserMenu?.width ?: 0)
     }
 
     override fun restore() {
-        val omnibarView = omnibar.omnibarView as? View
-        if (omnibarView != null) {
-            val ctx = omnibarView.context
-            omnibarView.findViewById<View?>(R.id.toolbarContainer)
-                ?.setBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar))
-            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
-                setCardBackgroundColor(ctx.getColorFromAttr(com.google.android.material.R.attr.colorSurface))
-                cardElevation = 1f.toPx()
-            }
-            omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
-                ?.setCardBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorWindow))
-        }
-
-        if (omnibar.omnibarType == OmnibarType.SINGLE_BOTTOM) {
-            val params = omnibarView?.layoutParams as? CoordinatorLayout.LayoutParams
-            if (params?.gravity == Gravity.TOP) {
-                omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> { gravity = Gravity.BOTTOM }
-                val parent = omnibarView.parent as? ViewGroup
-                parent?.removeView(omnibarView)
-                parent?.addView(omnibarView)
-                omnibarView.elevation = 0f
-                rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                    behavior = BottomOmnibarBrowserContainerLayoutBehavior()
-                }
-            }
-        }
-
+        (omnibar.omnibarView as? View)?.let { removeLayoutListener(it) }
+        restoreOmnibarColors()
+        restoreBottomOmnibarPosition()
         if (omnibar.omnibarType == OmnibarType.SPLIT) {
             rootView.findViewById<View?>(R.id.navigationBar)?.show()
         }
-
         omnibar.isScrollingEnabled = true
+    }
+
+    private fun restoreOmnibarColors() {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        val ctx = omnibarView.context
+        omnibarView.findViewById<View?>(R.id.toolbarContainer)
+            ?.setBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar))
+        omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainerShadow)?.apply {
+            setCardBackgroundColor(ctx.getColorFromAttr(com.google.android.material.R.attr.colorSurface))
+            cardElevation = 1f.toPx()
+        }
+        omnibarView.findViewById<MaterialCardView?>(R.id.omniBarContainer)
+            ?.setCardBackgroundColor(ctx.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorWindow))
+    }
+
+    private fun restoreBottomOmnibarPosition() {
+        if (omnibar.omnibarType != OmnibarType.SINGLE_BOTTOM) return
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        val params = omnibarView.layoutParams as? CoordinatorLayout.LayoutParams ?: return
+        if (params.gravity != Gravity.TOP) return
+
+        omnibarView.updateLayoutParams<CoordinatorLayout.LayoutParams> { gravity = Gravity.BOTTOM }
+        val parent = omnibarView.parent as? ViewGroup
+        parent?.removeView(omnibarView)
+        parent?.addView(omnibarView)
+        omnibarView.elevation = 0f
+        rootView.findViewById<View?>(R.id.browserLayout)?.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+            behavior = BottomOmnibarBrowserContainerLayoutBehavior()
+        }
     }
 
     override fun forceToTop() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -24,7 +24,6 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.core.net.toUri
 import androidx.core.view.updateLayoutParams
-import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -66,13 +65,7 @@ interface NativeInputWidget {
     fun hideKeyboard()
     fun selectChatTab()
     fun isChatTabSelected(): Boolean
-    fun setMainButtonsVisibility(isVisible: Boolean)
-
-    fun bindMainButtons(
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-    )
+    fun hideMainButtons()
 
     fun bindInputEvents(
         onSearchTextChanged: (String) -> Unit,
@@ -88,7 +81,6 @@ interface NativeInputWidget {
     fun bindChatSuggestions(
         lifecycleOwner: LifecycleOwner,
         onChatSuggestionSelected: (String) -> Unit,
-        onChatTabSelected: () -> Unit,
         onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     )
@@ -111,7 +103,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
-    private var showMainButtons: Boolean = true
     private var submitButtons: InputScreenButtons? = null
     private var chatStateJob: Job? = null
     private var chatSuggestionsSettingJob: Job? = null
@@ -234,22 +225,18 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun configureMainButtonsVisibility() {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        updateMainButtonsVisibility()
         updateDuckAiSubmitButton()
         toggle.addOnTabSelectedListener(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
-                    updateMainButtonsVisibility()
                     updateDuckAiSubmitButton()
                 }
                 override fun onTabUnselected(tab: TabLayout.Tab) {}
                 override fun onTabReselected(tab: TabLayout.Tab) {
-                    updateMainButtonsVisibility()
                     updateDuckAiSubmitButton()
                 }
             },
         )
-        inputField.doAfterTextChanged { updateMainButtonsVisibility() }
     }
 
     override fun focusInput(activity: Activity?) {
@@ -276,28 +263,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    override fun setMainButtonsVisibility(isVisible: Boolean) {
-        showMainButtons = isVisible
-        updateMainButtonsVisibility()
-    }
-
-    override fun bindMainButtons(
-        onFireButtonTapped: () -> Unit,
-        onTabSwitcherTapped: () -> Unit,
-        onMenuTapped: () -> Unit,
-    ) {
-        this.onFireButtonTapped = {
-            focusMainButton(R.id.inputFieldFireButton)
-            onFireButtonTapped()
-        }
-        this.onTabSwitcherTapped = {
-            focusMainButton(R.id.inputFieldTabsMenu)
-            onTabSwitcherTapped()
-        }
-        this.onMenuTapped = {
-            focusMainButton(R.id.inputFieldBrowserMenu)
-            onMenuTapped()
-        }
+    override fun hideMainButtons() {
+        setMainButtonsVisible(false)
     }
 
     override fun bindInputEvents(
@@ -332,7 +299,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun bindChatSuggestions(
         lifecycleOwner: LifecycleOwner,
         onChatSuggestionSelected: (String) -> Unit,
-        onChatTabSelected: () -> Unit,
         onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     ) {
@@ -360,7 +326,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val previousOnChatSelected = this.onChatSelected
         this.onChatSelected = {
             previousOnChatSelected?.invoke()
-            onChatTabSelected()
             showSuggestions(text)
         }
 
@@ -428,13 +393,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    private fun updateMainButtonsVisibility() {
-        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        val isSearchTab = toggle.selectedTabPosition == 0
-        val hasText = inputField.text?.isNotBlank() == true
-        setMainButtonsVisible(showMainButtons && isSearchTab && !hasText)
-    }
-
     private fun updateDuckAiSubmitButton() {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isChatTab = toggle.selectedTabPosition == 1
@@ -465,14 +423,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         container.addView(buttons)
         submitButtons = buttons
-    }
-
-    private fun focusMainButton(id: Int) {
-        findViewById<View?>(id)?.let { button ->
-            button.isFocusableInTouchMode = true
-            button.requestFocus()
-            button.isFocusableInTouchMode = false
-        }
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1212305800759148?focus=true

### Description

- Updates the the unfocussed native input UI

### Steps to test this PR

Enable feature flag > “nativeInputField", AI Features > “Native Input Field”

- [x] While the widget is showing, hide the keyboard
- [x] Verify that the widget contracts and the omnibar tabs + menu button are visible
- [x] Focus the widget
- [x] Verify that the widget fills the width and the buttons are hidden
- [x] Repeat for bottom and split configurations


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI behavior change that alters omnibar/widget layering, margins, and button visibility based on keyboard and mode; risk is primarily visual regressions across bottom/split/AI configurations.
> 
> **Overview**
> Implements an *unfocused native input* state: when the keyboard hides (non-DuckAI, non-split), the native input widget contracts and the omnibar `tabs` + `menu` buttons are shown again, with updated z-ordering and end-margin sizing based on measured button widths.
> 
> Refactors native input/omnibar coordination by adding split-mode awareness, extracting omnibar transparency/content-hiding into reusable helpers with a managed layout listener, and updating widget card styling (new fully-rounded shape + compat padding) plus dynamic card margins/translationZ to prevent overlap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2deccbd8b2c13af5410e2155e38f01930ab7a8f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->