### PR TITLE
Add crashanr and native crash observers to pir process

### DIFF
--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
@@ -20,7 +20,9 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.IsMainProcess
+import com.duckduckgo.app.di.ProcessName
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.lifecycle.PirProcessLifecycleObserver
 import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
@@ -45,6 +47,10 @@ import javax.inject.Inject
     scope = AppScope::class,
     boundType = VpnProcessLifecycleObserver::class,
 )
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PirProcessLifecycleObserver::class,
+)
 @SingleInstanceIn(AppScope::class)
 class NativeCrashInit @Inject constructor(
     private val context: Context,
@@ -53,10 +59,10 @@ class NativeCrashInit @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val nativeCrashFeature: NativeCrashFeature,
     private val webViewVersionProvider: WebViewVersionProvider,
-) : MainProcessLifecycleObserver, VpnProcessLifecycleObserver, LibraryLoaderListener {
+    @ProcessName private val processName: String,
+) : MainProcessLifecycleObserver, VpnProcessLifecycleObserver, LibraryLoaderListener, PirProcessLifecycleObserver {
 
     private val isCustomTab: Boolean by lazy { customTabDetector.isCustomTab() }
-    private val processName: String by lazy { if (isMainProcess) "main" else "vpn" }
 
     private val webViewVersion: String by lazy {
         if (nativeCrashFeature.nativeCrashReportsFullWebViewVersion().isEnabled()) {
@@ -89,7 +95,15 @@ class NativeCrashInit @Inject constructor(
         if (!isMainProcess) {
             asyncLoadNativeLibrary()
         } else {
-            logcat(ERROR) { "ndk-crash: onCreate wrongly called in the main process" }
+            logcat(ERROR) { "ndk-crash: onVpnProcessCreated wrongly called in the main process" }
+        }
+    }
+
+    override fun onPirProcessCreated() {
+        if (!isMainProcess) {
+            asyncLoadNativeLibrary()
+        } else {
+            logcat(ERROR) { "ndk-crash: onPirProcessCreated wrongly called in the main process" }
         }
     }
 

--- a/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/store/CrashAnrsObserver.kt
+++ b/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/store/CrashAnrsObserver.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.anrs.store.AnrsDatabase
 import com.duckduckgo.app.anrs.store.UncaughtExceptionDao
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.lifecycle.PirProcessLifecycleObserver
 import com.duckduckgo.app.lifecycle.VpnProcessLifecycleObserver
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -45,6 +46,10 @@ import javax.inject.Inject
     scope = AppScope::class,
     boundType = VpnProcessLifecycleObserver::class,
 )
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PirProcessLifecycleObserver::class,
+)
 @SingleInstanceIn(AppScope::class)
 class CrashAnrsObserver @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -52,7 +57,7 @@ class CrashAnrsObserver @Inject constructor(
     private val repository: CrashANRsRepository,
     private val anrDatabase: AnrsDatabase,
     private val uncaughtExceptionDao: UncaughtExceptionDao,
-) : MainProcessLifecycleObserver, VpnProcessLifecycleObserver {
+) : MainProcessLifecycleObserver, VpnProcessLifecycleObserver, PirProcessLifecycleObserver {
 
     private var anrObserverJob: ConflatedJob = ConflatedJob()
     private var crashObserverJob: ConflatedJob = ConflatedJob()
@@ -63,6 +68,11 @@ class CrashAnrsObserver @Inject constructor(
     }
 
     override fun onVpnProcessCreated() {
+        anrObserverJob += observeAnrDatabase()
+        crashObserverJob += observeCrashDatabase()
+    }
+
+    override fun onPirProcessCreated() {
         anrObserverJob += observeAnrDatabase()
         crashObserverJob += observeCrashDatabase()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1213720604927994?focus=true 

### Description
See attached task description

### Steps to test this PR

_Run PIR_
- [x] Filter in your logcat "ndk-crash:" and "Observing"
- [x] Start PIR scan
- [x] Verify logcat shows "ndk-crash: Library loaded in process :pir", "Native crash handler successfully initialized on :pir." and "Observing Crashes database..." and "Observing ANRs database..."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends native crash handler initialization and crash/ANR DB observation into the PIR process, which affects multi-process startup behavior and native library loading. Risk is moderate due to potential process-specific lifecycle/order issues but changes are localized.
> 
> **Overview**
> Extends crash/ANR instrumentation to run in the PIR process.
> 
> `NativeCrashInit` is now registered as a `PirProcessLifecycleObserver`, injects the DI-provided `@ProcessName` (instead of hardcoding), and loads/initializes the NDK crash handler when `onPirProcessCreated` fires (with updated log messaging).
> 
> `CrashAnrsObserver` is likewise registered for PIR and starts observing the ANR and uncaught-exception databases on `onPirProcessCreated`, matching existing main/VPN behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96904c6d66cbf0da2b9172170b85776819c191d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->