### PR TITLE
Migrate DAO/database instrumentation tests to unit tests (PR 1/7)

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/bookmarks/db/BookmarksDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/db/BookmarksDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.bookmarks.db
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -28,7 +29,9 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class BookmarksDaoTest {
 
     @get:Rule

--- a/app/src/test/java/com/duckduckgo/app/cta/db/DismissedCtaDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/db/DismissedCtaDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.cta.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
@@ -26,7 +27,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class DismissedCtaDaoTest {
 
     private lateinit var db: AppDatabase
@@ -34,7 +37,9 @@ class DismissedCtaDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.dismissedCtaDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/fire/fireproofwebsite/data/FireproofWebsiteRepositoryImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/fireproofwebsite/data/FireproofWebsiteRepositoryImplTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.fire.fireproofwebsite.data
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.global.db.AppDatabase
@@ -32,9 +33,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
+@RunWith(AndroidJUnit4::class)
 class FireproofWebsiteRepositoryImplTest {
 
     @get:Rule

--- a/app/src/test/java/com/duckduckgo/app/global/events/db/UserEventsDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/events/db/UserEventsDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.global.events.db
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -27,7 +28,9 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class UserEventsDaoTest {
 
     @get:Rule
@@ -44,7 +47,9 @@ class UserEventsDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.userEventsDao()
         testee = AppUserEventsStore(dao, coroutineRule.testDispatcherProvider)
     }

--- a/app/src/test/java/com/duckduckgo/app/notification/db/NotificationDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/notification/db/NotificationDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.notification.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.notification.model.Notification
@@ -25,7 +26,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class NotificationDaoTest {
 
     private lateinit var db: AppDatabase
@@ -33,7 +36,9 @@ class NotificationDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.notificationDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/privacy/db/NetworkLeaderboardDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/privacy/db/NetworkLeaderboardDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.privacy.db
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.common.test.blockingObserve
@@ -27,7 +28,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class NetworkLeaderboardDaoTest {
 
     private lateinit var db: AppDatabase

--- a/app/src/test/java/com/duckduckgo/app/privacy/db/PrivacyProtectionCountDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/privacy/db/PrivacyProtectionCountDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.privacy.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.privacy.model.PrivacyProtectionCountsEntity
@@ -24,7 +25,9 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class PrivacyProtectionCountDaoTest {
 
     private lateinit var db: AppDatabase

--- a/app/src/test/java/com/duckduckgo/app/survey/db/SurveyDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/db/SurveyDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.survey.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.survey.model.Survey
@@ -25,7 +26,9 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class SurveyDaoTest {
 
     private lateinit var db: AppDatabase
@@ -33,7 +36,9 @@ class SurveyDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.surveyDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsCnameEntityDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsCnameEntityDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.trackerdetection.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.trackerdetection.model.TdsCnameEntity
@@ -25,7 +26,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TdsCnameEntityDaoTest {
 
     private lateinit var db: AppDatabase
@@ -33,7 +36,9 @@ class TdsCnameEntityDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.tdsCnameEntityDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsDomainEntityDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsDomainEntityDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.trackerdetection.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.trackerdetection.model.TdsDomainEntity
@@ -25,7 +26,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TdsDomainEntityDaoTest {
 
     private lateinit var db: AppDatabase
@@ -33,7 +36,9 @@ class TdsDomainEntityDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.tdsDomainEntityDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsEntityDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsEntityDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.trackerdetection.db
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
@@ -26,7 +27,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TdsEntityDaoTest {
 
     @get:Rule

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsMetadataDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsMetadataDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.trackerdetection.db
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.trackerdetection.model.TdsMetadata
@@ -26,7 +27,9 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TdsMetadataDaoTest {
     @get:Rule
     @Suppress("unused")

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsTrackerDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/db/TdsTrackerDaoTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.trackerdetection.db
 
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.app.global.db.AppDatabase
@@ -27,7 +28,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TdsTrackerDaoTest {
 
     private lateinit var db: AppDatabase
@@ -35,7 +38,9 @@ class TdsTrackerDaoTest {
 
     @Before
     fun before() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java).build()
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
         dao = db.tdsTrackerDao()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/usage/search/SearchCountDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/usage/search/SearchCountDaoTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.usage.search
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.global.db.AppDatabase
 import org.junit.After
@@ -25,7 +26,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class SearchCountDaoTest {
 
     @get:Rule


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213608684208017

### Description

Migrates 14 DAO and database instrumentation tests from `src/androidTest/` to `src/test/` so they run on the JVM via Robolectric instead of requiring a device or emulator. The only code changes are adding `@RunWith(AndroidJUnit4::class)` (which Robolectric intercepts) and `.allowMainThreadQueries()` to Room builders that were missing it. This is PR 1 of a larger effort to migrate ~130 androidTest files to unit tests to reduce CI time and improve local feedback loops.

### Steps to test this PR

- [x] Run `./gradlew :app:testPlayDebugUnitTest --tests "com.duckduckgo.app.trackerdetection.db.*" --tests "com.duckduckgo.app.bookmarks.db.BookmarksDaoTest" --tests "com.duckduckgo.app.notification.db.NotificationDaoTest" --tests "com.duckduckgo.app.survey.db.SurveyDaoTest" --tests "com.duckduckgo.app.privacy.db.*" --tests "com.duckduckgo.app.usage.search.SearchCountDaoTest" --tests "com.duckduckgo.app.global.events.db.UserEventsDaoTest" --tests "com.duckduckgo.app.cta.db.DismissedCtaDaoTest" --tests "com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepositoryImplTest"` and confirm all 81 tests pass
- [x] Run `./gradlew :app:assembleAndroidTest` and confirm it still compiles (the remaining instrumentation tests are unaffected)
- [x] Confirm none of the migrated test classes appear in the androidTest source set

### UI changes

N/A — test-only change, no UI impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates that adjust how in-memory Room databases are initialized and executed; no production logic changes.
> 
> **Overview**
> **Updates several Room DAO/unit tests to run consistently under Robolectric/JUnit4.** The affected test classes are now annotated with `@RunWith(AndroidJUnit4::class)`.
> 
> In tests that create an in-memory `AppDatabase`, the Room builders are updated to include `.allowMainThreadQueries()` to avoid thread violations during test execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90d1149c505ed79d89d94dbe5617729de7230787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->