### PR TITLE
Prevent orphaned sync devices when auto-restoring

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -66,7 +66,7 @@ interface SyncAccountRepository {
     fun isSyncSupported(): Boolean
     fun createAccount(): Result<Boolean>
     fun isSignedIn(): Boolean
-    fun processCode(code: SyncAuthCode): Result<Boolean>
+    fun processCode(code: SyncAuthCode, existingDeviceId: String? = null): Result<Boolean>
     fun getAccountInfo(): AccountInfo
     fun logout(deviceId: String): Result<Boolean>
     fun deleteAccount(): Result<Boolean>
@@ -140,11 +140,11 @@ class AppSyncAccountRepository @Inject constructor(
         }
     }
 
-    override fun processCode(code: SyncAuthCode): Result<Boolean> {
+    override fun processCode(code: SyncAuthCode, existingDeviceId: String?): Result<Boolean> {
         when (code) {
             is Recovery -> {
                 logcat { "Sync: code is a recovery code" }
-                return login(code.b64Code)
+                return login(code.b64Code, existingDeviceId)
             }
 
             is Connect -> {
@@ -287,7 +287,7 @@ class AppSyncAccountRepository @Inject constructor(
         }
     }
 
-    private fun login(recoveryCode: RecoveryCode): Result<Boolean> {
+    private fun login(recoveryCode: RecoveryCode, existingDeviceId: String? = null): Result<Boolean> {
         var wasUserLogout = false
         if (isSignedIn()) {
             val allowSwitchAccount = syncFeature.seamlessAccountSwitching().isEnabled()
@@ -306,7 +306,7 @@ class AppSyncAccountRepository @Inject constructor(
 
         val primaryKey = recoveryCode.primaryKey
         val userId = recoveryCode.userId
-        val deviceId = syncDeviceIds.deviceId()
+        val deviceId = existingDeviceId ?: syncDeviceIds.deviceId()
         val deviceName = syncDeviceIds.deviceName()
 
         return performLogin(userId, deviceId, deviceName, primaryKey).onFailure {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.sync.impl.autorestore
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.persistentstorage.api.PersistentStorage
 import com.duckduckgo.sync.api.SyncAutoRestore
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
@@ -37,7 +36,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealSyncAutoRestore @Inject constructor(
-    private val persistentStorage: PersistentStorage,
+    private val manager: SyncAutoRestoreManager,
     private val syncFeature: SyncFeature,
     private val syncAccountRepository: SyncAccountRepository,
     @AppCoroutineScope private val appScope: CoroutineScope,
@@ -47,26 +46,29 @@ class RealSyncAutoRestore @Inject constructor(
     override suspend fun canRestore(): Boolean {
         return withContext(dispatcherProvider.io()) {
             if (!syncFeature.syncAutoRestore().isEnabled()) return@withContext false
-            persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull() != null
+            manager.retrieveRecoveryPayload() != null
         }
     }
 
     override fun restoreSyncAccount() {
         appScope.launch(dispatcherProvider.io()) {
             try {
+                if (!syncFeature.syncAutoRestore().isEnabled()) {
+                    logcat(LogPriority.WARN) { "Sync-Recovery: syncAutoRestore FF disabled, skipping restore" }
+                    return@launch
+                }
                 logcat { "Sync-Recovery: restoreSyncAccount called" }
 
-                val recoveryBytes = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull()
-                if (recoveryBytes == null) {
+                val payload = manager.retrieveRecoveryPayload()
+                if (payload == null) {
                     logcat(LogPriority.WARN) { "Sync-Recovery: no recovery key found in persistent storage" }
                     return@launch
                 }
 
-                val recoveryCodeString = String(recoveryBytes, Charsets.UTF_8)
                 logcat { "Sync-Recovery: recovery key retrieved, attempting login" }
 
-                val parsedCode = syncAccountRepository.parseSyncAuthCode(recoveryCodeString)
-                when (val result = syncAccountRepository.processCode(parsedCode)) {
+                val parsedCode = syncAccountRepository.parseSyncAuthCode(payload.recoveryCode)
+                when (val result = syncAccountRepository.processCode(parsedCode, existingDeviceId = payload.deviceId)) {
                     is Result.Success -> logcat(LogPriority.INFO) { "Sync-Recovery: account restored successfully" }
                     is Result.Error -> logcat(LogPriority.WARN) { "Sync-Recovery: restore failed - code=${result.code}, reason=${result.reason}" }
                 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserver.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserver.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class SyncAutoRestoreAccountDisabledObserver @Inject constructor(
+    @AppCoroutineScope val appCoroutineScope: CoroutineScope,
+    private val syncStore: SyncStore,
+    private val syncAutoRestoreManager: SyncAutoRestoreManager,
+    private val syncFeature: SyncFeature,
+    private val dispatcherProvider: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        syncStore.isSignedInFlow()
+            // only interested in changes, not initial value
+            .drop(1)
+            .distinctUntilChanged()
+            // only interested when user signs out
+            .filter { isSignedIn -> !isSignedIn }
+            .filter { syncFeature.syncAutoRestore().isEnabled() }
+            .onEach {
+                logcat { "Sync-Recovery: sync disabled, clearing recovery code from Block Store" }
+                syncAutoRestoreManager.clearRecoveryCode()
+            }
+            .flowOn(dispatcherProvider.io())
+            .launchIn(appCoroutineScope)
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreManager.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import logcat.logcat
+import javax.inject.Inject
+
+interface SyncAutoRestoreManager {
+    suspend fun saveRecoveryPayload(recoveryCode: String, deviceId: String?)
+    suspend fun retrieveRecoveryPayload(): RestorePayload?
+    suspend fun clearRecoveryCode()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSyncAutoRestoreManager @Inject constructor(
+    private val persistentStorage: PersistentStorage,
+    private val dispatcherProvider: DispatcherProvider,
+    private val moshi: Moshi,
+) : SyncAutoRestoreManager {
+
+    override suspend fun saveRecoveryPayload(recoveryCode: String, deviceId: String?) {
+        withContext(dispatcherProvider.io()) {
+            val payload = RestorePayload(recoveryCode = recoveryCode, deviceId = deviceId)
+            val payloadJson = moshi.adapter(RestorePayload::class.java).toJson(payload)
+            logcat { "Sync-Recovery: storing recovery code and device ID ($deviceId) to Block Store" }
+            persistentStorage.store(SyncRecoveryPersistentStorageKey, payloadJson.toByteArray(Charsets.UTF_8))
+                .onSuccess { logcat { "Sync-Recovery: payload stored successfully" } }
+                .onFailure { logcat(LogPriority.ERROR) { "Sync-Recovery: failed to store payload - ${it.message}" } }
+        }
+    }
+
+    override suspend fun retrieveRecoveryPayload(): RestorePayload? {
+        return withContext(dispatcherProvider.io()) {
+            val bytes = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull() ?: return@withContext null
+            val rawString = String(bytes, Charsets.UTF_8)
+            moshi.adapter(RestorePayload::class.java).fromJson(rawString)
+        }
+    }
+
+    override suspend fun clearRecoveryCode() {
+        withContext(dispatcherProvider.io()) {
+            logcat { "Sync-Recovery: clearing recovery code from Block Store" }
+            persistentStorage.clear(SyncRecoveryPersistentStorageKey)
+                .onSuccess { logcat { "Sync-Recovery: recovery code cleared successfully" } }
+                .onFailure { logcat(LogPriority.ERROR) { "Sync-Recovery: failed to clear recovery code - ${it.message}" } }
+        }
+    }
+}
+
+data class RestorePayload(
+    @field:Json(name = "recovery_code") val recoveryCode: String,
+    @field:Json(name = "device_id") val deviceId: String?,
+)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.sync.impl.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.widget.Toast
@@ -101,7 +104,17 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
         binding.clearHistoryPasswordScreenPromo.setOnClickListener { viewModel.onClearHistoryPasswordScreenPromoClicked() }
-        binding.blockStoreWriteButton.setOnClickListener { viewModel.onBlockStoreWriteClicked(binding.blockStoreInput.text) }
+        binding.userIdTextView.setOnClickListener { copyToClipboard("User ID", binding.userIdTextView.text.toString()) }
+        binding.deviceNameTextView.setOnClickListener { copyToClipboard("Device Name", binding.deviceNameTextView.text.toString()) }
+        binding.deviceIdTextView.setOnClickListener { copyToClipboard("Device ID", binding.deviceIdTextView.text.toString()) }
+        binding.secretKeyTextView.setOnClickListener { copyToClipboard("Secret Key", binding.secretKeyTextView.text.toString()) }
+        binding.tokenTextView.setOnClickListener { copyToClipboard("Token", binding.tokenTextView.text.toString()) }
+        binding.blockStoreWriteButton.setOnClickListener {
+            viewModel.onBlockStoreWriteClicked(
+                recoveryCode = binding.blockStoreRecoveryCodeInput.text,
+                deviceId = binding.blockStoreDeviceIdInput.text.takeIf { it.isNotBlank() },
+            )
+        }
         binding.blockStoreClearButton.setOnClickListener { viewModel.onBlockStoreClearClicked() }
     }
 
@@ -150,6 +163,12 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         }
     }
 
+    private fun copyToClipboard(label: String, value: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+        Toast.makeText(this, "$label copied", Toast.LENGTH_SHORT).show()
+    }
+
     private fun getScanOptions(): ScanOptions {
         val options = ScanOptions()
         options.setDesiredBarcodeFormats(ScanOptions.QR_CODE)
@@ -189,9 +208,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.blockStoreCurrentValue.text = when (val value = viewState.blockStoreCurrentValue) {
             is SyncInternalSettingsViewModel.BlockStoreValue.Loading -> "Loading..."
             is SyncInternalSettingsViewModel.BlockStoreValue.NotSet -> "(key not set)"
-            is SyncInternalSettingsViewModel.BlockStoreValue.HasValue -> {
-                if (value.value.isEmpty()) "(empty string)" else value.value
-            }
+            is SyncInternalSettingsViewModel.BlockStoreValue.HasValue -> value.value
         }
 
         binding.syncInternalEnvironment.quietlySetIsChecked(viewState.useDevEnvironment) { _, enabled ->

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
@@ -65,6 +66,7 @@ constructor(
     private val dispatchers: DispatcherProvider,
     private val syncPromotionDataStore: SyncPromotionDataStore,
     private val persistentStorage: PersistentStorage,
+    private val syncAutoRestoreManager: SyncAutoRestoreManager,
     private val syncFeature: SyncFeature,
 ) : ViewModel() {
 
@@ -364,37 +366,44 @@ constructor(
     }
 
     private suspend fun refreshBlockStoreValue() {
-        val result = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull()
+        val bytes = persistentStorage.retrieve(SyncRecoveryPersistentStorageKey).getOrNull()
         val blockStoreValue = when {
-            result == null -> BlockStoreValue.NotSet
-            else -> BlockStoreValue.HasValue(String(result))
+            bytes == null -> BlockStoreValue.NotSet
+            else -> BlockStoreValue.HasValue(String(bytes, Charsets.UTF_8))
         }
         viewState.update { it.copy(blockStoreCurrentValue = blockStoreValue) }
     }
 
-    fun onBlockStoreWriteClicked(data: String) {
+    fun onBlockStoreWriteClicked(recoveryCode: String, deviceId: String?) {
         viewModelScope.launch(dispatchers.io()) {
-            persistentStorage.store(SyncRecoveryPersistentStorageKey, data.toByteArray())
-                .onSuccess {
-                    refreshBlockStoreValue()
-                    command.send(ShowMessage("Stored successfully"))
-                }
-                .onFailure { error ->
-                    command.send(ShowMessage("Store failed: ${error.message}"))
-                }
+            if (recoveryCode.isBlank()) {
+                command.send(ShowMessage("Recovery code is required"))
+                return@launch
+            }
+            val trimmedDeviceId = deviceId?.takeIf { it.isNotBlank() }
+            if (trimmedDeviceId != null && trimmedDeviceId.length !in 8..64) {
+                command.send(ShowMessage("Device ID must be 8–64 chars (or leave blank)"))
+                return@launch
+            }
+            runCatching {
+                syncAutoRestoreManager.saveRecoveryPayload(recoveryCode, deviceId?.takeIf { it.isNotBlank() })
+                refreshBlockStoreValue()
+                command.send(ShowMessage("Stored successfully"))
+            }.onFailure { error ->
+                command.send(ShowMessage("Store failed: ${error.message}"))
+            }
         }
     }
 
     fun onBlockStoreClearClicked() {
         viewModelScope.launch(dispatchers.io()) {
-            persistentStorage.clear(SyncRecoveryPersistentStorageKey)
-                .onSuccess {
-                    refreshBlockStoreValue()
-                    command.send(ShowMessage("Cleared successfully"))
-                }
-                .onFailure { error ->
-                    command.send(ShowMessage("Clear failed: ${error.message}"))
-                }
+            runCatching {
+                syncAutoRestoreManager.clearRecoveryCode()
+                refreshBlockStoreValue()
+                command.send(ShowMessage("Cleared successfully"))
+            }.onFailure { error ->
+                command.send(ShowMessage("Clear failed: ${error.message}"))
+            }
         }
     }
 }

--- a/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
@@ -115,11 +115,22 @@
                 app:typography="body1" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextInput
-                android:id="@+id/blockStoreInput"
+                android:id="@+id/blockStoreRecoveryCodeInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/keyline_4"
-                android:hint="@string/sync_internal_block_store_input_hint"
+                android:hint="@string/sync_internal_block_store_recovery_code_hint"
+                app:editable="true"
+                app:type="single_line" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/blockStoreDeviceIdInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:hint="@string/sync_internal_block_store_device_id_hint"
                 app:editable="true"
                 app:type="single_line" />
 

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -37,7 +37,8 @@
     <!-- Block Store -->
     <string name="sync_internal_block_store_header">Persistent Storage / Block Store</string>
     <string name="sync_internal_block_store_current_value_label">Current stored value (SyncRecovery key)</string>
-    <string name="sync_internal_block_store_input_hint">Data to store</string>
+    <string name="sync_internal_block_store_recovery_code_hint">Recovery code</string>
+    <string name="sync_internal_block_store_device_id_hint">Device ID (optional, 8–64 chars)</string>
     <string name="sync_internal_block_store_write">Write</string>
     <string name="sync_internal_block_store_clear">Clear</string>
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreManagerTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.persistentstorage.api.PersistentStorage
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealSyncAutoRestoreManagerTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val persistentStorage: PersistentStorage = mock()
+
+    private lateinit var testee: RealSyncAutoRestoreManager
+
+    @Before
+    fun setup() = runTest {
+        whenever(persistentStorage.store(any(), any())).thenReturn(Result.success(Unit))
+        whenever(persistentStorage.clear(any())).thenReturn(Result.success(Unit))
+        testee = RealSyncAutoRestoreManager(
+            persistentStorage = persistentStorage,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+            moshi = Moshi.Builder().build(),
+        )
+    }
+
+    @Test
+    fun whenSaveRecoveryPayloadCalledThenStoresSerializedJson() = runTest {
+        val recoveryCode = "recovery-abc-123"
+        val deviceId = "device-xyz-456"
+
+        testee.saveRecoveryPayload(recoveryCode, deviceId)
+
+        val bytesCaptor = argumentCaptor<ByteArray>()
+        verify(persistentStorage).store(any(), bytesCaptor.capture())
+        val json = String(bytesCaptor.firstValue, Charsets.UTF_8)
+        assert(json.contains("\"recovery_code\":\"$recoveryCode\"")) { "JSON missing recovery_code: $json" }
+        assert(json.contains("\"device_id\":\"$deviceId\"")) { "JSON missing device_id: $json" }
+    }
+
+    @Test
+    fun whenSaveRecoveryPayloadWithNullDeviceIdThenSerializesWithoutDeviceIdField() = runTest {
+        testee.saveRecoveryPayload("code", null)
+
+        val bytesCaptor = argumentCaptor<ByteArray>()
+        verify(persistentStorage).store(any(), bytesCaptor.capture())
+        val json = String(bytesCaptor.firstValue, Charsets.UTF_8)
+        assert(json.contains("\"recovery_code\":\"code\"")) { "JSON missing recovery_code: $json" }
+        // Moshi omits null fields by default
+        assert(!json.contains("device_id")) { "JSON should not contain device_id when null: $json" }
+    }
+
+    @Test
+    fun whenRetrievePayloadAndStorageHasDataThenReturnsDeserializedPayload() = runTest {
+        val json = """{"recovery_code":"code-123","device_id":"device-456"}"""
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(json.toByteArray(Charsets.UTF_8)))
+
+        val result = testee.retrieveRecoveryPayload()
+
+        assertEquals(RestorePayload(recoveryCode = "code-123", deviceId = "device-456"), result)
+    }
+
+    @Test
+    fun whenRetrievePayloadAndDeviceIdIsAbsentThenReturnsPayloadWithNullDeviceId() = runTest {
+        // Moshi omits null fields when storing, so a payload saved without device_id has no device_id key
+        val json = """{"recovery_code":"code-123"}"""
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(json.toByteArray(Charsets.UTF_8)))
+
+        val result = testee.retrieveRecoveryPayload()
+
+        assertEquals(RestorePayload(recoveryCode = "code-123", deviceId = null), result)
+    }
+
+    @Test
+    fun whenRetrievePayloadAndStorageReturnsNullBytesThenReturnsNull() = runTest {
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(null))
+
+        val result = testee.retrieveRecoveryPayload()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenRetrievePayloadAndStorageFailsThenReturnsNull() = runTest {
+        whenever(persistentStorage.retrieve(any())).thenReturn(Result.failure(RuntimeException("Block Store error")))
+
+        val result = testee.retrieveRecoveryPayload()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenClearRecoveryCodeCalledThenClearsPersistentStorage() = runTest {
+        testee.clearRecoveryCode()
+
+        verify(persistentStorage).clear(any())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestoreTest.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
-import com.duckduckgo.persistentstorage.api.PersistentStorage
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeature
@@ -31,6 +30,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -44,15 +45,16 @@ class RealSyncAutoRestoreTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
-    private val persistentStorage: PersistentStorage = mock()
+    private val manager: SyncAutoRestoreManager = mock()
     private val syncAccountRepository: SyncAccountRepository = mock()
 
     private lateinit var testee: RealSyncAutoRestore
 
     @Before
-    fun setup() {
+    fun setup() = runTest {
+        configureAutoRestoreEnabled(true)
         testee = RealSyncAutoRestore(
-            persistentStorage = persistentStorage,
+            manager = manager,
             syncFeature = syncFeature,
             syncAccountRepository = syncAccountRepository,
             appScope = coroutineTestRule.testScope,
@@ -70,7 +72,7 @@ class RealSyncAutoRestoreTest {
     @Test
     fun whenFeatureFlagEnabledButNoStoredKeyThenCanRestoreReturnsFalse() = runTest {
         configureAutoRestoreEnabled(true)
-        configureRetrieveSuccess(value = null)
+        configureRetrieveSuccess(payload = null)
 
         assertFalse(testee.canRestore())
     }
@@ -78,87 +80,102 @@ class RealSyncAutoRestoreTest {
     @Test
     fun whenFeatureFlagEnabledAndKeyExistsThenCanRestoreReturnsTrue() = runTest {
         configureAutoRestoreEnabled(true)
-        configureRetrieveSuccess(value = "recovery_key_bytes")
+        configureRetrieveSuccess(payload = RestorePayload(recoveryCode = "recovery_key", deviceId = null))
 
         assertTrue(testee.canRestore())
     }
 
     @Test
-    fun whenStorageRetrievalFailsThenCanRestoreReturnsFalse() = runTest {
+    fun whenStorageRetrievalReturnsNullThenCanRestoreReturnsFalse() = runTest {
         configureAutoRestoreEnabled(true)
-        configureRetrieveFailure()
+        configureRetrieveSuccess(payload = null)
 
         assertFalse(testee.canRestore())
     }
 
     @Test
+    fun whenFeatureFlagDisabledThenRestoreSyncAccountDoesNotCallProcessCode() = runTest {
+        configureAutoRestoreEnabled(false)
+        configureRetrieveSuccess(payload = RestorePayload(recoveryCode = "code", deviceId = null))
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test
     fun whenRestoreSyncAccountCalledThenRetrievesKeyAndCallsProcessCode() = runTest {
         val recoveryCodeString = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
-        configureRetrieveSuccess(value = recoveryCodeString)
+        val deviceId = "device-abc-123"
+        configureRetrieveSuccess(payload = RestorePayload(recoveryCode = recoveryCodeString, deviceId = deviceId))
         configureProcessCodeResult(SyncResult.Success(true))
 
         testee.restoreSyncAccount()
 
         verify(syncAccountRepository).parseSyncAuthCode(recoveryCodeString)
-        verify(syncAccountRepository).processCode(any())
+        verify(syncAccountRepository).processCode(any(), eq(deviceId))
     }
 
     @Test
     fun whenRestoreSyncAccountCalledButNoStoredKeyThenDoesNotCallProcessCode() = runTest {
-        configureRetrieveSuccess(value = null)
+        configureRetrieveSuccess(payload = null)
 
         testee.restoreSyncAccount()
 
-        verify(syncAccountRepository, never()).processCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
     @Test
-    fun whenRestoreSyncAccountCalledButStorageFailsThenDoesNotCallProcessCode() = runTest {
-        configureRetrieveFailure()
+    fun whenRestoreSyncAccountCalledButStorageReturnsNullThenDoesNotCallProcessCode() = runTest {
+        configureRetrieveSuccess(payload = null)
 
         testee.restoreSyncAccount()
 
-        verify(syncAccountRepository, never()).processCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenRestoreSyncAccountCalledButRetrieveThrowsThenDoesNotCallProcessCode() = runTest {
+        whenever(manager.retrieveRecoveryPayload()).thenThrow(RuntimeException("Storage failure"))
+
+        testee.restoreSyncAccount()
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
     @Test
     fun whenProcessCodeFailsThenRestoreSyncAccountDoesNotThrow() = runTest {
-        val recoveryCodeString = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
-        configureRetrieveSuccess(value = recoveryCodeString)
+        val recoveryCode = "eyJyZWNvdmVyeSI6eyJwcmltYXJ5X2tleSI6ImFiYzEyMyIsInVzZXJfaWQiOiJ1c2VyMTIzIn19"
+        configureRetrieveSuccess(payload = RestorePayload(recoveryCode = recoveryCode, deviceId = "device-123"))
         configureProcessCodeResult(SyncResult.Error(code = 52, reason = "Login failed"))
 
         testee.restoreSyncAccount()
 
-        verify(syncAccountRepository).processCode(any())
+        verify(syncAccountRepository).processCode(any(), anyOrNull())
     }
 
     @Test
     fun whenParseSyncAuthCodeThrowsThenRestoreSyncAccountDoesNotCrash() = runTest {
         val recoveryCodeString = "invalid_not_base64"
-        configureRetrieveSuccess(value = recoveryCodeString)
+        configureRetrieveSuccess(payload = RestorePayload(recoveryCode = recoveryCodeString, deviceId = "device-123"))
         whenever(syncAccountRepository.parseSyncAuthCode(recoveryCodeString)).thenThrow(RuntimeException("Parse error"))
 
         testee.restoreSyncAccount()
 
-        verify(syncAccountRepository, never()).processCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
     private fun configureAutoRestoreEnabled(enabled: Boolean) {
         syncFeature.syncAutoRestore().setRawStoredState(State(enable = enabled))
     }
 
-    private suspend fun configureRetrieveSuccess(value: String?) {
-        val bytes = value?.toByteArray(Charsets.UTF_8)
-        whenever(persistentStorage.retrieve(any())).thenReturn(Result.success(bytes))
+    private suspend fun configureRetrieveSuccess(payload: RestorePayload?) {
+        whenever(manager.retrieveRecoveryPayload()).thenReturn(payload)
     }
 
     private fun configureProcessCodeResult(result: SyncResult<Boolean>) {
         val mockParsedCode = mock<SyncAuthCode.Recovery>()
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(mockParsedCode)
-        whenever(syncAccountRepository.processCode(mockParsedCode)).thenReturn(result)
-    }
-
-    private suspend fun configureRetrieveFailure() {
-        whenever(persistentStorage.retrieve(any())).thenReturn(Result.failure(RuntimeException("Retrieve failed")))
+        whenever(syncAccountRepository.processCode(eq(mockParsedCode), anyOrNull())).thenReturn(result)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserverTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/autorestore/SyncAutoRestoreAccountDisabledObserverTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+import android.annotation.SuppressLint
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class SyncAutoRestoreAccountDisabledObserverTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val syncStore: SyncStore = mock()
+    private val syncAutoRestoreManager: SyncAutoRestoreManager = mock()
+
+    private lateinit var testee: SyncAutoRestoreAccountDisabledObserver
+
+    @Before
+    fun setup() {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = true))
+        testee = SyncAutoRestoreAccountDisabledObserver(
+            appCoroutineScope = coroutineTestRule.testScope,
+            syncStore = syncStore,
+            syncAutoRestoreManager = syncAutoRestoreManager,
+            syncFeature = syncFeature,
+            dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenSignedOutThenClearsRecoveryCode() = runTest {
+        val isSignedInFlow = MutableStateFlow(true)
+        whenever(syncStore.isSignedInFlow()).thenReturn(isSignedInFlow)
+        testee.onCreate(mock())
+
+        isSignedInFlow.emit(false)
+
+        verify(syncAutoRestoreManager).clearRecoveryCode()
+    }
+
+    @Test
+    fun whenSignedInAfterSignOutEventThenDoesNotClearRecoveryCode() = runTest {
+        val isSignedInFlow = MutableStateFlow(false)
+        whenever(syncStore.isSignedInFlow()).thenReturn(isSignedInFlow)
+        testee.onCreate(mock())
+
+        isSignedInFlow.emit(true)
+
+        verify(syncAutoRestoreManager, never()).clearRecoveryCode()
+    }
+
+    @Test
+    fun whenInitialSignedOutValueWithNoChangesThenDoesNotClearRecoveryCode() = runTest {
+        val isSignedInFlow = MutableStateFlow(false)
+        whenever(syncStore.isSignedInFlow()).thenReturn(isSignedInFlow)
+
+        testee.onCreate(mock())
+
+        verify(syncAutoRestoreManager, never()).clearRecoveryCode()
+    }
+
+    @Test
+    fun whenSignedOutButFeatureFlagDisabledThenDoesNotClearRecoveryCode() = runTest {
+        syncFeature.syncAutoRestore().setRawStoredState(State(enable = false))
+        val isSignedInFlow = MutableStateFlow(true)
+        whenever(syncStore.isSignedInFlow()).thenReturn(isSignedInFlow)
+        testee.onCreate(mock())
+
+        isSignedInFlow.emit(false)
+
+        verify(syncAutoRestoreManager, never()).clearRecoveryCode()
+    }
+
+    @Test
+    fun whenSignedOutMultipleTimesThenClearsRecoveryCodeEachTime() = runTest {
+        val isSignedInFlow = MutableStateFlow(true)
+        whenever(syncStore.isSignedInFlow()).thenReturn(isSignedInFlow)
+        testee.onCreate(mock())
+
+        isSignedInFlow.emit(false)
+        isSignedInFlow.emit(true)
+        isSignedInFlow.emit(false)
+
+        verify(syncAutoRestoreManager, org.mockito.kotlin.times(2)).clearRecoveryCode()
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -56,6 +56,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -105,7 +106,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenAnswer {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
             Success(true)
         }
@@ -124,7 +125,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonConnectKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonConnectKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonConnectKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenAnswer {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
             Success(true)
         }
@@ -143,7 +144,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn("invalid code")
         whenever(syncAccountRepository.parseSyncAuthCode("invalid code")).thenReturn(Unknown("invalid code"))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = INVALID_CODE.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = INVALID_CODE.code))
 
         testee.onPasteCodeClicked()
 
@@ -160,7 +161,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = ALREADY_SIGNED_IN.code))
 
         testee.onPasteCodeClicked()
 
@@ -176,7 +177,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = ALREADY_SIGNED_IN.code))
 
         testee.onPasteCodeClicked()
 
@@ -208,7 +209,7 @@ internal class EnterCodeViewModelTest {
     fun whenSignedInUserProcessCodeSucceedsAndAccountChangedThenReturnSwitchAccount() = runTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenAnswer {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountB)
             Success(true)
         }
@@ -226,7 +227,7 @@ internal class EnterCodeViewModelTest {
     fun whenSignedOutUserScansRecoveryCodeAndLoginSucceedsThenReturnLoginSuccess() = runTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenAnswer {
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncAccountRepository.getAccountInfo()).thenReturn(accountA)
             Success(true)
         }
@@ -245,7 +246,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = LOGIN_FAILED.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = LOGIN_FAILED.code))
 
         testee.onPasteCodeClicked()
 
@@ -261,7 +262,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = LOGIN_FAILED.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = LOGIN_FAILED.code))
 
         testee.onPasteCodeClicked()
 
@@ -276,7 +277,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonConnectKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonConnectKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonConnectKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = CONNECT_FAILED.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = CONNECT_FAILED.code))
 
         testee.onPasteCodeClicked()
 
@@ -292,7 +293,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = CREATE_ACCOUNT_FAILED.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = CREATE_ACCOUNT_FAILED.code))
 
         testee.onPasteCodeClicked()
 
@@ -308,7 +309,7 @@ internal class EnterCodeViewModelTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncAccountRepository.processCode(any())).thenReturn(Error(code = GENERIC_ERROR.code))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = GENERIC_ERROR.code))
 
         testee.onPasteCodeClicked()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -48,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -175,7 +176,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserScansConnectQRCodeAndConnectDeviceSucceedsThenCommandIsLoginSuccess() = runTest {
         whenever(syncRepository.parseSyncAuthCode(jsonConnectKeyEncoded)).thenReturn(Connect(ConnectCode(jsonConnectKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Success(true))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
         testee.commands().test {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
@@ -190,7 +191,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserScansRecoveryCodeButSignedInThenCommandIsError() = runTest {
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -205,7 +206,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserScansConnectQRCodeAndConnectDeviceFailsThenCommandIsError() = runTest {
         whenever(syncRepository.parseSyncAuthCode(jsonConnectKeyEncoded)).thenReturn(Connect(ConnectCode(jsonConnectKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = CONNECT_FAILED.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = CONNECT_FAILED.code))
 
         testee.commands().test {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -34,6 +34,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -66,7 +67,7 @@ class SyncLoginViewModelTest {
     @Test
     fun whenProcessRecoveryCodeThenPerformLoginAndEmitResult() = runTest {
         whenever(syncRepostitory.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepostitory.processCode(any())).thenReturn(Success(true))
+        whenever(syncRepostitory.processCode(any(), anyOrNull())).thenReturn(Success(true))
 
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -63,6 +63,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -222,7 +223,7 @@ class SyncWithAnotherDeviceViewModelTest {
         syncFeature.seamlessAccountSwitching().setRawStoredState(State(false))
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -240,7 +241,7 @@ class SyncWithAnotherDeviceViewModelTest {
         syncFeature.seamlessAccountSwitching().setRawStoredState(State(false))
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -256,7 +257,7 @@ class SyncWithAnotherDeviceViewModelTest {
     fun whenUserScansRecoveryCodeButSignedInThenCommandIsAskToSwitchAccount() = runTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -273,7 +274,7 @@ class SyncWithAnotherDeviceViewModelTest {
         configureExchangeKeysSupported()
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -354,7 +355,7 @@ class SyncWithAnotherDeviceViewModelTest {
     fun whenSignedInUserScansRecoveryCodeAndLoginSucceedsThenReturnSwitchAccount() = runTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenAnswer {
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncRepository.getAccountInfo()).thenReturn(accountB)
             Success(true)
         }
@@ -372,7 +373,7 @@ class SyncWithAnotherDeviceViewModelTest {
     fun whenSignedOutUserScansRecoveryCodeAndLoginSucceedsThenReturnLoginSuccess() = runTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenAnswer {
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenAnswer {
             whenever(syncRepository.getAccountInfo()).thenReturn(accountB)
             Success(true)
         }
@@ -390,7 +391,7 @@ class SyncWithAnotherDeviceViewModelTest {
     fun whenUserScansRecoveryQRCodeAndConnectDeviceFailsThenCommandIsError() = runTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(syncRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Recovery(RecoveryCode(jsonRecoveryKey, primaryKey)))
-        whenever(syncRepository.processCode(any())).thenReturn(Result.Error(code = LOGIN_FAILED.code))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Error(code = LOGIN_FAILED.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
@@ -424,7 +425,7 @@ class SyncWithAnotherDeviceViewModelTest {
         val authCodeToUse = AuthCode(qrCode = jsonExchangeKey, rawCode = "something else")
         whenever(syncRepository.generateExchangeInvitationCode()).thenReturn(Success(authCodeToUse))
         whenever(qrEncoder.encodeAsBitmap(eq(jsonExchangeKey), any(), any())).thenReturn(bitmap)
-        whenever(syncRepository.processCode(any())).thenReturn(Success(true))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Success(true))
         return Pair(bitmap, authCodeToUse)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213646602671393?focus=true

### Description

When auto-restoring a sync account from Block Store on reinstall, the previous implementation called `login()` without providing the original device ID, causing the sync backend to assign a new device ID. This left the old device entry as an orphan on the account — visible to other connected devices as a ghost entry.

This PR fixes the orphaned device problem by storing the device ID alongside the recovery code in Block Store as a JSON payload, then reusing that device ID during auto-restore login. This matches the approach iOS already uses.

No user-facing prod changes as it is still guarded by `syncAutoRestore` FF which remains `DISABLED`

### Steps to test this PR

Logcat filter `message~:"Sync-Recovery|Sync-AutoRestore"`
**Pre-requsites**
1. Device/emulator with Google Play Services
2. Be signed in to the Google account on your device, and have device-level backups enabled
3. Have device-level auth set (PIN/Pattern/Password)

### Feature flag disabled (default)
- [x] Fresh install `internalDebug`, launch app
- [x] Verify in logs, `Sync-AutoRestore: canRestore=false`

### Feature flag enabled
❗ **hardcode the feature flag to enabled for the following tests**

**Testing recovery code cleared when logging out of sync**
- [x] Apply patch below
- [x] Install `internalDebug` and launch
- [x] Verify `canRestore=false` in logs
- [x] Verify you do **not** see "Restore my stuff" dialog
- [x] Set up sync `Sync and Back Up This Device` then disable sync again
- [x] Verify in logs, `sync disabled, clearing recovery code from Block Store`

**Ensuring device not orphaned on restore**
- [x] Set up sync again, and this time copy the recovery code using the `Copy Code` button
- [x] Visit `Sync Dev Settings`, and paste into the `Recovery code` edit text (in the `Persistent storage` section)
- [x] Scroll down to the `Account Settings` section, and tap on `Device id`'s value
- [x] Paste into the `Device ID` edit text
- [x] Tap the `Write` button and verify you see the `Stored successfully` toast and JSON containing both recovery and device ID is shown
- [x] Uninstall and reinstall (do not use clear app data). Launch app
- [x] Verify you see in logs, `canRestore=true`
- [x] Verify you are offered to `Restore My Stuff`. Tap that button.
- [x] Skip rest of onboarding, and visit `Settings -> Sync & Backup`
- [x] Verify sync is set up, and that there is only one device showing


### Patch to enabled `syncAutoRestore` feature flag
```
Index: sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt	(revision Staged)
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt	(date 1773659914685)
@@ -78,6 +78,6 @@
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun syncAutoRecoveryCapabilityDetectionRead(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun syncAutoRestore(): Toggle
 }
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync auto-restore login behavior to reuse a stored device ID and adds new persistence/cleanup logic; mistakes could cause failed restores or unexpected sign-in/device registration behavior.
> 
> **Overview**
> Fixes sync auto-restore creating *orphaned/ghost devices* by allowing `processCode`/recovery `login` to accept an `existingDeviceId` and using it during restore instead of always generating a new one.
> 
> Introduces `SyncAutoRestoreManager` to persist a JSON payload (`recovery_code` + optional `device_id`) in Block Store, updates `RealSyncAutoRestore` to read that payload (and to hard-skip when the `syncAutoRestore` flag is off), and adds a lifecycle observer that clears the stored recovery payload when the user signs out while auto-restore is enabled.
> 
> Updates internal sync settings UI to write/read the new payload format (separate recovery-code and device-id inputs, plus tap-to-copy fields) and adjusts/extends unit tests to cover the new manager, observer, and updated auto-restore flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb430784fe2144f795947db1a35ac81c4510298. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->