### PR TITLE
Fix m_remote_message_dismissed pixel schema to use dismissType

### DIFF
--- a/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
+++ b/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
@@ -44,7 +44,7 @@
                 "type": "string"
             },
             {
-                "key": "dismiss_type",
+                "key": "dismissType",
                 "description": "The type of dismissal. This value is optional",
                 "type": "string",
                 "enum": ["close_button", "back_button_or_gesture"]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213808012470077?focus=true

### Description
The pixel schema defined the dismiss parameter as `dismiss_type` (snake_case) but the Kotlin code sends it as `dismissType` (camelCase), causing pixel validation failures. Updated the schema key to match the actual pixel payload.

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that renames a single pixel parameter key; main risk is breaking any producers/consumers still using `dismiss_type`.
> 
> **Overview**
> Updates the `m_remote_message_dismissed` pixel definition in `remote_messaging_framework.json5` to rename the dismissal parameter key from `dismiss_type` to `dismissType`, aligning schema validation with the actual emitted payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 428658634c9d4ba7e331d5aaa24a779fd07b9977. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->