### PR TITLE
Fix FileBasedFaviconPersister FileAlreadyExistsException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
@@ -96,7 +96,11 @@ class FileBasedFaviconPersister(
     ) {
         withContext(dispatcherProvider.io()) {
             val persistedFile = fileForFavicon(directory, newSubfolder, newFilename)
-            file.copyTo(persistedFile, overwrite = true)
+            try {
+                file.copyTo(persistedFile, overwrite = true)
+            } catch (e: FileAlreadyExistsException) {
+                logcat { "FaviconPersister: failed to overwrite ${persistedFile.name}: ${e.message}" }
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213736584422142?focus=true

### Description

- Catches `FileAlreadyExistsException` if `copyTo` throws

### Steps to test this PR

- [ ] Verify that favicons work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: wraps a single file copy operation to avoid crashing when copy fails (e.g., existing destination/race), with no behavioral changes elsewhere.
> 
> **Overview**
> Prevents crashes when persisting favicons by wrapping `FileBasedFaviconPersister.copyToDirectory`’s `file.copyTo(...)` call in `runCatching`, effectively swallowing `FileAlreadyExistsException`/IO failures during the copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2789592767880eddbfe792a54a6badd948131c57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->