### PR TITLE
Fix toolbar disappearing after coming back from Duck.ai

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -623,6 +623,12 @@ class OmnibarLayoutViewModel @Inject constructor(
                 }
             }
         }
+
+        if (currentViewMode == ViewMode.DuckAI && viewMode != ViewMode.DuckAI) {
+            viewModelScope.launch {
+                command.send(Command.FocusInputField)
+            }
+        }
     }
 
     fun onPrivacyShieldChanged(privacyShieldState: PrivacyShieldState) {

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.webview
 
 import android.content.Context
+import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -44,6 +45,13 @@ class TopOmnibarBrowserContainerLayoutBehavior(
     attrs: AttributeSet?,
 ) : ScrollingViewBehavior(context, attrs) {
     private val marginOffsetPx = (MARGIN_OFFSET_DP * context.resources.displayMetrics.density).toInt()
+
+    override fun onRequestChildRectangleOnScreen(
+        parent: CoordinatorLayout,
+        child: View,
+        rectangle: Rect,
+        immediate: Boolean,
+    ): Boolean = false
 
     override fun layoutDependsOn(
         parent: CoordinatorLayout,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213689666003865?focus=true

### Description

- Overrides `onRequestChildRectangleOnScreen` to prevent the omnibar from hiding on focus change
- Focuses the input in the omnibar when going back from Duck.ai

### Steps to test this PR

- [x] Open a new tab
- [x] Type something and tap the Duck.ai omnibar icon
- [x] Swipe back
- [x] Verify that the input is focussed
- [x] Tap on the overflow menu
- [x] Verify that the omnibar does not hide

### UI changes

Before

https://github.com/user-attachments/assets/da125548-5df1-4cc1-b7c1-473b601ee231

After

https://github.com/user-attachments/assets/c5e01290-3f8e-43db-bbdd-7a716ad15fcf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar focus/command behavior and `CoordinatorLayout` scrolling behavior, which can affect navigation/scrolling UI across many screens. Risk is moderate due to potential regressions in focus handling and child scroll requests.
> 
> **Overview**
> Fixes returning from `ViewMode.DuckAI` by explicitly re-focusing the omnibar input (`Command.FocusInputField`) when switching back to non-DuckAI modes.
> 
> Prevents the webview container from triggering automatic scroll-to-rectangle behavior by overriding `TopOmnibarBrowserContainerLayoutBehavior.onRequestChildRectangleOnScreen` to always return `false`, avoiding unintended layout/toolbar shifts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72652f51a22b81201a60c7832a179adaf33651d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->