### PR TITLE
Add more tests for RealSqlCipherLoaderTest

### DIFF
--- a/sqlcipher-loader/sqlcipher-loader-impl/build.gradle
+++ b/sqlcipher-loader/sqlcipher-loader-impl/build.gradle
@@ -40,11 +40,19 @@ dependencies {
     testImplementation project(path: ':common-test')
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
+    testImplementation Testing.robolectric
+    testImplementation AndroidX.test.ext.junit
+    testImplementation AndroidX.core
 }
 
 android {
     anvil {
         generateDaggerFactories = true
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
     }
     namespace 'com.duckduckgo.sqlcipher.loader.impl'
 }

--- a/sqlcipher-loader/sqlcipher-loader-impl/src/test/kotlin/com/duckduckgo/sqlcipher/loader/impl/RealSqlCipherLoaderTest.kt
+++ b/sqlcipher-loader/sqlcipher-loader-impl/src/test/kotlin/com/duckduckgo/sqlcipher/loader/impl/RealSqlCipherLoaderTest.kt
@@ -16,44 +16,80 @@
 
 package com.duckduckgo.sqlcipher.loader.impl
 
+import android.annotation.SuppressLint
 import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.common.utils.DispatcherProvider
-import kotlinx.coroutines.CoroutineDispatcher
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.library.loader.LibraryLoader
+import com.duckduckgo.sqlcipher.loader.impl.SqlCipherPixelName.LIBRARY_LOAD_FAILURE_SQLCIPHER
+import com.duckduckgo.sqlcipher.loader.impl.SqlCipherPixelName.LIBRARY_LOAD_TIMEOUT_SQLCIPHER
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import kotlin.coroutines.CoroutineContext
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
 
+@SuppressLint("DenyListedApi")
+@RunWith(AndroidJUnit4::class)
+@Config(shadows = [ShadowLibraryLoader::class])
 @OptIn(ExperimentalCoroutinesApi::class)
 class RealSqlCipherLoaderTest {
 
-    private val mockContext: Context = mock()
-    private val mockDispatchers: DispatcherProvider = mock()
-    private val mockPixel: Pixel = mock()
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
-    // A dispatcher that never runs its tasks, keeping libraryLoaded pending.
-    private val neverDispatcher = object : CoroutineDispatcher() {
-        override fun dispatch(context: CoroutineContext, block: Runnable) = Unit
+    private val mockContext: Context = mock()
+    private val mockPixel: Pixel = mock()
+    private lateinit var loader: RealSqlCipherLoader
+
+    @Before
+    fun setup() {
+        ShadowLibraryLoader.reset()
+        loader = RealSqlCipherLoader(
+            context = mockContext,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+            pixel = mockPixel,
+            appCoroutineScope = coroutineTestRule.testScope,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        ShadowLibraryLoader.reset()
     }
 
     @Test
     fun whenCallerCancelledWhileAwaitingLibraryLoadThenCancellationExceptionPropagates() = runTest {
-        whenever(mockDispatchers.io()).thenReturn(neverDispatcher)
-        val appScope = CoroutineScope(SupervisorJob() + neverDispatcher)
         val testee = RealSqlCipherLoader(
             context = mockContext,
-            dispatchers = mockDispatchers,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
             pixel = mockPixel,
-            appCoroutineScope = appScope,
+            appCoroutineScope = coroutineTestRule.testScope,
         )
 
         var result: Result<Unit>? = null
@@ -74,5 +110,184 @@ class RealSqlCipherLoaderTest {
         // CancellationException must be rethrown (cooperative cancellation), not
         // swallowed and returned as Result.failure — which was the pre-fix bug.
         assertNull(result)
+    }
+
+    @Test
+    fun whenLoadSucceedsThenReturnsSuccess() = runTest {
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad() }
+
+        ShadowLibraryLoader.completeAsyncSuccess()
+
+        assertTrue(resultDeferred.await().isSuccess)
+    }
+
+    @Test
+    fun whenLoadFailsThenReturnsFailure() = runTest {
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad() }
+
+        ShadowLibraryLoader.completeAsyncFailure(UnsatisfiedLinkError("Test error"))
+
+        resultDeferred.await().assertIsFailure<UnsatisfiedLinkError>()
+    }
+
+    @Test
+    fun whenTimeoutOccursThenReturnsFailureWithTimeoutException() = runTest {
+        // Don't complete the load — let the timeout fire
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad(timeoutMillis = 100) }
+
+        resultDeferred.await().assertIsFailure<TimeoutCancellationException>()
+    }
+
+    @Test
+    fun whenTimeoutOccursThenTimeoutPixelFired() = runTest {
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad(timeoutMillis = 100) }
+        resultDeferred.await()
+
+        verify(mockPixel).fire(LIBRARY_LOAD_TIMEOUT_SQLCIPHER, type = Daily())
+        verify(mockPixel, never()).fire(eq(LIBRARY_LOAD_FAILURE_SQLCIPHER), any(), any(), any())
+        verifyNoMoreInteractions(mockPixel)
+    }
+
+    @Test
+    fun whenLoadFailsThenFailurePixelFired() = runTest {
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad() }
+        ShadowLibraryLoader.completeAsyncFailure(UnsatisfiedLinkError("Test error"))
+        resultDeferred.await()
+
+        verify(mockPixel).fire(LIBRARY_LOAD_FAILURE_SQLCIPHER, type = Daily())
+        verify(mockPixel, never()).fire(eq(LIBRARY_LOAD_TIMEOUT_SQLCIPHER), any(), any(), any())
+        verifyNoMoreInteractions(mockPixel)
+    }
+
+    @Test
+    fun whenLoadSucceedsThenNoPixelFired() = runTest {
+        val resultDeferred = asyncImmediately { loader.waitForLibraryLoad() }
+        ShadowLibraryLoader.completeAsyncSuccess()
+        resultDeferred.await()
+
+        verify(mockPixel, never()).fire(eq(LIBRARY_LOAD_TIMEOUT_SQLCIPHER), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(LIBRARY_LOAD_FAILURE_SQLCIPHER), any(), any(), any())
+        verifyNoMoreInteractions(mockPixel)
+    }
+
+    @Test
+    fun whenCalledMultipleTimesThenInitializesOnlyOnce() = runTest {
+        // First call
+        val result1Deferred = asyncImmediately { loader.waitForLibraryLoad() }
+        ShadowLibraryLoader.completeAsyncSuccess()
+        val result1 = result1Deferred.await()
+
+        // Reset shadow state to detect new initialization attempts
+        ShadowLibraryLoader.asyncCallback = null
+
+        // Second call — should reuse the already-completed initialization
+        val result2 = loader.waitForLibraryLoad()
+
+        assertNull("Should not start new initialization", ShadowLibraryLoader.asyncCallback)
+        assertTrue(result1.isSuccess)
+        assertTrue(result2.isSuccess)
+    }
+
+    @Test
+    fun whenMultipleCallersWaitConcurrentlyThenAllSucceed() = runTest {
+        val result1 = asyncImmediately { loader.waitForLibraryLoad() }
+        val result2 = asyncImmediately { loader.waitForLibraryLoad() }
+        val result3 = asyncImmediately { loader.waitForLibraryLoad() }
+
+        ShadowLibraryLoader.completeAsyncSuccess()
+
+        assertTrue(result1.await().isSuccess)
+        assertTrue(result2.await().isSuccess)
+        assertTrue(result3.await().isSuccess)
+    }
+
+    @Test
+    fun whenMultipleCallersWaitWithTimeoutThenAllTimeout() = runTest {
+        val result1 = asyncImmediately { loader.waitForLibraryLoad(timeoutMillis = 100) }
+        val result2 = asyncImmediately { loader.waitForLibraryLoad(timeoutMillis = 100) }
+
+        result1.await().assertIsFailure<TimeoutCancellationException>()
+        result2.await().assertIsFailure<TimeoutCancellationException>()
+    }
+
+    @Test
+    fun whenOnCreateFiredBeforeWaitThenLoadTriggeredEarly() = runTest {
+        loader.onCreate(mock<LifecycleOwner>())
+
+        assertNotNull("onCreate should trigger library load", ShadowLibraryLoader.asyncCallback)
+
+        ShadowLibraryLoader.completeAsyncSuccess()
+        assertTrue(loader.waitForLibraryLoad().isSuccess)
+    }
+
+    @Test
+    fun whenOnPirProcessCreatedFiredBeforeWaitThenLoadTriggeredEarly() = runTest {
+        loader.onPirProcessCreated()
+
+        assertNotNull(
+            "onPirProcessCreated should trigger library load",
+            ShadowLibraryLoader.asyncCallback,
+        )
+
+        ShadowLibraryLoader.completeAsyncSuccess()
+        assertTrue(loader.waitForLibraryLoad().isSuccess)
+    }
+
+    /**
+     * Launch async coroutine with UNDISPATCHED start to force immediate execution.
+     * Eliminates need for yield() calls - coroutine executes immediately until first suspension.
+     *
+     * This lets us start it immediately while not blocking waiting for it so we can test interim state, but still be able to get the result.
+     */
+    private fun <T> CoroutineScope.asyncImmediately(block: suspend () -> T): Deferred<T> =
+        async(start = CoroutineStart.UNDISPATCHED) { block() }
+
+    private inline fun <reified T : Throwable> Result<*>.assertIsFailure() {
+        assertTrue("Expected failure but was success", isFailure)
+        assertTrue(
+            "Expected ${T::class.simpleName} but was ${exceptionOrNull()?.javaClass?.simpleName}",
+            exceptionOrNull() is T,
+        )
+    }
+}
+
+/**
+ * Shadow for LibraryLoader to avoid actual native library loading in tests.
+ * Allows tests to control when async loading completes and whether it succeeds or fails.
+ */
+@Implements(LibraryLoader::class)
+class ShadowLibraryLoader {
+    @Suppress("unused")
+    companion object {
+        var asyncCallback: LibraryLoader.LibraryLoaderListener? = null
+
+        @JvmStatic
+        @Implementation
+        fun loadLibrary(
+            context: Context,
+            name: String,
+            listener: LibraryLoader.LibraryLoaderListener,
+        ) {
+            // Store callback — test controls when to complete
+            asyncCallback = listener
+        }
+
+        @JvmStatic
+        @Implementation
+        fun loadLibrary(context: Context, name: String) {
+            // Sync load succeeds immediately in tests
+        }
+
+        fun completeAsyncSuccess() {
+            asyncCallback?.success()
+        }
+
+        fun completeAsyncFailure(throwable: Throwable) {
+            asyncCallback?.failure(throwable)
+        }
+
+        fun reset() {
+            asyncCallback = null
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1213737428120588?focus=true

### Description
Add back removed test for SqlCipher loader

### Steps to test this PR
QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only unit test and Gradle test configuration changes, no production logic modifications. Main risk is potential test flakiness or slower test execution due to added Robolectric resources.
> 
> **Overview**
> Adds a Robolectric-based test suite for `RealSqlCipherLoader.waitForLibraryLoad`, covering success, load failure, timeout handling, cancellation propagation, single-initialization behavior, concurrent callers, and early-load triggers via `onCreate`/`onPirProcessCreated`.
> 
> Updates `sqlcipher-loader-impl` test setup to support these cases by adding Robolectric/AndroidX test dependencies, enabling `includeAndroidResources`, and introducing a `ShadowLibraryLoader` to simulate native library load callbacks without loading real binaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 143c4464720c85d49f897698b1b75f617302aa44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->