### PR TITLE
Extract tracker counter logic

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -41,6 +41,10 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
+import com.duckduckgo.app.trackerdetection.db.WebTrackerBlocked
+import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
+import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -71,6 +75,7 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.anyMap
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -112,6 +117,7 @@ class WebViewRequestInterceptorTest {
     )
     private var fakeMaliciousSiteBlockerWebViewIntegration: MaliciousSiteBlockerWebViewIntegration = FakeMaliciousSiteBlockerWebViewIntegration(true)
     private val fakeAndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private val mockWebTrackersBlockedDao: WebTrackersBlockedDao = mock()
 
     private var webView: WebView = mock()
 
@@ -141,6 +147,7 @@ class WebViewRequestInterceptorTest {
             appCoroutineScope = coroutinesTestRule.testScope,
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             isMainProcess = true,
+            webTrackersBlockedDao = mockWebTrackersBlockedDao,
         )
     }
 
@@ -211,6 +218,7 @@ class WebViewRequestInterceptorTest {
             appCoroutineScope = coroutinesTestRule.testScope,
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             isMainProcess = true,
+            webTrackersBlockedDao = mockWebTrackersBlockedDao,
         )
         testee.shouldIntercept(
             request = mockRequest,
@@ -681,6 +689,41 @@ class WebViewRequestInterceptorTest {
     }
 
     @Test
+    fun whenInterceptFromServiceWorkerAndDirectTrackerBlockedThenInsertIntoWebTrackersBlockedDao() = runTest {
+        whenever(mockResourceSurrogates.get(any())).thenReturn(SurrogateResponse(responseAvailable = false))
+        whenever(mockRequest.url).thenReturn("foo.com".toUri())
+        whenever(mockRequest.requestHeaders).thenReturn(emptyMap())
+        configureShouldBlock()
+
+        testee.shouldInterceptFromServiceWorker(
+            request = mockRequest,
+            documentUrl = "foo.com".toUri(),
+        )
+
+        verify(mockWebTrackersBlockedDao).insert(any())
+    }
+
+    @Test
+    fun whenInterceptFromServiceWorkerAndCloakedCnameTrackerBlockedThenInsertIntoWebTrackersBlockedDao() = runTest {
+        whenever(mockRequest.requestHeaders).thenReturn(emptyMap())
+        configureNull()
+        configureBlockedCnameTrackingEvent(trackerUrl = "uncloaked-host.com")
+
+        val uri = "host.com".toUri()
+        whenever(mockRequest.url).thenReturn(uri)
+        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(anyString(), any())).thenReturn("uncloaked-host.com")
+
+        testee.shouldInterceptFromServiceWorker(
+            request = mockRequest,
+            documentUrl = "foo.com".toUri(),
+        )
+
+        val captor = argumentCaptor<WebTrackerBlocked>()
+        verify(mockWebTrackersBlockedDao).insert(captor.capture())
+        assertEquals("uncloaked-host.com", captor.firstValue.trackerUrl)
+    }
+
+    @Test
     fun whenIsAppUrlPixelThenShouldContinueToLoad() = runTest {
         whenever(mockRequest.url).thenReturn(
             "https://improving.duckduckgo.com/t/m_nav_nt_p_android_phone?atb=v336-7&appVersion=5.131.0&test=1".toUri(),
@@ -772,6 +815,29 @@ class WebViewRequestInterceptorTest {
 
         verify(mockCloakedCnameDetector).detectCnameCloakedHost("foo.com", uri)
         assertCancelledResponse(response)
+    }
+
+    @Test
+    fun whenCloakedCnameTrackerIsBlockedThenInsertIntoWebTrackersBlockedDaoWithUncloakedUrl() = runTest {
+        configureNull()
+        configureShouldNotUpgrade()
+        configureBlockedCnameTrackingEvent(trackerUrl = "uncloaked-host.com", entity = TdsEntity("Tracker Inc", "Tracker Inc", 10.0))
+
+        val uri = "host.com".toUri()
+        whenever(mockRequest.url).thenReturn(uri)
+        whenever(mockCloakedCnameDetector.detectCnameCloakedHost(anyString(), any())).thenReturn("uncloaked-host.com")
+
+        testee.shouldIntercept(
+            request = mockRequest,
+            documentUri = "foo.com".toUri(),
+            webView = webView,
+            webViewClientListener = null,
+        )
+
+        val captor = argumentCaptor<WebTrackerBlocked>()
+        verify(mockWebTrackersBlockedDao).insert(captor.capture())
+        assertEquals("uncloaked-host.com", captor.firstValue.trackerUrl)
+        assertEquals("Tracker Inc", captor.firstValue.trackerCompany)
     }
 
     @Test
@@ -896,21 +962,21 @@ class WebViewRequestInterceptorTest {
         whenever(mockTrackerDetector.evaluate(anyString(), any<Uri>(), eq(true), anyMap())).thenReturn(null)
     }
 
-    private fun configureBlockedCnameTrackingEvent() {
-        configureCnameTrackingEvent(TrackerStatus.BLOCKED)
+    private fun configureBlockedCnameTrackingEvent(trackerUrl: String = "", entity: Entity? = null) {
+        configureCnameTrackingEvent(TrackerStatus.BLOCKED, trackerUrl = trackerUrl, entity = entity)
     }
 
     private fun configureAllowedCnameTrackingEvent() {
         configureCnameTrackingEvent(TrackerStatus.ALLOWED)
     }
 
-    private fun configureCnameTrackingEvent(status: TrackerStatus) {
+    private fun configureCnameTrackingEvent(status: TrackerStatus, trackerUrl: String = "", entity: Entity? = null) {
         val trackingEvent = TrackingEvent(
             status = status,
             type = TrackerType.OTHER,
             documentUrl = "",
-            trackerUrl = "",
-            entity = null,
+            trackerUrl = trackerUrl,
+            entity = entity,
             categories = null,
             surrogateId = null,
         )

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -194,6 +194,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
             appCoroutineScope = coroutinesTestRule.testScope,
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             isMainProcess = true,
+            webTrackersBlockedDao = mockWebTrackersBlockedDao,
         )
     }
 
@@ -248,7 +249,6 @@ class DomainsReferenceTest(private val testCase: TestCase) {
             mockUserAllowListDao,
             mockContentBlocking,
             mockTrackerAllowlist,
-            mockWebTrackersBlockedDao,
             mockAdClickManager,
         )
         trackerDetector = trackerDetectorImpl

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
@@ -231,6 +231,7 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             appCoroutineScope = coroutinesTestRule.testScope,
             isMainProcess = true,
+            webTrackersBlockedDao = mockWebTrackersBlockedDao,
         )
     }
 
@@ -301,7 +302,6 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
             userAllowlistDao,
             contentBlocking,
             trackerAllowlist,
-            mockWebTrackersBlockedDao,
             mockAdClickManager,
         )
         trackerDetector = trackerDetectorImpl

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -197,6 +197,7 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
             appCoroutineScope = coroutinesTestRule.testScope,
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             isMainProcess = true,
+            webTrackersBlockedDao = mockWebTrackersBlockedDao,
         )
     }
 
@@ -243,7 +244,6 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
             mockUserAllowListDao,
             mockContentBlocking,
             mockTrackerAllowlist,
-            mockWebTrackersBlockedDao,
             mockAdClickManager,
         )
         trackerDetector = trackerDetectorImpl

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.privacy.model.TrustedSites
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
+import com.duckduckgo.app.trackerdetection.db.WebTrackerBlocked
+import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.common.utils.AppUrl
@@ -108,6 +110,7 @@ class WebViewRequestInterceptor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     @IsMainProcess private val isMainProcess: Boolean,
+    private val webTrackersBlockedDao: WebTrackersBlockedDao,
 ) : RequestInterceptor {
 
     private var checkMaliciousAfterHttpsUpgrade = false
@@ -350,6 +353,7 @@ class WebViewRequestInterceptor(
     ): WebResourceResponse? {
         val trackingEvent = trackingEvent(request, documentUrl, webViewClientListener)
         if (trackingEvent?.status == TrackerStatus.BLOCKED) {
+            recordTrackerBlocked(trackingEvent)
             return blockRequest(trackingEvent, request, webViewClientListener)
         } else if (trackingEvent == null ||
             trackingEvent.status == TrackerStatus.ALLOWED ||
@@ -358,6 +362,7 @@ class WebViewRequestInterceptor(
             cloakedCnameDetector.detectCnameCloakedHost(documentUrl.toString(), request.url)?.let { uncloakedHost ->
                 trackingEvent(request, documentUrl, webViewClientListener, false, uncloakedHost)?.let { cloakedTrackingEvent ->
                     if (cloakedTrackingEvent.status == TrackerStatus.BLOCKED) {
+                        recordTrackerBlocked(cloakedTrackingEvent)
                         return blockRequest(cloakedTrackingEvent, request, webViewClientListener)
                     }
                 }
@@ -460,6 +465,11 @@ class WebViewRequestInterceptor(
         val trackingEvent = trackerDetector.evaluate(url, documentUrl, checkFirstParty, request.requestHeaders) ?: return null
         webViewClientListener?.trackerDetected(trackingEvent)
         return trackingEvent
+    }
+
+    private fun recordTrackerBlocked(trackingEvent: TrackingEvent) {
+        val trackerCompany = trackingEvent.entity?.displayName ?: "Undefined"
+        webTrackersBlockedDao.insert(WebTrackerBlocked(trackerUrl = trackingEvent.trackerUrl, trackerCompany = trackerCompany))
     }
 
     private fun appUrlPixel(url: Uri?): Boolean =

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -79,6 +79,7 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.surrogates.ResourceSurrogates
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.trackerdetection.CloakedCnameDetector
+import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.ThirdPartyCookieNames
@@ -242,6 +243,7 @@ class BrowserModule {
         dispatchers: DispatcherProvider,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         @IsMainProcess isMainProcess: Boolean,
+        webTrackersBlockedDao: WebTrackersBlockedDao,
     ): RequestInterceptor =
         WebViewRequestInterceptor(
             resourceSurrogates,
@@ -263,6 +265,7 @@ class BrowserModule {
             androidBrowserConfigFeature,
             appCoroutineScope,
             isMainProcess,
+            webTrackersBlockedDao,
         )
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -62,6 +62,7 @@ object DatabaseModule {
             .addCallback(migrationsProvider.CHANGE_JOURNAL_ON_OPEN)
             .addCallback(databaseBookmarksMigrationCallbackProvider.provideCallbacks())
             .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .enableMultiInstanceInvalidation()
             .build()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -22,8 +22,6 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomainPair
 import com.duckduckgo.app.privacy.db.UserAllowListDao
 import com.duckduckgo.app.trackerdetection.Client.ClientType.BLOCKING
-import com.duckduckgo.app.trackerdetection.db.WebTrackerBlocked
-import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
@@ -48,7 +46,6 @@ class TrackerDetectorImpl @Inject constructor(
     private val userAllowListDao: UserAllowListDao,
     private val contentBlocking: ContentBlocking,
     private val trackerAllowlist: TrackerAllowlist,
-    private val webTrackersBlockedDao: WebTrackersBlockedDao,
     private val adClickManager: AdClickManager,
 ) : TrackerDetector, TrackerDetectorClientProvider {
 
@@ -137,11 +134,6 @@ class TrackerDetectorImpl @Inject constructor(
         }
 
         val type = if (isInAdClickAllowList) TrackerType.AD else TrackerType.OTHER
-
-        if (status == TrackerStatus.BLOCKED) {
-            val trackerCompany = entity?.displayName ?: "Undefined"
-            webTrackersBlockedDao.insert(WebTrackerBlocked(trackerUrl = urlString, trackerCompany = trackerCompany))
-        }
 
         logcat(VERBOSE) { "$documentUrlString resource $urlString WAS identified as a tracker and status=$status" }
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
@@ -21,7 +21,6 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.privacy.db.UserAllowListDao
-import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -43,7 +42,6 @@ class TrackerDetectorClientTypeTest {
     private val mockEntityLookup: EntityLookup = mock()
     private val mockBlockingClient: Client = mock()
     private val mockUserAllowListDao: UserAllowListDao = mock()
-    private val mockWebTrackersBlockedDao: WebTrackersBlockedDao = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
     private val mockAdClickManager: AdClickManager = mock()
@@ -53,7 +51,6 @@ class TrackerDetectorClientTypeTest {
         mockUserAllowListDao,
         mockContentBlocking,
         mockTrackerAllowlist,
-        mockWebTrackersBlockedDao,
         mockAdClickManager,
     )
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorTest.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.privacy.db.UserAllowListDao
 import com.duckduckgo.app.trackerdetection.Client.ClientName
 import com.duckduckgo.app.trackerdetection.Client.ClientName.EASYLIST
 import com.duckduckgo.app.trackerdetection.Client.ClientName.EASYPRIVACY
-import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
@@ -47,7 +46,6 @@ class TrackerDetectorTest {
     private val mockUserAllowListDao: UserAllowListDao = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
-    private val mockWebTrackersBlockedDao: WebTrackersBlockedDao = mock()
     private val mockAdClickManager: AdClickManager = mock()
 
     private val trackerDetector = TrackerDetectorImpl(
@@ -55,7 +53,6 @@ class TrackerDetectorTest {
         mockUserAllowListDao,
         mockContentBlocking,
         mockTrackerAllowlist,
-        mockWebTrackersBlockedDao,
         mockAdClickManager,
     )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213529826859023?focus=true

### Description
- Extracts blocked trackers counter logic from TrackerDetector to WebViewRequestInterceptor. Since TrackerDetector will be used in PIR and we don't want to contribute to counter logic.
- Enables multi process invalidation for the AppDatabase since it will be also accessed from :pir process.

### Steps to test this PR

- [x] Smoke test web page loading and tracker blocking
- [x] Load a few pages, check that the blocked trackers counter on new tab page increases correctly

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves persistence of blocked-tracker records to a different call site and enables Room multi-process invalidation, which could affect tracker counts and database behavior across processes.
> 
> **Overview**
> **Blocked-tracker recording is moved out of `TrackerDetectorImpl` and into `WebViewRequestInterceptor`.** The interceptor now inserts `WebTrackerBlocked` rows via `WebTrackersBlockedDao` whenever a request (including cloaked CNAME cases and service worker interceptions) is blocked.
> 
> `WebViewRequestInterceptor` and its DI wiring are updated to accept `WebTrackersBlockedDao`, and tests/reference tests are updated accordingly (including new assertions that uncloaked CNAME URLs and entity display names are recorded).
> 
> **Database config change:** `AppDatabase` now enables Room `enableMultiInstanceInvalidation()` to support multi-process access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c74f660ac701cd68e64861ff08ae6ad4e816334. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->