### PR TITLE
Add DRM enabled status to broken site feedback reports

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import com.duckduckgo.site.permissions.store.SitePermissionsPreferences
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -83,6 +84,7 @@ class BrokenSiteSubmitter @Inject constructor(
     private val webViewVersionProvider: WebViewVersionProvider,
     private val ampLinks: AmpLinks,
     private val inventory: FeatureTogglesInventory,
+    private val sitePermissionsPreferences: SitePermissionsPreferences,
 ) : BrokenSiteSender {
 
     override fun submitBrokenSiteFeedback(brokenSite: BrokenSite, toggle: Boolean) {
@@ -135,6 +137,7 @@ class BrokenSiteSubmitter @Inject constructor(
                 USER_REFRESH_COUNT to brokenSite.userRefreshCount.toString(),
                 OPENER_CONTEXT to brokenSite.openerContext.orEmpty(),
                 JS_PERFORMANCE to brokenSite.jsPerformance?.joinToString(",").orEmpty(),
+                DRM_ENABLED to sitePermissionsPreferences.askDrmEnabled.toString(),
             )
 
             brokenSite.reportFlow?.let { reportFlow ->
@@ -245,6 +248,7 @@ class BrokenSiteSubmitter @Inject constructor(
         private const val CONTENT_SCOPE_EXPERIMENTS = "contentScopeExperiments"
         private const val DEBUG_FLAGS = "debugFlags"
         private const val BREAKAGE_DATA = "breakageData"
+        private const val DRM_ENABLED = "drmEnabled"
     }
 }
 

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.privacy.config.api.PrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyConfigData
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import com.duckduckgo.site.permissions.store.SitePermissionsPreferences
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
@@ -108,6 +109,8 @@ class BrokenSiteSubmitterTest {
 
     private val ampLinks: AmpLinks = mock()
 
+    private val sitePermissionsPreferences: SitePermissionsPreferences = mock()
+
     private lateinit var testBlockListFeature: TestBlockListFeature
     private lateinit var inventory: FeatureTogglesInventory
 
@@ -126,6 +129,7 @@ class BrokenSiteSubmitterTest {
         whenever(mockVariantManager.getVariantKey()).thenReturn("g")
         whenever(mockPrivacyConfig.privacyConfigData()).thenReturn(PrivacyConfigData(version = "v", eTag = "e"))
         runBlocking { whenever(networkProtectionState.isRunning()) }.thenReturn(false)
+        whenever(sitePermissionsPreferences.askDrmEnabled).thenReturn(true)
 
         testBlockListFeature = FeatureToggles.Builder(
             FakeToggleStore(),
@@ -163,6 +167,7 @@ class BrokenSiteSubmitterTest {
             webViewVersionProvider,
             ampLinks,
             inventory,
+            sitePermissionsPreferences,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -160,6 +160,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
             webViewVersionProvider,
             ampLinks = mock(),
             inventory,
+            sitePermissionsPreferences = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -157,6 +157,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             webViewVersionProvider,
             ampLinks = mock(),
             inventory,
+            sitePermissionsPreferences = mock(),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212899445123800?focus=true

### Description

This change adds the DRM (Digital Rights Management) enabled status to broken site feedback reports. The `SitePermissionsPreferences.askDrmEnabled` flag is now captured and included in the breakage data sent to the backend when users report broken sites.

**Changes:**
- Injected `SitePermissionsPreferences` into `BrokenSiteSubmitter`
- Added `DRM_ENABLED` field to the breakage data payload, populated with the current DRM enabled status
- Updated all test classes to mock the new dependency

This allows the backend to correlate broken site reports with DRM settings, which may help identify sites that have issues when DRM protection is enabled.

### Steps to test this PR

- [ ] Run `BrokenSiteSubmitterTest` to verify the DRM enabled status is correctly included in reports
- [ ] Run `BrokenSitesReferenceTest` and `BrokenSitesMultipleReportReferenceTest` to ensure reference tests pass with the new dependency
- [ ] Verify that broken site reports include the `drmEnabled` field in the payload

### UI changes
N/A

https://claude.ai/code/session_01QWfhGE2bNNpZMb679uoupk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new `drmEnabled` parameter to broken-site feedback payloads and wires a new preference dependency, with tests updated accordingly.
> 
> **Overview**
> Broken site feedback submissions now include the current DRM setting by injecting `SitePermissionsPreferences` into `BrokenSiteSubmitter` and sending a new `drmEnabled` field with each report.
> 
> Unit/reference tests are updated to provide/mocks this new dependency so existing broken-site report assertions continue to pass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90fdcf2ee86cb79d855a8e9b1a4c3bbb54216cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->