### PR TITLE
Add voice search to native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -346,6 +346,7 @@ import com.duckduckgo.user.agent.api.ClientBrandHintProvider
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.duckduckgo.voice.api.VoiceSearchLauncher
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
+import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -968,12 +969,17 @@ class BrowserTabFragment :
                 is VoiceSearchLauncher.Event.VoiceRecognitionSuccess -> {
                     when (val result = it.result) {
                         is VoiceSearchLauncher.VoiceRecognitionResult.SearchResult -> {
+                            nativeInputManager.hideNativeInput(animate = false)
                             omnibar.setText(result.query)
                             userEnteredQuery(result.query)
                         }
 
                         is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult -> {
-                            duckChat.openDuckChatWithAutoPrompt(result.query)
+                            if (nativeInputManager.isNativeInputEnabled()) {
+                                nativeInputManager.handleDuckAiVoiceResult(result.query)
+                            } else {
+                                duckChat.openDuckChatWithAutoPrompt(result.query)
+                            }
                         }
                     }
                     resumeWebView()
@@ -1283,6 +1289,12 @@ class BrowserTabFragment :
                             params = JSONObject("{}"),
                         ),
                     )
+                },
+                onVoiceSearchPressed = { isChatTab ->
+                    val mode = if (isChatTab) VoiceSearchMode.DUCK_AI else VoiceSearchMode.SEARCH
+                    webView?.onPause()
+                    hideKeyboard()
+                    voiceSearchLauncher.launch(requireActivity(), mode)
                 },
             ),
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
+import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.launchIn
@@ -47,6 +48,7 @@ class NativeInputCallbacks(
     val onChatSuggestionSelected: (String) -> Unit,
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
+    val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
 )
 
 interface NativeInputManager {
@@ -59,7 +61,8 @@ interface NativeInputManager {
         query: String = "",
         callbacks: NativeInputCallbacks,
     )
-    fun hideNativeInput(): Boolean
+    fun hideNativeInput(animate: Boolean = true): Boolean
+    fun handleDuckAiVoiceResult(query: String)
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
 }
 
@@ -67,6 +70,7 @@ interface NativeInputManager {
 class RealNativeInputManager @Inject constructor(
     private val duckChat: DuckChat,
     private val animator: NativeInputAnimator,
+    private val voiceSearchAvailability: VoiceSearchAvailability,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -92,7 +96,19 @@ class RealNativeInputManager @Inject constructor(
 
     override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
 
-    override fun hideNativeInput(): Boolean {
+    override fun handleDuckAiVoiceResult(query: String) {
+        val widget = widgetFrom(rootView)
+        if (widget != null) {
+            if (!widget.isChatTabSelected()) {
+                widget.selectChatTab()
+            }
+            widget.submitMessage(query)
+        } else {
+            duckChat.openDuckChatWithAutoPrompt(query)
+        }
+    }
+
+    override fun hideNativeInput(animate: Boolean): Boolean {
         if (!isNativeInputFieldEnabled) return false
 
         val widgetView = rootView.findViewById<View?>(R.id.inputModeTopRoot)
@@ -101,6 +117,18 @@ class RealNativeInputManager @Inject constructor(
 
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
+
+        if (!animate) {
+            animator.cancelAnimation()
+            isExiting = false
+            omnibarController.restore()
+            omnibarController.show()
+            removeWidget()
+            if (omnibarController.isBrowserMode()) {
+                hideNtp()
+            }
+            return !omnibarController.isDuckAiMode()
+        }
 
         val card = widgetView.findViewById<View?>(R.id.inputModeWidgetCard)
         val omnibarCard = omnibarController.getCardView()
@@ -371,6 +399,10 @@ class RealNativeInputManager @Inject constructor(
             onStopTapped = callbacks.onStopTapped
             bindTabCount(lifecycleOwner, tabs.map { it.size })
             hideMainButtons()
+            if (voiceSearchAvailability.isVoiceSearchAvailable) {
+                setVoiceButtonVisible(true)
+                onVoiceClick = { callbacks.onVoiceSearchPressed(isChatTabSelected()) }
+            }
         }
         bindSearchCallbacks(widgetView, callbacks)
         bindAutocompleteVisibility(widgetView)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -57,6 +57,7 @@ interface NativeInputWidget {
     var onChatSelected: (() -> Unit)?
     var onClearTextTapped: (() -> Unit)?
     var onStopTapped: (() -> Unit)?
+    var onVoiceClick: (() -> Unit)?
 
     fun focusInput(activity: Activity?)
     fun hasInputFocus(): Boolean
@@ -67,6 +68,8 @@ interface NativeInputWidget {
     fun selectChatTab()
     fun isChatTabSelected(): Boolean
     fun hideMainButtons()
+    fun setVoiceButtonVisible(visible: Boolean)
+    fun submitMessage(message: String?)
 
     fun bindInputEvents(
         onSearchTextChanged: (String) -> Unit,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213814620948013?focus=true

### Description

- Adds private voice search to native input

### Steps to test this PR

_With native input enabled_

- [ ] Enable private voice search
- [ ] Tap the microphone button on the native input
- [ ] Verify that it works as expected (both search and Duck.ai)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Integrates voice search into native input and alters voice-result routing (search vs Duck.ai), which could affect user flows around input/keyboard and Duck.ai submission behavior.
> 
> **Overview**
> Adds a voice-search entry point to the native input widget: the widget can now show a mic button (gated by `VoiceSearchAvailability`) and report clicks via a new `NativeInputCallbacks.onVoiceSearchPressed` callback.
> 
> Updates voice search handling to support two modes (`SEARCH` vs `DUCK_AI`): native input can launch voice search in the appropriate mode, search results now hide native input without animation before populating the omnibar, and Duck.ai voice results are routed into native input (auto-selecting the chat tab and submitting the message) when native input is enabled, otherwise falling back to opening DuckChat.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6687035645d14a02f6e03f9d66814828643e150f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->