### PR TITLE
Add native input to contextual

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.google.android.material.card.MaterialCardView
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.json.JSONObject
+import javax.inject.Inject
+
+interface ContextualNativeInputManager {
+    fun init(
+        card: MaterialCardView,
+        widget: NativeInputModeWidget,
+        jsMessaging: JsMessaging,
+        lifecycleOwner: LifecycleOwner,
+        onSearchSubmitted: (String) -> Unit,
+    )
+
+    fun onWebViewMode()
+    fun onInputMode()
+}
+
+@ContributesBinding(FragmentScope::class)
+class RealContextualNativeInputManager @Inject constructor(
+    private val duckChat: DuckChat,
+) : ContextualNativeInputManager {
+
+    private var isNativeInputEnabled = false
+    private var card: MaterialCardView? = null
+    private var jsMessaging: JsMessaging? = null
+
+    override fun init(
+        card: MaterialCardView,
+        widget: NativeInputModeWidget,
+        jsMessaging: JsMessaging,
+        lifecycleOwner: LifecycleOwner,
+        onSearchSubmitted: (String) -> Unit,
+    ) {
+        this.card = card
+        this.jsMessaging = jsMessaging
+
+        applyCardShape(card)
+        setupWidget(widget, onSearchSubmitted)
+        observeNativeInputSetting(lifecycleOwner)
+    }
+
+    override fun onWebViewMode() {
+        if (isNativeInputEnabled) card?.show() else card?.gone()
+    }
+
+    override fun onInputMode() {
+        card?.gone()
+    }
+
+    private fun applyCardShape(card: MaterialCardView) {
+        val radius = card.resources.getDimension(
+            com.duckduckgo.mobile.android.R.dimen.extraLargeShapeCornerRadius,
+        )
+        card.shapeAppearanceModel = card.shapeAppearanceModel.toBuilder()
+            .setTopLeftCornerSize(radius)
+            .setTopRightCornerSize(radius)
+            .setBottomLeftCornerSize(0f)
+            .setBottomRightCornerSize(0f)
+            .build()
+    }
+
+    private fun setupWidget(widget: NativeInputModeWidget, onSearchSubmitted: (String) -> Unit) {
+        widget.selectChatTab()
+        widget.hideMainButtons()
+        widget.onStopTapped = ::sendStopEvent
+        widget.bindInputEvents(
+            onSearchTextChanged = { },
+            onSearchSubmitted = { query ->
+                widget.hideKeyboard()
+                onSearchSubmitted(query)
+            },
+            onChatSubmitted = { prompt ->
+                sendPrompt(prompt)
+                widget.text = ""
+            },
+        )
+    }
+
+    private fun observeNativeInputSetting(lifecycleOwner: LifecycleOwner) {
+        duckChat.observeNativeInputFieldUserSettingEnabled()
+            .onEach { isEnabled -> isNativeInputEnabled = isEnabled }
+            .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    private fun sendPrompt(prompt: String) {
+        val params = JSONObject().apply {
+            put("platform", "android")
+            put("tool", "query")
+            put(
+                "query",
+                JSONObject().apply {
+                    put("prompt", prompt)
+                    put("autoSubmit", true)
+                },
+            )
+        }
+        jsMessaging?.sendSubscriptionEvent(
+            SubscriptionEventData(
+                featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
+                subscriptionName = "submitAIChatNativePrompt",
+                params = params,
+            ),
+        )
+    }
+
+    private fun sendStopEvent() {
+        jsMessaging?.sendSubscriptionEvent(
+            SubscriptionEventData(
+                featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
+                subscriptionName = "submitPromptInterruption",
+                params = JSONObject("{}"),
+            ),
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -176,6 +176,9 @@ class DuckChatContextualFragment :
     @Inject
     lateinit var faviconManager: FaviconManager
 
+    @Inject
+    lateinit var contextualNativeInputManager: ContextualNativeInputManager
+
     private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     private var pendingFileDownload: FileDownloader.PendingFileDownload? = null
@@ -411,6 +414,16 @@ class DuckChatContextualFragment :
 
         configureBottomSheet(view)
         setupBackPressHandling()
+        contextualNativeInputManager.init(
+            card = binding.contextualNativeInputCard,
+            widget = binding.contextualNativeInputWidget,
+            jsMessaging = contentScopeScripts,
+            lifecycleOwner = viewLifecycleOwner,
+            onSearchSubmitted = { query ->
+                viewModel.onContextualClose()
+                startActivity(browserNav.openInNewTab(requireContext(), query))
+            },
+        )
         observeViewModel()
 
         requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)?.let { tabId ->
@@ -612,7 +625,8 @@ class DuckChatContextualFragment :
         when (viewState.sheetMode) {
             DuckChatContextualViewModel.SheetMode.INPUT -> {
                 binding.contextualModeNativeContent.show()
-                binding.simpleWebview.gone()
+                binding.contextualWebviewContainer.gone()
+                contextualNativeInputManager.onInputMode()
 
                 binding.contextualNewChat.gone()
 
@@ -635,8 +649,9 @@ class DuckChatContextualFragment :
 
             DuckChatContextualViewModel.SheetMode.WEBVIEW -> {
                 binding.contextualModeNativeContent.gone()
-                binding.simpleWebview.show()
+                binding.contextualWebviewContainer.show()
                 binding.contextualNewChat.show()
+                contextualNativeInputManager.onWebViewMode()
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
@@ -332,10 +332,35 @@
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
 
-    <WebView
-        android:id="@+id/simpleWebview"
+    <FrameLayout
+        android:id="@+id/contextualWebviewContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="gone">
+
+        <WebView
+            android:id="@+id/simpleWebview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/contextualNativeInputCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            app:cardBackgroundColor="?attr/daxColorSurface"
+            app:cardElevation="4dp"
+            app:cardUseCompatPadding="false">
+
+            <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+                android:id="@+id/contextualNativeInputWidget"
+                android:paddingHorizontal="8dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </FrameLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213433888294716?focus=true

### Description

- Adds the native input to the Duck.ai contextual sheet

### Steps to test this PR

- [ ] Enable the native input
- [ ] Open contextual Duck.ai and send prompt
- [ ] Verify that the native input is visible
- [ ] Send a prompt
- [ ] Verify that the prompt is submitted
- [ ] Change to search
- [ ] Submit a query
- [ ] Very that contextual is closed and the search is submitted

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1280" height="2856" alt="Screenshot_20260317_004850" src="https://github.com/user-attachments/assets/e20c0ffc-de95-4ea8-98e3-36b65285c59c" />|<img width="1280" height="2856" alt="Screenshot_20260317_010044" src="https://github.com/user-attachments/assets/2682325c-72b6-4617-8668-bbe9a6e0ad44" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new native input overlay that sends JS subscription events into the contextual WebView and changes sheet-mode rendering/visibility, so regressions could impact prompt submission or UI state toggling.
> 
> **Overview**
> Adds an optional **native input overlay** to the Duck.ai contextual sheet when in WebView mode, driven by a new `ContextualNativeInputManager` that wires up `NativeInputModeWidget` and toggles visibility based on the user setting.
> 
> Native chat prompts are now submitted via `JsMessaging` subscription events (`submitAIChatNativePrompt` / `submitPromptInterruption`), while search submissions close the contextual sheet and open the query in a new browser tab. The layout is updated to wrap the `WebView` in a container and overlay the new input card at the bottom.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31a9ea390d00593528b8e3537866d0898a23efef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->