### PR TITLE
Fix logo moving when native input resizes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -146,31 +146,38 @@ class NativeInputLayoutCoordinator(
             )
         }
 
+        fun isLogoVisible(view: View): Boolean {
+            return view == newTabContent &&
+                rootView.findViewById<View?>(R.id.ddgLogo)?.visibility == View.VISIBLE
+        }
+
+        fun computeDeltaTop(view: View, isBottom: Boolean, anchorBottomInWindow: Int): Int {
+            if (isBottom || isLogoVisible(view)) return 0
+            val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
+            return maxOf(0, anchorBottomInWindow - viewLocation[1])
+        }
+
+        fun computeDeltaBottom(isBottom: Boolean): Int {
+            if (!isBottom) return 0
+            return if (omnibarState.isOmnibarBottom()) {
+                maxOf(0, overlap)
+            } else {
+                maxOf(0, anchor.height - overlap)
+            }
+        }
+
         fun applyOffset() {
             if (!widgetView.isShown) {
-                targets.forEach { target ->
-                    applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
-                }
+                targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
                 return
             }
             val isBottom = isWidgetBottom()
             val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
             val anchorBottomInWindow = anchorLocation[1] + anchor.height
+            val deltaBottom = computeDeltaBottom(isBottom)
             targets.forEach { target ->
-                val view = target.view
-                val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
-                val deltaTop = if (isBottom) 0 else maxOf(0, anchorBottomInWindow - viewLocation[1])
-                val deltaBottom =
-                    if (isBottom) {
-                        if (omnibarState.isOmnibarBottom()) {
-                            maxOf(0, overlap)
-                        } else {
-                            maxOf(0, anchor.height - overlap)
-                        }
-                    } else {
-                        0
-                    }
-                applyPadding(view, target.basePadding, deltaTop, deltaBottom)
+                val deltaTop = computeDeltaTop(target.view, isBottom, anchorBottomInWindow)
+                applyPadding(target.view, target.basePadding, deltaTop, deltaBottom)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
@@ -58,10 +58,12 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerOnboardingActivityWithEmptyParamsParams
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.DeeplinkActivityParams
@@ -109,6 +111,9 @@ class NewTabPageView @JvmOverloads constructor(
     @Inject
     lateinit var androidBrowserConfig: AndroidBrowserConfigFeature
 
+    @Inject
+    lateinit var duckChat: DuckChat
+
     private val binding: ViewNewTabBinding by viewBinding()
 
     private val homeBackgroundLogo by lazy { HomeBackgroundLogo(binding.ddgLogo) }
@@ -123,6 +128,7 @@ class NewTabPageView @JvmOverloads constructor(
 
     private val conflatedStateJob = ConflatedJob()
     private val conflatedCommandJob = ConflatedJob()
+    private val conflatedNativeInputJob = ConflatedJob()
 
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
@@ -138,6 +144,10 @@ class NewTabPageView @JvmOverloads constructor(
             .onEach { processCommands(it) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope!!)
 
+        conflatedNativeInputJob += duckChat.observeNativeInputFieldUserSettingEnabled()
+            .onEach { enabled -> updateLogoMargin(enabled) }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope!!)
+
         disableViewStateSaving()
     }
 
@@ -147,6 +157,7 @@ class NewTabPageView @JvmOverloads constructor(
         findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         conflatedStateJob.cancel()
         conflatedCommandJob.cancel()
+        conflatedNativeInputJob.cancel()
     }
 
     private fun disableViewStateSaving() {
@@ -157,6 +168,15 @@ class NewTabPageView @JvmOverloads constructor(
             if (disableViewStateSaving) {
                 binding.messageCta.disableStateSaving()
             }
+        }
+    }
+
+    private fun updateLogoMargin(nativeInputEnabled: Boolean) {
+        val baseMargin = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.homeTabDdgLogoTopMargin)
+        val extraMargin = if (nativeInputEnabled) 48.toPx() else 0
+        (binding.ddgLogo.layoutParams as? MarginLayoutParams)?.let {
+            it.topMargin = baseMargin + extraMargin
+            binding.ddgLogo.requestLayout()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -110,6 +110,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var chatSuggestionsJob: Job? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
+    private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     override var onStopTapped: (() -> Unit)? = null
 
@@ -303,6 +304,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     ) {
+        this.onShowSuggestions = onShowSuggestions
         this.onClearSuggestions = onClearSuggestions
 
         val adapter = ChatSuggestionsAdapter { suggestion ->
@@ -314,7 +316,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 hideChatSuggestions(hideList = true)
                 return
             }
-            onShowSuggestions(adapter)
             fetchChatSuggestions(lifecycleOwner, query, adapter)
         }
 
@@ -338,6 +339,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun tearDownChatSuggestions() {
         hideChatSuggestions(hideList = true)
         chatSuggestionsAdapter = null
+        onShowSuggestions = null
         onClearSuggestions = null
     }
 
@@ -362,6 +364,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsJob?.cancel()
         chatSuggestionsJob = lifecycleOwner.lifecycleScope.launch {
             val suggestions = runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+            if (suggestions.isNotEmpty()) {
+                onShowSuggestions?.invoke(adapter)
+            }
             adapter.submitList(suggestions)
             if (suggestions.isEmpty()) {
                 onClearSuggestions?.invoke(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213736599090976?focus=true

### Description

- Locks the logo in place when the native input is enabled
- Adds extra top margin to the logo when the native input is enabled (so that the widget does not overlap)
- Fixes NTP flickering when typing with Duck.ai toggled

### Steps to test this PR

_With native input enabled_
- [x] Focus the omnibar
- [x] Verify that the DDG logo is not pushed down
- [x] Toggle to Duck.ai
- [x] Verify that the widget does not overlap with the logo
- [x] Type something
- [x] Verify that the logo does not flicker
- [x] Add favorite
- [x] Verify that the favorite is pushed down when toggling between modes

_With native input disabled_
- [x] Verify that the logo is in it’s original position

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: changes layout/padding logic across the NTP and browser content offsets and adjusts chat suggestions visibility timing, which could cause regressions in widget overlap or spacing on different configurations.
> 
> **Overview**
> Prevents the New Tab Page DDG logo from being pushed/flickering when the native input widget resizes by **skipping top padding offsets** for the NTP when the logo is visible, and by refactoring the offset math into clearer helpers in `NativeInputLayoutCoordinator`.
> 
> When native input is enabled, `NewTabPageView` now observes the DuckChat native-input setting and **adds extra top margin** to `ddgLogo` to avoid overlap with the widget.
> 
> Reduces Duck.ai typing flicker by only calling `onShowSuggestions` in `NativeInputModeWidget` after non-empty suggestions are fetched, and by storing/clearing the callback during suggestion lifecycle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba8a6b289898dde48b62f0ea51991c0bc938b63c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->