### PR TITLE
Fix bug where input screen is re-enabled after disabling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
@@ -78,6 +78,7 @@ class OnboardingInputScreenSelectionObserver @Inject constructor(
     private fun setSelectionWhenEstablished() {
         userStageStore.userAppStageFlow()
             .distinctUntilChanged()
+            .drop(1)
             .filter { it == AppStage.ESTABLISHED }
             .onEach {
                 val selection = onboardingStore.getInputScreenSelection()

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
@@ -141,6 +141,28 @@ class OnboardingInputScreenSelectionObserverTest {
         }
 
     @Test
+    fun whenAppRestartsWithStageAlreadyEstablishedThenDoNotReApplyOnboardingSelection() =
+        runTest {
+            userAppStageFlow.value = AppStage.ESTABLISHED
+
+            whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)
+            whenever(mockOnboardingStore.getInputScreenSelection()).thenReturn(true)
+            whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenSettingFlow)
+            whenever(mockDuckChat.observeCosmeticInputScreenUserSettingEnabled()).thenReturn(cosmeticInputScreenSettingFlow)
+
+            OnboardingInputScreenSelectionObserver(
+                mockAppCoroutineScope,
+                dispatcherProvider,
+                mockUserStageStore,
+                mockOnboardingStore,
+                mockDuckChat,
+                mockInputScreenOnboardingWideEvent,
+            )
+
+            verify(mockDuckChat, never()).setInputScreenUserSetting(any())
+        }
+
+    @Test
     fun whenUserChangesInputScreenSettingBeforeEstablishedThenMarkAsOverriddenByUser() =
         runTest {
             whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213684427531072?focus=true

### Description

- Fixes an issue where “Search & Duck.ai” would be re-enabled after disabling it in settings.

### Steps to test this PR

- [ ] Fresh install
- [ ] Select “Search & Duck.ai” in onboarding
- [ ] Complete onboarding
- [ ] Go to “AI Features” and select “Search Only"
- [ ] Kill the app and reopen
- [ ] Verify that “Search & Duck.ai” is still disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small flow-logic change limited to onboarding state observation, with a focused unit test to prevent regressions.
> 
> **Overview**
> Prevents `OnboardingInputScreenSelectionObserver` from re-applying the stored onboarding input-screen selection when the app starts up already in `AppStage.ESTABLISHED`, by skipping the initial `userAppStageFlow` emission (adds `.drop(1)`).
> 
> Adds a unit test asserting that a restart with stage already `ESTABLISHED` does *not* call `duckChat.setInputScreenUserSetting`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 343cba128922c13f60d86a67082ccc149dfcbfc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->