### PR TITLE
Add image attachment button to native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1296,6 +1296,9 @@ class BrowserTabFragment :
                     hideKeyboard()
                     voiceSearchLauncher.launch(requireActivity(), mode)
                 },
+                onImageButtonPressed = {
+                    // To be implemented
+                },
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -49,6 +49,7 @@ class NativeInputCallbacks(
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
+    val onImageButtonPressed: () -> Unit = {},
 )
 
 interface NativeInputManager {
@@ -403,6 +404,7 @@ class RealNativeInputManager @Inject constructor(
                 setVoiceButtonVisible(true)
                 onVoiceClick = { callbacks.onVoiceSearchPressed(isChatTabSelected()) }
             }
+            onImageClick = { callbacks.onImageButtonPressed() }
         }
         bindSearchCallbacks(widgetView, callbacks)
         bindAutocompleteVisibility(widgetView)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -40,6 +40,7 @@ interface ContextualNativeInputManager {
         jsMessaging: JsMessaging,
         lifecycleOwner: LifecycleOwner,
         onSearchSubmitted: (String) -> Unit,
+        onImageButtonPressed: () -> Unit = {},
     )
 
     fun onWebViewMode()
@@ -61,12 +62,13 @@ class RealContextualNativeInputManager @Inject constructor(
         jsMessaging: JsMessaging,
         lifecycleOwner: LifecycleOwner,
         onSearchSubmitted: (String) -> Unit,
+        onImageButtonPressed: () -> Unit,
     ) {
         this.card = card
         this.jsMessaging = jsMessaging
 
         applyCardShape(card)
-        setupWidget(widget, onSearchSubmitted)
+        setupWidget(widget, onSearchSubmitted, onImageButtonPressed)
         observeNativeInputSetting(lifecycleOwner)
     }
 
@@ -90,10 +92,11 @@ class RealContextualNativeInputManager @Inject constructor(
             .build()
     }
 
-    private fun setupWidget(widget: NativeInputModeWidget, onSearchSubmitted: (String) -> Unit) {
+    private fun setupWidget(widget: NativeInputModeWidget, onSearchSubmitted: (String) -> Unit, onImageButtonPressed: () -> Unit) {
         widget.selectChatTab()
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
+        widget.onImageClick = onImageButtonPressed
         widget.bindInputEvents(
             onSearchTextChanged = { },
             onSearchSubmitted = { query ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -423,6 +423,9 @@ class DuckChatContextualFragment :
                 viewModel.onContextualClose()
                 startActivity(browserNav.openInNewTab(requireContext(), query))
             },
+            onImageButtonPressed = {
+                // To be implemented
+            },
         )
         observeViewModel()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -21,8 +21,11 @@ import android.content.Context
 import android.graphics.Color
 import android.util.AttributeSet
 import android.view.View
+import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.ImageView
 import androidx.core.net.toUri
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -58,6 +61,7 @@ interface NativeInputWidget {
     var onClearTextTapped: (() -> Unit)?
     var onStopTapped: (() -> Unit)?
     var onVoiceClick: (() -> Unit)?
+    var onImageClick: (() -> Unit)?
 
     fun focusInput(activity: Activity?)
     fun hasInputFocus(): Boolean
@@ -70,6 +74,7 @@ interface NativeInputWidget {
     fun hideMainButtons()
     fun setVoiceButtonVisible(visible: Boolean)
     fun submitMessage(message: String?)
+    fun setImageButtonVisible(visible: Boolean)
 
     fun bindInputEvents(
         onSearchTextChanged: (String) -> Unit,
@@ -116,9 +121,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     override var onStopTapped: (() -> Unit)? = null
+    override var onImageClick: (() -> Unit)? = null
+
+    private val imageButton: ImageView by lazy { findViewById(R.id.inputFieldImageButton) }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        imageButton.setOnClickListener { onImageClick?.invoke() }
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
@@ -179,6 +188,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         setBackgroundColor(Color.TRANSPARENT)
         hideBackArrow()
         hideInputFieldBackground()
+        removeMargins()
         if (duckChatInternal.isEnabled()) {
             setToggleMatchParent()
         } else {
@@ -186,6 +196,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         prepareSubmitButtons()
         configureMainButtonsVisibility()
+    }
+
+    private fun removeMargins() {
+        findViewById<EditText?>(R.id.inputField)?.updateLayoutParams<MarginLayoutParams> {
+            marginStart = 0
+        }
+        findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer)?.updateLayoutParams<MarginLayoutParams> {
+            marginEnd = 0
+        }
     }
 
     private fun prepareSubmitButtons() {
@@ -398,15 +417,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         if (streaming) {
             submitButtons?.setStopButton()
         } else {
-            submitButtons?.clearStopButton(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+            submitButtons?.clearStopButton(R.drawable.ic_arrow_up_24)
         }
     }
 
     private fun updateDuckAiSubmitButton() {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isChatTab = toggle.selectedTabPosition == 1
+        setImageButtonVisible(isChatTab)
         if (isChatTab) {
-            submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+            submitButtons?.setSendButtonIcon(R.drawable.ic_arrow_up_24)
             submitButtons?.setSendButtonVisible(true)
             if (!canExpand) {
                 inputField.minLines = 1
@@ -418,6 +438,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
             submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_find_search_24)
             submitButtons?.setSendButtonVisible(false)
         }
+    }
+
+    override fun setImageButtonVisible(visible: Boolean) {
+        imageButton.isVisible = visible
     }
 
     private fun ensureSubmitButtons() {

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -78,6 +78,8 @@
             style="@style/Widget.DuckDuckGo.OmnibarCardView"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:clipChildren="false"
+            android:clipToPadding="false"
             app:cardElevation="0dp"
             app:strokeColor="?attr/daxColorAccentBlue"
             app:strokeWidth="@dimen/omnibarOutlineWidth"
@@ -88,6 +90,8 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:clipChildren="false"
+                android:clipToPadding="false"
                 android:orientation="vertical">
 
                 <LinearLayout
@@ -147,12 +151,32 @@
                 </LinearLayout>
 
                 <FrameLayout
-                    android:id="@+id/inputScreenButtonsContainer"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_marginEnd="8dp"
-                    android:visibility="invisible" />
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
+
+                    <ImageView
+                        android:id="@+id/inputFieldImageButton"
+                        android:layout_width="@dimen/toolbarIcon"
+                        android:layout_height="@dimen/toolbarIcon"
+                        android:layout_gravity="start|center_vertical"
+                        android:background="@drawable/selectable_item_rounded_corner_background"
+                        android:importantForAccessibility="no"
+                        android:scaleType="center"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/ic_image_24"
+                        tools:visibility="visible" />
+
+                    <FrameLayout
+                        android:id="@+id/inputScreenButtonsContainer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_marginEnd="8dp"
+                        android:visibility="invisible" />
+
+                </FrameLayout>
 
             </LinearLayout>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213433888294713?focus=true

### Description

- Adds the image attachment button to the native input (no-op)
- Changes the submit button to the up arrow
- Removes margins to improve positioning

### Steps to test this PR

_With native input enabled_

- [ ] Tap the omnibar and toggle to Duck.ai
- [ ] Verify that the attach image button is visible
- [ ] Verify that the submit button is the up arrow


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI wiring: adds a new image-button callback and tweaks icons/margins without changing search/chat submission or data handling logic.
> 
> **Overview**
> Adds an **image attachment button (currently no-op)** to the native input widget and threads a new `onImageButtonPressed` callback through `NativeInputCallbacks` and the contextual/native input managers.
> 
> Updates Duck.ai native input UI by switching the submit/stop button icon to an **up arrow**, showing the new image button only on the Duck.ai tab, and adjusting layout (removing input/button container margins and allowing children to render outside card padding).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79228b6717be12937e3aa5472dfb077901b46901. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->