### PR TITLE
always run ci.yml and skip jobs when needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,13 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "Direct push to branch — running checks"; echo "should_run=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.event.after }}"
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          if ! CHANGED=$(git diff --name-only "$BASE" "$HEAD"); then
+            echo "git diff failed — running checks as fallback"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
           echo "Changed files:"; echo "$CHANGED"
           if ([ -n "$CHANGED" ] && echo "$CHANGED" | grep -qvE '(\.md$|^\.github/)') || \
              echo "$CHANGED" | grep -qF '.github/workflows/ci.yml'; then


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1213642299611483?focus=true

### Description

Instead of skipping the workflow at the trigger level, the workflow now always runs but gates all jobs behind a check_changes job that inspects the diff.
- If only `.md` or `.github/` files changed → all jobs are skipped (GitHub treats skipped as passing for branch protection)
- If `ci.yml` itself changed → all jobs run normally, so regressions are caught before merging
- If any code file changed → all jobs run normally

### Steps to test this PR

QA optional:
- Open a PR that only modifies an `.md` file → check_changes should pass, all other jobs should be skipped, PR should be mergeable
- Open a PR that only modifies a `.github` workflow file (not `ci.yml`) → check_changes should pass, all other jobs should be skipped, PR should be mergeable
- Open a PR that modifies `.github/workflows/ci.yml` → all jobs should run
- Open a PR that modifies any source file → all jobs should run

I tested all of these via https://github.com/duckduckgo/Android/pull/7962.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the CI workflow execution logic to conditionally skip most jobs based on diff contents, which could unintentionally reduce coverage if the change-detection logic is wrong.
> 
> **Overview**
> The CI workflow no longer uses trigger-level `paths-ignore`; instead it always starts and runs a new `check_changes` job that diffs the PR (or always allows `push`/`workflow_dispatch`) to decide whether checks should run.
> 
> All existing jobs (`code_formatting`, `unit_tests`, `lint`, `android_tests`) now `need` `check_changes` and are gated by `if: needs.check_changes.outputs.should_run == 'true'`, so docs-only or non-`ci.yml` `.github/` changes skip the expensive checks while changes to `ci.yml` or any code still run the full suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff5ad834846cef05d062fa137313f93928bb23c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->