### PR TITLE
Remove rounding from attributed metrics

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/metrics/AdClickAttributedMetric.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/metrics/AdClickAttributedMetric.kt
@@ -38,7 +38,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 interface AdClickCollector {
     fun onAdClick()
@@ -107,7 +106,7 @@ class RealAdClickAttributedMetric @Inject constructor(
     override suspend fun getMetricParameters(): Map<String, String> {
         val stats = getEventStats()
         val params = mutableMapOf(
-            "count" to getBucketValue(stats.rollingAverage.roundToInt()).toString(),
+            "count" to getBucketValue(stats.rollingAverage).toString(),
             "version" to bucketConfig.await().version.toString(),
         )
         if (!hasCompleteDataWindow()) {
@@ -120,7 +119,7 @@ class RealAdClickAttributedMetric @Inject constructor(
         return daysSinceInstalled().toString()
     }
 
-    private suspend fun getBucketValue(avg: Int): Int {
+    private suspend fun getBucketValue(avg: Double): Int {
         val buckets = bucketConfig.await().buckets
         return buckets.indexOfFirst { bucket -> avg <= bucket }.let { index ->
             if (index == -1) buckets.size else index

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/metrics/RealAdClickAttributedMetricTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/metrics/RealAdClickAttributedMetricTest.kt
@@ -202,12 +202,12 @@ class RealAdClickAttributedMetricTest {
             0.0 to 0, // 0 clicks -> bucket 0 (≤2)
             1.0 to 0, // 1 click -> bucket 0 (≤2)
             2.0 to 0, // 2 clicks -> bucket 0 (≤2)
-            2.1 to 0, // 2.1 clicks rounds to 2 -> bucket 0 (≤2)
-            2.5 to 1, // 2.5 clicks rounds to 3 -> bucket 1 (≤5)
-            2.7 to 1, // 2.7 clicks rounds to 3 -> bucket 1 (≤5)
+            2.1 to 1, // 2.1 > 2, >2 and ≤5 -> bucket 1
+            2.5 to 1, // >2 and ≤5 -> bucket 1
+            2.7 to 1, // >2 and ≤5 -> bucket 1
             3.0 to 1, // 3 clicks -> bucket 1 (≤5)
             5.0 to 1, // 5 clicks -> bucket 1 (≤5)
-            5.1 to 1, // 5.1 clicks rounds to 5 -> bucket 1 (≤5)
+            5.1 to 2, // 5.1 > 5, >5 -> bucket 2
             6.0 to 2, // 6 clicks -> bucket 2 (>5)
             10.0 to 2, // 10 clicks -> bucket 2 (>5)
         )

--- a/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetric.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/main/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetric.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 /**
  * Search Count 7d avg Attributed Metric
@@ -125,7 +124,7 @@ class SearchAttributedMetric @Inject constructor(
     override suspend fun getMetricParameters(): Map<String, String> {
         val stats = getEventStats()
         val params = mutableMapOf(
-            "count" to getBucketValue(stats.rollingAverage.roundToInt()).toString(),
+            "count" to getBucketValue(stats.rollingAverage).toString(),
             "version" to getBucketConfig().version.toString(),
         )
         if (!hasCompleteDataWindow()) {
@@ -141,7 +140,7 @@ class SearchAttributedMetric @Inject constructor(
             ?: "no-atb" // should not happen, but just in case
     }
 
-    private suspend fun getBucketValue(searches: Int): Int {
+    private suspend fun getBucketValue(searches: Double): Int {
         val buckets = getBucketConfig().buckets
         return buckets.indexOfFirst { bucket -> searches <= bucket }.let { index ->
             if (index == -1) buckets.size else index

--- a/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetricTest.kt
+++ b/attributed-metrics/attributed-metrics-impl/src/test/java/com/duckduckgo/app/attributed/metrics/search/SearchAttributedMetricTest.kt
@@ -237,11 +237,11 @@ class SearchAttributedMetricTest {
             2.2 to 0, // ≤5 -> bucket 0
             4.4 to 0, // ≤5 -> bucket 0
             5.0 to 0, // ≤5 -> bucket 0
-            5.1 to 0, // rounds to 5, ≤5 -> bucket 0
-            5.8 to 1, // rounds to 6, >5 and ≤9 -> bucket 1
+            5.1 to 1, // 5.1 > 5, >5 and ≤9 -> bucket 1
+            5.8 to 1, // >5 and ≤9 -> bucket 1
             6.6 to 1, // >5 and ≤9 -> bucket 1
             9.0 to 1, // >5 and ≤9 -> bucket 1
-            9.3 to 1, // rounds to 9, >5 and ≤9 -> bucket 1
+            9.3 to 2, // 9.3 > 9, >9 -> bucket 2
             10.0 to 2, // >9 -> bucket 2
             14.1 to 2, // >9 -> bucket 2
         )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetric.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetric.kt
@@ -38,7 +38,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 interface DuckAiMetricCollector {
     fun onMessageSent()
@@ -83,7 +82,7 @@ class DuckAiAttributedMetric @Inject constructor(
     override suspend fun getMetricParameters(): Map<String, String> {
         val stats = getEventStats()
         val params = mutableMapOf(
-            "count" to getBucketValue(stats.rollingAverage.roundToInt()).toString(),
+            "count" to getBucketValue(stats.rollingAverage).toString(),
             "version" to bucketConfig.await().version.toString(),
         )
         if (!hasCompleteDataWindow()) {
@@ -113,7 +112,7 @@ class DuckAiAttributedMetric @Inject constructor(
         }
     }
 
-    private suspend fun getBucketValue(avg: Int): Int {
+    private suspend fun getBucketValue(avg: Double): Int {
         val buckets = bucketConfig.await().buckets
         return buckets.indexOfFirst { bucket -> avg <= bucket }.let { index ->
             if (index == -1) buckets.size else index

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetricTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/metric/DuckAiAttributedMetricTest.kt
@@ -184,11 +184,11 @@ class DuckAiAttributedMetricTest {
             2.2 to 0, // ≤5 -> bucket 0
             4.4 to 0, // ≤5 -> bucket 0
             5.0 to 0, // ≤5 -> bucket 0
-            5.1 to 0, // rounds to 5, ≤5 -> bucket 0
-            5.8 to 1, // rounds to 6, >5 and ≤9 -> bucket 1
+            5.1 to 1, // 5.1 > 5, >5 and ≤9 -> bucket 1
+            5.8 to 1, // >5 and ≤9 -> bucket 1
             6.6 to 1, // >5 and ≤9 -> bucket 1
             9.0 to 1, // >5 and ≤9 -> bucket 1
-            9.3 to 1, // rounds to 9, >5 and ≤9 -> bucket 1
+            9.3 to 2, // 9.3 > 9, >9 -> bucket 2
             10.0 to 2, // >9 -> bucket 2
             14.1 to 2, // >9 -> bucket 2
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1213357771405943?focus=true 

### Description
Removes rounding when calculating buckets on attributed metrics

### Steps to test this PR
Changes are very simple, and covered with unit test. QA-Optional

if reviewer want further testing: smoke test following steps in https://github.com/duckduckgo/Android/pull/6899

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, but it changes production metric bucket assignment (and thus pixel payloads) near bucket boundaries for ad clicks, searches, and DuckAI usage.
> 
> **Overview**
> **Bucketing logic now uses the raw `Double` rolling average instead of rounding to `Int`** when computing the `count` parameter for attributed metrics.
> 
> This updates ad click (`RealAdClickAttributedMetric`), search (`SearchAttributedMetric`), and DuckAI usage (`DuckAiAttributedMetric`) to pass `rollingAverage` directly into `getBucketValue`, and revises unit tests to reflect new boundary behavior (e.g., `2.1` no longer buckets as `2`, `9.3` no longer buckets as `9`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d8d85f53f9dfd6f27bcb1c1f211cd04396f7aff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->