### PR TITLE
Avoid input screen when promo onboarding dialog shown

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -845,8 +845,14 @@ class BrowserTabViewModel @Inject constructor(
                 val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch.value
                 val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen.value
                 if (!hasPendingTabLaunch && !hasPendingDuckAiOpen) {
-                    // whenever an event fires, so the user switched to a new tab page, launch the input screen
-                    command.value = LaunchInputScreen
+                    viewModelScope.launch {
+                        // whenever an event fires, so the user switched to a new tab page, launch the input screen
+                        // unless an onboarding promo message is displayed
+                        val hasPendingOnboardingPromo = ctaViewModel.isPromoOnboardingDialogShowing()
+                        if (!hasPendingOnboardingPromo) {
+                            command.value = LaunchInputScreen
+                        }
+                    }
                 }
             }.launchIn(viewModelScope)
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -504,6 +504,11 @@ class CtaViewModel @Inject constructor(
             }
         }
 
+    suspend fun isPromoOnboardingDialogShowing(): Boolean =
+        withContext(dispatchers.io()) {
+            canShowPrivacyProCtaForSkippedOnboarding()
+        }
+
     companion object {
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2
         private const val PRIVACY_PRO_SKIPPED_ONBOARDING_MIN_DAYS = 7L

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -151,6 +151,7 @@ import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_NETWORK
 import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_TRACKERS_FOUND
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
+import com.duckduckgo.app.cta.model.CtaId.DAX_INTRO_PRIVACY_PRO
 import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.cta.ui.BrokenSitePromptDialogCta
 import com.duckduckgo.app.cta.ui.Cta
@@ -8012,6 +8013,45 @@ class BrowserTabViewModelTest {
             val commands = commandCaptor.allValues
             assertFalse(
                 "LaunchInputScreen command should be suppressed when Duck.ai is opened",
+                commands.any { it is Command.LaunchInputScreen },
+            )
+        }
+
+    @Test
+    fun whenInputScreenEnabledAndPrivacyProSkippedOnboardingDialogShowingThenLaunchInputScreenCommandSuppressed() =
+        runTest {
+            val initialTabId = "initial-tab"
+            val initialTab =
+                TabEntity(
+                    tabId = initialTabId,
+                    url = "https://example.com",
+                    title = "EX",
+                    skipHome = false,
+                    viewed = true,
+                    position = 0,
+                )
+            val ntpTabId = "ntp-tab"
+            val ntpTab = TabEntity(tabId = ntpTabId, url = null, title = "", skipHome = false, viewed = true, position = 0)
+            whenever(mockTabRepository.getTab(initialTabId)).thenReturn(initialTab)
+            whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
+            flowSelectedTab.emit(initialTab)
+
+            whenever(ctaViewModelMockSettingsStore.hideTips).thenReturn(true)
+            whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
+            whenever(mockDismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
+            whenever(mockExtendedOnboardingFeatureToggles.privacyProCtaSkippedOnboarding()).thenReturn(mockEnabledToggle)
+            whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+            whenever(subscriptions.isEligible()).thenReturn(true)
+
+            testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
+
+            flowSelectedTab.emit(ntpTab)
+
+            verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+            val commands = commandCaptor.allValues
+            assertFalse(
+                "LaunchInputScreen command should be suppressed when Privacy Pro skipped-onboarding dialog is showing",
                 commands.any { it is Command.LaunchInputScreen },
             )
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213568547695591

### Description
Avoid launching input screen when onboarding promo dialog is shown

### Steps to test this PR

- [x] Apply patch pinned on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Fresh install
- [x] Skip onboarding tapping on "I've been here before" > "Start browsing"
- [x] Check duck ai toggle is enabled
- [x] Close the app and set the date to 7 days from today.
- [x] Open app
- [x] Check duck.ai toggle is not launched and the onboarding dialog shows correctly

### UI changes
| Before  | After |
| ------ | ----- |
<img width="370" height="820" alt="Screenshot 2026-03-10 at 15 44 35" src="https://github.com/user-attachments/assets/bca20627-4460-426a-98c9-98fb5d4f6d8c" />|<img width="380" height="844" alt="Screenshot 2026-03-10 at 11 21 50" src="https://github.com/user-attachments/assets/fae4208a-ed57-4a32-96dd-aa1fd93e4d19" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX gating change that only affects when `LaunchInputScreen` is emitted for new blank tabs; main risk is unintended suppression/extra IO on tab switches due to the new suspend check.
> 
> **Overview**
> Prevents Duck.ai’s input screen from auto-launching on a new blank tab when the Privacy Pro skipped-onboarding promo dialog is eligible to be shown.
> 
> `BrowserTabViewModel` now checks `CtaViewModel.isPromoOnboardingDialogShowing()` before issuing `Command.LaunchInputScreen`, and tests add coverage to ensure the command is suppressed under that promo-onboarding condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a0cd34a4dbeea3befbfdcf9411d2ae0f38bfaaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->