### PR TITLE
Update PIR broker bundle - 2026-03-20

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
@@ -1,7 +1,7 @@
 {
   "name": "BeenVerified",
   "url": "beenverified.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts",
   "mirrorSites": [
     {
@@ -161,7 +161,7 @@
     },
     {
       "stepType": "optOut",
-      "scanType": "formOptOut",
+      "optOutType": "formOptOut",
       "actions": [
         {
           "actionType": "navigate",
@@ -220,7 +220,6 @@
           ],
           "id": "018eb6ef-b469-41a6-af92-da9056c00781"
         },
-
         {
           "actionType": "expectation",
           "expectations": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1213743671031838/f 

 ----- 
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (1):**
- beenverified.com.json (0.7.0 → 0.8.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data/config update affecting only the BeenVerified opt-out workflow definition; main risk is runtime incompatibility if consumers still expect `scanType` on `optOut` steps.
> 
> **Overview**
> Updates the BeenVerified broker JSON bundle to `0.8.0`.
> 
> The opt-out step schema is adjusted by renaming `scanType: "formOptOut"` to `optOutType: "formOptOut"`, aligning the step definition with the expected opt-out configuration fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 517cf55f420e4f5d452fd90c76c6e26b027f21cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->