### PR TITLE
Update FF when refreshing pro entitlements

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -301,6 +301,9 @@ interface PrivacyProFeature {
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun handleExpiredStateWhenSubscriptionChangeSelected(): Toggle
+
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    fun fetchProTierEntitlements(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -69,7 +69,7 @@ class SubscriptionFeaturesFetcher @Inject constructor(
         playBillingManager.productsFlow
             .firstOrNull() { it.isNotEmpty() }
             ?.filter {
-                if (privacyProFeature.allowProTierPurchase().isEnabled()) {
+                if (privacyProFeature.fetchProTierEntitlements().isEnabled()) {
                     it.productId == BASIC_SUBSCRIPTION || it.productId == ADVANCED_SUBSCRIPTION
                 } else {
                     it.productId == BASIC_SUBSCRIPTION


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213641986703613?focus=true 

### Description
Introduces new FF to enabled/disable pro entitlements fetcher
Decouples that logic from the actual feature

### Steps to test this PR

_Feature 1_
- [x] Apply staging patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] fresh install
- [x] Skip onboarding
- [x] Subscription settings are visible
- [x] Enter purchase flow -> ensure you see "See all Plans"
- [x] don't continue, navigate back
- [x] Go to feature flags inventory and disable `allowProTierPuchase`
- [x] Go back to settings and enter purchase flow -> should only allow plus plans

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription feature/entitlement fetching logic at app startup to be controlled by a new remote flag, which could affect which base plans are queried and cached. Impact is limited in scope but touches subscription availability behavior.
> 
> **Overview**
> Decouples pro-tier entitlements refresh from purchase availability by introducing a new `privacyPro.fetchProTierEntitlements` remote flag (default **enabled**).
> 
> `SubscriptionFeaturesFetcher` now uses this new flag (instead of `allowProTierPurchase`) to decide whether to include both Basic and Advanced subscription products when selecting base plans to fetch and cache subscription features/entitlements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d1bab76e0e616374de8997b95538802a49fc928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->