### PR TITLE
Collect page context on page load

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2801,7 +2801,7 @@ class BrowserTabFragment :
             is Command.DuckAIFullScreenDisabled -> {
                 omnibar.setViewMode(Browser(it.url))
                 nativeInputManager.hideNativeInput()
-                sharedContextualViewModel.onMainBrowserPageFinished(it.url)
+                sharedContextualViewModel.onMainBrowserPageFinished(it.url, androidBrowserConfigFeature.storePageContext().isEnabled())
             }
 
             is Command.ShowDuckAIContextualMode -> showDuckChatContextualSheet(it.tabId)
@@ -2810,7 +2810,7 @@ class BrowserTabFragment :
             }
 
             is Command.PageContextReceived -> {
-                sharedContextualViewModel.onPageContextReceived(it.tabId, it.pageContext)
+                sharedContextualViewModel.onPageContextReceived(it.tabId, it.pageContext, androidBrowserConfigFeature.storePageContext().isEnabled())
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2169,6 +2169,10 @@ class BrowserTabViewModel @Inject constructor(
             serpLogoJob += viewModelScope.launch {
                 evaluateSerpLogoState(url)
             }
+
+            if (androidBrowserConfig.storePageContext().isEnabled()) {
+                collectPageContext()
+            }
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5634,6 +5634,28 @@ class BrowserTabViewModelTest {
         }
 
     @Test
+    fun whenPageFinishedAndStorePageContextEnabledThenCollectPageContext() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.storePageContext().setRawStoredState(State(enable = true))
+            val webViewNavState = WebViewNavigationState(mockStack, 100)
+
+            testee.pageFinished(mockWebView, webViewNavState, "https://example.com")
+
+            verify(mockPageContextJSHelper).collectPageContext()
+        }
+
+    @Test
+    fun whenPageFinishedAndStorePageContextDisabledThenDoNotCollectPageContext() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.storePageContext().setRawStoredState(State(enable = false))
+            val webViewNavState = WebViewNavigationState(mockStack, 100)
+
+            testee.pageFinished(mockWebView, webViewNavState, "https://example.com")
+
+            verify(mockPageContextJSHelper, never()).collectPageContext()
+        }
+
+    @Test
     fun whenProcessJsCallbackMessageScreenLockNotEnabledDoNotSendCommand() =
         runTest {
             whenever(mockEnabledToggle.isEnabled()).thenReturn(false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -584,11 +584,11 @@ class DuckChatContextualFragment :
             .onEach { command ->
                 when (command) {
                     is DuckChatContextualSharedViewModel.Command.PageContextAttached -> {
-                        viewModel.onPageContextReceived(command.tabId, command.pageContext)
+                        viewModel.onPageContextReceived(command.tabId, command.pageContext, command.isStorePageContextEnabled)
                     }
 
-                    DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished -> {
-                        viewModel.onMainBrowserPageFinished()
+                    is DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished -> {
+                        viewModel.onMainBrowserPageFinished(command.isStorePageContextEnabled)
                     }
 
                     DuckChatContextualSharedViewModel.Command.OpenSheet -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModel.kt
@@ -26,8 +26,8 @@ class DuckChatContextualSharedViewModel() : ViewModel() {
     private val _command = MutableSharedFlow<Command>(extraBufferCapacity = 10)
     val commands = _command.asSharedFlow()
 
-    fun onPageContextReceived(tabId: String, pageContext: String) {
-        _command.tryEmit(Command.PageContextAttached(tabId, pageContext))
+    fun onPageContextReceived(tabId: String, pageContext: String, isStorePageContextEnabled: Boolean = false) {
+        _command.tryEmit(Command.PageContextAttached(tabId, pageContext, isStorePageContextEnabled))
     }
 
     fun onOpenRequested() {
@@ -38,21 +38,22 @@ class DuckChatContextualSharedViewModel() : ViewModel() {
         _command.tryEmit(Command.CollectPageContext)
     }
 
-    fun onMainBrowserPageFinished(url: String?) {
+    fun onMainBrowserPageFinished(url: String?, isStorePageContextEnabled: Boolean = false) {
         logcat { "Duck.ai: onMainBrowserPageFinished $url" }
-        _command.tryEmit(Command.MainBrowserPageFinished)
+        _command.tryEmit(Command.MainBrowserPageFinished(isStorePageContextEnabled))
     }
 
     sealed class Command {
         data class PageContextAttached(
             val tabId: String,
             val pageContext: String,
+            val isStorePageContextEnabled: Boolean = false,
         ) : Command()
 
         data object OpenSheet : Command()
 
         data object CollectPageContext : Command()
 
-        data object MainBrowserPageFinished : Command()
+        data class MainBrowserPageFinished(val isStorePageContextEnabled: Boolean = false) : Command()
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.contextual
 
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -72,6 +73,9 @@ class DuckChatContextualViewModel @Inject constructor(
     var updatedPageContext: String = ""
     var sheetTabId: String = ""
 
+    @VisibleForTesting
+    internal var isPageContextRequested: Boolean = false
+
     sealed class Command {
         data class LoadUrl(val url: String) : Command()
         data object SendSubscriptionAuthUpdateEvent : Command()
@@ -114,6 +118,7 @@ class DuckChatContextualViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             withContext(dispatchers.main()) {
                 logcat { "Duck.ai: requesting page context after sheet reopened" }
+                isPageContextRequested = true
                 commandChannel.trySend(Command.RequestPageContext)
             }
 
@@ -175,6 +180,7 @@ class DuckChatContextualViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
             withContext(dispatchers.main()) {
+                isPageContextRequested = true
                 commandChannel.trySend(Command.RequestPageContext)
             }
             sheetTabId = tabId
@@ -365,6 +371,7 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onSheetClosed() {
+        isPageContextRequested = false
         persistTabClosed()
         duckChatPixels.reportContextualSheetDismissed()
     }
@@ -499,7 +506,14 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onPageContextReceived(
         tabId: String,
         pageContext: String,
+        isStorePageContextEnabled: Boolean = false,
     ) {
+        if (isStorePageContextEnabled && !isPageContextRequested && !duckChatInternal.isAutomaticContextAttachmentEnabled()) {
+            // Only applies when storePageContext is enabled.
+            // We don't process what we receive if the sheet did not specifically request it and automatic context attachment is disabled
+            return
+        }
+
         if (isContextValid(pageContext)) {
             updatedPageContext = pageContext
             val json = JSONObject(updatedPageContext)
@@ -606,8 +620,13 @@ class DuckChatContextualViewModel @Inject constructor(
         return elapsedMs <= timeoutMs
     }
 
-    fun onMainBrowserPageFinished() {
+    fun onMainBrowserPageFinished(isStorePageContextEnabled: Boolean = false) {
         logcat { "Duck.ai: onMainBrowserPageFinished" }
+        if (isStorePageContextEnabled) {
+            isPageContextRequested = false
+            // When storePageContext is enabled, page context is already collected on page load by the browser
+            return
+        }
         val currentState = _viewState.value
         if (currentState.sheetMode != SheetMode.INPUT) return
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualSharedViewModelTest.kt
@@ -79,7 +79,7 @@ class DuckChatContextualSharedViewModelTest {
             testee.onMainBrowserPageFinished("https://example.com")
 
             val command = awaitItem()
-            assertEquals(DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished, command)
+            assertEquals(DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished(), command)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -90,7 +90,7 @@ class DuckChatContextualSharedViewModelTest {
             testee.onMainBrowserPageFinished(null)
 
             val command = awaitItem()
-            assertEquals(DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished, command)
+            assertEquals(DuckChatContextualSharedViewModel.Command.MainBrowserPageFinished(), command)
             cancelAndConsumeRemainingEvents()
         }
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -665,6 +665,98 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
+    fun `when page context received without request and attachments disabled then context ignored`() =
+        runTest {
+            whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+            whenever(duckChatInternal.areMultipleContentAttachmentsEnabled()).thenReturn(false)
+            testee =
+                DuckChatContextualViewModel(
+                    dispatchers = coroutineRule.testDispatcherProvider,
+                    duckChat = duckChat,
+                    duckChatInternal = duckChatInternal,
+                    duckChatJSHelper = duckChatJSHelper,
+                    contextualDataStore = contextualDataStore,
+                    sessionTimeoutProvider = sessionTimeoutProvider,
+                    timeProvider = timeProvider,
+                    duckChatPixels = duckChatPixels,
+                )
+
+            val serializedPageData =
+                """
+                {
+                    "title": "Ctx Title",
+                    "url": "https://ctx.com",
+                    "content": "content"
+                }
+                """.trimIndent()
+
+            testee.onPageContextReceived("tab-1", serializedPageData, isStorePageContextEnabled = true)
+
+            val state = testee.viewState.value
+            assertEquals("", state.contextTitle)
+            assertEquals("", state.contextUrl)
+            assertEquals("", testee.updatedPageContext)
+        }
+
+    @Test
+    fun `when page context received after sheet opened and attachments disabled then context processed`() =
+        runTest {
+            whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+            whenever(duckChatInternal.areMultipleContentAttachmentsEnabled()).thenReturn(false)
+            testee =
+                DuckChatContextualViewModel(
+                    dispatchers = coroutineRule.testDispatcherProvider,
+                    duckChat = duckChat,
+                    duckChatInternal = duckChatInternal,
+                    duckChatJSHelper = duckChatJSHelper,
+                    contextualDataStore = contextualDataStore,
+                    sessionTimeoutProvider = sessionTimeoutProvider,
+                    timeProvider = timeProvider,
+                    duckChatPixels = duckChatPixels,
+                )
+
+            val serializedPageData =
+                """
+                {
+                    "title": "Ctx Title",
+                    "url": "https://ctx.com",
+                    "content": "content"
+                }
+                """.trimIndent()
+
+            testee.onSheetOpened("tab-1")
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+            testee.onPageContextReceived("tab-1", serializedPageData, isStorePageContextEnabled = true)
+
+            val state = testee.viewState.value
+            assertEquals("Ctx Title", state.contextTitle)
+            assertEquals("https://ctx.com", state.contextUrl)
+            assertEquals(serializedPageData, testee.updatedPageContext)
+        }
+
+    @Test
+    fun `when page context received with storePageContext enabled and auto attachment enabled then context processed`() =
+        runTest {
+            whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+            val serializedPageData =
+                """
+                {
+                    "title": "Ctx Title",
+                    "url": "https://ctx.com",
+                    "content": "content"
+                }
+                """.trimIndent()
+
+            testee.onPageContextReceived("tab-1", serializedPageData, isStorePageContextEnabled = true)
+
+            val state = testee.viewState.value
+            assertEquals("Ctx Title", state.contextTitle)
+            assertEquals("https://ctx.com", state.contextUrl)
+            assertEquals(serializedPageData, testee.updatedPageContext)
+        }
+
+    @Test
     fun `when page context received after user removed context then auto-attached pixel not fired`() =
         runTest {
             val serializedPageData =
@@ -1172,6 +1264,40 @@ class DuckChatContextualViewModelTest {
             expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `when main browser page finished with storePageContext enabled then no command emitted and flag reset`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.isPageContextRequested)
+
+        // drain any pending commands from onSheetOpened
+        testee.commands.test {
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands.test {
+            testee.onMainBrowserPageFinished(isStorePageContextEnabled = true)
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertFalse(testee.isPageContextRequested)
+    }
+
+    @Test
+    fun `when sheet closed then isPageContextRequested is reset`() = runTest {
+        val tabId = "tab-1"
+        testee.onSheetOpened(tabId)
+        assertTrue(testee.isPageContextRequested)
+
+        testee.onSheetClosed()
+
+        assertFalse(testee.isPageContextRequested)
     }
 
     private class FakeDuckChat : com.duckduckgo.duckchat.api.DuckChat {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213731439915337?focus=true 

### Description

We want to collect the page context for open tabs and store them in local DB.

Adding this on Page load will have direct impact on the Contextual Sheet. It was directly tied to the context collection, as it assumes it was the only consumer. Which is no longer the case.
To accommodate to that, I added a isPageContextRequested boolean to specifically know when the page context was requested by the sheet or not. The sheet should accept the new context in 2 cases:
1. If it asked for it
2. If Auto Attach Context is on 

Note: I pass the feature flag as a param because it is defined in a different module.  

### Steps to test this PR
1. Pull the changes
2. With the storePageContext Feature flag OFF --> No collection and no regression on existing behaviour with the contextual sheet. 
3. Turn on the storePageContext flag.
4. Verify collection is triggered on every page load (can use Database explorer for that, the page will be stored in tab_page_context table)
5. Verify that contextual sheet works the same as the feature flag OFF. No regression should be introduced for both Automatic context collection ON or OFF.

Only change introduced to the contextual sheet is if it is in WEBVIEW mode, Automatic context is ON, and the page refreshes in the background The context is updated. This is a new behavior that didn't exist before, but it's gated behind the feature flag.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds feature-flagged page-context collection on every page load and changes DuckChat contextual sheet gating logic, which can affect when/if context is attached to chats. Risk is moderated by the `storePageContext` flag but touches cross-module event flow between browser and DuckChat.
> 
> **Overview**
> Enables **feature-flagged page context collection on page load** by triggering `collectPageContext()` from `BrowserTabViewModel.pageFinished` when `storePageContext` is enabled.
> 
> Updates the DuckChat contextual integration to pass `isStorePageContextEnabled` through shared commands (`onPageContextReceived`, `onMainBrowserPageFinished`) and adds an `isPageContextRequested` guard so the sheet ignores unsolicited context unless *auto-attach* is enabled; when the flag is on, `onMainBrowserPageFinished` no longer triggers an extra context request. Tests are expanded to cover the new flag-gated behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 649a04df530a4d5613ef05497e5a9531556f9f27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->