### PR TITLE
Fire original popup menu pixels from the bottom sheet menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1826,6 +1826,7 @@ class BrowserTabFragment :
     }
 
     private fun launchBottomSheetMenu(addExtraDelay: Boolean) {
+        val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
         val delay = if (addExtraDelay) BOTTOM_SHEET_MENU_DELAY * 2 else BOTTOM_SHEET_MENU_DELAY
         // small delay added to let keyboard disappear and avoid jarring transition
         binding.rootView.postDelayed(delay) {
@@ -1846,6 +1847,7 @@ class BrowserTabFragment :
                 } else {
                     pixel.fire(AppPixelName.EXPERIMENTAL_MENU_DISPLAYED)
                 }
+                fireMenuOpenedPixels(isFocusedNtp, viewState)
             }
         }
     }
@@ -1874,21 +1876,25 @@ class BrowserTabFragment :
                     popupMenu?.show(binding.rootView, omnibar.toolbar)
                 }
                 viewModel.onPopupMenuLaunched()
-                if (isActiveCustomTab()) {
-                    pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
-                } else if (omnibar.viewMode == ViewMode.DuckAI) {
-                    pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_MENU_OPEN.pixelName)
-                } else {
-                    val vpnStatus = currentViewState?.vpnMenuState?.pixelParam.toString()
-                    val params = mapOf(
-                        PixelParameter.FROM_FOCUSED_NTP to isFocusedNtp.toString(),
-                        PixelParameter.STATUS to vpnStatus,
-                    )
-                    pixel.fire(AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName, params)
-                    pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_MENU_OPENED.pixelName)
-                    pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_MENU_OPENED_DAILY.pixelName, type = Daily())
-                }
+                fireMenuOpenedPixels(isFocusedNtp, currentViewState)
             }
+        }
+    }
+
+    private fun fireMenuOpenedPixels(isFocusedNtp: Boolean, viewState: BrowserViewState?) {
+        if (isActiveCustomTab()) {
+            pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
+        } else if (omnibar.viewMode == ViewMode.DuckAI) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_MENU_OPEN.pixelName)
+        } else {
+            val vpnStatus = viewState?.vpnMenuState?.pixelParam.toString()
+            val params = mapOf(
+                PixelParameter.FROM_FOCUSED_NTP to isFocusedNtp.toString(),
+                PixelParameter.STATUS to vpnStatus,
+            )
+            pixel.fire(AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName, params)
+            pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_MENU_OPENED.pixelName)
+            pixel.fire(AppPixelName.PRODUCT_TELEMETRY_SURFACE_MENU_OPENED_DAILY.pixelName, type = Daily())
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213821484521605?focus=true 

### Description

Fire original popup menu pixels from the bottom sheet browser menu to maintain backward compatibility with existing Grafana dashboards.

### Steps to test this PR

_Bottom sheet menu pixels on NTP_
- [x] Open a new tab and open the browser menu
- [x] Verify in logcat that both `m_experimental-browsing-menu_displayed_ntp` and `m_nav_pm_o` fire

_Bottom sheet menu pixels on a webpage_
- [x] Navigate to any webpage and open the browser menu
- [x] Verify in logcat that both `m_experimental-browsing-menu_displayed` and `m_nav_pm_o` fire
- [x] Verify `m_product_telemetry_surface_usage_menu` fires

_Bottom sheet menu in Duck.ai_
- [x] Open Duck.ai and open the browser menu
- [x] Verify in logcat that both `m_experimental-browsing-menu_displayed_aichat` and `m_duck-chat_settings-menu-open` fire

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to analytics/pixel firing when opening browser menus, with no functional UI or navigation behavior changes.
> 
> **Overview**
> Ensures the bottom sheet browser menu fires the same *menu-opened* pixels as the classic popup menu to preserve backwards compatibility for existing dashboards.
> 
> Refactors menu-open pixel logic into `fireMenuOpenedPixels` and calls it from both `launchBottomSheetMenu` and `launchPopupMenu`, including passing the focused-NTP and VPN status params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71cc4bb96b8a398ee5a3df0a4dd4dda788eb2c4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->