### PR TITLE
Fix incorrect param in pixel defintion

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1089,7 +1089,7 @@
                 "type": "string"
             },
             {
-                "key": "actionID",
+                "key": "action_id",
                 "description": "The unique identifier of the action that failed",
                 "type": "string"
             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213767687510099?focus=true 

### Description
Update actionID to action_id which was incorrectly defined in the pixel definition for m_dbp_data_broker_action-failed_error

### Steps to test this PR
QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that renames a single pixel parameter key; main risk is downstream analytics expecting the old `actionID` name and needing to align.
> 
> **Overview**
> Fixes the `m_dbp_data_broker_action-failed_error` pixel definition by renaming the parameter key from `actionID` to `action_id`, aligning it with the naming used by other PIR/DBP pixels and expected event payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70bad22ee4aad23f972915a346a94e012ecf5b7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->