### PR TITLE
Fix navigation back from Duck.ai mode when using the native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1249,10 +1249,6 @@ class BrowserTabFragment :
                     binding.focusedView.gone()
                 },
                 onSearchSubmitted = { query -> onUserSubmittedText(query) },
-                onBrowserChatSubmitted = { query ->
-                    val url = duckChat.getDuckChatUrl(query, true)
-                    browserActivity?.launchNewTab(query = url, skipHome = true)
-                },
                 onDuckAiChatSubmitted = { query ->
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -42,7 +42,6 @@ import javax.inject.Inject
 class NativeInputCallbacks(
     val onSearchTextChanged: (String) -> Unit,
     val onSearchSubmitted: (String) -> Unit,
-    val onBrowserChatSubmitted: (String) -> Unit,
     val onDuckAiChatSubmitted: (String) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
     val onClearAutocomplete: () -> Unit,
@@ -93,7 +92,6 @@ class RealNativeInputManager @Inject constructor(
     override fun hideNativeInput(): Boolean {
         if (!isNativeInputFieldEnabled) return false
 
-        if (omnibarController.isDuckAiMode()) return false
         val removed = removeWidget()
         if (!removed) return false
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
@@ -103,7 +101,7 @@ class RealNativeInputManager @Inject constructor(
         }
         omnibarController.restore()
         omnibarController.show()
-        return true
+        return !omnibarController.isDuckAiMode()
     }
 
     override fun onKeyboardVisibilityChanged(isVisible: Boolean) {
@@ -230,7 +228,7 @@ class RealNativeInputManager @Inject constructor(
                     callbacks.onDuckAiChatSubmitted(query)
                 } else {
                     hideNativeInput()
-                    callbacks.onBrowserChatSubmitted(query)
+                    callbacks.onSearchSubmitted(duckChat.getDuckChatUrl(query, true))
                 }
             },
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -158,11 +158,20 @@ class RealNativeInputOmnibarController(
     override fun restore() {
         (omnibar.omnibarView as? View)?.let { removeLayoutListener(it) }
         restoreOmnibarColors()
+        restoreOmnibarContent()
         restoreBottomOmnibarPosition()
         if (omnibar.omnibarType == OmnibarType.SPLIT) {
             rootView.findViewById<View?>(R.id.navigationBar)?.show()
         }
         omnibar.isScrollingEnabled = true
+    }
+
+    private fun restoreOmnibarContent() {
+        val omnibarView = omnibar.omnibarView as? View ?: return
+        omnibarView.findViewById<View?>(R.id.endIconsContainer)?.show()
+        omnibarView.findViewById<View?>(R.id.omnibarIconContainer)?.show()
+        omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.show()
+        omnibarView.findViewById<View?>(R.id.duckAIHeader)?.gone()
     }
 
     private fun restoreOmnibarColors() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213736599090979?focus=true

### Description

- Fixes an issue where once in Duck.ai mode (with native input enabled), you can't navigate back to previous site.
- Also fixes an issue where the state of the omnibar is not restored properly when navigating back.

### Steps to test this PR

- [ ] Navigate to a site
- [ ] Open native input and enter a Duck.ai prompt
- [ ] From Duck.ai, navigate back
- [ ] Verify that it navigates to the previous site
- [ ] On new tab, tap the Duck.ai omnibar icon
- [ ] Navigate back
- [ ] Verify that the omnibar restores correctly


### Recording

https://github.com/user-attachments/assets/5a4aba1b-35a0-4dd7-97e5-16f9c6e3e9b7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native input hide/submit behavior and omnibar restoration, which can affect navigation/back handling and toolbar UI state across modes. Changes are localized but impact a core interaction path.
> 
> **Overview**
> Fixes native input behavior when leaving Duck.ai so back navigation works and the toolbar state restores correctly.
> 
> Native input no longer blocks hiding/removal in Duck.ai mode; instead `hideNativeInput` cleans up the widget/UI and returns `false` only to allow the normal back flow to continue. Chat submissions outside Duck.ai now route through the existing search-submit path by submitting the Duck.ai URL, removing the separate “browser chat” callback/tab-launch logic.
> 
> Omnibar restoration now explicitly restores hidden content views (icons/text/header) when the native-input controller calls `restore`, preventing leftover Duck.ai header/hidden controls after navigating back.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ce9309a56b3253b9b2f13228f16190df52fafe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->