### PR TITLE
pin gradle-profiler version to 0.23.0 for the nightly build benchmarks

### DIFF
--- a/.github/workflows/build-benchmark-nightly.yml
+++ b/.github/workflows/build-benchmark-nightly.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Gradle Profiler
         run: |
           source "$HOME/.sdkman/bin/sdkman-init.sh"
-          sdk install gradleprofiler
+          sdk install gradleprofiler 0.23.0
           gradle-profiler --version
 
       - name: Run Build Benchmarks and Process Results


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213635828556477?focus=true

### Description
Pins the version of the gradler-profiler to v0.23.0 to stabilize our metrics. Refs https://github.com/gradle/gradle-profiler/issues/739.

### Steps to test this PR

No QA needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins a tool version to improve benchmark stability; main impact is potential workflow failure if that version becomes unavailable.
> 
> **Overview**
> **Stabilizes nightly build benchmark metrics** by pinning the SDKMAN `gradleprofiler` install step to version `0.23.0` instead of installing the latest available version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c701820379d08e99b378157ec22940a0add499b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->