### PR TITLE
Wire Default Toggle Setting to New Tab Page behaviour

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1302,7 +1302,7 @@ class BrowserTabFragment :
         )
     }
 
-    private fun launchInputScreen(query: String) {
+    private fun launchInputScreen(query: String, isNewTab: Boolean = false) {
         logcat { "Duck.ai: launchInputScreen" }
         val isTopOmnibar = omnibar.omnibarType != OmnibarType.SINGLE_BOTTOM
         val intent =
@@ -1313,6 +1313,7 @@ class BrowserTabFragment :
                     isTopOmnibar = isTopOmnibar,
                     browserButtonsConfig = InputScreenBrowserButtonsConfig.Enabled(tabs = viewModel.tabs.value?.size ?: 0),
                     launchOnChat = omnibar.viewMode == ViewMode.DuckAI,
+                    isNewTab = isNewTab,
                     useBottomSheetMenu = viewModel.browserViewState.value?.useBottomSheetMenu ?: false,
                     showReturnHatch = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled(),
                 ),
@@ -2815,7 +2816,7 @@ class BrowserTabFragment :
             is Command.LaunchInputScreen -> {
                 // if the fire button is used, prevent automatically launching the input screen until the process reloads
                 if ((requireActivity() as? BrowserActivity)?.isDataClearingInProgress == false) {
-                    launchInputScreen(query = "")
+                    launchInputScreen(query = "", isNewTab = true)
                 }
             }
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -29,6 +29,7 @@ import java.io.Serializable
  * @param browserButtonsConfig configuration for displaying browser buttons (Fire Button, Tab Switcher, Menu)
  * @param showInstalledApps whether apps installed on the device should appear in autocomplete results
  * @param launchWithVoice whether to immediately launch voice input on activity start, if supported and enabled
+ * @param isNewTab whether the input screen is being launched as part of a new tab creation action
  */
 data class InputScreenActivityParams(
     val query: String,
@@ -39,6 +40,7 @@ data class InputScreenActivityParams(
     val launchOnChat: Boolean = false,
     val useBottomSheetMenu: Boolean = false,
     val showReturnHatch: Boolean = false,
+    val isNewTab: Boolean = false,
 ) : GlobalActivityStarter.ActivityParams
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -117,6 +117,16 @@ interface DuckChatInternal : DuckChat {
     fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition>
 
     /**
+     * Saves the last used toggle position. Called on submission from the input screen.
+     */
+    suspend fun saveLastUsedTogglePosition(position: String)
+
+    /**
+     * Observes the last used toggle position.
+     */
+    fun observeLastUsedTogglePosition(): Flow<String?>
+
+    /**
      * Observes whether DuckChat is user enabled or disabled.
      */
     fun observeEnableDuckChatUserSetting(): Flow<Boolean>
@@ -773,6 +783,13 @@ class RealDuckChat @Inject constructor(
     override fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition> =
         duckChatFeatureRepository.observeDefaultTogglePosition()
             .map { DefaultTogglePosition.fromName(it) }
+
+    override suspend fun saveLastUsedTogglePosition(position: String) {
+        duckChatFeatureRepository.setLastUsedTogglePosition(position)
+    }
+
+    override fun observeLastUsedTogglePosition(): Flow<String?> =
+        duckChatFeatureRepository.observeLastUsedTogglePosition()
 
     private suspend fun hasActiveSession(): Boolean {
         val now = System.currentTimeMillis()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -86,6 +86,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewMode
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelFactory
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelProviderFactory
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchLauncher
@@ -283,7 +284,11 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         configureLogoAnimation()
         configureKeyboardListener()
 
-        val launchOnChat = params?.launchOnChat ?: false
+        val launchOnChat = if (duckChatFeature.rememberTogglePosition().isEnabled() && params?.isNewTab == true) {
+            viewModel.getNewTabTogglePosition() == DefaultTogglePosition.DUCK_AI
+        } else {
+            params?.launchOnChat ?: false
+        }
         if (launchOnChat) {
             inputModeWidget.initOnChat()
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -45,8 +45,8 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
-import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
@@ -85,6 +85,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
 import com.duckduckgo.duckchat.impl.pixel.fireCountAndDaily
 import com.duckduckgo.duckchat.impl.pixel.inputScreenPixelsModeParam
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import dagger.assisted.Assisted
@@ -138,7 +139,7 @@ class InputScreenViewModel @AssistedInject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val voiceSearchAvailability: VoiceSearchAvailability,
     private val autoCompleteSettings: AutoCompleteSettings,
-    private val duckChat: DuckChat,
+    private val duckChat: DuckChatInternal,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckChatFeature: DuckChatFeature,
     private val pixel: Pixel,
@@ -202,6 +203,22 @@ class InputScreenViewModel @AssistedInject constructor(
     private var cachedTabs: List<TabAttachmentItem> = emptyList()
 
     private val refreshSuggestions = MutableSharedFlow<Unit>()
+
+    private val defaultTogglePosition: StateFlow<DefaultTogglePosition> =
+        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
+            duckChat.observeDefaultTogglePosition()
+                .stateIn(appCoroutineScope, SharingStarted.Eagerly, DefaultTogglePosition.SEARCH)
+        } else {
+            MutableStateFlow(DefaultTogglePosition.SEARCH)
+        }
+
+    private val lastUsedTogglePosition: StateFlow<String?> =
+        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
+            duckChat.observeLastUsedTogglePosition()
+                .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
+        } else {
+            MutableStateFlow(null)
+        }
 
     /**
      * This becomes true when either:
@@ -394,6 +411,7 @@ class InputScreenViewModel @AssistedInject constructor(
         if (visibilityState.value.fullScreenMode) {
             onChatSubmitted(prompt)
         } else {
+            saveLastUsedTogglePosition()
             duckChatJSHelper.clearTabContextPromptEvent()
             command.value = Command.SubmitChat(prompt)
             duckChat.openDuckChatWithAutoPrompt(prompt)
@@ -438,6 +456,7 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun onUserSubmittedQuery(query: String) {
+        saveLastUsedTogglePosition()
         command.value = Command.UserSubmittedQuery(query)
         _visibilityState.update {
             it.copy(
@@ -475,6 +494,7 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun onSearchSubmitted(query: String) {
+        saveLastUsedTogglePosition()
         val sanitizedQuery = query.replace(oldValue = "\n", newValue = " ")
         command.value = Command.SubmitSearch(sanitizedQuery)
         val params =
@@ -493,6 +513,7 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun onChatSubmitted(query: String) {
+        saveLastUsedTogglePosition()
         viewModelScope.launch {
             if (queryUrlPredictor.isUrl(query)) {
                 command.value = Command.SubmitSearch(query)
@@ -784,6 +805,7 @@ class InputScreenViewModel @AssistedInject constructor(
         omnibarRepository.omnibarType != OmnibarType.SPLIT
 
     fun onChatSuggestionSelected(chatId: String, pinned: Boolean) {
+        saveLastUsedTogglePosition()
         duckChatJSHelper.clearTabContextPromptEvent()
         viewModelScope.launch {
             val url = duckChat.getDuckChatUrl("", false)
@@ -914,6 +936,25 @@ class InputScreenViewModel @AssistedInject constructor(
         duckChatJSHelper.storeTabContextPromptEvent(query, enrichedContexts)
 
         return true
+    }
+
+    fun getNewTabTogglePosition(): DefaultTogglePosition {
+        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return DefaultTogglePosition.SEARCH
+
+        val position = defaultTogglePosition.value
+        return if (position == DefaultTogglePosition.LAST_USED) {
+            DefaultTogglePosition.fromName(lastUsedTogglePosition.value)
+        } else {
+            position
+        }
+    }
+
+    private fun saveLastUsedTogglePosition() {
+        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
+        val position = if (isSearchModeFlow.value) DefaultTogglePosition.SEARCH else DefaultTogglePosition.DUCK_AI
+        appCoroutineScope.launch(dispatchers.io()) {
+            duckChat.saveLastUsedTogglePosition(position.name)
+        }
     }
 
     override fun onCleared() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -100,6 +100,10 @@ interface DuckChatFeatureRepository {
     suspend fun getDefaultTogglePosition(): String?
 
     fun observeDefaultTogglePosition(): Flow<String?>
+
+    suspend fun setLastUsedTogglePosition(position: String)
+
+    fun observeLastUsedTogglePosition(): Flow<String?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -213,6 +217,12 @@ class RealDuckChatFeatureRepository @Inject constructor(
     override suspend fun getDefaultTogglePosition(): String? = duckChatDataStore.getDefaultTogglePosition()
 
     override fun observeDefaultTogglePosition(): Flow<String?> = duckChatDataStore.observeDefaultTogglePosition()
+
+    override suspend fun setLastUsedTogglePosition(position: String) {
+        duckChatDataStore.setLastUsedTogglePosition(position)
+    }
+
+    override fun observeLastUsedTogglePosition(): Flow<String?> = duckChatDataStore.observeLastUsedTogglePosition()
 
     private fun updateWidgets() {
         val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Key
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_DEFAULT_TOGGLE_POSITION
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_USER_SETTING
+import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_LAST_USED_TOGGLE_POSITION
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_NATIVE_INPUT_FIELD_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_TERMS_ACCEPTED
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_BACKGROUND_TIMESTAMP
@@ -145,6 +146,10 @@ interface DuckChatDataStore {
     suspend fun getDefaultTogglePosition(): String?
 
     fun observeDefaultTogglePosition(): Flow<String?>
+
+    suspend fun setLastUsedTogglePosition(position: String)
+
+    fun observeLastUsedTogglePosition(): Flow<String?>
 }
 
 @ContributesBinding(AppScope::class)
@@ -174,6 +179,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING = booleanPreferencesKey(name = "DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING")
         val DUCK_AI_TERMS_ACCEPTED = booleanPreferencesKey(name = "DUCK_AI_TERMS_ACCEPTED")
         val DUCK_AI_DEFAULT_TOGGLE_POSITION = stringPreferencesKey(name = "DUCK_AI_DEFAULT_TOGGLE_POSITION")
+        val DUCK_AI_LAST_USED_TOGGLE_POSITION = stringPreferencesKey(name = "DUCK_AI_LAST_USED_TOGGLE_POSITION")
     }
 
     private fun Preferences.defaultShowInAddressBar(): Boolean =
@@ -248,6 +254,12 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
     private val defaultTogglePositionFlow: StateFlow<String?> =
         store.data
             .map { prefs -> prefs[DUCK_AI_DEFAULT_TOGGLE_POSITION] }
+            .distinctUntilChanged()
+            .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
+
+    private val lastUsedTogglePositionFlow: StateFlow<String?> =
+        store.data
+            .map { prefs -> prefs[DUCK_AI_LAST_USED_TOGGLE_POSITION] }
             .distinctUntilChanged()
             .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
 
@@ -408,4 +420,10 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         store.data.firstOrNull()?.let { it[DUCK_AI_DEFAULT_TOGGLE_POSITION] }
 
     override fun observeDefaultTogglePosition(): Flow<String?> = defaultTogglePositionFlow
+
+    override suspend fun setLastUsedTogglePosition(position: String) {
+        store.edit { prefs -> prefs[DUCK_AI_LAST_USED_TOGGLE_POSITION] = position }
+    }
+
+    override fun observeLastUsedTogglePosition(): Flow<String?> = lastUsedTogglePositionFlow
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRES
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BAR_SELECTION
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -56,6 +57,7 @@ import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -1535,5 +1537,46 @@ class RealDuckChatTest {
             "addressBarTension": 7.8
         }
         """.trimIndent()
+    }
+
+    @Test
+    fun `when setDefaultTogglePosition then repository is called with name`() = runTest {
+        testee.setDefaultTogglePosition(DefaultTogglePosition.DUCK_AI)
+
+        verify(mockDuckChatFeatureRepository).setDefaultTogglePosition("DUCK_AI")
+    }
+
+    @Test
+    fun `when observeDefaultTogglePosition then maps string to enum`() = runTest {
+        whenever(mockDuckChatFeatureRepository.observeDefaultTogglePosition()).thenReturn(flowOf("DUCK_AI"))
+
+        val result = testee.observeDefaultTogglePosition().first()
+
+        assertEquals(DefaultTogglePosition.DUCK_AI, result)
+    }
+
+    @Test
+    fun `when observeDefaultTogglePosition with null then maps to SEARCH`() = runTest {
+        whenever(mockDuckChatFeatureRepository.observeDefaultTogglePosition()).thenReturn(flowOf(null))
+
+        val result = testee.observeDefaultTogglePosition().first()
+
+        assertEquals(DefaultTogglePosition.SEARCH, result)
+    }
+
+    @Test
+    fun `when saveLastUsedTogglePosition then repository is called`() = runTest {
+        testee.saveLastUsedTogglePosition("DUCK_AI")
+
+        verify(mockDuckChatFeatureRepository).setLastUsedTogglePosition("DUCK_AI")
+    }
+
+    @Test
+    fun `when observeLastUsedTogglePosition then delegates to repository`() = runTest {
+        whenever(mockDuckChatFeatureRepository.observeLastUsedTogglePosition()).thenReturn(flowOf("SEARCH"))
+
+        val result = testee.observeLastUsedTogglePosition().first()
+
+        assertEquals("SEARCH", result)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -184,6 +184,10 @@ class FakeDuckChatInternal(
     override fun observeDefaultTogglePosition(): Flow<DefaultTogglePosition> =
         _defaultTogglePosition.map { DefaultTogglePosition.fromName(it) }
 
+    override suspend fun saveLastUsedTogglePosition(position: String) { }
+
+    override fun observeLastUsedTogglePosition(): Flow<String?> = MutableStateFlow(null)
+
     fun setDuckChatUserEnabled(enabled: Boolean) {
         enableDuckChatUserSetting.value = enabled
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
@@ -332,4 +332,42 @@ class DuckChatFeatureRepositoryTest {
         assertTrue(results[0])
         assertFalse(results[1])
     }
+
+    @Test
+    fun `when setDefaultTogglePosition then set in data store`() = runTest {
+        testee.setDefaultTogglePosition("DUCK_AI")
+
+        verify(mockDataStore).setDefaultTogglePosition("DUCK_AI")
+    }
+
+    @Test
+    fun `when getDefaultTogglePosition then get from data store`() = runTest {
+        whenever(mockDataStore.getDefaultTogglePosition()).thenReturn("DUCK_AI")
+        assertEquals("DUCK_AI", testee.getDefaultTogglePosition())
+    }
+
+    @Test
+    fun `when observeDefaultTogglePosition then observe data store`() = runTest {
+        whenever(mockDataStore.observeDefaultTogglePosition()).thenReturn(flowOf(null, "DUCK_AI"))
+
+        val results = testee.observeDefaultTogglePosition().take(2).toList()
+        assertNull(results[0])
+        assertEquals("DUCK_AI", results[1])
+    }
+
+    @Test
+    fun `when setLastUsedTogglePosition then set in data store`() = runTest {
+        testee.setLastUsedTogglePosition("SEARCH")
+
+        verify(mockDataStore).setLastUsedTogglePosition("SEARCH")
+    }
+
+    @Test
+    fun `when observeLastUsedTogglePosition then observe data store`() = runTest {
+        whenever(mockDataStore.observeLastUsedTogglePosition()).thenReturn(flowOf(null, "DUCK_AI"))
+
+        val results = testee.observeLastUsedTogglePosition().take(2).toList()
+        assertNull(results[0])
+        assertEquals("DUCK_AI", results[1])
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -391,4 +391,43 @@ class SharedPreferencesDuckChatDataStoreTest {
         testee.setUserAcceptedTerms()
         assertTrue(testee.hasUserAcceptedTerms())
     }
+
+    @Test
+    fun `when observeDefaultTogglePosition then receive updates`() = runTest {
+        val results = mutableListOf<String?>()
+        val job = launch {
+            testee.observeDefaultTogglePosition()
+                .take(2)
+                .toList(results)
+        }
+        testee.setDefaultTogglePosition("DUCK_AI")
+        job.join()
+
+        assertEquals(listOf(null, "DUCK_AI"), results)
+    }
+
+    @Test
+    fun `when getDefaultTogglePosition default then return null`() = runTest {
+        assertNull(testee.getDefaultTogglePosition())
+    }
+
+    @Test
+    fun `when setDefaultTogglePosition then getDefaultTogglePosition returns value`() = runTest {
+        testee.setDefaultTogglePosition("DUCK_AI")
+        assertEquals("DUCK_AI", testee.getDefaultTogglePosition())
+    }
+
+    @Test
+    fun `when setLastUsedTogglePosition then observeLastUsedTogglePosition receives update`() = runTest {
+        val results = mutableListOf<String?>()
+        val job = launch {
+            testee.observeLastUsedTogglePosition()
+                .take(2)
+                .toList(results)
+        }
+        testee.setLastUsedTogglePosition("DUCK_AI")
+        job.join()
+
+        assertEquals(listOf(null, "DUCK_AI"), results)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
-import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
@@ -46,6 +46,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.tabattachments.TabAttachmentI
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.history.api.NavigationHistory
@@ -93,7 +94,7 @@ class InputScreenViewModelTest {
     private val autoCompleteSettings: AutoCompleteSettings = mock()
     private val pixel: Pixel = mock()
     private val inputScreenSessionStore: InputScreenSessionStore = mock()
-    private val duckChat: DuckChat = mock()
+    private val duckChat: DuckChatInternal = mock()
     private val inputScreenDiscoveryFunnel: InputScreenDiscoveryFunnel = mock()
     private val inputScreenSessionUsageMetric: InputScreenSessionUsageMetric = mock()
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
@@ -2824,6 +2825,166 @@ class InputScreenViewModelTest {
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT)
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY, type = Daily())
             verify(duckChat).openVoiceDuckChat()
+        }
+
+    // endregion
+
+    // region default toggle position
+
+    @Test
+    fun `getNewTabTogglePosition returns SEARCH when feature flag is off`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DefaultTogglePosition.SEARCH, viewModel.getNewTabTogglePosition())
+        }
+
+    @Test
+    fun `getNewTabTogglePosition returns SEARCH when setting is SEARCH`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DefaultTogglePosition.SEARCH, viewModel.getNewTabTogglePosition())
+        }
+
+    @Test
+    fun `getNewTabTogglePosition returns DUCK_AI when setting is DUCK_AI`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DefaultTogglePosition.DUCK_AI, viewModel.getNewTabTogglePosition())
+        }
+
+    @Test
+    fun `getNewTabTogglePosition returns SEARCH when setting is LAST_USED and last used is null`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.LAST_USED))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DefaultTogglePosition.SEARCH, viewModel.getNewTabTogglePosition())
+        }
+
+    @Test
+    fun `getNewTabTogglePosition returns DUCK_AI when setting is LAST_USED and last used is DUCK_AI`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.LAST_USED))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI.name))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DefaultTogglePosition.DUCK_AI, viewModel.getNewTabTogglePosition())
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition never called when feature flag is off`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+            whenever(queryUrlPredictor.isUrl(any())).thenReturn(false)
+
+            val viewModel = createViewModel()
+            viewModel.onSearchSubmitted("test query")
+            viewModel.onChatSelected()
+            viewModel.onChatSubmitted("test prompt")
+            viewModel.onUserSubmittedQuery("test autocomplete")
+            viewModel.userSelectedAutocomplete(AutoCompleteSuggestion.AutoCompleteDuckAIPrompt("test ai prompt"))
+            viewModel.onChatSuggestionSelected("chat-id", pinned = false)
+
+            verify(duckChat, never()).saveLastUsedTogglePosition(any())
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition called with SEARCH on search submission`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+            viewModel.onSearchSubmitted("test query")
+
+            verify(duckChat).saveLastUsedTogglePosition(DefaultTogglePosition.SEARCH.name)
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition called with DUCK_AI on chat submission`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+            whenever(queryUrlPredictor.isUrl(any())).thenReturn(false)
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatSubmitted("test prompt")
+
+            verify(duckChat).saveLastUsedTogglePosition(DefaultTogglePosition.DUCK_AI.name)
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition called with SEARCH on autocomplete selection`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+            viewModel.onUserSubmittedQuery("test query")
+
+            verify(duckChat).saveLastUsedTogglePosition(DefaultTogglePosition.SEARCH.name)
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition called with DUCK_AI on duck ai prompt autocomplete`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.userSelectedAutocomplete(AutoCompleteSuggestion.AutoCompleteDuckAIPrompt("test prompt"))
+
+            verify(duckChat).saveLastUsedTogglePosition(DefaultTogglePosition.DUCK_AI.name)
+        }
+
+    @Test
+    fun `saveLastUsedTogglePosition called with DUCK_AI on chat suggestion selected`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatSuggestionSelected("chat-id-123", pinned = false)
+
+            verify(duckChat).saveLastUsedTogglePosition(DefaultTogglePosition.DUCK_AI.name)
         }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213800808542014?focus=true

### Description
- Wires the "Default Toggle Position" setting (from the [previous PR](https://github.com/duckduckgo/Android/pull/8072)) to control the actual toggle state when opening new tabs
- New tabs respect the user's setting: Search, Duck.ai, or Last Used
- Existing tabs preserve current behavior (duck.ai domain → Duck.ai toggle, else → Search)
- Saves "last used" toggle position on any navigation submission from the input screen (search, chat, autocomplete, chat suggestions, Duck AI prompts)

### Dev notes:
- Updated the DuckChat injection in `InputScreenViewModel` to DuckChatInternal instead. As this is internal to the module so it can use the internal API which has additional functions I need. 
- All behavior is gated behind the rememberTogglePosition feature flag
- Added missed unit tests from previous PR


### Steps to test this PR
- Enable the `rememberTogglePosition` feature flag and select "Search & Duck.ai" mode
- Setting = Search: Create a new tab → verify toggle defaults to Search
- Setting = Duck.ai: Create a new tab → verify toggle defaults to Duck.ai
- Setting = Last Used: 
  - Submit a search query → create new tab → verify toggle defaults to Search.
  - Submit a chat prompt → create new tab → verify toggle defaults to Duck.ai
  - Last used updates on autocomplete: Select an autocomplete suggestion from Search mode → create new tab → verify defaults to Search
  - Last used updates on chat suggestion: Select a recent chat from Duck.ai mode → create new tab → verify defaults to Duck.ai
  - Persists across app kills: Set to Duck.ai, kill the app, reopen → create new tab → verify defaults still Duck.ai
- Existing tab behavior unchanged: No matter which setting is selected (try with multiple). Navigate to a website, tap the omnibar → verify toggle is on Search. Navigate to duck.ai, tap the omnibar → verify toggle is on Duck.ai
- FF off = no impact: verify all toggle behavior is unchanged from current production behaviour
- Toggle switch alone does not update last used. Switch between Search and Duck.ai without submitting → create new tab → verify last used is unchanged



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the input screen’s initial mode selection and adds persistence for a new "last used" toggle state, which could affect new-tab UX and preference storage (though gated behind a feature flag).
> 
> **Overview**
> **New tabs now respect the "Default Toggle Position" setting** (Search, Duck.ai, or Last Used) when launching the input screen, via a new `isNewTab` launch parameter and updated initialization logic.
> 
> Adds persistence for a **"last used" toggle position** and saves it on input-screen submissions (search, chat, autocomplete, chat suggestion/prompt actions), wiring new DataStore-backed repository APIs through `DuckChatInternal`, and expanding unit coverage for default/last-used toggle behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e28f51f22f2a2ef65015e3dbb8cee7ab9bba41b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->