### PR TITLE
Add a snackbar message for multiple tabs being burned

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="singleTabFireDialogSubtitleSiteData">Deleting site data can sign you out of accounts.</string>
     <string name="singleTabFireDialogSubtitleDownloads">This will cancel downloads in progress.</string>
     <string name="singleTabFireDialogSnackbar">1 tab and its data deleted</string>
+    <string name="singleTabFireDialogMultipleTabsSnackbar" instruction="Placeholder is the number of tabs">%1$s tabs and their data deleted</string>
     <string name="singleTabFireDialogClearNotSupportedSnackbar">Site data could not be deleted. Please update WebView.</string>
     <string name="singleTabFireDialogClearErrorSnackbar">Site data could not be deleted due to an error.</string>
 


### PR DESCRIPTION
Smartling translation trigger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk localization-only change: adds a new string resource for a multi-tab clear snackbar with no logic changes.
> 
> **Overview**
> Adds a new string resource `singleTabFireDialogMultipleTabsSnackbar` to support showing a snackbar message when *multiple* tabs (and their site data) are deleted, including a `%1$s` placeholder for the tab count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e313d96549002bd02fb133a1dd61b1ce26c7093. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->