### PR TITLE
Add temporary pixel for PIR eligible

### DIFF
--- a/PixelDefinitions/pixels/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/personal_information_removal.json5
@@ -1064,6 +1064,13 @@
             }
         ]
     },
+    "m_dbp_user-eligible": {
+        "description": "Android specific daily pixel fired when the user is eligible to run PIR (flag enabled, valid subscription, PIR entitlement, and repository available).",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_dbp_data_broker_action-failed_error": {
         "description": "Fired when a scan or opt-out action fails while processing a data broker.",
         "owners": ["karlenDimla", "landomen"],

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +45,7 @@ class PirDataUpdateObserver @Inject constructor(
     private val pirFeatureDataCleaner: PirFeatureDataCleaner,
     private val pirRepository: PirRepository,
     private val currentTimeProvider: CurrentTimeProvider,
+    private val pirPixelSender: PirPixelSender,
 ) : MainProcessLifecycleObserver {
     override fun onCreate(owner: LifecycleOwner) {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -53,6 +55,7 @@ class PirDataUpdateObserver @Inject constructor(
                 .collectLatest { enabled ->
                     val featureReceiveMs = pirRepository.getFeatureReceivedMs()
                     if (enabled) {
+                        pirPixelSender.reportCanRunPir()
                         // We only set the value if it was not set previously
                         if (featureReceiveMs == 0L) {
                             pirRepository.setFeatureReceivedMs(currentTimeProvider.currentTimeMillis())

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
@@ -309,6 +309,10 @@ enum class PirPixel(
         baseName = "m_dbp_bundle_broker-json_failure",
         types = setOf(Count, Daily()),
     ),
+    PIR_CAN_RUN_PIR(
+        baseName = "m_dbp_user-eligible",
+        type = Daily(),
+    ),
     ;
 
     constructor(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_7DAY_UNCO
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_OPTOUT_SUBMIT_SUCCESSRATE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BUNDLE_BROKER_JSON_FAILURE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BUNDLE_BROKER_JSON_LOADED
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_CAN_RUN_PIR
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_CPU_USAGE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_DASHBOARD_OPENED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_DOWNLOAD_BROKER_JSON_FAILURE
@@ -364,6 +365,11 @@ interface PirPixelSender {
      * Emits a pixel when an opt-out is unconfirmed within 42 days.
      */
     fun reportBrokerOptOutUnconfirmed42Days(brokerUrl: String)
+
+    /**
+     * Emits a daily pixel to report that the user is eligible to run PIR.
+     */
+    fun reportCanRunPir()
 
     /**
      * Emits a pixel to report Daily Active Users for PIR.
@@ -907,6 +913,10 @@ class RealPirPixelSender @Inject constructor(
         )
 
         enqueueFire(PIR_BROKER_CUSTOM_STATS_42DAY_UNCONFIRMED_OPTOUT, params)
+    }
+
+    override fun reportCanRunPir() {
+        enqueueFire(PIR_CAN_RUN_PIR)
     }
 
     override fun reportDAU() {

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -47,6 +48,7 @@ class PirDataUpdateObserverTest {
     private val pirFeatureDataCleaner: PirFeatureDataCleaner = mock()
     private val pirRepository: PirRepository = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
+    private val pirPixelSender: PirPixelSender = mock()
     private val canRunPirFlow = MutableStateFlow(false)
 
     private lateinit var pirDataUpdateObserver: PirDataUpdateObserver
@@ -65,6 +67,7 @@ class PirDataUpdateObserverTest {
             pirFeatureDataCleaner = pirFeatureDataCleaner,
             pirRepository = pirRepository,
             currentTimeProvider = currentTimeProvider,
+            pirPixelSender = pirPixelSender,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213726950062653?focus=true 

### Description
See attached task description

### Steps to test this PR

_Feature 1_
- [x] Install debug build
- [x] Verify m_dbp_user-eligible_d is not emitted 
- [x] Obtain a susbcription
- [x] Verify that m_dbp_user-eligible_d is emitted
- [x] Reopen app and verify suucceeding pixels for m_dbp_user-eligible_d are dropped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new analytics pixel and a single call site when `canRunPir()` becomes true, with minimal impact on PIR behavior beyond an extra enqueue.
> 
> **Overview**
> Adds a new Android PIR daily analytics pixel, `m_dbp_user-eligible_d`, to report when a user is eligible to run PIR.
> 
> Wires the pixel through `PirPixel`/`PirPixelSender` and emits it from `PirDataUpdateObserver` when `canRunPir()` transitions to enabled; updates unit tests to inject and mock the new `PirPixelSender` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9635c946e5546786f746d1e1b79f4b46f0d80306. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->