### PR TITLE
PIR: Improve download and extraction step for broker json

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerDataDownloader.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/BrokerDataDownloader.kt
@@ -26,12 +26,14 @@ import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.logcat
-import okhttp3.ResponseBody
 import okio.FileSystem.Companion.SYSTEM
 import okio.Path.Companion.toPath
+import okio.buffer
+import okio.source
 import java.io.File
 import java.io.FileOutputStream
 import java.util.zip.ZipInputStream
@@ -55,36 +57,61 @@ class RealBrokerDataDownloader @Inject constructor(
     private val context: Context,
     private val pirPixelSender: PirPixelSender,
 ) : BrokerDataDownloader {
+
+    private val brokerAdapter by lazy {
+        Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .add(StepsAsStringAdapter())
+            .build()
+            .adapter(PirJsonBroker::class.java)
+    }
+
     override suspend fun downloadBrokerData(brokersToUpdate: List<String>) {
         withContext(dispatcherProvider.io()) {
             if (brokersToUpdate.isNotEmpty()) {
+                logcat { "PIR-update: Starting to download broker data" }
                 val extractFolder = File(context.filesDir, "unzipped-broker-json")
-                extractJsonFilesFromResponse(dbpService.getBrokerJsonFiles(), extractFolder)
-                processBrokerJsonFiles(extractFolder, brokersToUpdate)
-                SYSTEM.deleteRecursively(extractFolder.path.toPath())
+                val zipFile = File.createTempFile("broker-data", ".zip", context.cacheDir)
+                try {
+                    dbpService.getBrokerJsonFiles().use { body ->
+                        body.byteStream().use { input ->
+                            zipFile.outputStream().use { input.copyTo(it) }
+                        }
+                    }
+                    extractJsonFilesFromZip(zipFile, extractFolder)
+                    processBrokerJsonFiles(extractFolder, brokersToUpdate)
+                } finally {
+                    zipFile.delete()
+                    if (extractFolder.exists()) {
+                        SYSTEM.deleteRecursively(extractFolder.path.toPath())
+                    }
+                }
+                logcat { "PIR-update: Done downloading broker data" }
             }
         }
     }
 
-    private fun extractJsonFilesFromResponse(
-        responseBody: ResponseBody,
+    private fun extractJsonFilesFromZip(
+        zipFile: File,
         outputDir: File,
     ) {
-        logcat { "PIR-update: Extracting data from $responseBody" }
-        ZipInputStream(responseBody.byteStream()).use { zipInputStream ->
+        logcat { "PIR-update: Extracting data from $zipFile" }
+        outputDir.mkdirs()
+        val outputDirCanonical = outputDir.canonicalPath
+        ZipInputStream(zipFile.inputStream().buffered()).use { zipInputStream ->
             var entry = zipInputStream.nextEntry
             while (entry != null) {
-                val outputFile = File(outputDir, entry.name)
-
-                if (entry.isDirectory) {
-                    outputFile.mkdirs()
-                } else {
-                    outputFile.parentFile?.mkdirs()
-                    FileOutputStream(outputFile).use { outputStream ->
-                        zipInputStream.copyTo(outputStream)
+                if (!entry.isDirectory && entry.name.endsWith(".json")) {
+                    val outputFile = File(outputDir, entry.name)
+                    if (outputFile.canonicalPath.startsWith(outputDirCanonical + File.separator)) {
+                        outputFile.parentFile?.mkdirs()
+                        FileOutputStream(outputFile).buffered().use { outputStream ->
+                            zipInputStream.copyTo(outputStream)
+                        }
+                    } else {
+                        logcat(ERROR) { "PIR-update: Skipping ZIP entry with invalid path: ${entry.name}" }
                     }
                 }
-
                 zipInputStream.closeEntry()
                 entry = zipInputStream.nextEntry
             }
@@ -102,18 +129,14 @@ class RealBrokerDataDownloader @Inject constructor(
             return
         }
 
-        val adapter = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .add(StepsAsStringAdapter())
-            .build()
-            .adapter(PirJsonBroker::class.java)
-
-        directory.listFiles()?.get(0)?.listFiles { file ->
-            file.extension == "json" && brokersToUpdate.contains(file.name)
+        val brokersToUpdateSet = brokersToUpdate.toHashSet()
+        directory.listFiles()?.firstOrNull()?.listFiles { file ->
+            file.extension == "json" && file.name in brokersToUpdateSet
         }?.forEach { jsonFile ->
             logcat { "PIR-update: Processing data from ${jsonFile.name}" }
-            val content = jsonFile.readText() // Read JSON file as string
-            val broker = runCatching { adapter.fromJson(content) }.getOrNull()
+            val broker = runCatching { jsonFile.source().buffer().use { brokerAdapter.fromJson(it) } }
+                .onFailure { logcat(ERROR) { "PIR-update: Failed to parse ${jsonFile.name}: $it" } }
+                .getOrNull()
             if (broker != null) {
                 try {
                     pirRepository.updateBrokerData(jsonFile.name, broker)
@@ -121,6 +144,8 @@ class RealBrokerDataDownloader @Inject constructor(
                         brokerJsonFileName = jsonFile.name,
                         removedAtMs = broker.removedAt ?: 0L,
                     )
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Throwable) {
                     pirPixelSender.reportUpdateBrokerJsonFailure(
                         brokerJsonFileName = jsonFile.name,

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/brokers/RealBrokerDataDownloaderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/brokers/RealBrokerDataDownloaderTest.kt
@@ -53,6 +53,7 @@ class RealBrokerDataDownloaderTest {
     @Before
     fun setUp() {
         whenever(mockContext.filesDir).thenReturn(tempFolder.root)
+        whenever(mockContext.cacheDir).thenReturn(tempFolder.root)
 
         testee = RealBrokerDataDownloader(
             dbpService = mockDbpService,
@@ -278,6 +279,42 @@ class RealBrokerDataDownloaderTest {
         testee.downloadBrokerData(brokersToUpdate)
 
         verify(mockPixelSender).reportUpdateBrokerJsonSuccess(eq("broker1.json"), eq(removedAtMs))
+    }
+
+    @Test
+    fun whenDownloadBrokerDataWithZipSlipEntryThenSkipMaliciousEntry() = runTest {
+        val brokersToUpdate = listOf("broker1.json")
+        val broker1Json = """
+            {
+                "name": "Broker One",
+                "url": "https://broker1.com",
+                "version": "1.0",
+                "parent": null,
+                "addedDatetime": 1000,
+                "optOutUrl": "https://broker1.com/optout",
+                "steps": [],
+                "schedulingConfig": {
+                    "retryError": 24,
+                    "confirmOptOutScan": 7,
+                    "maintenanceScan": 30,
+                    "maxAttempts": 3
+                },
+                "removedAt": null
+            }
+        """.trimIndent()
+
+        val zipBytes = createZipWithFiles(
+            mapOf(
+                "data/broker1.json" to broker1Json,
+                "../../malicious.json" to """{ "attack": true }""",
+            ),
+        )
+        whenever(mockDbpService.getBrokerJsonFiles()).thenReturn(zipBytes.toResponseBody())
+
+        testee.downloadBrokerData(brokersToUpdate)
+
+        verify(mockPirRepository).updateBrokerData(eq("broker1.json"), any())
+        verify(mockPirRepository, never()).updateBrokerData(eq("malicious.json"), any())
     }
 
     private fun createZipWithFiles(files: Map<String, String>): ByteArray {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213634152051167?focus=true

### Description
See attached task description

### Steps to test this PR
Smoke test PIR broker json download 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the broker-data download/extraction pipeline and adds ZIP path validation; issues here could prevent broker updates or drop files unexpectedly, but impact is contained to PIR updates.
> 
> **Overview**
> **Hardens PIR broker JSON updates** by downloading the broker ZIP to a temp file in `cacheDir`, extracting only `.json` entries, and always cleaning up temp/extract folders.
> 
> **Improves safety and robustness**: adds ZIP-slip protection via canonical-path checks, reuses a single lazy Moshi `brokerAdapter`, streams JSON parsing with okio instead of `readText()`, and ensures coroutine cancellation is rethrown. Adds a unit test verifying malicious ZIP entries are skipped and updates existing tests to provide `cacheDir`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d1c20d64ed00d4c9933812f4f09e17bbd5e457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->