### PR TITLE
Single tab burn: Translations

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -79,17 +79,4 @@
       }]
     </string>
 
-    <!-- Single tab burning -->
-    <string name="singleTabFireDialogTitle">Delete tabs and site data?</string>
-    <string name="singleTabFireDialogTitleWithChats">Delete tabs, site data, and chats?</string>
-    <string name="singleTabFireDialogDeleteAll">Delete All</string>
-    <string name="singleTabFireDialogDeleteThisTab">Delete This Tab</string>
-    <string name="singleTabFireDialogDeleteThisChat">Delete This Chat</string>
-    <string name="singleTabFireDialogSubtitleDuckAi">\"Delete All\" will not delete your Duck.ai chat history.</string>
-    <string name="singleTabFireDialogSubtitleSiteData">Deleting site data can sign you out of accounts.</string>
-    <string name="singleTabFireDialogSubtitleDownloads">This will cancel downloads in progress.</string>
-    <string name="singleTabFireDialogSnackbar">1 tab and its data deleted</string>
-    <string name="singleTabFireDialogClearNotSupportedSnackbar">Site data could not be deleted. Please update WebView.</string>
-    <string name="singleTabFireDialogClearErrorSnackbar">Site data could not be deleted due to an error.</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,19 @@
         <item quantity="other" instruction="Placeholder is the number of tabs">Delete from %1$d sites. May sign you out of accounts.</item>
     </plurals>
 
+    <!-- Single tab burning -->
+    <string name="singleTabFireDialogTitle">Delete tabs and site data?</string>
+    <string name="singleTabFireDialogTitleWithChats">Delete tabs, site data, and chats?</string>
+    <string name="singleTabFireDialogDeleteAll">Delete All</string>
+    <string name="singleTabFireDialogDeleteThisTab">Delete This Tab</string>
+    <string name="singleTabFireDialogDeleteThisChat">Delete This Chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Delete All\" will not delete your Duck.ai chat history.</string>
+    <string name="singleTabFireDialogSubtitleSiteData">Deleting site data can sign you out of accounts.</string>
+    <string name="singleTabFireDialogSubtitleDownloads">This will cancel downloads in progress.</string>
+    <string name="singleTabFireDialogSnackbar">1 tab and its data deleted</string>
+    <string name="singleTabFireDialogClearNotSupportedSnackbar">Site data could not be deleted. Please update WebView.</string>
+    <string name="singleTabFireDialogClearErrorSnackbar">Site data could not be deleted due to an error.</string>
+
     <!-- Permissions -->
     <string name="permissionsActivityTitle">Permissions</string>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1213567124475417?focus=true

### Description

Moves the strings for translations in Smartling.

### Steps to test this PR

QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only relocates Android string resources; behavior changes are unlikely beyond potential translation/extraction effects.
> 
> **Overview**
> Moves the *Single tab burning* UI strings from `donottranslate.xml` into `strings.xml` so they can be picked up by the translation pipeline (e.g., Smartling).
> 
> No wording changes; resource names/usages remain the same, just reclassified from non-translatable to translatable resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f829e46523d7c15f71164db057c3128b433f37e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->