### PR TITLE
VPN menu item: Show 'Try for Free' pill only for eligible users

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
@@ -59,7 +59,7 @@ class VpnMenuStateProviderImpl @Inject constructor(
                 // User has subscription but no NetP entitlement
                 subscriptionStatus.isActive() -> VpnMenuState.Hidden
                 else -> {
-                    if (vpnMenuStore.canShowVpnMenuForNotSubscribed()) {
+                    if (vpnMenuStore.canShowVpnMenuForNotSubscribed() && subscriptions.isFreeTrialEligible()) {
                         VpnMenuState.NotSubscribed
                     } else {
                         VpnMenuState.NotSubscribedNoPill

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
@@ -64,12 +64,13 @@ class VpnMenuStateProviderTest {
     private lateinit var testee: VpnMenuStateProviderImpl
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         whenever(androidBrowserConfigFeature.vpnMenuItem()).thenReturn(vpnMenuItemToggle)
         whenever(androidBrowserConfigFeature.vpnMenuItemInternational()).thenReturn(vpnMenuItemInternationalToggle)
         whenever(vpnMenuItemToggle.isEnabled()).thenReturn(true)
         whenever(vpnMenuItemInternationalToggle.isEnabled()).thenReturn(true)
         whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(true)
+        whenever(subscriptions.isFreeTrialEligible()).thenReturn(true)
         testee = VpnMenuStateProviderImpl(
             subscriptions,
             networkProtectionState,
@@ -329,6 +330,22 @@ class VpnMenuStateProviderTest {
             whenever(connectionState.isConnected()).thenReturn(false)
             whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
             whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(false)
+
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribedNoPill, state)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when user not subscribed and not free trial eligible then return NotSubscribedNoPill`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            whenever(subscriptions.isFreeTrialEligible()).thenReturn(false)
 
             testee.getVpnMenuState().test {
                 val state = awaitItem()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1213813587575801?focus=true

### Description
Update logic to show 'Try for Free' VPN menu item pill to eligible users

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_No eligible users_
- [x] Fresh install
- [x] Skip onbaording
- [x] Open menu in New Tab Page
- [x] Check VPN menu item doesn't have 'Try For Free' label

_Eligible users_
- [x] Open Play Billing Lab App
- [x] Go to configuration Settings > Edit
- [x] Check 'Test free trial or introductory offer
- [x] Go back to the app
- [x] Open overflow menu in New Tab Page
- [x] Check 'Try for Free' pill is visible

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens the conditions for showing the non-subscribed VPN promo pill and updates unit tests accordingly, with no changes to subscription entitlement or connection logic.
> 
> **Overview**
> **Changes VPN menu state logic** so the non-subscribed VPN menu item (the “Try for Free” pill) is shown only when both the existing frequency-cap check passes *and* `subscriptions.isFreeTrialEligible()` is true; otherwise it falls back to `NotSubscribedNoPill`.
> 
> **Updates tests** to mock `isFreeTrialEligible()` by default and adds coverage for the new “not free-trial eligible” case (and keeps the frequency-cap/no-pill behavior verified).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d3ee77f235d3e959087de47b45bc6b663caa5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->