### PR TITLE
New browser menu: Update vpn menu item yellow pill padding

### DIFF
--- a/browser/browser-ui/src/main/res/layout/view_menu_item_vpn.xml
+++ b/browser/browser-ui/src/main/res/layout/view_menu_item_vpn.xml
@@ -60,7 +60,7 @@
         android:id="@+id/tryForFreePill"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_2"
+        android:layout_marginEnd="@dimen/keyline_4"
         android:padding="@dimen/keyline_2"
         android:text="@string/browserMenuVpnTryForFree"
         android:visibility="gone"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1213813587575791?focus=true

### Description
Fix VPN menu item yellow pill alignment in the new browser menu

### Steps to test this PR
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Fresh install
- [x] Enable new experiment browser menu in Settings > Appearance
- [x] Check VPN menu item yellow pill is aligned to horizontal divider

### UI changes
| Before  | After |
| ------ | ----- |
<img height="846" alt="Screenshot 2026-03-26 at 14 23 28" src="https://github.com/user-attachments/assets/4864421a-5c2f-43b1-aebf-e22c17990804" />|<img width="382" height="846" alt="Screenshot 2026-03-26 at 14 23 28" src="https://github.com/user-attachments/assets/3df51cbe-2693-428a-8b35-9ef6a3d5c059" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak that only changes spacing for the VPN menu item pill; no logic or data flow is affected.
> 
> **Overview**
> Adjusts the VPN browser menu item layout so the `tryForFreePill` (yellow pill) aligns with the horizontal divider by increasing its end margin from `@dimen/keyline_2` to `@dimen/keyline_4` in `view_menu_item_vpn.xml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ba816696c7dbd55ebbb34e31059c288862b0ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->