### PR TITLE
Force locked=false for duck.ai URLs in uiLockChanged JS callback

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4169,7 +4169,11 @@ class BrowserTabViewModel @Inject constructor(
             BROWSER_UI_LOCK_FEATURE_NAME -> {
                 when (method) {
                     "uiLockChanged" -> {
-                        val locked = data?.optBoolean("locked", false) ?: false
+                        val host = getWebViewUrl()?.toUri()?.host
+                        var locked = data?.optBoolean("locked", false) ?: false
+                        if (host?.endsWith("duck.ai") == true) {
+                            locked = false
+                        }
                         uiLockChanged(locked)
                     }
                 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5626,7 +5626,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertTrue(this.locked)
@@ -5644,7 +5644,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": false }"""),
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5662,7 +5662,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandNotIssued<Command.UiLockChanged>()
         }
@@ -5678,7 +5678,7 @@ class BrowserTabViewModelTest {
                 null,
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5696,7 +5696,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "other": "value" }"""),
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5714,9 +5714,45 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "someUrl" },
+                { "https://example.com" },
             )
             assertCommandNotIssued<Command.UiLockChanged>()
+        }
+
+    @Test
+    fun whenProcessJsCallbackMessageUiLockChangedFromDuckAiThenSendCommandWithLockedFalse() =
+        runTest {
+            fakeBrowserUiLockFeature.self().setRawStoredState(State(enable = true))
+            testee.processJsCallbackMessage(
+                BROWSER_UI_LOCK_FEATURE_NAME,
+                "uiLockChanged",
+                null,
+                JSONObject("""{ "locked": true }"""),
+                false,
+                null,
+                { "https://duck.ai" },
+            )
+            assertCommandIssued<Command.UiLockChanged> {
+                assertFalse(this.locked)
+            }
+        }
+
+    @Test
+    fun whenProcessJsCallbackMessageUiLockChangedFromDuckAiSubpageThenSendCommandWithLockedFalse() =
+        runTest {
+            fakeBrowserUiLockFeature.self().setRawStoredState(State(enable = true))
+            testee.processJsCallbackMessage(
+                BROWSER_UI_LOCK_FEATURE_NAME,
+                "uiLockChanged",
+                null,
+                JSONObject("""{ "locked": true }"""),
+                false,
+                null,
+                { "https://duck.ai/some/path" },
+            )
+            assertCommandIssued<Command.UiLockChanged> {
+                assertFalse(this.locked)
+            }
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213647284656734

### Description

When the `uiLockChanged` JS callback fires, the `locked` value should be forced to `false` if the current URL is from `duck.ai`. This is a temporary fix to avoid the omnibar being hidden in some scenarios.

### Steps to test this PR

_Browser UI Lock — duck.ai behaviour_
- [ ] Open a duck.ai page and trigger a `uiLockChanged` JS callback with `locked: true` — verify the UI lock does **not** activate
- [ ] Open a non-duck.ai page and trigger a `uiLockChanged` JS callback with `locked: true` — verify the UI lock **does** activate
- [ ] Verify that disabling the `browserUiLock` feature flag prevents the command from being issued entirely

|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 18e3f23a58ebcf4c8d83d01895a810d0ad9a68a8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->