### PR TITLE
Add PirProcessLifecycleObserver

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.di.AppComponent
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.DaggerAppComponent
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.lifecycle.PirProcessLifecycleObserver
 import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -43,6 +44,7 @@ import java.io.File
 import javax.inject.Inject
 
 private const val VPN_PROCESS_NAME = "vpn"
+private const val PIR_PROCESS_NAME = "pir"
 
 open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() {
 
@@ -57,6 +59,9 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
 
     @Inject
     lateinit var vpnLifecycleObserverPluginPoint: PluginPoint<VpnProcessLifecycleObserver>
+
+    @Inject
+    lateinit var pirLifecycleObserverPluginPoint: PluginPoint<PirProcessLifecycleObserver>
 
     @Inject
     lateinit var activityLifecycleCallbacks: PluginPoint<com.duckduckgo.browser.api.ActivityLifecycleCallbacks>
@@ -112,6 +117,17 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
                     ProcessLifecycleOwner.get().lifecycle.apply {
                         vpnLifecycleObserverPluginPoint.getPlugins().forEach {
                             it.onVpnProcessCreated()
+                        }
+                    }
+                }
+
+                if (shortProcessName == PIR_PROCESS_NAME) {
+                    // ProcessLifecycleOwner doesn't know about secondary processes, so the callbacks are our own callbacks and limited to onCreate which
+                    // is good enough.
+                    // See https://developer.android.com/reference/android/arch/lifecycle/ProcessLifecycleOwner#get
+                    ProcessLifecycleOwner.get().lifecycle.apply {
+                        pirLifecycleObserverPluginPoint.getPlugins().forEach {
+                            it.onPirProcessCreated()
                         }
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/global/plugin/PirProcessLifecycleObserverPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/plugin/PirProcessLifecycleObserverPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.plugin
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.lifecycle.PirProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = PirProcessLifecycleObserver::class,
+)
+@Suppress("unused")
+interface PirProcessLifecycleObserverPluginPoint

--- a/di/src/main/java/com/duckduckgo/app/lifecycle/PirProcessLifecycleObserver.kt
+++ b/di/src/main/java/com/duckduckgo/app/lifecycle/PirProcessLifecycleObserver.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.lifecycle
+
+interface PirProcessLifecycleObserver {
+    fun onPirProcessCreated()
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1213720450436951?focus=true

### Description
Adds a `PirProcessLifecycleObserver` similar to existing `VpnProcessLifecycleObserver`

### Steps to test this PR
Nothing to test

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new lifecycle observer interface and dispatch hook for the `pir` secondary process, mirroring existing VPN behavior without changing core app flows or data handling.
> 
> **Overview**
> Adds support for a new `pir` secondary process lifecycle callback.
> 
> `DuckDuckGoApplication` now recognizes the `pir` process name and dispatches `onPirProcessCreated()` to a new `PluginPoint<PirProcessLifecycleObserver>`, alongside the existing VPN process handling. This PR also introduces the `PirProcessLifecycleObserver` interface and an Anvil `ContributesPluginPoint` (`PirProcessLifecycleObserverPluginPoint`) so features can register PIR process startup observers via DI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63fd8025f6d0a39c23ee8b6431e36456b746a943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->