### PR TITLE
Enable SyncFeature#sendSyncSetupWideEvent feature flag by default

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -78,6 +78,6 @@ interface SyncFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun recoverDataEasilySetupScreen(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun sendSyncSetupWideEvent(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1213820606846974?focus=true

### Description
Enables Sync Setup wide event collection by default.

### Steps to test this PR

No QA needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag default change with no logic modifications; primary impact is increased event collection if downstream code is gated on this toggle.
> 
> **Overview**
> Enables `SyncFeature.sendSyncSetupWideEvent` by default by changing its `@Toggle.DefaultValue` from `INTERNAL` to `TRUE`, so Sync setup wide event collection is on unless explicitly disabled remotely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54e9185ea2ed896aa89c2df0b86080d13c427df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->