### PR TITLE
Enqueue critical PIR pixels instead of just firing them

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -834,7 +834,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_OPTOUT_SUBMIT_SUCCESS_RATE to optOutSuccessRate.toString(),
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_OPTOUT_SUBMIT_SUCCESSRATE, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_OPTOUT_SUBMIT_SUCCESSRATE, params)
     }
 
     override fun reportBrokerOptOutConfirmed7Days(brokerUrl: String) {
@@ -842,7 +842,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_7DAY_CONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_7DAY_CONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutUnconfirmed7Days(brokerUrl: String) {
@@ -850,7 +850,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_7DAY_UNCONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_7DAY_UNCONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutConfirmed14Days(brokerUrl: String) {
@@ -858,7 +858,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_14DAY_CONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_14DAY_CONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutUnconfirmed14Days(brokerUrl: String) {
@@ -866,7 +866,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_14DAY_UNCONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_14DAY_UNCONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutConfirmed21Days(brokerUrl: String) {
@@ -874,7 +874,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_21DAY_CONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_21DAY_CONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutUnconfirmed21Days(brokerUrl: String) {
@@ -882,7 +882,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_21DAY_UNCONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_21DAY_UNCONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutConfirmed42Days(brokerUrl: String) {
@@ -890,7 +890,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_42DAY_CONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_42DAY_CONFIRMED_OPTOUT, params)
     }
 
     override fun reportBrokerOptOutUnconfirmed42Days(brokerUrl: String) {
@@ -898,19 +898,19 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER to brokerUrl,
         )
 
-        fire(PIR_BROKER_CUSTOM_STATS_42DAY_UNCONFIRMED_OPTOUT, params)
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_42DAY_UNCONFIRMED_OPTOUT, params)
     }
 
     override fun reportDAU() {
-        fire(PIR_ENGAGEMENT_DAU)
+        enqueueFire(PIR_ENGAGEMENT_DAU)
     }
 
     override fun reportWAU() {
-        fire(PIR_ENGAGEMENT_WAU)
+        enqueueFire(PIR_ENGAGEMENT_WAU)
     }
 
     override fun reportMAU() {
-        fire(PIR_ENGAGEMENT_MAU)
+        enqueueFire(PIR_ENGAGEMENT_MAU)
     }
 
     override fun reportWeeklyChildOrphanedOptOuts(
@@ -924,7 +924,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_ORPHANED_COUNT to orphanedRecordsCount.toString(),
         )
 
-        fire(PIR_WEEKLY_CHILD_ORPHANED_OPTOUTS, params)
+        enqueueFire(PIR_WEEKLY_CHILD_ORPHANED_OPTOUTS, params)
     }
 
     override fun reportScanStarted(brokerUrl: String) {
@@ -1351,7 +1351,7 @@ class RealPirPixelSender @Inject constructor(
         val params = mapOf(
             PARAM_KEY_SCAN_FREQUENCY to scanFrequencyWithinThreshold.toString(),
         )
-        fire(PIR_BG_STATS, params)
+        enqueueFire(PIR_BG_STATS, params)
     }
 
     override fun reportScanInvalidEvent(
@@ -1394,9 +1394,9 @@ class RealPirPixelSender @Inject constructor(
         pixel: PirPixel,
         params: Map<String, String> = emptyMap(),
     ) {
-        pixel.getPixelNames().forEach { (_, pixelName) ->
+        pixel.getPixelNames().forEach { (pixelType, pixelName) ->
             logcat { "PIR-LOGGING: $pixelName params: $params" }
-            pixelSender.enqueueFire(pixelName = pixelName, parameters = params)
+            pixelSender.enqueueFire(pixelName = pixelName, type = pixelType, parameters = params)
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -494,14 +494,14 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportBrokerCustomStateOptOutSubmitRateThenFiresPixelWithParameters() = runTest {
+    fun whenReportBrokerCustomStateOptOutSubmitRateThenEnqueuesPixelWithParameters() = runTest {
         testee.reportBrokerCustomStateOptOutSubmitRate(
             brokerUrl = "https://broker.com",
             optOutSuccessRate = 0.75,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -514,11 +514,11 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportBrokerOptOutConfirmed7DaysThenFiresPixelWithBrokerUrl() = runTest {
+    fun whenReportBrokerOptOutConfirmed7DaysThenEnqueuesPixelWithBrokerUrl() = runTest {
         testee.reportBrokerOptOutConfirmed7Days("https://broker.com")
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -529,11 +529,11 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportBrokerOptOutUnconfirmed7DaysThenFiresPixelWithBrokerUrl() = runTest {
+    fun whenReportBrokerOptOutUnconfirmed7DaysThenEnqueuesPixelWithBrokerUrl() = runTest {
         testee.reportBrokerOptOutUnconfirmed7Days("https://broker.com")
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -544,11 +544,11 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportDAUThenFiresCorrectPixel() = runTest {
+    fun whenReportDAUThenEnqueuesCorrectPixel() = runTest {
         testee.reportDAU()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -559,11 +559,11 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportWAUThenFiresCorrectPixel() = runTest {
+    fun whenReportWAUThenEnqueuesCorrectPixel() = runTest {
         testee.reportWAU()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -574,11 +574,11 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportMAUThenFiresCorrectPixel() = runTest {
+    fun whenReportMAUThenEnqueuesCorrectPixel() = runTest {
         testee.reportMAU()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),
@@ -589,7 +589,7 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportWeeklyChildOrphanedOptOutsThenFiresPixelWithAllParameters() = runTest {
+    fun whenReportWeeklyChildOrphanedOptOutsThenEnqueuesPixelWithAllParameters() = runTest {
         testee.reportWeeklyChildOrphanedOptOuts(
             brokerUrl = "https://child-broker.com",
             childParentRecordDifference = 5,
@@ -597,7 +597,7 @@ class RealPirPixelSenderTest {
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixelSender).fire(
+        verify(mockPixelSender).enqueueFire(
             pixelName = any(),
             parameters = paramsCaptor.capture(),
             encodedParameters = any(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213609042223141?focus=true 

### Description
See attached task description

### Steps to test this PR
Smoke test PIR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry delivery semantics (queued vs immediate) for multiple important PIR pixels, which could impact analytics timing/delivery if enqueue behavior differs across app states.
> 
> **Overview**
> Updates `RealPirPixelSender` so several *critical* PIR pixels (broker custom opt-out stats, DAU/WAU/MAU engagement, weekly orphaned opt-outs, and background scan stats) are sent via `enqueueFire` instead of `fire`.
> 
> Fixes `enqueueFire` to pass through each pixel’s `PixelType` (matching `fire` behavior), and updates unit tests to verify enqueued sending for the affected report methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 797bd6593557714f59e9c24a63c64a616043a5ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->