### PR TITLE
Add setting to select toggle position (input screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRES
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BAR_SELECTION
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
@@ -67,6 +68,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
@@ -103,6 +105,16 @@ interface DuckChatInternal : DuckChat {
      * Set user setting to determine whether the native input field should be used.
      */
     suspend fun setNativeInputFieldUserSetting(isEnabled: Boolean)
+
+    /**
+     * Sets the user's preferred default toggle position.
+     */
+    suspend fun setDefaultTogglePosition(position: DefaultTogglePosition)
+
+    /**
+     * Observes the user's preferred default toggle position.
+     */
+    fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition>
 
     /**
      * Observes whether DuckChat is user enabled or disabled.
@@ -753,6 +765,14 @@ class RealDuckChat @Inject constructor(
 
     override fun isChatSuggestionsFeatureAvailable(): Boolean =
         duckChatFeature.aiChatSuggestions().isEnabled()
+
+    override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
+        duckChatFeatureRepository.setDefaultTogglePosition(position.name)
+    }
+
+    override fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition> =
+        duckChatFeatureRepository.observeDefaultTogglePosition()
+            .map { DefaultTogglePosition.fromName(it) }
 
     private suspend fun hasActiveSession(): Boolean {
         val now = System.currentTimeMillis()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -205,4 +205,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun duckAiVoiceEntryPoint(): Toggle
+
+    /**
+     * @return `true` when the "Default Toggle Position" setting should be visible in AI Features Settings.
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun rememberTogglePosition(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -94,6 +94,12 @@ interface DuckChatFeatureRepository {
     suspend fun isAIChatHistoryEnabled(): Boolean
 
     suspend fun setChatSuggestionsUserSetting(enabled: Boolean)
+
+    suspend fun setDefaultTogglePosition(position: String)
+
+    suspend fun getDefaultTogglePosition(): String?
+
+    fun observeDefaultTogglePosition(): Flow<String?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -199,6 +205,14 @@ class RealDuckChatFeatureRepository @Inject constructor(
     override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) {
         duckChatDataStore.setChatSuggestionsUserSetting(enabled)
     }
+
+    override suspend fun setDefaultTogglePosition(position: String) {
+        duckChatDataStore.setDefaultTogglePosition(position)
+    }
+
+    override suspend fun getDefaultTogglePosition(): String? = duckChatDataStore.getDefaultTogglePosition()
+
+    override fun observeDefaultTogglePosition(): Flow<String?> = duckChatDataStore.observeDefaultTogglePosition()
 
     private fun updateWidgets() {
         val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DefaultTogglePosition.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DefaultTogglePosition.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.store
+
+enum class DefaultTogglePosition {
+    SEARCH,
+    DUCK_AI,
+    LAST_USED,
+    ;
+
+    fun getOptionIndex(): Int {
+        return when (this) {
+            SEARCH -> 1
+            DUCK_AI -> 2
+            LAST_USED -> 3
+        }
+    }
+
+    companion object {
+        fun fromName(v: String?): DefaultTogglePosition =
+            entries.firstOrNull { it.name == v } ?: SEARCH
+    }
+}
+
+fun Int.getDefaultTogglePositionForIndex(): DefaultTogglePosition {
+    return when (this) {
+        2 -> DefaultTogglePosition.DUCK_AI
+        3 -> DefaultTogglePosition.LAST_USED
+        else -> DefaultTogglePosition.SEARCH
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.di.DuckChat
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_AUTOMATIC_CONTEXT_ATTACHMENT
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING
+import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_DEFAULT_TOGGLE_POSITION
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_USER_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_NATIVE_INPUT_FIELD_SETTING
@@ -138,6 +139,12 @@ interface DuckChatDataStore {
     suspend fun hasUserAcceptedTerms(): Boolean
 
     suspend fun setUserAcceptedTerms()
+
+    suspend fun setDefaultTogglePosition(position: String)
+
+    suspend fun getDefaultTogglePosition(): String?
+
+    fun observeDefaultTogglePosition(): Flow<String?>
 }
 
 @ContributesBinding(AppScope::class)
@@ -166,6 +173,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_AI_NATIVE_INPUT_FIELD_SETTING = booleanPreferencesKey(name = "DUCK_AI_NATIVE_INPUT_FIELD_SETTING")
         val DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING = booleanPreferencesKey(name = "DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING")
         val DUCK_AI_TERMS_ACCEPTED = booleanPreferencesKey(name = "DUCK_AI_TERMS_ACCEPTED")
+        val DUCK_AI_DEFAULT_TOGGLE_POSITION = stringPreferencesKey(name = "DUCK_AI_DEFAULT_TOGGLE_POSITION")
     }
 
     private fun Preferences.defaultShowInAddressBar(): Boolean =
@@ -236,6 +244,12 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
             .map { prefs -> prefs[DUCK_CHAT_SHOW_IN_VOICE_SEARCH] ?: true }
             .distinctUntilChanged()
             .stateIn(appCoroutineScope, SharingStarted.Eagerly, true)
+
+    private val defaultTogglePositionFlow: StateFlow<String?> =
+        store.data
+            .map { prefs -> prefs[DUCK_AI_DEFAULT_TOGGLE_POSITION] }
+            .distinctUntilChanged()
+            .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
 
     private val chatSuggestionsUserSettingEnabled: StateFlow<Boolean> =
         store.data
@@ -385,4 +399,13 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
     override suspend fun setUserAcceptedTerms() {
         store.edit { prefs -> prefs[DUCK_AI_TERMS_ACCEPTED] = true }
     }
+
+    override suspend fun setDefaultTogglePosition(position: String) {
+        store.edit { prefs -> prefs[DUCK_AI_DEFAULT_TOGGLE_POSITION] = position }
+    }
+
+    override suspend fun getDefaultTogglePosition(): String? =
+        store.data.firstOrNull()?.let { it[DUCK_AI_DEFAULT_TOGGLE_POSITION] }
+
+    override fun observeDefaultTogglePosition(): Flow<String?> = defaultTogglePositionFlow
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.addClickableSpan
+import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChatNativeSettingsNoParams
@@ -49,6 +50,8 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.ActivityDuckChatSettingsBinding
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_SETTINGS_DISPLAYED
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.duckchat.impl.store.getDefaultTogglePositionForIndex
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.DuckChatSettingsViewModelFactory
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.ViewState
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -182,6 +185,19 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
             withAi = InputScreenToggleButton.WithAi(isActive = viewState.isInputScreenEnabled, appTheme.isLightModeEnabled()),
         )
 
+        binding.duckAiDefaultTogglePosition.isVisible = viewState.isDefaultTogglePositionVisible
+        binding.duckAiDefaultTogglePosition.setSecondaryText(
+            when (viewState.defaultTogglePosition) {
+                DefaultTogglePosition.SEARCH -> getString(R.string.duckAiDefaultTogglePositionSearch)
+                DefaultTogglePosition.DUCK_AI -> getString(R.string.duckAiDefaultTogglePositionDuckAi)
+                DefaultTogglePosition.LAST_USED -> getString(R.string.duckAiDefaultTogglePositionLastUsed)
+            },
+        )
+        binding.duckAiDefaultTogglePosition.setOnClickListener {
+            viewModel.onDefaultTogglePositionClicked()
+        }
+        binding.duckAiDefaultTogglePosition.updatePadding(left = offset)
+
         binding.duckAiInputScreenDescription.isVisible = viewState.shouldShowInputScreenToggle
         binding.duckAiInputScreenDescription.addClickableSpan(
             textSequence = getText(R.string.input_screen_user_pref_description),
@@ -276,7 +292,33 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
             is DuckChatSettingsViewModel.Command.LaunchFeedback -> {
                 globalActivityStarter.start(this, FeedbackActivityWithEmptyParams)
             }
+
+            is DuckChatSettingsViewModel.Command.ShowDefaultTogglePositionDialog -> {
+                showDefaultTogglePositionDialog(command.currentPosition)
+            }
         }
+    }
+
+    private fun showDefaultTogglePositionDialog(currentPosition: DefaultTogglePosition) {
+        RadioListAlertDialogBuilder(this)
+            .setTitle(R.string.duckAiDefaultTogglePositionTitle)
+            .setOptions(
+                listOf(
+                    R.string.duckAiDefaultTogglePositionSearch,
+                    R.string.duckAiDefaultTogglePositionDuckAi,
+                    R.string.duckAiDefaultTogglePositionLastUsed,
+                ),
+                currentPosition.getOptionIndex(),
+            )
+            .setPositiveButton(CommonR.string.dialogSave)
+            .setNegativeButton(CommonR.string.cancel)
+            .addEventListener(
+                object : RadioListAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked(selectedItem: Int) {
+                        viewModel.onDefaultTogglePositionSelected(selectedItem.getDefaultTogglePositionForIndex())
+                    }
+                },
+            ).show()
     }
 
     private fun configureInputScreenToggle(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLink
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLinkInNewTab
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenShortcutSettings
@@ -72,6 +73,8 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         val isAutomaticContextEnabled: Boolean = false,
         val isNativeInputFieldVisible: Boolean = false,
         val isNativeInputFieldEnabled: Boolean = false,
+        val isDefaultTogglePositionVisible: Boolean = false,
+        val defaultTogglePosition: DefaultTogglePosition = DefaultTogglePosition.SEARCH,
     )
 
     private data class FeatureState(
@@ -85,6 +88,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
     private data class FeatureVisibility(
         val isHideGeneratedImagesOptionVisible: Boolean,
         val isNativeInputFieldSettingVisible: Boolean,
+        val isRememberTogglePositionVisible: Boolean,
     )
 
     private val featureState =
@@ -110,6 +114,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 FeatureVisibility(
                     isHideGeneratedImagesOptionVisible = duckChatFeature.showHideAiGeneratedImages().isEnabled(),
                     isNativeInputFieldSettingVisible = duckChatFeature.nativeInputField().isEnabled(),
+                    isRememberTogglePositionVisible = duckChatFeature.rememberTogglePosition().isEnabled(),
                 ),
             )
         }.flowOn(dispatcherProvider.io())
@@ -118,11 +123,13 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         combine(
             featureState,
             featureVisibility,
-        ) { featureState, featureVisibility ->
+            duckChat.observeDefaultTogglePosition(),
+        ) { featureState, featureVisibility, defaultTogglePosition ->
             val isDuckChatUserEnabled = featureState.isDuckChatUserEnabled
+            val isInputScreenEnabled = featureState.isCosmeticInputScreenEnabled ?: featureState.isInputScreenEnabled
             ViewState(
                 isDuckChatUserEnabled = isDuckChatUserEnabled,
-                isInputScreenEnabled = featureState.isCosmeticInputScreenEnabled ?: featureState.isInputScreenEnabled,
+                isInputScreenEnabled = isInputScreenEnabled,
                 shouldShowShortcuts = isDuckChatUserEnabled,
                 shouldShowInputScreenToggle = isDuckChatUserEnabled && duckChat.isInputScreenFeatureAvailable(),
                 isSearchSectionVisible = isSearchSectionVisible(duckChatActivityParams),
@@ -131,6 +138,9 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 isAutomaticContextVisible = isDuckChatUserEnabled && duckChatFeature.automaticContextAttachment().isEnabled(),
                 isNativeInputFieldEnabled = featureState.isNativeInputFieldEnabled,
                 isNativeInputFieldVisible = isDuckChatUserEnabled && featureVisibility.isNativeInputFieldSettingVisible,
+                isDefaultTogglePositionVisible = isDuckChatUserEnabled && isInputScreenEnabled &&
+                    duckChat.isInputScreenFeatureAvailable() && featureVisibility.isRememberTogglePositionVisible,
+                defaultTogglePosition = defaultTogglePosition,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 
@@ -147,6 +157,10 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         data object OpenShortcutSettings : Command()
 
         data object LaunchFeedback : Command()
+
+        data class ShowDefaultTogglePositionDialog(
+            val currentPosition: DefaultTogglePosition,
+        ) : Command()
     }
 
     fun onDuckChatUserEnabledToggled(checked: Boolean) {
@@ -249,6 +263,22 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
             inputScreenDiscoveryFunnel.onInputScreenEnabled()
             duckChat.setInputScreenUserSetting(enabled = true)
+        }
+    }
+
+    fun onDefaultTogglePositionClicked() {
+        viewModelScope.launch {
+            commandChannel.send(
+                Command.ShowDefaultTogglePositionDialog(
+                    currentPosition = viewState.value.defaultTogglePosition,
+                ),
+            )
+        }
+    }
+
+    fun onDefaultTogglePositionSelected(position: DefaultTogglePosition) {
+        viewModelScope.launch {
+            duckChat.setDefaultTogglePosition(position)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
@@ -181,6 +181,14 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/duckAiDefaultTogglePosition"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="@string/duckAiDefaultTogglePositionTitle"
+                app:secondaryText="@string/duckAiDefaultTogglePositionSearch" />
+
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/duckAiInputScreenDescription"
                 android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -17,4 +17,8 @@
 <resources>
     <string name="duckAiNativeInputFieldTitle">Native Input Field</string>
     <string name="duckAiNativeInputFieldMessage">Use the native input field for Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionTitle">Default Toggle Position</string>
+    <string name="duckAiDefaultTogglePositionSearch">Search</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -21,9 +21,11 @@ import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 
 /**
  * Fake implementation of [DuckChatInternal] for testing purposes.
@@ -172,6 +174,15 @@ class FakeDuckChatInternal(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
+
+    private val _defaultTogglePosition = MutableStateFlow<String?>(null)
+
+    override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
+        _defaultTogglePosition.value = position.name
+    }
+
+    override fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition> =
+        _defaultTogglePosition.map { DefaultTogglePosition.fromName(it) }
 
     fun setDuckChatUserEnabled(enabled: Boolean) {
         enableDuckChatUserSetting.value = enabled

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -27,10 +27,12 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.LaunchFeedback
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLink
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLinkInNewTab
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenShortcutSettings
+import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.ShowDefaultTogglePositionDialog
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.settings.api.SettingsPageFeature
@@ -72,6 +74,7 @@ class DuckChatSettingsViewModelTest {
             whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false))
             whenever(duckChat.observeAutomaticContextAttachmentUserSettingEnabled()).thenReturn(flowOf(false))
             whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(flowOf(false))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
                 duckChat = duckChat,
@@ -830,5 +833,160 @@ class DuckChatSettingsViewModelTest {
             testee.viewState.test {
                 assertFalse(awaitItem().isNativeInputFieldEnabled)
             }
+        }
+
+    @Test
+    fun `default toggle position - visible when all conditions met`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                assertTrue(awaitItem().isDefaultTogglePositionVisible)
+            }
+        }
+
+    @Test
+    fun `default toggle position - hidden when duck chat disabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
+            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDefaultTogglePositionVisible)
+            }
+        }
+
+    @Test
+    fun `default toggle position - hidden when input screen disabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false))
+            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDefaultTogglePositionVisible)
+            }
+        }
+
+    @Test
+    fun `default toggle position - hidden when feature flag disabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDefaultTogglePositionVisible)
+            }
+        }
+
+    @Test
+    fun `default toggle position - hidden when input screen feature not available`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(false)
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDefaultTogglePositionVisible)
+            }
+        }
+
+    @Test
+    fun `when default toggle position clicked then show dialog command emitted`() =
+        runTest {
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+            )
+
+            testee.viewState.test {
+                awaitItem()
+                testee.onDefaultTogglePositionClicked()
+
+                testee.commands.test {
+                    val command = awaitItem()
+                    assertTrue(command is ShowDefaultTogglePositionDialog)
+                    assertEquals(DefaultTogglePosition.DUCK_AI, (command as ShowDefaultTogglePositionDialog).currentPosition)
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+    @Test
+    fun `when default toggle position selected then set user setting`() =
+        runTest {
+            testee.onDefaultTogglePositionSelected(DefaultTogglePosition.LAST_USED)
+            verify(duckChat).setDefaultTogglePosition(DefaultTogglePosition.LAST_USED)
         }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213651290816858?focus=true 

### Description
We want to add a settings allowing the user to configure the default toggle position in the input screen. This PR only adds the settings UI and interaction. 

- Adds a `rememberTogglePosition` feature flag (defaults to false)
- Adds a "Default Toggle Position" setting under AI Features with three options: Search, Duck.ai, and Last Used
- The setting is visible only when "Search & Duck.ai" is selected and the feature flag is enabled
- Selection is persisted to DataStore but not yet hooked up to change toggle behavior

### Steps to test this PR
- Enable the `rememberTogglePosition` feature flag
- Go to Settings → AI Features
- Verify the "Default Toggle Position" setting is not visible when "Search only" is selected
- Select "Search & Duck.ai" and verify the "Default Toggle Position" setting appears between the radio buttons and the description text
- Tap the setting and verify a dialog appears with Search, Duck.ai, and Last Used options
- Select "Duck.ai", tap Save, and verify the subtitle updates to "Duck.ai"
- Kill and reopen the app, go back to the setting, and verify "Duck.ai" is still selected
- Disable Duck.ai via the main toggle and verify the setting disappears
- Disable the rememberTogglePosition feature flag and verify the setting disappears regardless of other conditions

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="540" height="1200" alt="Before" src="https://github.com/user-attachments/assets/2b4b697b-4f40-4939-a412-99abbc730574" />|<img width="540" height="1200" alt="After" src="https://github.com/user-attachments/assets/334da467-a3e6-4f36-9460-3ae86d19fbd2" />|
|-|<img width="540" height="1200" alt="open" src="https://github.com/user-attachments/assets/8abc1171-4408-4e9a-9e14-8a62e2b48b85" />|




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/settings change that adds a new persisted preference and feature-flagged visibility logic, without altering chat or input-screen behavior yet.
> 
> **Overview**
> Adds a new **feature-flagged** AI Features setting, "Default Toggle Position", letting users choose `Search`, `Duck.ai`, or `Last Used` via a radio-list dialog.
> 
> Persists the selection in `DuckChatDataStore`/`DuckChatFeatureRepository` and exposes it through `DuckChatInternal` as a `Flow<DefaultTogglePosition>`; updates `DuckChatSettingsViewModel` visibility rules and tests, but does *not* yet apply the preference to change the input-screen toggle behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9425141a59d90e5f2d72097bd8cfad68410a12ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->