### PR TITLE
Update Privacy pro references on PIR

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
@@ -107,8 +107,8 @@
     <string name="changePlanDescription">Your subscription was purchased through the Apple App Store. To change your plan or billing settings, please go to Settings > Apple Account > Subscriptions on a device signed in to the same Apple Account used to purchase your subscription.</string>
 
     <!-- PIR Activity-->
-    <string name="pirTitle">Activate Privacy Pro on desktop to set up Personal Information Removal</string>
-    <string name="pirDescription">In the DuckDuckGo browser for desktop, go to <b>Settings > Privacy Pro</b> and click <b>I Have a Subscription</b> to get started.</string>
+    <string name="pirTitle">Activate the DuckDuckGo subscription on desktop to set up Personal Information Removal</string>
+    <string name="pirDescription">In the DuckDuckGo browser for desktop, go to <b>Settings > Subscribe to DuckDuckGo</b> and click <b>I Have a Subscription</b> to get started.</string>
     <string name="pirWindowsButton" translatable="false">Windows</string>
     <string name="pirMacOsButton" translatable="false">Mac</string>
 
@@ -168,7 +168,7 @@
     <string name="activitySubscriptions">Subscriptions</string>
     <string name="activitySubscriptionSettings">Subscription Settings</string>
     <string name="activityActivateSubscription">I Have a Subscription</string>
-    <string name="activityPir" translatable="false">Privacy Pro</string>
+    <string name="activityPir" translatable="false">Personal Information Removal</string>
     <string name="activitySendFeedback">Send Feedback</string>
 
     <string name="subscriptionSettingSubscribeWithDuckAiSubtitle">Subscribers get our VPN, advanced AI models in Duck.ai, Personal Information Removal, and Identity Theft Restoration.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213377943508982?focus=true 

### Description
Updates copy referencing privacy pro on PIR with new copies.

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only copy updates in Android resources; no functional or data-handling code changes.
> 
> **Overview**
> Updates Personal Information Removal (PIR) UI copy to remove “Privacy Pro” branding and instead reference the DuckDuckGo subscription.
> 
> This adjusts the PIR activation instructions (desktop navigation text) and renames the PIR activity title from `Privacy Pro` to `Personal Information Removal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75fe2c880c30be77111051fea5f68e1403264f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->