### PR TITLE
Revert "Force locked=false for duck.ai URLs in uiLockChanged JS callback"

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4198,11 +4198,7 @@ class BrowserTabViewModel @Inject constructor(
             BROWSER_UI_LOCK_FEATURE_NAME -> {
                 when (method) {
                     "uiLockChanged" -> {
-                        val host = getWebViewUrl()?.toUri()?.host
-                        var locked = data?.optBoolean("locked", false) ?: false
-                        if (host?.endsWith("duck.ai") == true) {
-                            locked = false
-                        }
+                        val locked = data?.optBoolean("locked", false) ?: false
                         uiLockChanged(locked)
                     }
                 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5678,7 +5678,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertTrue(this.locked)
@@ -5696,7 +5696,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": false }"""),
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5714,7 +5714,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandNotIssued<Command.UiLockChanged>()
         }
@@ -5730,7 +5730,7 @@ class BrowserTabViewModelTest {
                 null,
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5748,7 +5748,7 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "other": "value" }"""),
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandIssued<Command.UiLockChanged> {
                 assertFalse(this.locked)
@@ -5766,45 +5766,9 @@ class BrowserTabViewModelTest {
                 JSONObject("""{ "locked": true }"""),
                 false,
                 null,
-                { "https://example.com" },
+                { "someUrl" },
             )
             assertCommandNotIssued<Command.UiLockChanged>()
-        }
-
-    @Test
-    fun whenProcessJsCallbackMessageUiLockChangedFromDuckAiThenSendCommandWithLockedFalse() =
-        runTest {
-            fakeBrowserUiLockFeature.self().setRawStoredState(State(enable = true))
-            testee.processJsCallbackMessage(
-                BROWSER_UI_LOCK_FEATURE_NAME,
-                "uiLockChanged",
-                null,
-                JSONObject("""{ "locked": true }"""),
-                false,
-                null,
-                { "https://duck.ai" },
-            )
-            assertCommandIssued<Command.UiLockChanged> {
-                assertFalse(this.locked)
-            }
-        }
-
-    @Test
-    fun whenProcessJsCallbackMessageUiLockChangedFromDuckAiSubpageThenSendCommandWithLockedFalse() =
-        runTest {
-            fakeBrowserUiLockFeature.self().setRawStoredState(State(enable = true))
-            testee.processJsCallbackMessage(
-                BROWSER_UI_LOCK_FEATURE_NAME,
-                "uiLockChanged",
-                null,
-                JSONObject("""{ "locked": true }"""),
-                false,
-                null,
-                { "https://duck.ai/some/path" },
-            )
-            assertCommandIssued<Command.UiLockChanged> {
-                assertFalse(this.locked)
-            }
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1213803327687450?focus=true

Reverts duckduckgo/Android#7970


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in JS callback handling that only affects `BROWSER_UI_LOCK_FEATURE_NAME` and is covered by updated unit tests.
> 
> **Overview**
> Reverts the special-case logic in `BrowserTabViewModel.processJsCallbackMessage` that *forced* `locked=false` for `duck.ai` URLs when handling the `uiLockChanged` JS callback; the ViewModel now always forwards the `locked` value provided by the page.
> 
> Updates `BrowserTabViewModelTest` by removing the `duck.ai`-specific assertions and simplifying related test inputs to match the reverted behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543857c51b2954e37beae5497255e0a18d84bcff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->