### PR TITLE
Headless sync recovery implementation

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
@@ -21,12 +21,16 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.persistentstorage.api.PersistentStorage
 import com.duckduckgo.sync.api.SyncAutoRestore
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority
 import logcat.logcat
 import javax.inject.Inject
 
@@ -35,6 +39,7 @@ import javax.inject.Inject
 class RealSyncAutoRestore @Inject constructor(
     private val persistentStorage: PersistentStorage,
     private val syncFeature: SyncFeature,
+    private val syncAccountRepository: SyncAccountRepository,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
 ) : SyncAutoRestore {
@@ -48,7 +53,27 @@ class RealSyncAutoRestore @Inject constructor(
 
     override fun restoreSyncAccount() {
         appScope.launch(dispatcherProvider.io()) {
-            logcat { "Sync-Recovery: restoreSyncAccount called, not yet implemented" }
+            try {
+                logcat { "Sync-Recovery: restoreSyncAccount called" }
+
+                val recoveryBytes = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull()
+                if (recoveryBytes == null) {
+                    logcat(LogPriority.WARN) { "Sync-Recovery: no recovery key found in persistent storage" }
+                    return@launch
+                }
+
+                val recoveryCodeString = String(recoveryBytes, Charsets.UTF_8)
+                logcat { "Sync-Recovery: recovery key retrieved, attempting login" }
+
+                val parsedCode = syncAccountRepository.parseSyncAuthCode(recoveryCodeString)
+                when (val result = syncAccountRepository.processCode(parsedCode)) {
+                    is Result.Success -> logcat(LogPriority.INFO) { "Sync-Recovery: account restored successfully" }
+                    is Result.Error -> logcat(LogPriority.WARN) { "Sync-Recovery: restore failed - code=${result.code}, reason=${result.reason}" }
+                }
+            } catch (t: Throwable) {
+                coroutineContext.ensureActive()
+                logcat(LogPriority.ERROR) { "Sync-Recovery: unexpected error during restore - ${t.message}" }
+            }
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeature
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -30,7 +32,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import com.duckduckgo.sync.impl.Result as SyncResult
 
 @SuppressLint("DenyListedApi")
 class RealSyncAutoRestoreTest {
@@ -40,6 +45,7 @@ class RealSyncAutoRestoreTest {
 
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
     private val persistentStorage: PersistentStorage = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
 
     private lateinit var testee: RealSyncAutoRestore
 
@@ -48,6 +54,7 @@ class RealSyncAutoRestoreTest {
         testee = RealSyncAutoRestore(
             persistentStorage = persistentStorage,
             syncFeature = syncFeature,
+            syncAccountRepository = syncAccountRepository,
             appScope = coroutineTestRule.testScope,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         )
@@ -84,6 +91,58 @@ class RealSyncAutoRestoreTest {
         assertFalse(testee.canRestore())
     }
 
+    @Test
+    fun whenRestoreSyncAccountCalledThenRetrievesKeyAndCallsProcessCode() = runTest {
+        val recoveryCodeString = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
+        configureRetrieveSuccess(value = recoveryCodeString)
+        configureProcessCodeResult(SyncResult.Success(true))
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository).parseSyncAuthCode(recoveryCodeString)
+        verify(syncAccountRepository).processCode(any())
+    }
+
+    @Test
+    fun whenRestoreSyncAccountCalledButNoStoredKeyThenDoesNotCallProcessCode() = runTest {
+        configureRetrieveSuccess(value = null)
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository, never()).processCode(any())
+    }
+
+    @Test
+    fun whenRestoreSyncAccountCalledButStorageFailsThenDoesNotCallProcessCode() = runTest {
+        configureRetrieveFailure()
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository, never()).processCode(any())
+    }
+
+    @Test
+    fun whenProcessCodeFailsThenRestoreSyncAccountDoesNotThrow() = runTest {
+        val recoveryCodeString = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
+        configureRetrieveSuccess(value = recoveryCodeString)
+        configureProcessCodeResult(SyncResult.Error(code = 52, reason = "Login failed"))
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository).processCode(any())
+    }
+
+    @Test
+    fun whenParseSyncAuthCodeThrowsThenRestoreSyncAccountDoesNotCrash() = runTest {
+        val recoveryCodeString = "invalid_not_base64"
+        configureRetrieveSuccess(value = recoveryCodeString)
+        whenever(syncAccountRepository.parseSyncAuthCode(recoveryCodeString)).thenThrow(RuntimeException("Parse error"))
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository, never()).processCode(any())
+    }
+
     private fun configureAutoRestoreEnabled(enabled: Boolean) {
         syncFeature.syncAutoRestore().setRawStoredState(State(enable = enabled))
     }
@@ -91,6 +150,12 @@ class RealSyncAutoRestoreTest {
     private suspend fun configureRetrieveSuccess(value: String?) {
         val bytes = value?.toByteArray(Charsets.UTF_8)
         whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(bytes))
+    }
+
+    private fun configureProcessCodeResult(result: SyncResult<Boolean>) {
+        val mockParsedCode = mock<SyncAuthCode.Recovery>()
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(mockParsedCode)
+        whenever(syncAccountRepository.processCode(mockParsedCode)).thenReturn(result)
     }
 
     private suspend fun configureRetrieveFailure() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211766481496464?focus=true

### Description
Adds in the headless sync setup using the persisted sync recovery key. 

This is still gated by the `syncAutoRestore` feature flag which **remains disabled** for now (you'll need to update this manually for some of the tests)

### Steps to test this PR

**Notes**
- Prerequisites: Internal build installed on a device with Google Play Services, logged into Google account. 
- Navigate to Settings > Sync Dev Settings to access Block Store controls.                                                                                          
- ℹ️ Clearing data and relaunching the app does not restore Block Store data; it has to be an uninstall/reinstall.
- Suggested logcat filter: `Sync-Recovery|Sync-AutoRestore`
                                                            
**Scenario 1: Feature flag OFF (default) — no restore offered regardless of stored key**
  - [x] Fresh install
  - [x] Launch app and verify the "Restore" dialog is not shown, normal onboarding flow proceeds
  - [x] go to Sync Dev Settings and write any string to Block Store
  - [x] Uninstall and reinstall (do not clear app data)
  - [x] Launch app and verify the "Restore" dialog is still not shown (because flag is off)

**Scenario 2: Feature flag ON, no recovery key — no restore offered**
  - [x] Apply the patch defined below to hardcode `syncAutoRestore` to be enabled, and install
  - [x] Clear app data to ensure Block Store has no data
  - [x] Launch app — verify the "Restore" dialog is not shown, normal onboarding proceeds

**Scenario 3: Feature flag ON, recovery key present — user accepts restore**
  - [x] Keep the hardcoded FF enabled changes from before
  - [x] Save a password or two
  - [x] Set up Sync on the device, using Sync & Backup -> Sync & Back Up This Device and copy the recovery key when it's available using the `Copy code` button
  - [x] Paste the recovery key into Block Store via Sync Dev Settings and use the `Write` button to persist it
  - [x] Uninstall and reinstall (do not clear app data)
  - [x] Go through onboarding — verify the "Restore" dialog is shown
  - [x] Tap "Restore My Stuff" — verify onboarding continues normally (e.g., comparison chart shown next)
  - [x] Complete onboarding, then go to Settings > Sync — verify sync account is re-established
  - [x] Verify previous password is available

**Scenario 4: Feature flag ON, recovery key present — user skips restore**
  - [x] Repeat setup from Scenario 3 (to get a valid recovery code in Block Store, uninstall and then reinstall)
  - [x] Launch app — verify the "Restore" dialog is shown
  - [x] Tap "Skip" button from that dialog — verify you see the `Got it! I'll skip other tips` dialog
  - [x] Complete onboarding, then go to Settings > Sync — verify sync is not set up

**Scenario 5: Invalid code persisted**
  - [x] Use `Sync Dev Settings` to write an invalid recovery code (e.g., a few random characters)
  - [x] Uninstall and reinstall (do not clear app data)
  - [x] Launch app — verify the "Restore" dialog is shown
  - [x] Tap `Restore My Stuff`. Verify the UX continues normally and in logs you see `Sync-Recovery: restore failed`

## Patch to enable FF for `syncAutoRestore`
```
Index: sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt	(revision Staged)
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt	(date 1773231063963)
@@ -78,6 +78,6 @@
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun syncAutoRecoveryCapabilityDetectionRead(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun syncAutoRestore(): Toggle
 }
```