### PR TITLE
Update url-predictor-android to 0.3.15

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -90,7 +90,7 @@ version.com.duckduckgo.netguard..netguard-android=1.10.2
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.7.0
 
-version.com.duckduckgo.urlpredictor..url-predictor-android=0.3.13
+version.com.duckduckgo.urlpredictor..url-predictor-android=0.3.15
 
 version.com.frybits.harmony..harmony=1.2.6
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1198194956794324/task/1213651965660200?focus=true

### Description

Updates `url-predictor-android` from `0.3.13` to `0.3.15`. This version includes a fix for embedded newlines and tab characters in omnibar input being misclassified as a Navigate decision (triggering navigation) instead of a Search decision (triggering a search query).

### Steps to test this PR

_Test_
- [x] In toggle input screen, select duck.ai input
- [x] Input `https://example.com` + newline + `test` into the omnibar. It should open a DDG search, **not** navigate to example.com
- [x] Paste text with an embedded newline where the URL comes second, e.g. `hello world` on line 1 and `https://example.com` on line 2 — should open a DDG search, not navigate
- [ ] Paste text with a tab character followed by something URL-like, e.g. a tab then `example.com` — should open a DDG search, not navigate

_Regression — normal navigation still works_
- [x] Type a plain URL in the omnibar (e.g. `duckduckgo.com`) and confirm it navigates to the site
- [x] Type a full URL with scheme (e.g. `https://wikipedia.org`) and confirm it navigates directly
- [x] Type a search query (e.g. `how do penguins sleep`) and confirm it opens a DDG search results page

### UI changes

N/A — no UI changes.
