### PR TITLE
Create DaxCard and DaxSurface components

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentFragment.kt
@@ -44,15 +44,15 @@ abstract class ComponentFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_component_list, container, false)
     }
 
+    @Suppress("DenyListedApi")
     override fun onViewCreated(
         view: View,
         savedInstanceBundle: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceBundle)
 
-        val recyclerView: RecyclerView = view.findViewById(R.id.recycler_view)
-
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
+        val recyclerView: RecyclerView = view.findViewById(R.id.recycler_view)
         val adapter = ComponentAdapter(isDarkTheme = isDarkTheme)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -67,7 +67,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
 
     class SwitchComponentViewHolder(
         parent: ViewGroup,
-        private val isDarkTheme: Boolean
+        private val isDarkTheme: Boolean,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_switch)) {
         override fun bind(component: Component) {
             view.setupThemedComposeView(id = R.id.compose_dax_switch_one, isDarkTheme = isDarkTheme) {

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -22,11 +22,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.common.ui.compose.cards.DaxCard
+import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -56,22 +65,30 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class TopAppBarComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_top_app_bar))
 
-    class SwitchComponentViewHolder(parent: ViewGroup, private val isDarkTheme: Boolean) :
-        ComponentViewHolder(inflate(parent, R.layout.component_switch)) {
+    class SwitchComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_switch)) {
         override fun bind(component: Component) {
             view.setupThemedComposeView(id = R.id.compose_dax_switch_one, isDarkTheme = isDarkTheme) {
                 var isChecked by remember { mutableStateOf(false) }
 
-                DaxSwitch(checked = isChecked, onCheckedChange = { enabled ->
-                    isChecked = enabled
-                })
+                DaxSwitch(
+                    checked = isChecked,
+                    onCheckedChange = { enabled ->
+                        isChecked = enabled
+                    },
+                )
             }
             view.setupThemedComposeView(id = R.id.compose_dax_switch_two, isDarkTheme = isDarkTheme) {
                 var isChecked by remember { mutableStateOf(true) }
 
-                DaxSwitch(checked = isChecked, onCheckedChange = { enabled ->
-                    isChecked = enabled
-                })
+                DaxSwitch(
+                    checked = isChecked,
+                    onCheckedChange = { enabled ->
+                        isChecked = enabled
+                    },
+                )
             }
             view.setupThemedComposeView(id = R.id.compose_dax_switch_three, isDarkTheme = isDarkTheme) {
                 DaxSwitch(checked = false, onCheckedChange = {}, enabled = false)
@@ -361,7 +378,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
 
     class DividerComponentViewHolder(parent: ViewGroup) : ComponentViewHolder(inflate(parent, R.layout.component_section_divider))
 
-    class CardComponentViewHolder(parent: ViewGroup) : ComponentViewHolder(inflate(parent, R.layout.component_card)) {
+    class CardComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_card)) {
         override fun bind(component: Component) {
             view.findViewById<MaterialCardView>(R.id.ticketViewCard).apply {
                 val cornerSize = resources.getDimension(CommonR.dimen.smallShapeCornerRadius)
@@ -374,6 +394,40 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 elevation = 8f
 
                 setOnClickListener { Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show() }
+            }
+
+            view.setupThemedComposeView(R.id.composeCards, isDarkTheme) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                ) {
+                    DaxCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                    ) { }
+                    DaxCard(
+                        onClick = {
+                            Snackbar.make(view, component.name, Snackbar.LENGTH_SHORT).show()
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                    ) { }
+                    DaxSurface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                    ) { }
+                    DaxSurface(
+                        onClick = {
+                            Snackbar.make(view, component.name, Snackbar.LENGTH_SHORT).show()
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                    ) { }
+                }
             }
         }
     }
@@ -410,7 +464,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SINGLE_LINE_LIST_ITEM -> OneLineListItemComponentViewHolder(parent)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent)
-                Component.CARD -> CardComponentViewHolder(parent)
+                Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {
                     TODO()

--- a/android-design-system/design-system-internal/src/main/res/layout/component_card.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_card.xml
@@ -78,6 +78,13 @@
         android:layout_width="match_parent"
         app:primaryText="Default Card"/>
 
+    <com.duckduckgo.common.ui.internal.ui.PlatformLabelView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_1"
+        app:platformType="view"/>
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/defaultCard"
         android:layout_width="match_parent"
@@ -89,5 +96,19 @@
         android:layout_width="match_parent"
         android:layout_height="100dp"
         android:layout_margin="@dimen/keyline_4"/>
+
+    <com.duckduckgo.common.ui.internal.ui.PlatformLabelView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_1"
+        app:platformType="compose"/>
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeCards"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_2" />
 
 </LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxCard.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxCard.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.cards
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DaxCard is a thin wrapper around Material3 Card that applies the default styling for Dax cards.
+ *
+ * @param modifier The [Modifier] to be applied to this card.
+ * @param shape The shape of the card container.
+ * @param colors The colors used for the card content and background.
+ * @param elevation The size of the shadow below this card.
+ * @param border Optional border to draw around this card.
+ * @param content The content to be displayed inside this card.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211670215000539
+ * Figma reference: https://www.figma.com/design/jHLwh4erLbNc2YeobQpGFt/Design-System-Guidelines?node-id=8796-21488&t=LXCzRHiuFnp4ybLo-4
+ */
+@Composable
+fun DaxCard(
+    modifier: Modifier = Modifier,
+    shape: Shape = DaxCardDefaults.shape,
+    colors: CardColors = DaxCardDefaults.colors,
+    elevation: CardElevation = DaxCardDefaults.elevation,
+    border: BorderStroke? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        content = content,
+    )
+}
+
+/**
+ * DaxCard with click handling is a thin wrapper around Material3 Card that applies the default styling for Dax cards and allows for click handling.
+ *
+ * @param onClick Callback invoked when the user clicks on the card.
+ * @param modifier The [Modifier] to be applied to this card.
+ * @param enabled Controls the enabled state of this card.
+ * @param shape The shape of the card container.
+ * @param colors The colors used for the card content and background.
+ * @param elevation The size of the shadow below this card.
+ * @param border Optional border to draw around this card.
+ * @param interactionSource The [MutableInteractionSource] representing the stream of interactions for this card.
+ * @param content The content to be displayed inside this card.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211670215000539
+ * Figma reference: https://www.figma.com/design/jHLwh4erLbNc2YeobQpGFt/Design-System-Guidelines?node-id=8796-21488&t=LXCzRHiuFnp4ybLo-4
+ */
+@Composable
+fun DaxCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = DaxCardDefaults.shape,
+    colors: CardColors = DaxCardDefaults.colors,
+    elevation: CardElevation = DaxCardDefaults.elevation,
+    border: BorderStroke? = null,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        content = content,
+        enabled = enabled,
+        interactionSource = interactionSource,
+    )
+}
+
+object DaxCardDefaults {
+    /**
+     * The default shape for Dax cards is the medium shape from the DuckDuckGo theme.
+     */
+    val shape: Shape
+        @Composable
+        get() = DuckDuckGoTheme.shapes.medium
+
+    /**
+     * The default colors for Dax cards are derived from the DuckDuckGo theme, with specific colors for the container, content, and disabled states.
+     */
+    val colors: CardColors
+        @Composable
+        get() = CardDefaults.cardColors(
+            containerColor = DuckDuckGoTheme.colors.backgrounds.window,
+            contentColor = DuckDuckGoTheme.colors.text.primary,
+            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.containerDisabled,
+            disabledContentColor = DuckDuckGoTheme.colors.text.disabled,
+        )
+
+    /**
+     * The default elevation for Dax cards is the card elevation from Material3, which can be customized as needed.
+     */
+    val elevation: CardElevation
+        @Composable
+        get() = CardDefaults.cardElevation(defaultElevation = 1.dp)
+}
+
+@Composable
+@PreviewLightDark
+private fun DaxCardPreview() {
+    PreviewBox {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            DaxCard {
+                DaxText(
+                    text = "Dax Card",
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+            DaxCard(onClick = {}) {
+                DaxText(
+                    text = "Dax Clickable Card",
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxCard.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxCard.kt
@@ -39,9 +39,6 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBox
  * DaxCard is a thin wrapper around Material3 Card that applies the default styling for Dax cards.
  *
  * @param modifier The [Modifier] to be applied to this card.
- * @param shape The shape of the card container.
- * @param colors The colors used for the card content and background.
- * @param elevation The size of the shadow below this card.
  * @param border Optional border to draw around this card.
  * @param content The content to be displayed inside this card.
  *
@@ -51,17 +48,14 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBox
 @Composable
 fun DaxCard(
     modifier: Modifier = Modifier,
-    shape: Shape = DaxCardDefaults.shape,
-    colors: CardColors = DaxCardDefaults.colors,
-    elevation: CardElevation = DaxCardDefaults.elevation,
     border: BorderStroke? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Card(
         modifier = modifier,
-        shape = shape,
-        colors = colors,
-        elevation = elevation,
+        shape = DaxCardDefaults.shape,
+        colors = DaxCardDefaults.colors,
+        elevation = DaxCardDefaults.elevation,
         border = border,
         content = content,
     )
@@ -73,9 +67,6 @@ fun DaxCard(
  * @param onClick Callback invoked when the user clicks on the card.
  * @param modifier The [Modifier] to be applied to this card.
  * @param enabled Controls the enabled state of this card.
- * @param shape The shape of the card container.
- * @param colors The colors used for the card content and background.
- * @param elevation The size of the shadow below this card.
  * @param border Optional border to draw around this card.
  * @param interactionSource The [MutableInteractionSource] representing the stream of interactions for this card.
  * @param content The content to be displayed inside this card.
@@ -88,9 +79,6 @@ fun DaxCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    shape: Shape = DaxCardDefaults.shape,
-    colors: CardColors = DaxCardDefaults.colors,
-    elevation: CardElevation = DaxCardDefaults.elevation,
     border: BorderStroke? = null,
     interactionSource: MutableInteractionSource? = null,
     content: @Composable ColumnScope.() -> Unit,
@@ -98,9 +86,9 @@ fun DaxCard(
     Card(
         onClick = onClick,
         modifier = modifier,
-        shape = shape,
-        colors = colors,
-        elevation = elevation,
+        shape = DaxCardDefaults.shape,
+        colors = DaxCardDefaults.colors,
+        elevation = DaxCardDefaults.elevation,
         border = border,
         content = content,
         enabled = enabled,
@@ -108,7 +96,7 @@ fun DaxCard(
     )
 }
 
-object DaxCardDefaults {
+private object DaxCardDefaults {
     /**
      * The default shape for Dax cards is the medium shape from the DuckDuckGo theme.
      */

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxSurface.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxSurface.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.cards
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DaxSurface is a thin wrapper around Material3 Surface that applies the default styling for Dax cards.
+ *
+ * @param modifier The [Modifier] to be applied to this surface.
+ * @param shape The shape of the surface container.
+ * @param color The background color of the surface container.
+ * @param contentColor The content color of the surface container.
+ * @param shadowElevation The size of the shadow below this surface.
+ * @param border Optional border to draw around this surface.
+ * @param content The content to be displayed inside this surface.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211670215000539
+ * Figma reference: https://www.figma.com/design/jHLwh4erLbNc2YeobQpGFt/Design-System-Guidelines?node-id=8796-21488&t=LXCzRHiuFnp4ybLo-4
+ */
+@Composable
+fun DaxSurface(
+    modifier: Modifier = Modifier,
+    shape: Shape = DuckDuckGoTheme.shapes.medium,
+    color: Color = DuckDuckGoTheme.colors.backgrounds.window,
+    contentColor: Color = DuckDuckGoTheme.colors.text.primary,
+    shadowElevation: Dp = 1.dp,
+    border: BorderStroke? = null,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+        shadowElevation = shadowElevation,
+        border = border,
+        content = content,
+    )
+}
+
+/**
+ * DaxSurface with click handling is a thin wrapper around Material3 Surface that applies the default styling for Dax cards and allows for click
+ * handling.
+ *
+ * @param onClick Callback invoked when this surface is clicked.
+ * @param modifier The [Modifier] to be applied to this surface.
+ * @param enabled Controls the enabled state of this surface.
+ * @param shape The shape of the surface container.
+ * @param color The background color of the surface container.
+ * @param contentColor The content color of the surface container.
+ * @param shadowElevation The size of the shadow below this surface.
+ * @param border Optional border to draw around this surface.
+ * @param interactionSource The [MutableInteractionSource] representing the stream of interactions for this surface.
+ * @param content The content to be displayed inside this surface.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211670215000539
+ * Figma reference: https://www.figma.com/design/jHLwh4erLbNc2YeobQpGFt/Design-System-Guidelines?node-id=8796-21488&t=LXCzRHiuFnp4ybLo-4
+ */
+@Composable
+fun DaxSurface(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = DuckDuckGoTheme.shapes.medium,
+    color: Color = DuckDuckGoTheme.colors.backgrounds.window,
+    contentColor: Color = DuckDuckGoTheme.colors.text.primary,
+    shadowElevation: Dp = 1.dp,
+    border: BorderStroke? = null,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+        shadowElevation = shadowElevation,
+        border = border,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Composable
+@PreviewLightDark
+private fun DaxSurfacePreview() {
+    PreviewBox {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            DaxSurface {
+                DaxText(
+                    text = "Dax Surface",
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+            DaxSurface(onClick = {}) {
+                DaxText(
+                    text = "Clickable Dax Surface",
+                    modifier = Modifier.padding(10.dp),
+                )
+            }
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxSurface.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/cards/DaxSurface.kt
@@ -37,10 +37,6 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBox
  * DaxSurface is a thin wrapper around Material3 Surface that applies the default styling for Dax cards.
  *
  * @param modifier The [Modifier] to be applied to this surface.
- * @param shape The shape of the surface container.
- * @param color The background color of the surface container.
- * @param contentColor The content color of the surface container.
- * @param shadowElevation The size of the shadow below this surface.
  * @param border Optional border to draw around this surface.
  * @param content The content to be displayed inside this surface.
  *
@@ -50,19 +46,15 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBox
 @Composable
 fun DaxSurface(
     modifier: Modifier = Modifier,
-    shape: Shape = DuckDuckGoTheme.shapes.medium,
-    color: Color = DuckDuckGoTheme.colors.backgrounds.window,
-    contentColor: Color = DuckDuckGoTheme.colors.text.primary,
-    shadowElevation: Dp = 1.dp,
     border: BorderStroke? = null,
     content: @Composable () -> Unit,
 ) {
     Surface(
         modifier = modifier,
-        shape = shape,
-        color = color,
-        contentColor = contentColor,
-        shadowElevation = shadowElevation,
+        shape = DaxSurfaceDefaults.shape,
+        color = DaxSurfaceDefaults.color,
+        contentColor = DaxSurfaceDefaults.contentColor,
+        shadowElevation = DaxSurfaceDefaults.elevation,
         border = border,
         content = content,
     )
@@ -75,10 +67,6 @@ fun DaxSurface(
  * @param onClick Callback invoked when this surface is clicked.
  * @param modifier The [Modifier] to be applied to this surface.
  * @param enabled Controls the enabled state of this surface.
- * @param shape The shape of the surface container.
- * @param color The background color of the surface container.
- * @param contentColor The content color of the surface container.
- * @param shadowElevation The size of the shadow below this surface.
  * @param border Optional border to draw around this surface.
  * @param interactionSource The [MutableInteractionSource] representing the stream of interactions for this surface.
  * @param content The content to be displayed inside this surface.
@@ -91,10 +79,6 @@ fun DaxSurface(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    shape: Shape = DuckDuckGoTheme.shapes.medium,
-    color: Color = DuckDuckGoTheme.colors.backgrounds.window,
-    contentColor: Color = DuckDuckGoTheme.colors.text.primary,
-    shadowElevation: Dp = 1.dp,
     border: BorderStroke? = null,
     interactionSource: MutableInteractionSource? = null,
     content: @Composable () -> Unit,
@@ -103,14 +87,44 @@ fun DaxSurface(
         onClick = onClick,
         modifier = modifier,
         enabled = enabled,
-        shape = shape,
-        color = color,
-        contentColor = contentColor,
-        shadowElevation = shadowElevation,
+        shape = DaxSurfaceDefaults.shape,
+        color = DaxSurfaceDefaults.color,
+        contentColor = DaxSurfaceDefaults.contentColor,
+        shadowElevation = DaxSurfaceDefaults.elevation,
         border = border,
         interactionSource = interactionSource,
         content = content,
     )
+}
+
+private object DaxSurfaceDefaults {
+    /**
+     * The default shape for Dax surfaces is the medium shape from the DuckDuckGo theme, which provides a balanced appearance that works well for card-like components.
+     */
+    val shape: Shape
+        @Composable
+        get() = DuckDuckGoTheme.shapes.medium
+
+    /**
+     * The default colors for Dax surfaces are derived from the DuckDuckGo theme.
+     */
+    val color: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.backgrounds.window
+
+    /**
+     * The default content color for Dax surfaces is the primary text color from the DuckDuckGo theme.
+     */
+    val contentColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.text.primary
+
+    /**
+     * The default elevation for Dax surfaces is 1.dp, which provides a subtle shadow to help the surface stand out from the background without being too prominent.
+     */
+    val elevation: Dp
+        @Composable
+        get() = 1.dp
 }
 
 @Composable


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211673324043441 

### Description

Adds `DaxCard` and `DaxSurface` Compose components to the Android Design System.

- `DaxCard` — thin wrapper around Material3 `Card` with DuckDuckGo theme defaults (`shapes.medium`, `backgrounds.window` container color, `text.primary` content, `1dp` elevation). Provides two overloads: static and clickable. Defaults are centralized in a `DaxCardDefaults` object.
- `DaxSurface` — thin wrapper around Material3 `Surface` with the same theme defaults. Provides two overloads: static and clickable.

### Steps to test this PR

_DaxCard and DaxSurface in the design system showcase_
- [ ] Build and install the internal build
- [ ] Open the design system app → navigate to the **Layouts** component section
- [ ] Verify `DaxCard` (static) and `DaxCard` (clickable) are displayed correctly
- [ ] Verify `DaxSurface` (static) and `DaxSurface` (clickable) are displayed correctly
- [ ] Toggle the theme to **Dark mode** and verify the Compose cards switch themes correctly
- [ ] Tap the clickable cards and verify a Snackbar appears

### UI changes
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/d683c090-682e-46ee-a7f0-3d6db7829425" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/07c3e4a5-e900-4489-b4ca-dc8f66fdb904" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New UI components and showcase/demo wiring only; no changes to app logic, data handling, or security-sensitive code.
> 
> **Overview**
> Adds new Compose `DaxCard` and `DaxSurface` components to the design system as thin, themed wrappers over Material3 `Card`/`Surface`, each with static and clickable overloads and light/dark previews.
> 
> Updates the internal design-system showcase to display these new components: extends the card layout with platform labels and a `ComposeView`, and wires `ComponentViewHolder.CardComponentViewHolder` to render `DaxCard`/`DaxSurface` examples using the current theme (including click Snackbars). Also adds a small lint suppression/ordering tweak in `ComponentFragment` around the theme lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0c9ac3575ec565f8a2ef5d9497d274d6fffaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->