### PR TITLE
Fix BookmarkAddedConfirmationDialog IllegalArgumentException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
@@ -138,7 +138,11 @@ class BookmarkAddedConfirmationDialog(
         autoDismissDialogJob += lifecycleScope.launch {
             delay(BOOKMARKS_BOTTOM_SHEET_DURATION)
             if (isShowing && isActive) {
-                dismiss()
+                try {
+                    dismiss()
+                } catch (e: IllegalArgumentException) {
+                    logcat { "Auto-dismiss failed, window already removed: ${e.message}" }
+                }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213720960821640?focus=true

### Description

- Catches `IllegalArgumentException` when `dismiss` is called on a destroyed view (after a delay).

### Steps to test this PR

- [ ] Visit a site
- [ ] Tap the overflow menu and add a bookmark
- [ ] Verify that the confirmation dialog is dismissed after a delay

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds defensive error handling around dialog dismissal to avoid a crash when the window is already gone.
> 
> **Overview**
> Prevents a crash in `BookmarkAddedConfirmationDialog` when the auto-dismiss timer fires after the dialog window has already been removed.
> 
> The auto-dismiss `dismiss()` call is now wrapped in a `try/catch` for `IllegalArgumentException` and logs a message instead of throwing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a14cdad4dc38efa5dabac387df44f591dd08f486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->