### PR TITLE
Update content scope scripts to version 13.31.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -603,7 +603,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -616,6 +616,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2138,7 +2138,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -2151,6 +2151,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2110,7 +2110,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -2123,6 +2123,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1468,7 +1468,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -1481,6 +1481,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -585,7 +585,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -598,6 +598,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -585,7 +585,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "webInterferenceDetection", "pageContext", "print"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "pageContext", "print"],
     "apple-isolated": [
       "contextMenu",
       "duckPlayer",
@@ -598,6 +598,7 @@
       "favicon",
       "webDetection",
       "webEvents",
+      "webInterferenceDetection",
       "pageObserver",
       "hover"
     ],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1936,6 +1936,19 @@
     return "function" == typeof t3 ? t3(n2) : t3;
   }
 
+  // shared/hooks/useMediaQuery.js
+  function useMediaQuery(query) {
+    const [matches, setMatches] = d2(() => window.matchMedia(query).matches);
+    y2(() => {
+      const mql = window.matchMedia(query);
+      setMatches(mql.matches);
+      const handler = () => setMatches(mql.matches);
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
+    }, [query]);
+    return matches;
+  }
+
   // shared/components/EnvironmentProvider.js
   var EnvironmentContext = R({
     isReducedMotion: false,
@@ -1961,14 +1974,8 @@
     injectName = "windows",
     locale = "en"
   }) {
-    const [theme, setTheme] = d2(window.matchMedia(THEME_QUERY).matches ? "dark" : "light");
+    const isDarkMode = useMediaQuery(THEME_QUERY);
     const [isReducedMotion, setReducedMotion] = d2(window.matchMedia(REDUCED_MOTION_QUERY).matches);
-    y2(() => {
-      const mediaQueryList = window.matchMedia(THEME_QUERY);
-      const listener = (e3) => setTheme(e3.matches ? "dark" : "light");
-      mediaQueryList.addEventListener("change", listener);
-      return () => mediaQueryList.removeEventListener("change", listener);
-    }, []);
     y2(() => {
       const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
       const listener = (e3) => setter(e3.matches);
@@ -1989,7 +1996,7 @@
         value: {
           isReducedMotion,
           debugState,
-          isDarkMode: theme === "dark",
+          isDarkMode,
           injectName,
           willThrow,
           env,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.54.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.29.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.31.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.58.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.58.0.tgz",
-      "integrity": "sha512-7Bifmg7CFonMQub51Jve4EfTFD6x6GeEyugwKjKg+IA1wPJwf5gFz4D5Ix4jbJd/a/1nZWwIC6rsU6Sdh33jJA==",
+      "version": "14.59.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.59.0.tgz",
+      "integrity": "sha512-vlRVRCup8jnXIlsn/RqSVdSq7JHyQNhproF/uI/fjOTxf7snMx07YxljPa7CZxoEbz1zgkhO9gbfj0RjIr+G6Q==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#13976e04d81eefac5a9c718d886ce99460a9123b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f62cafbfad7023e658269caec9f23ca862c5cf03",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.54.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.29.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.31.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213628236396385/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency update changes which content-scope features are enabled on Apple vs `apple-isolated`, and tweaks Duck Player’s environment detection logic; both could affect injected feature availability and theming at runtime.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `13.29.0` to `13.31.0` (with updated vendored `node_modules` build artifacts).
> 
> This shifts `webInterferenceDetection` out of the `apple` platform feature list into `apple-isolated` across the Android build bundles, changing where that feature is enabled.
> 
> Duck Player’s bundled `EnvironmentProvider` now uses a shared `useMediaQuery` hook to track dark-mode changes (instead of bespoke listener code), while leaving reduced-motion handling as-is. `package-lock.json` also bumps `@duckduckgo/autoconsent` to `14.59.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6da1bc2bf280cb045e0d4b0bf8e4f5b6d2919be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->