### PR TITLE
Add new sync screen for showing recovery code

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -74,4 +74,7 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun syncAutoRestore(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun recoverDataEasilySetupScreen(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreManager.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.sync.impl.autorestore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
+import com.duckduckgo.sync.impl.SyncFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
@@ -29,18 +31,30 @@ import logcat.logcat
 import javax.inject.Inject
 
 interface SyncAutoRestoreManager {
+    suspend fun isAutoRestoreAvailable(): Boolean
     suspend fun saveRecoveryPayload(recoveryCode: String, deviceId: String?)
     suspend fun retrieveRecoveryPayload(): RestorePayload?
     suspend fun clearRecoveryCode()
+    suspend fun isRestoreOnReinstallEnabled(): Boolean
+    suspend fun setRestoreOnReinstallEnabled(enabled: Boolean)
 }
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealSyncAutoRestoreManager @Inject constructor(
     private val persistentStorage: PersistentStorage,
+    private val dataStore: SyncAutoRestorePreferenceDataStore,
+    private val syncFeature: SyncFeature,
     private val dispatcherProvider: DispatcherProvider,
     private val moshi: Moshi,
 ) : SyncAutoRestoreManager {
+
+    override suspend fun isAutoRestoreAvailable(): Boolean {
+        return withContext(dispatcherProvider.io()) {
+            syncFeature.syncAutoRestore().isEnabled() &&
+                persistentStorage.checkAvailability() is PersistentStorageAvailability.Available
+        }
+    }
 
     override suspend fun saveRecoveryPayload(recoveryCode: String, deviceId: String?) {
         withContext(dispatcherProvider.io()) {
@@ -67,6 +81,18 @@ class RealSyncAutoRestoreManager @Inject constructor(
             persistentStorage.clear(SyncRecoveryPersistentStorageKey)
                 .onSuccess { logcat { "Sync-Recovery: recovery code cleared successfully" } }
                 .onFailure { logcat(LogPriority.ERROR) { "Sync-Recovery: failed to clear recovery code - ${it.message}" } }
+        }
+    }
+
+    override suspend fun isRestoreOnReinstallEnabled(): Boolean {
+        return withContext(dispatcherProvider.io()) {
+            dataStore.isRestoreOnReinstallEnabled()
+        }
+    }
+
+    override suspend fun setRestoreOnReinstallEnabled(enabled: Boolean) {
+        withContext(dispatcherProvider.io()) {
+            dataStore.setRestoreOnReinstallEnabled(enabled)
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestorePreferenceDataStore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestorePreferenceDataStore.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.di.SyncAutoRestoreStore
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+interface SyncAutoRestorePreferenceDataStore {
+    suspend fun isRestoreOnReinstallEnabled(): Boolean
+    suspend fun setRestoreOnReinstallEnabled(enabled: Boolean)
+}
+
+@ContributesBinding(AppScope::class)
+class RealSyncAutoRestorePreferenceDataStore @Inject constructor(
+    @SyncAutoRestoreStore private val dataStore: DataStore<Preferences>,
+) : SyncAutoRestorePreferenceDataStore {
+
+    override suspend fun isRestoreOnReinstallEnabled(): Boolean {
+        return dataStore.data.map { it[restoreOnReinstallKey] }.firstOrNull() ?: false
+    }
+
+    override suspend fun setRestoreOnReinstallEnabled(enabled: Boolean) {
+        dataStore.edit { it[restoreOnReinstallKey] = enabled }
+    }
+
+    companion object {
+        private val restoreOnReinstallKey = booleanPreferencesKey("restore_on_reinstall")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -168,7 +168,21 @@ object SyncStoreModule {
     fun provideSyncPromotionsDataStore(context: Context): DataStore<Preferences> {
         return context.dataStore
     }
+
+    private val Context.autoRestoreDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "com.duckduckgo.sync.auto_restore",
+    )
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @SyncAutoRestoreStore
+    fun provideSyncAutoRestoreDataStore(context: Context): DataStore<Preferences> {
+        return context.autoRestoreDataStore
+    }
 }
 
 @Qualifier
 annotation class SyncPromotion
+
+@Qualifier
+annotation class SyncAutoRestoreStore

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.sync.impl.ui.SyncInternalSettingsViewModel.Command.ReadQR
 import com.duckduckgo.sync.impl.ui.SyncInternalSettingsViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncInternalSettingsViewModel.Command.ShowQR
 import com.duckduckgo.sync.impl.ui.SyncInternalSettingsViewModel.ViewState
+import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity
 import com.google.android.material.snackbar.Snackbar
 import com.google.zxing.BarcodeFormat.QR_CODE
 import com.journeyapps.barcodescanner.BarcodeEncoder
@@ -84,6 +85,11 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         configureListeners()
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.onResume()
+    }
+
     private fun configureListeners() {
         binding.showQRCode.setOnClickListener {
             viewModel.onShowQRClicked()
@@ -109,6 +115,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.deviceIdTextView.setOnClickListener { copyToClipboard("Device ID", binding.deviceIdTextView.text.toString()) }
         binding.secretKeyTextView.setOnClickListener { copyToClipboard("Secret Key", binding.secretKeyTextView.text.toString()) }
         binding.tokenTextView.setOnClickListener { copyToClipboard("Token", binding.tokenTextView.text.toString()) }
+        binding.launchRecoverDataScreenButton.setOnClickListener {
+            viewModel.onLaunchRecoverDataScreen()
+        }
         binding.blockStoreWriteButton.setOnClickListener {
             viewModel.onBlockStoreWriteClicked(
                 recoveryCode = binding.blockStoreRecoveryCodeInput.text,
@@ -116,6 +125,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
             )
         }
         binding.blockStoreClearButton.setOnClickListener { viewModel.onBlockStoreClearClicked() }
+        binding.blockStoreWriteRecoveryCodeButton.setOnClickListener { viewModel.onBlockStoreWriteRecoveryCode() }
     }
 
     private fun observeUiEvents() {
@@ -159,6 +169,10 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
 
             LoginSuccess -> {
                 Snackbar.make(binding.syncRecoveryCodeCta, "Login Success", Snackbar.LENGTH_SHORT).show()
+            }
+
+            Command.LaunchRecoverDataScreen -> {
+                startActivity(SetupAccountActivity.intent(this, SetupAccountActivity.Companion.Screen.RECOVERY_CODE, null))
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
@@ -106,6 +106,7 @@ constructor(
         data object ReadConnectQR : Command()
         data class ShowQR(val string: String) : Command()
         data object LoginSuccess : Command()
+        data object LaunchRecoverDataScreen : Command()
     }
 
     init {
@@ -114,6 +115,22 @@ constructor(
             checkSyncAutoRestoreFlag()
             checkBlockStoreAvailability()
             refreshBlockStoreValue()
+        }
+    }
+
+    fun onResume() {
+        viewModelScope.launch(dispatchers.io()) {
+            refreshBlockStoreValue()
+        }
+    }
+
+    fun onLaunchRecoverDataScreen() {
+        viewModelScope.launch(dispatchers.io()) {
+            if (syncAccountRepository.isSignedIn()) {
+                command.send(Command.LaunchRecoverDataScreen)
+            } else {
+                command.send(Command.ShowMessage("Not signed in — create an account first"))
+            }
         }
     }
 
@@ -372,6 +389,24 @@ constructor(
             else -> BlockStoreValue.HasValue(String(bytes, Charsets.UTF_8))
         }
         viewState.update { it.copy(blockStoreCurrentValue = blockStoreValue) }
+    }
+
+    fun onBlockStoreWriteRecoveryCode() {
+        viewModelScope.launch(dispatchers.io()) {
+            val recoveryCode = syncAccountRepository.getRecoveryCode().getOrNull()
+            if (recoveryCode == null) {
+                command.send(ShowMessage("No recovery code available"))
+                return@launch
+            }
+            val deviceId = syncAccountRepository.getAccountInfo().deviceId
+            runCatching {
+                syncAutoRestoreManager.saveRecoveryPayload(recoveryCode.rawCode, deviceId)
+                refreshBlockStoreValue()
+                command.send(ShowMessage("Recovery code stored successfully"))
+            }.onFailure { error ->
+                command.send(ShowMessage("Store failed: ${error.message}"))
+            }
+        }
     }
 
     fun onBlockStoreWriteClicked(recoveryCode: String, deviceId: String?) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataFragment.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.setup
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.hide
+import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.sync.impl.PermissionRequest
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.ShareAction
+import com.duckduckgo.sync.impl.databinding.FragmentRecoverDataBinding
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.CheckIfUserHasStoragePermission
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.FinishWithError
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Next
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.RecoveryCodePDFSuccess
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.ShowMessage
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.CreatingAccount
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.SignedIn
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewState
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.*
+
+@InjectWith(FragmentScope::class)
+class RecoverDataFragment : DuckDuckGoFragment(R.layout.fragment_recover_data) {
+    @Inject
+    lateinit var viewModelFactory: FragmentViewModelFactory
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    lateinit var storagePermission: PermissionRequest
+
+    @Inject
+    lateinit var shareAction: ShareAction
+
+    private val binding: FragmentRecoverDataBinding by viewBinding()
+
+    private val viewModel: RecoverDataViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[RecoverDataViewModel::class.java]
+    }
+
+    private val listener: SyncSetupNavigationFlowListener?
+        get() = activity as? SyncSetupNavigationFlowListener
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        observeUiEvents()
+        configureListeners()
+        registerForPermission()
+    }
+
+    private fun registerForPermission() {
+        storagePermission.registerResultsCallback(this) {
+            binding.root.makeSnackbarWithNoBottomInset(R.string.sync_permission_required_store_recovery_code, Snackbar.LENGTH_LONG).show()
+        }
+    }
+
+    private fun configureListeners() {
+        binding.downloadAsPdfButton.setOnClickListener {
+            viewModel.onDownloadAsPdfClicked()
+        }
+        binding.footerNextButton.setOnClickListener {
+            viewModel.onNextClicked()
+        }
+        binding.copyCodeButton.setOnClickListener {
+            viewModel.onCopyCodeClicked()
+        }
+        binding.restoreOnReinstallToggle.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.onToggleChanged(isChecked)
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    viewModel.onBackPressed()
+                }
+            },
+        )
+    }
+
+    private fun observeUiEvents() {
+        viewModel
+            .viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .onEach { viewState -> renderViewState(viewState) }
+            .launchIn(lifecycleScope)
+
+        viewModel
+            .commands()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .onEach { processCommand(it) }
+            .launchIn(lifecycleScope)
+        binding.recoveryCodeSkeleton.startShimmer()
+    }
+
+    private fun processCommand(it: Command) {
+        when (it) {
+            FinishWithError -> {
+                requireActivity().setResult(Activity.RESULT_CANCELED)
+                requireActivity().finish()
+            }
+            Close -> {
+                requireActivity().setResult(Activity.RESULT_CANCELED)
+                requireActivity().finish()
+            }
+            is Next -> {
+                listener?.launchDeviceConnectedScreen()
+            }
+            is RecoveryCodePDFSuccess -> {
+                shareAction.shareFile(requireContext(), it.recoveryCodePDFFile)
+            }
+            CheckIfUserHasStoragePermission -> {
+                storagePermission.invokeOrRequestPermission {
+                    viewModel.generateRecoveryCode(requireContext())
+                }
+            }
+            is ShowMessage -> {
+                Snackbar.make(binding.root, it.message, Snackbar.LENGTH_LONG).show()
+            }
+            is ShowError -> showDialogError(it)
+        }
+    }
+
+    private fun showDialogError(it: ShowError) {
+        val context = context ?: return
+        TextAlertDialogBuilder(context)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(it.message) + "\n" + it.reason)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onErrorDialogDismissed()
+                    }
+                },
+            ).show()
+    }
+
+    private fun renderViewState(viewState: ViewState) {
+        when (val viewMode = viewState.viewMode) {
+            is SignedIn -> {
+                binding.recoveryCodeSkeleton.stopShimmer()
+                binding.recoveryCodeSkeleton.gone()
+                binding.recoverCodeContainer.show()
+                binding.recoveryCodeText.text = viewMode.b64RecoveryCode
+            }
+
+            CreatingAccount -> {
+                binding.recoverCodeContainer.hide()
+                binding.recoveryCodeSkeleton.startShimmer()
+            }
+        }
+        if (viewState.showRestoreOnReinstall) {
+            binding.restoreOnReinstallToggle.show()
+            binding.restoreOnReinstallToggle.quietlySetIsChecked(viewState.restoreOnReinstallEnabled) { _, isChecked ->
+                viewModel.onToggleChanged(isChecked)
+            }
+        } else {
+            binding.restoreOnReinstallToggle.gone()
+        }
+    }
+
+    companion object {
+        fun instance() = RecoverDataFragment()
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataViewModel.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.setup
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.clipboard.ClipboardInteractor
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.RecoveryCodePDF
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.getOrNull
+import com.duckduckgo.sync.impl.onFailure
+import com.duckduckgo.sync.impl.onSuccess
+import com.duckduckgo.sync.impl.pixels.SyncAccountOperation
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.CheckIfUserHasStoragePermission
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Next
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.RecoveryCodePDFSuccess
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.ShowMessage
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.CreatingAccount
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.SignedIn
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import javax.inject.*
+
+@ContributesViewModel(ActivityScope::class)
+class RecoverDataViewModel @Inject constructor(
+    private val recoveryCodePDF: RecoveryCodePDF,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val clipboard: ClipboardInteractor,
+    private val dispatchers: DispatcherProvider,
+    private val syncPixels: SyncPixels,
+    private val syncAutoRestoreManager: SyncAutoRestoreManager,
+) : ViewModel() {
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+    private val viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = viewState.onStart { createAccount() }
+
+    private fun createAccount() = viewModelScope.launch(dispatchers.io()) {
+        val showRestore = syncAutoRestoreManager.isAutoRestoreAvailable()
+
+        if (!syncAccountRepository.isSignedIn()) {
+            viewState.emit(ViewState(viewMode = CreatingAccount, showRestoreOnReinstall = showRestore))
+            syncAccountRepository.createAccount().onFailure {
+                command.send(Command.ShowError(R.string.sync_create_account_generic_error))
+                return@launch
+            }
+        }
+
+        syncAccountRepository.getRecoveryCode().getOrNull()?.let { recoveryCode ->
+            viewState.emit(
+                ViewState(
+                    viewMode = SignedIn(b64RecoveryCode = recoveryCode.rawCode),
+                    showRestoreOnReinstall = showRestore,
+                ),
+            )
+        } ?: command.send(Command.FinishWithError)
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    data class ViewState(
+        val viewMode: ViewMode = CreatingAccount,
+        val showRestoreOnReinstall: Boolean = false,
+        val restoreOnReinstallEnabled: Boolean = true,
+    )
+
+    sealed class ViewMode {
+        data object CreatingAccount : ViewMode()
+        data class SignedIn(
+            val b64RecoveryCode: String,
+        ) : ViewMode()
+    }
+
+    sealed class Command {
+        data object Next : Command()
+        data object Close : Command()
+        data class ShowMessage(val message: Int) : Command()
+        data object FinishWithError : Command()
+        data object CheckIfUserHasStoragePermission : Command()
+        data class RecoveryCodePDFSuccess(val recoveryCodePDFFile: File) : Command()
+        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+    }
+
+    fun onToggleChanged(enabled: Boolean) {
+        viewModelScope.launch {
+            viewState.emit(viewState.value.copy(restoreOnReinstallEnabled = enabled))
+        }
+    }
+
+    private suspend fun persistTogglePreference() {
+        syncAutoRestoreManager.setRestoreOnReinstallEnabled(viewState.value.restoreOnReinstallEnabled)
+    }
+
+    private suspend fun persistRecoveryPayload() {
+        if (viewState.value.restoreOnReinstallEnabled) {
+            val recoveryCode = syncAccountRepository.getRecoveryCode().getOrNull()?.rawCode
+            val deviceId = syncAccountRepository.getAccountInfo().deviceId
+            if (recoveryCode != null) {
+                syncAutoRestoreManager.saveRecoveryPayload(recoveryCode, deviceId)
+            }
+        } else {
+            syncAutoRestoreManager.clearRecoveryCode()
+        }
+    }
+
+    fun onNextClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            if (viewState.value.showRestoreOnReinstall) {
+                persistTogglePreference()
+                persistRecoveryPayload()
+            }
+            command.send(Next)
+        }
+    }
+
+    fun onBackPressed() {
+        viewModelScope.launch(dispatchers.io()) {
+            if (viewState.value.showRestoreOnReinstall) {
+                persistTogglePreference()
+                persistRecoveryPayload()
+            }
+            command.send(Close)
+        }
+    }
+
+    fun onCopyCodeClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val authCode = syncAccountRepository.getRecoveryCode().getOrNull() ?: return@launch
+            val notificationShown = clipboard.copyToClipboard(authCode.rawCode, isSensitive = true)
+            if (!notificationShown) {
+                command.send(ShowMessage(R.string.sync_code_copied_message))
+            }
+        }
+    }
+
+    fun onDownloadAsPdfClicked() {
+        viewModelScope.launch {
+            command.send(CheckIfUserHasStoragePermission)
+        }
+    }
+
+    fun generateRecoveryCode(viewContext: Context) {
+        viewModelScope.launch(dispatchers.io()) {
+            syncAccountRepository.getRecoveryCode()
+                .onSuccess { authCode ->
+                    kotlin.runCatching {
+                        recoveryCodePDF.generateAndStoreRecoveryCodePDF(viewContext, authCode.rawCode)
+                    }.onSuccess { generateRecoveryCodePDF ->
+                        command.send(RecoveryCodePDFSuccess(generateRecoveryCodePDF))
+                    }.onFailure {
+                        syncPixels.fireSyncAccountErrorPixel(Error(reason = it.message.toString()), type = SyncAccountOperation.CREATE_PDF)
+                        command.send(Command.ShowError(R.string.sync_recovery_pdf_error))
+                    }
+                }.onFailure {
+                    command.send(Command.ShowError(R.string.sync_recovery_pdf_error))
+                }
+        }
+    }
+
+    fun onErrorDialogDismissed() {
+        viewModelScope.launch(dispatchers.io()) {
+            command.send(Command.FinishWithError)
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
@@ -142,10 +142,15 @@ class SetupAccountActivity : DuckDuckGoActivity(), SyncSetupNavigationFlowListen
                 }
             }
 
-            AskSaveRecoveryCode -> {
+            is AskSaveRecoveryCode -> {
                 screen = RECOVERY_CODE
+                val fragment = if (viewState.viewMode.useNewScreen) {
+                    RecoverDataFragment.instance()
+                } else {
+                    SaveRecoveryCodeFragment.instance()
+                }
                 supportFragmentManager.commitNow {
-                    replace(id.fragment_container_view, SaveRecoveryCodeFragment.instance(), TAG_RECOVER_ACCOUNT)
+                    replace(id.fragment_container_view, fragment, TAG_RECOVER_ACCOUNT)
                 }
             }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.promotion.SyncGetOnOtherPlatformsLaunchSource
 import com.duckduckgo.sync.impl.promotion.SyncGetOnOtherPlatformsLaunchSource.SOURCE_ACTIVATING
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen
@@ -45,10 +46,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
-class SetupAccountViewModel @Inject constructor(private val dispatchers: DispatcherProvider) : ViewModel() {
+class SetupAccountViewModel @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
     private val viewState = MutableStateFlow(ViewState())
@@ -56,12 +61,14 @@ class SetupAccountViewModel @Inject constructor(private val dispatchers: Dispatc
 
     fun viewState(screen: Screen): Flow<ViewState> = viewState.onStart {
         if (!initialStateProcessed) {
-            val viewMode = when (screen) {
-                SYNC_SETUP -> CreateAccount
-                SETUP_COMPLETE -> SyncSetupCompleted
-                RECOVERY_CODE -> AskSaveRecoveryCode
-                SYNC_INTRO -> IntroCreateAccount
-                RECOVERY_INTRO -> IntroRecoveryCode
+            val viewMode = withContext(dispatchers.io()) {
+                when (screen) {
+                    SYNC_SETUP -> CreateAccount
+                    SETUP_COMPLETE -> SyncSetupCompleted
+                    RECOVERY_CODE -> AskSaveRecoveryCode(useNewScreen = syncFeature.recoverDataEasilySetupScreen().isEnabled())
+                    SYNC_INTRO -> IntroCreateAccount
+                    RECOVERY_INTRO -> IntroRecoveryCode
+                }
             }
             viewState.emit(ViewState(viewMode))
             initialStateProcessed = true
@@ -76,7 +83,7 @@ class SetupAccountViewModel @Inject constructor(private val dispatchers: Dispatc
 
     sealed class ViewMode {
         data object CreateAccount : ViewMode()
-        data object AskSaveRecoveryCode : ViewMode()
+        data class AskSaveRecoveryCode(val useNewScreen: Boolean = false) : ViewMode()
         data object SyncSetupCompleted : ViewMode()
 
         data object IntroCreateAccount : ViewMode()
@@ -121,8 +128,8 @@ class SetupAccountViewModel @Inject constructor(private val dispatchers: Dispatc
     }
 
     fun onRecoveryCodePrompt() {
-        viewModelScope.launch {
-            viewState.emit(ViewState(viewMode = AskSaveRecoveryCode))
+        viewModelScope.launch(dispatchers.io()) {
+            viewState.emit(ViewState(viewMode = AskSaveRecoveryCode(useNewScreen = syncFeature.recoverDataEasilySetupScreen().isEnabled())))
         }
     }
 

--- a/sync/sync-impl/src/main/res/drawable/background_card_container.xml
+++ b/sync/sync-impl/src/main/res/drawable/background_card_container.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/daxColorContainer" />
+    <corners android:radius="@dimen/largeShapeCornerRadius" />
+</shape>

--- a/sync/sync-impl/src/main/res/drawable/ic_qr_24.xml
+++ b/sync/sync-impl/src/main/res/drawable/ic_qr_24.xml
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,5.75C5,5.336 5.336,5 5.75,5H7.25C7.664,5 8,5.336 8,5.75V7.25C8,7.664 7.664,8 7.25,8H5.75C5.336,8 5,7.664 5,7.25V5.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M2,5C2,3.343 3.343,2 5,2H8C9.657,2 11,3.343 11,5V8C11,9.657 9.657,11 8,11H5C3.343,11 2,9.657 2,8V5ZM5,3.5C4.172,3.5 3.5,4.172 3.5,5V8C3.5,8.828 4.172,9.5 5,9.5H8C8.828,9.5 9.5,8.828 9.5,8V5C9.5,4.172 8.828,3.5 8,3.5H5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M5.75,16C5.336,16 5,16.336 5,16.75V18.25C5,18.664 5.336,19 5.75,19H7.25C7.664,19 8,18.664 8,18.25V16.75C8,16.336 7.664,16 7.25,16H5.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M2,16C2,14.343 3.343,13 5,13H8C9.657,13 11,14.343 11,16V19C11,20.657 9.657,22 8,22H5C3.343,22 2,20.657 2,19V16ZM5,14.5C4.172,14.5 3.5,15.172 3.5,16V19C3.5,19.828 4.172,20.5 5,20.5H8C8.828,20.5 9.5,19.828 9.5,19V16C9.5,15.172 8.828,14.5 8,14.5H5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M16.75,5C16.336,5 16,5.336 16,5.75V7.25C16,7.664 16.336,8 16.75,8H18.25C18.664,8 19,7.664 19,7.25V5.75C19,5.336 18.664,5 18.25,5H16.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M16,2C14.343,2 13,3.343 13,5V8C13,9.657 14.343,11 16,11H19C20.657,11 22,9.657 22,8V5C22,3.343 20.657,2 19,2H16ZM14.5,5C14.5,4.172 15.172,3.5 16,3.5H19C19.828,3.5 20.5,4.172 20.5,5V8C20.5,8.828 19.828,9.5 19,9.5H16C15.172,9.5 14.5,8.828 14.5,8V5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M16,16.75C16,16.336 16.336,16 16.75,16H18.25C18.664,16 19,16.336 19,16.75V18.25C19,18.664 18.664,19 18.25,19H16.75C16.336,19 16,18.664 16,18.25V16.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M22,13.75C22,13.336 21.664,13 21.25,13H19.75C19.336,13 19,13.336 19,13.75C19,14.164 19.336,14.5 19.75,14.5H20.5V16.25C20.5,16.664 20.836,17 21.25,17C21.664,17 22,16.664 22,16.25V13.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M13,21.25V18.75C13,18.336 13.336,18 13.75,18C14.164,18 14.5,18.336 14.5,18.75V20.5H15.25C15.664,20.5 16,20.836 16,21.25C16,21.664 15.664,22 15.25,22H13.75C13.336,22 13,21.664 13,21.25Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M18,21.25C18,20.836 18.336,20.5 18.75,20.5H20.5V19.75C20.5,19.336 20.836,19 21.25,19C21.664,19 22,19.336 22,19.75V21.25C22,21.664 21.664,22 21.25,22H18.75C18.336,22 18,21.664 18,21.25Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M13,13.75C13,13.336 13.336,13 13.75,13H16.25C16.664,13 17,13.336 17,13.75C17,14.164 16.664,14.5 16.25,14.5H14.5V15.25C14.5,15.664 14.164,16 13.75,16C13.336,16 13,15.664 13,15.25V13.75Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
@@ -156,6 +156,25 @@
                     android:text="@string/sync_internal_block_store_clear" />
 
             </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/blockStoreWriteRecoveryCodeButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                app:daxButtonSize="large"
+                android:text="@string/sync_internal_block_store_write_recovery_code" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/launchRecoverDataScreenButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                app:daxButtonSize="large"
+                android:text="@string/sync_internal_launch_recover_data_screen"/>
+
         </LinearLayout>
 
         <com.duckduckgo.common.ui.view.divider.HorizontalDivider

--- a/sync/sync-impl/src/main/res/layout/fragment_recover_data.xml
+++ b/sync/sync-impl/src/main/res/layout/fragment_recover_data.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorSurface"
+    tools:ignore="Overdraw"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.duckduckgo.common.ui.view.button.IconButton
+            android:id="@+id/close_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:padding="@dimen/keyline_4"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_close_24" />
+
+    </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/content_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fadeScrollbars="false"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/footer_next_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingStart="@dimen/keyline_5"
+            android:paddingEnd="@dimen/keyline_5"
+            android:paddingTop="20dp"
+            android:clipToPadding="false">
+
+            <ImageView
+                android:id="@+id/content_illustration"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:src="@drawable/ic_download_qr_128"
+                tools:ignore="ContentDescription" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/content_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:gravity="center"
+                android:text="@string/sync_recover_data_title"
+                app:textType="primary"
+                app:typography="h1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/content_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:gravity="center"
+                android:paddingStart="@dimen/keyline_2"
+                android:paddingEnd="@dimen/keyline_2"
+                android:text="@string/sync_recover_data_content"
+                app:textType="primary"
+                app:typography="body1" />
+
+            <!-- Shimmer skeleton shown while loading -->
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/recoveryCodeSkeleton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:background="@drawable/background_card_container"
+                android:padding="@dimen/keyline_4"
+                android:visibility="invisible"
+                tools:visibility="gone">
+
+                <com.duckduckgo.common.ui.view.SkeletonView
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp" />
+
+            </com.facebook.shimmer.ShimmerFrameLayout>
+
+            <!-- Recovery code card -->
+            <LinearLayout
+                android:id="@+id/recover_code_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:background="@drawable/background_card_container"
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/keyline_4"
+                android:visibility="visible">
+
+                <!-- Recovery code list item row -->
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="64dp"
+                    android:paddingStart="@dimen/keyline_4"
+                    android:paddingEnd="@dimen/keyline_4"
+                    android:paddingTop="@dimen/keyline_3"
+                    android:paddingBottom="@dimen/keyline_3">
+
+                    <!-- QR icon with container background -->
+                    <FrameLayout
+                        android:id="@+id/recoveryCodeIcon"
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:background="@drawable/list_item_image_round_background"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent">
+
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:layout_gravity="center"
+                            android:src="@drawable/ic_qr_24"
+                            tools:ignore="ContentDescription" />
+
+                    </FrameLayout>
+
+                    <!-- Recovery code label + text -->
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/keyline_4"
+                        android:layout_marginEnd="@dimen/keyline_4"
+                        android:orientation="vertical"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/copyCodeButton"
+                        app:layout_constraintStart_toEndOf="@id/recoveryCodeIcon"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.duckduckgo.common.ui.view.text.DaxTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/sync_recover_data_recovery_code_label"
+                            app:textType="secondary"
+                            app:typography="body1" />
+
+                        <com.duckduckgo.common.ui.view.text.DaxTextView
+                            android:id="@+id/recoveryCodeText"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:ellipsize="end"
+                            android:maxLines="2"
+                            app:textType="secondary"
+                            app:typography="body1_mono" />
+
+                    </LinearLayout>
+
+                    <!-- Copy button -->
+                    <com.duckduckgo.common.ui.view.button.IconButton
+                        android:id="@+id/copyCodeButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?selectableItemBackgroundBorderless"
+                        app:srcCompat="@drawable/ic_copy_24"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <!-- Download as PDF button -->
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/downloadAsPdfButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/keyline_4"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="@string/sync_recover_data_download_pdf"
+                    app:daxButtonSize="small" />
+
+            </LinearLayout>
+
+            <!-- Restore on Reinstall card -->
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/restoreOnReinstallToggle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:background="@drawable/background_card_container"
+                app:primaryText="@string/sync_restore_on_reinstall_title"
+                app:secondaryText="@string/sync_restore_on_reinstall_description"
+                app:showSwitch="true" />
+
+        </LinearLayout>
+    </ScrollView>
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/footer_next_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_5"
+        android:layout_marginEnd="@dimen/keyline_5"
+        android:text="@string/sync_recovery_code_skip_button"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -34,6 +34,17 @@
     <string name="sync_internal_promotions_clear_history_bookmark_screen_promo">Clear history (bookmark screen)</string>
     <string name="sync_internal_promotions_clear_history_password_screen_promo">Clear history (password screen)</string>
 
+    <!-- Recover Data Screen -->
+    <string name="sync_recover_data_title">Recover Your Data Easily</string>
+    <string name="sync_recover_data_content">Use this code to restore your data if you lose access to this device. Sync &amp; Backup data can\'t be recovered after 18 months of inactivity.</string>
+    <string name="sync_recover_data_recovery_code_label">Recovery Code</string>
+    <string name="sync_recover_data_download_pdf">Download as PDF</string>
+    <string name="sync_restore_on_reinstall_title">Restore on App Reinstall</string>
+    <string name="sync_restore_on_reinstall_description">If you reinstall the DuckDuckGo app, we\'ll ask if you want to restore your data on this device.</string>
+
+    <string name="sync_internal_launch_recover_data_screen">Launch Recover Data Screen</string>
+    <string name="sync_internal_block_store_write_recovery_code">Save Recovery Code to Persistent Storage</string>
+
     <!-- Block Store -->
     <string name="sync_internal_block_store_header">Persistent Storage / Block Store</string>
     <string name="sync_internal_block_store_current_value_label">Current stored value (SyncRecovery key)</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreManagerTest.kt
@@ -16,12 +16,19 @@
 
 package com.duckduckgo.sync.impl.autorestore
 
+import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
+import com.duckduckgo.sync.impl.SyncFeature
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,12 +38,16 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 class RealSyncAutoRestoreManagerTest {
 
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
+    // you might also need to add  if setting raw values for feature toggles
     private val persistentStorage: PersistentStorage = mock()
+    private val dataStore: SyncAutoRestorePreferenceDataStore = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var testee: RealSyncAutoRestoreManager
 
@@ -46,6 +57,8 @@ class RealSyncAutoRestoreManagerTest {
         whenever(persistentStorage.clear(any())).thenReturn(Result.success(Unit))
         testee = RealSyncAutoRestoreManager(
             persistentStorage = persistentStorage,
+            dataStore = dataStore,
+            syncFeature = syncFeature,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             moshi = Moshi.Builder().build(),
         )
@@ -121,5 +134,29 @@ class RealSyncAutoRestoreManagerTest {
         testee.clearRecoveryCode()
 
         verify(persistentStorage).clear(any())
+    }
+
+    @Test
+    fun whenFFEnabledAndStorageAvailableThenIsAutoRestoreAvailableReturnsTrue() = runTest {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = true))
+        whenever(persistentStorage.checkAvailability()).thenReturn(PersistentStorageAvailability.Available(isEndToEndEncryptionSupported = true))
+
+        assertTrue(testee.isAutoRestoreAvailable())
+    }
+
+    @Test
+    fun whenFFDisabledThenIsAutoRestoreAvailableReturnsFalse() = runTest {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = false))
+        whenever(persistentStorage.checkAvailability()).thenReturn(PersistentStorageAvailability.Available(isEndToEndEncryptionSupported = true))
+
+        assertFalse(testee.isAutoRestoreAvailable())
+    }
+
+    @Test
+    fun whenFFEnabledAndStorageUnavailableThenIsAutoRestoreAvailableReturnsFalse() = runTest {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = true))
+        whenever(persistentStorage.checkAvailability()).thenReturn(PersistentStorageAvailability.Unavailable)
+
+        assertFalse(testee.isAutoRestoreAvailable())
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
@@ -105,6 +105,7 @@ class RealSyncAutoRestoreTest {
 
     @Test
     fun whenRestoreSyncAccountCalledThenRetrievesKeyAndCallsProcessCode() = runTest {
+        configureAutoRestoreEnabled(true)
         val recoveryCodeString = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
         val deviceId = "device-abc-123"
         configureRetrieveSuccess(payload = RestorePayload(recoveryCode = recoveryCodeString, deviceId = deviceId))
@@ -156,12 +157,23 @@ class RealSyncAutoRestoreTest {
 
     @Test
     fun whenParseSyncAuthCodeThrowsThenRestoreSyncAccountDoesNotCrash() = runTest {
+        configureAutoRestoreEnabled(true)
         val recoveryCodeString = "invalid_not_base64"
         configureRetrieveSuccess(payload = RestorePayload(recoveryCode = recoveryCodeString, deviceId = "device-123"))
         whenever(syncAccountRepository.parseSyncAuthCode(recoveryCodeString)).thenThrow(RuntimeException("Parse error"))
 
         testee.restoreSyncAccount()
 
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenRestoreSyncAccountCalledButFFDisabledThenDoesNotAccessStorage() = runTest {
+        configureAutoRestoreEnabled(false)
+
+        testee.restoreSyncAccount()
+
+        verify(manager, never()).retrieveRecoveryPayload()
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserverTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserverTest.kt
@@ -29,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -110,6 +111,6 @@ class SyncAutoRestoreAccountDisabledObserverTest {
         isSignedInFlow.emit(true)
         isSignedInFlow.emit(false)
 
-        verify(syncAutoRestoreManager, org.mockito.kotlin.times(2)).clearRecoveryCode()
+        verify(syncAutoRestoreManager, times(2)).clearRecoveryCode()
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataViewModelTest.kt
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.setup
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.app.clipboard.ClipboardInteractor
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailInvalid
+import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
+import com.duckduckgo.sync.TestSyncFixtures.pdfFile
+import com.duckduckgo.sync.impl.AccountInfo
+import com.duckduckgo.sync.impl.RecoveryCodePDF
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
+import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.Next
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.Command.RecoveryCodePDFSuccess
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.CreatingAccount
+import com.duckduckgo.sync.impl.ui.setup.RecoverDataViewModel.ViewMode.SignedIn
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+@RunWith(AndroidJUnit4::class)
+class RecoverDataViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val recoveryPDF: RecoveryCodePDF = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val clipboard: ClipboardInteractor = mock()
+    private val syncPixels: SyncPixels = mock()
+    private val syncAutoRestoreManager: SyncAutoRestoreManager = mock()
+
+    private val testee = RecoverDataViewModel(
+        recoveryPDF,
+        syncAccountRepository,
+        clipboard,
+        coroutineTestRule.testDispatcherProvider,
+        syncPixels,
+        syncAutoRestoreManager,
+    )
+
+    @Test
+    fun whenUserIsNotSignedInThenAccountCreatedAndViewStateUpdated() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
+        whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            assertTrue(viewState.viewMode is SignedIn)
+            assertTrue(viewState.restoreOnReinstallEnabled)
+            assertTrue(viewState.showRestoreOnReinstall)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserSignedInThenShowViewState() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            assertTrue(viewState.viewMode is SignedIn)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPersistentStorageUnavailableThenShowRestoreOnReinstallFalse() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            assertTrue(viewState.viewMode is SignedIn)
+            assertFalse(viewState.showRestoreOnReinstall)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCreateAccountFailsThenEmitShowError() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
+        whenever(syncAccountRepository.createAccount()).thenReturn(accountCreatedFailInvalid)
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            assertTrue(viewState.viewMode is CreatingAccount)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is Command.ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksNextThenSetsRestorePreferenceAndEmitsNext() = runTest {
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(AccountInfo(deviceId = "test-device-id"))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            testee.onNextClicked()
+            val command = awaitItem()
+            assertTrue(command is Next)
+            verify(syncAutoRestoreManager).setRestoreOnReinstallEnabled(true)
+            verify(syncAutoRestoreManager).saveRecoveryPayload("test-recovery-code", "test-device-id")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenToggleChangedToFalseAndNextClickedThenSetsRestoreDisabledAndClearsPayload() = runTest {
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.onToggleChanged(false)
+
+        testee.commands().test {
+            testee.onNextClicked()
+            val command = awaitItem()
+            assertTrue(command is Next)
+            verify(syncAutoRestoreManager).setRestoreOnReinstallEnabled(false)
+            verify(syncAutoRestoreManager).clearRecoveryCode()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenBackPressedThenPersistsToggleAndPayloadAndEmitsClose() = runTest {
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(AccountInfo(deviceId = "test-device-id"))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            testee.onBackPressed()
+            val command = awaitItem()
+            assertTrue(command is Close)
+            verify(syncAutoRestoreManager).setRestoreOnReinstallEnabled(true)
+            verify(syncAutoRestoreManager).saveRecoveryPayload("test-recovery-code", "test-device-id")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenToggleChangedToFalseAndBackPressedThenSetsRestoreDisabledAndClearsPayload() = runTest {
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.onToggleChanged(false)
+
+        testee.commands().test {
+            testee.onBackPressed()
+            val command = awaitItem()
+            assertTrue(command is Close)
+            verify(syncAutoRestoreManager).setRestoreOnReinstallEnabled(false)
+            verify(syncAutoRestoreManager).clearRecoveryCode()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAutoRestoreUnavailableAndNextClickedThenDoesNotPersistPayloadOrPreference() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            testee.onNextClicked()
+            val command = awaitItem()
+            assertTrue(command is Next)
+            verify(syncAutoRestoreManager, never()).setRestoreOnReinstallEnabled(any())
+            verify(syncAutoRestoreManager, never()).saveRecoveryPayload(any(), any())
+            verify(syncAutoRestoreManager, never()).clearRecoveryCode()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAutoRestoreUnavailableAndBackPressedThenDoesNotPersistPayloadOrPreference() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "test-recovery-code")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            testee.onBackPressed()
+            val command = awaitItem()
+            assertTrue(command is Close)
+            verify(syncAutoRestoreManager, never()).setRestoreOnReinstallEnabled(any())
+            verify(syncAutoRestoreManager, never()).saveRecoveryPayload(any(), any())
+            verify(syncAutoRestoreManager, never()).clearRecoveryCode()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksOnDownloadAsPdfThenEmitCheckPermissionCommand() = runTest {
+        testee.commands().test {
+            testee.onDownloadAsPdfClicked()
+            val command = awaitItem()
+            assertTrue(command is Command.CheckIfUserHasStoragePermission)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenGenerateRecoveryCodeThenGenerateFileAndEmitSuccessCommand() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(recoveryPDF.generateAndStoreRecoveryCodePDF(any(), eq(authCodeToUse.rawCode))).thenReturn(pdfFile())
+
+        testee.commands().test {
+            testee.generateRecoveryCode(mock())
+            val command = awaitItem()
+            assertTrue(command is RecoveryCodePDFSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksCopyThenCopyToClipboard() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(clipboard.copyToClipboard(any(), any())).thenReturn(false)
+        testee.commands().test {
+            testee.onCopyCodeClicked()
+            val command = awaitItem()
+            verify(clipboard).copyToClipboard(eq("something else"), eq(true))
+            assertTrue(command is Command.ShowMessage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksCopyAndSystemShowsNotificationThenNoSnackbar() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(clipboard.copyToClipboard(any(), any())).thenReturn(true)
+        testee.commands().test {
+            testee.onCopyCodeClicked()
+            verify(clipboard).copyToClipboard(eq("something else"), eq(true))
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAutoRestoreNotAvailableThenShowRestoreOnReinstallFalse() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            assertTrue(viewState.viewMode is SignedIn)
+            assertFalse(viewState.showRestoreOnReinstall)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenToggleChangedThenViewStateUpdated() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(true)
+
+        testee.viewState().test {
+            val initialState = awaitItem()
+            assertTrue(initialState.restoreOnReinstallEnabled)
+
+            testee.onToggleChanged(false)
+            val updatedState = awaitItem()
+            assertFalse(updatedState.restoreOnReinstallEnabled)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountViewModelTest.kt
@@ -16,14 +16,19 @@
 
 package com.duckduckgo.sync.impl.ui.setup
 
+import android.annotation.SuppressLint
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountViewModel.Command
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountViewModel.ViewMode
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +37,9 @@ class SetupAccountViewModelTest {
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
-    private val testee = SetupAccountViewModel(coroutineTestRule.testDispatcherProvider)
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    private val testee = SetupAccountViewModel(coroutineTestRule.testDispatcherProvider, syncFeature)
 
     @Test
     fun whenFlowStartedFromSyncSetupScreenViewModeThenCreateAccountCommandSent() = runTest {
@@ -138,5 +145,31 @@ class SetupAccountViewModelTest {
             }
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenRecoverDataEasilySetupScreenEnabledThenRecoveryCodeScreenUsesNewScreen() = runTest {
+        setRawFeatureFlagState(true)
+        testee.viewState(Screen.RECOVERY_CODE).test {
+            val viewState = awaitItem()
+            val viewMode = viewState.viewMode as ViewMode.AskSaveRecoveryCode
+            assertTrue(viewMode.useNewScreen)
+        }
+    }
+
+    @Test
+    fun whenRecoverDataEasilySetupScreenDisabledThenRecoveryCodeScreenUsesOldScreen() = runTest {
+        setRawFeatureFlagState(false)
+        val testee = SetupAccountViewModel(coroutineTestRule.testDispatcherProvider, syncFeature)
+        testee.viewState(Screen.RECOVERY_CODE).test {
+            val viewState = awaitItem()
+            val viewMode = viewState.viewMode as ViewMode.AskSaveRecoveryCode
+            assertFalse(viewMode.useNewScreen)
+        }
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun setRawFeatureFlagState(state: Boolean) {
+        syncFeature.recoverDataEasilySetupScreen().setRawStoredState(State(enable = state))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213299640229975?focus=true

### Description
Adds a new "Recover Your Data Easily" screen as an alternative to the existing recovery code screen during sync setup. The new screen includes a "Restore on App Reinstall" toggle that, when enabled, persists the recovery code and device ID to Block Store when the user taps Next or Back.

- Gated by `recoverDataEasilySetupScreen` (INTERNAL — enabled for internal builds by default)
- The toggle is shown only when `syncAutoRestore` is enabled **and** Block Store is available on the device
- Toggle preference is persisted to DataStore so it is remembered if the screen is revisited (which will be needed in follow up PR)
- On Next or Back: if toggle is ON, saves recovery code + device ID to Block Store; if OFF, clears any existing payload

### Steps to test this PR

**Notes**
- Prerequisites: Internal build installed on a device with Google Play Services, logged into a Google account.
- Navigate to **Settings > Sync Dev Settings** to access Block Store controls and to launch the new screen directly.
- ℹ️ Clearing app data does **not** restore Block Store data; it must be an uninstall/reinstall.
- Suggested logcat filter: `Sync-Recovery|Sync-AutoRestore`

**Scenario 1: `recoverDataEasilySetupScreen` OFF — old screen shown, no regression**
- [x] Disable `recoverDataEasilySetupScreen` FF by hardcoding it to `FALSE`
- [x] Fresh install `internalDebug`
- [x] Set up Sync via **Sync & Backup → Sync & Back Up This Device**
- [x] Verify the old recovery code screen is shown (title: "Save Recovery Code")
- [x] Tap **Next** — verify sync setup continues normally

**Scenario 2: `recoverDataEasilySetupScreen` ON, `syncAutoRestore` OFF — new screen shown, no toggle**
- [x] Discard local changes, to return `recoverDataEasilySetupScreen` to `INTERNAL`
- [x] Fresh install
- [x] Set up Sync via **Sync & Backup → Sync & Back Up This Device**
- [x] Verify the new "Recover Your Data Easily" screen is shown
- [x] Verify the "Restore on App Reinstall" toggle is **not** visible
- [x] Tap **Next** — verify sync setup continues normally
- [x] Go to **Sync Dev Settings** → verify Block Store is empty (nothing was written)

**Scenario 3: `recoverDataEasilySetupScreen` ON, `syncAutoRestore` ON — toggle ON, payload saved on Next**
- [x] Set both `recoverDataEasilySetupScreen` and `syncAutoRestore` to `INTERNAL`
- [x] Fresh install
- [x] Set up Sync via **Sync & Backup → Sync & Back Up This Device**
- [x] Verify the new "Recover Your Data Easily" screen is shown with the toggle visible and **ON** by default
- [x] Tap **Next**
- [x] Go to **Sync Dev Settings** → verify Block Store shows a JSON payload containing both `recovery_code` and `device_id`

**Scenario 4: `recoverDataEasilySetupScreen` ON, `syncAutoRestore` ON — toggle turned OFF, payload cleared**
- [x] Clear app data and restart (clear data this time as you want a fresh slate)
- [x] Set up Sync. On the new screen, toggle "Restore on App Reinstall" to **OFF**
- [x] Tap **Next**
- [x] Go to **Sync Dev Settings** → verify Block Store is empty (payload was cleared)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new sync setup screen and new persistence paths (DataStore + Block Store writes/clears) that affect account recovery behavior and device state. Risk is mitigated by feature-flag gating (`recoverDataEasilySetupScreen`) and additional unit test coverage, but flow/regression risk remains in setup navigation and storage availability checks.
> 
> **Overview**
> Adds an alternative **“Recover Your Data Easily”** recovery-code step during sync setup (new `RecoverDataFragment`/`RecoverDataViewModel` + layout/drawables/strings), selected via a new `recoverDataEasilySetupScreen` feature toggle.
> 
> Extends auto-restore support by detecting Block Store availability (`isAutoRestoreAvailable`) and introducing a persisted *Restore on App Reinstall* user preference via a new `DataStore` (`SyncAutoRestorePreferenceDataStore` + DI wiring). When the toggle is enabled/disabled, the flow now writes or clears the recovery payload (recovery code + device id) in persistent storage on Next/Back.
> 
> Updates internal sync dev settings to refresh Block Store values on resume, add a one-tap “store current recovery code” action, and provide a shortcut to launch the new recovery screen; adds/updates unit tests around the new availability gating and setup-screen selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39f9946d71701bd3ad3a279a59202c277eed5aaa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->