### PR TITLE
Fix SubscriptionsWebViewActivity.canGoBack UnsupportedOperationException

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -672,6 +672,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
         if (binding.webview.canGoBack()) {
             binding.webview.url?.let { url ->
                 val uri = url.toUri()
+                if (!uri.isHierarchical) return true
                 return uri.getQueryParameter("preventBackNavigation") != "true"
             }
             return false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213736584422131?focus=true

### Description

- Returns early if the URL is non-hierarchical on the subscriptions WebView (allowing the back nav)

### Steps to test this PR

- [x] Go to the subscriptions WebView
- [x] Verify that you can go back

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to back-navigation gating that adds a safety check to prevent an `UnsupportedOperationException` when the WebView URL is non-hierarchical.
> 
> **Overview**
> Fixes a crash in `SubscriptionsWebViewActivity.canGoBack()` by checking `uri.isHierarchical` before reading query parameters.
> 
> Non-hierarchical URLs now bypass the `preventBackNavigation` query check, preventing `UnsupportedOperationException` during back navigation decisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72e615e209de702328714155bf24271118403d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->