### PR TITLE
Additional pixels for foreground scan

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1142,7 +1142,14 @@
         "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "manufacturer",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            }
+        ]
     },
     "m_dbp_foreground-run_started": {
         "description": "Fired when pir run is started in the foreground",
@@ -1154,6 +1161,11 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "power_saving",
+                "description": "Whether the device is in power saving mode",
                 "type": "string"
             }
         ]
@@ -1173,6 +1185,11 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "battery-optimizations",
+                "description": "Whether battery optimizations are enabled for the app",
                 "type": "string"
             }
         ]

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -61,6 +61,7 @@ class PirPixelInterceptor @Inject constructor(
             "m_dbp_scheduled-run_completed",
             "m_dbp_email-confirmation_started",
             "m_dbp_email-confirmation_completed",
+            "m_dbp_initial-scan_incomplete",
         )
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -95,16 +95,22 @@ import javax.inject.Inject
 interface PirPixelSender {
     /**
      * Emits a pixel to signal that a manually initiated scan has started.
+     *
+     * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      */
-    fun reportManualScanStarted()
+    fun reportManualScanStarted(
+        isPowerSavingEnabled: Boolean,
+    )
 
     /**
      * Emits a pixel to signal that a manually initiated scan has been completed.
      *
      * @param totalTimeInMillis - how long it took for the scan to complete
+     * @param batteryOptimizationsEnabled - whether battery optimizations are enabled for the app
      */
     fun reportManualScanCompleted(
         totalTimeInMillis: Long,
+        batteryOptimizationsEnabled: Boolean,
     )
 
     /**
@@ -602,15 +608,22 @@ class RealPirPixelSender @Inject constructor(
     private val pixelSender: Pixel,
     private val networkProtectionState: NetworkProtectionState,
 ) : PirPixelSender {
-    override fun reportManualScanStarted() {
-        fire(PIR_FOREGROUND_RUN_STARTED)
+    override fun reportManualScanStarted(
+        isPowerSavingEnabled: Boolean,
+    ) {
+        val params = mapOf(
+            PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
+        )
+        fire(PIR_FOREGROUND_RUN_STARTED, params)
     }
 
     override fun reportManualScanCompleted(
         totalTimeInMillis: Long,
+        batteryOptimizationsEnabled: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
+            PARAM_KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
         )
         fire(PIR_FOREGROUND_RUN_COMPLETED, params)
     }
@@ -1470,5 +1483,7 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_PROFILE_QUERY_COUNT = "profile_queries"
         private const val PARAM_KEY_SCAN_FREQUENCY = "scanFrequencyWithinThreshold"
         private const val PARAM_KEY_VPN_STATE = "vpn_connection_state"
+        private const val PARAM_KEY_POWER_SAVING = "power_saving"
+        private const val PARAM_KEY_BATTERY_OPTIMIZATIONS = "battery-optimizations"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.pir.impl.scheduling
 
 import android.content.Context
+import android.os.PowerManager
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.isIgnoringBatteryOptimizations
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirConstants
 import com.duckduckgo.pir.impl.common.PirJob.RunType
@@ -74,7 +76,7 @@ class RealPirJobsRunner @Inject constructor(
     ): Result<Unit> = withContext(dispatcherProvider.io()) {
         val startTimeInMillis = currentTimeProvider.currentTimeMillis()
 
-        emitStartPixel(executionType)
+        emitStartPixel(context, executionType)
 
         // Clean up any already running scan jobs before starting new ones as this function can be called
         // while previous instance is still running in case of profile edits.
@@ -94,13 +96,13 @@ class RealPirJobsRunner @Inject constructor(
 
         if (profileQueries.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No profile queries available. Completing run." }
-            emitCompletedPixel(executionType, startTimeInMillis)
+            emitCompletedPixel(context, executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
 
         if (activeBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active brokers available. Completing run." }
-            emitCompletedPixel(executionType, startTimeInMillis)
+            emitCompletedPixel(context, executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
 
@@ -121,7 +123,7 @@ class RealPirJobsRunner @Inject constructor(
 
         if (activeFormOptOutBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active parent brokers available for optout. Completing run." }
-            emitCompletedPixel(executionType, startTimeInMillis)
+            emitCompletedPixel(context, executionType, startTimeInMillis)
             return@withContext Result.success(Unit)
         }
 
@@ -129,7 +131,7 @@ class RealPirJobsRunner @Inject constructor(
         executeOptOutJobs(context, activeFormOptOutBrokers)
 
         logcat { "PIR-JOB-RUNNER: Completed." }
-        emitCompletedPixel(executionType, startTimeInMillis)
+        emitCompletedPixel(context, executionType, startTimeInMillis)
         return@withContext Result.success(Unit)
     }
 
@@ -150,21 +152,29 @@ class RealPirJobsRunner @Inject constructor(
         }
     }
 
-    private fun emitStartPixel(executionType: PirExecutionType) {
+    private fun emitStartPixel(
+        context: Context,
+        executionType: PirExecutionType,
+    ) {
         if (executionType == MANUAL) {
-            pixelSender.reportManualScanStarted()
+            val isPowerSavingEnabled = runCatching {
+                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
+            }.getOrDefault(false)
+            pixelSender.reportManualScanStarted(isPowerSavingEnabled)
         } else {
             pixelSender.reportScheduledScanStarted()
         }
     }
 
     private fun emitCompletedPixel(
+        context: Context,
         executionType: PirExecutionType,
         startTimeInMillis: Long,
     ) {
         val totalTimeMillis = currentTimeProvider.currentTimeMillis() - startTimeInMillis
         if (executionType == MANUAL) {
-            pixelSender.reportManualScanCompleted(totalTimeMillis)
+            val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
+            pixelSender.reportManualScanCompleted(totalTimeMillis, batteryOptimizationsEnabled)
         } else {
             pixelSender.reportScheduledScanCompleted(totalTimeMillis)
         }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
@@ -160,4 +160,22 @@ class PirPixelInterceptorTest {
         val man = capturedRequest.url.queryParameter("manufacturer")
         assertEquals("TestManufacturer", man)
     }
+
+    @Test
+    fun whenInterceptInitialScanIncompletePixelThenAddsManufacturerParameter() = runTest {
+        val request = Request.Builder()
+            .url("https://example.com/m_dbp_initial-scan_incomplete")
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        val man = capturedRequest.url.queryParameter("manufacturer")
+        assertEquals("TestManufacturer", man)
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -39,8 +39,8 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportManualScanStartedThenFiresCorrectPixel() = runTest {
-        testee.reportManualScanStarted()
+    fun whenReportManualScanStartedThenFiresPixelWithPowerSavingParam() = runTest {
+        testee.reportManualScanStarted(isPowerSavingEnabled = true)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender, times(2)).fire(
@@ -50,14 +50,15 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue.isEmpty())
+        assert(paramsCaptor.firstValue.containsKey("power_saving"))
+        assert(paramsCaptor.firstValue["power_saving"] == "true")
     }
 
     @Test
-    fun whenReportManualScanCompletedThenFiresPixelWithTotalTime() = runTest {
+    fun whenReportManualScanCompletedThenFiresPixelWithTotalTimeAndBatteryOptimizations() = runTest {
         val totalTimeInMillis = 12345L
 
-        testee.reportManualScanCompleted(totalTimeInMillis)
+        testee.reportManualScanCompleted(totalTimeInMillis, batteryOptimizationsEnabled = false)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender).fire(
@@ -69,6 +70,8 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue.containsKey("totalTimeInMillis"))
         assert(paramsCaptor.firstValue["totalTimeInMillis"] == "12345")
+        assert(paramsCaptor.firstValue.containsKey("battery-optimizations"))
+        assert(paramsCaptor.firstValue["battery-optimizations"] == "false")
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.pir.impl.scheduling
 
 import android.content.Context
+import android.os.PowerManager
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.PirConstants.DEFAULT_PROFILE_QUERIES
@@ -62,10 +63,16 @@ class RealPirJobsRunnerTest {
     private val mockPirOptOut: PirOptOut = mock()
     private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
     private val mockContext: Context = mock()
+    private val mockPowerManager: PowerManager = mock()
     private val mockPixelSender: PirPixelSender = mock()
 
     @Before
     fun setUp() {
+        whenever(mockContext.getSystemService(Context.POWER_SERVICE)).thenReturn(mockPowerManager)
+        whenever(mockContext.packageName).thenReturn("com.duckduckgo.mobile.android")
+        whenever(mockPowerManager.isPowerSaveMode).thenReturn(false)
+        whenever(mockPowerManager.isIgnoringBatteryOptimizations(any())).thenReturn(true)
+
         testee = RealPirJobsRunner(
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             pirRepository = mockPirRepository,
@@ -156,8 +163,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanStarted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -265,8 +272,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanStarted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -315,10 +322,10 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted()
+        verify(mockPixelSender).reportManualScanStarted(any())
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -366,8 +373,8 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanStarted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
         verify(mockPirScan).executeScanForJobs(
@@ -544,8 +551,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirScan).stop()
-        verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanStarted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
                 OptOutJobRecord(
@@ -696,8 +703,8 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted()
-        verify(mockPixelSender).reportManualScanCompleted(any())
+        verify(mockPixelSender).reportManualScanStarted(any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any())
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213759328043722?focus=true 

### Description
See attached task description

### Steps to test this PR
- https://app.asana.com/1/137249556945/task/1213759328043723?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PIR scan-start/complete telemetry by changing `PirPixelSender` method signatures and wiring in device power/battery-optimization state, which could affect pixel emission if call sites or parameter keys mismatch. Logic is simple and covered by updated tests, so overall impact is moderate.
> 
> **Overview**
> Adds additional metadata to PIR foreground scan pixels.
> 
> Pixel definitions are updated so `m_dbp_foreground-run_started` includes `power_saving`, `m_dbp_foreground-run_completed` includes `battery-optimizations`, and `m_dbp_initial-scan_incomplete` now includes `manufacturer`; `PirPixelInterceptor` allowlists the initial-scan pixel to append `manufacturer`.
> 
> `RealPirJobsRunner` now reads `PowerManager.isPowerSaveMode` at manual-run start and checks battery optimization status at completion, passing these through the updated `PirPixelSender` API; unit tests are updated/added to validate the new parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b9606c38788a7caecdd15ac362bed40433aa939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->