### PR TITLE
Fix: String mismatch that broke the build

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Да изтрием ли раздели, данни от сайтове и чатове?</string>
     <string name="singleTabFireDialogDeleteAll">Изтриване на всички</string>
     <string name="singleTabFireDialogDeleteThisTab">Изтриване на този раздел</string>
-    <string name="singleTabFireDialogDeleteChat">Изтриване на чата</string>
-    <string name="singleTabFireDialogTitleDuckAi">Да бъде ли изтрит този чат?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Изтриване на този чат</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">„Изтриване на всички“ няма да изтрие историята на чатовете в Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Изтриването на данни от сайта може да те отпише от акаунтите.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Това ще отмени текущите изтегляния.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Vymazat karty, data stránek a chaty?</string>
     <string name="singleTabFireDialogDeleteAll">Smazat vše</string>
     <string name="singleTabFireDialogDeleteThisTab">Vymazat tuto kartu</string>
-    <string name="singleTabFireDialogDeleteChat">Smazat chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Smazat tento chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Smazat tento chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Příkaz „Smazat vše“ nesmaže tvoji historii chatu na Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Když vymažeš data stránek, může dojít ke tvému odhlášení z účtů.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tím se zruší probíhající stahování.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Slet faner, webstedsdata og chats?</string>
     <string name="singleTabFireDialogDeleteAll">Slet alle</string>
     <string name="singleTabFireDialogDeleteThisTab">Slet denne fane</string>
-    <string name="singleTabFireDialogDeleteChat">Slet chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Slet denne chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Slet denne chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Slet alle\" sletter ikke din Duck.ai-chathistorik.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Sletning af webstedsdata kan logge dig ud af konti.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dette annullerer igangværende downloads.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Tabs, Seitendaten und Chats löschen?</string>
     <string name="singleTabFireDialogDeleteAll">Alle löschen</string>
     <string name="singleTabFireDialogDeleteThisTab">Diesen Tab löschen</string>
-    <string name="singleTabFireDialogDeleteChat">Chat löschen</string>
-    <string name="singleTabFireDialogTitleDuckAi">Diesen Chat löschen?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Diesen Chat löschen</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Mit „Alle löschen“ wird dein Duck.ai-Chatverlauf nicht gelöscht.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Das Löschen von Website-Daten kann dazu führen, dass du aus deinen Konten abgemeldet wirst.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dadurch werden bereits gestartete Downloads abgebrochen.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Διαγραφή καρτελών, δεδομένων ιστότοπου και συνομιλιών;</string>
     <string name="singleTabFireDialogDeleteAll">Διαγραφή όλων</string>
     <string name="singleTabFireDialogDeleteThisTab">Διαγραφή αυτής της καρτέλας</string>
-    <string name="singleTabFireDialogDeleteChat">Διαγραφή συνομιλίας</string>
-    <string name="singleTabFireDialogTitleDuckAi">Διαγραφή αυτής της συνομιλίας;</string>
+    <string name="singleTabFireDialogDeleteThisChat">Διαγραφή αυτής της συνομιλίας</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Η επιλογή «Διαγραφή όλων» δεν θα διαγράψει το ιστορικό συνομιλιών σας στο Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Η διαγραφή δεδομένων ιστότοπου μπορεί να σας αποσυνδέσει από τους λογαριασμούς.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Αυτό θα ακυρώσει λήψεις που βρίσκονται σε εξέλιξη.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">¿Eliminar pestañas, datos del sitio y chats?</string>
     <string name="singleTabFireDialogDeleteAll">Eliminar todo</string>
     <string name="singleTabFireDialogDeleteThisTab">Eliminar esta pestaña</string>
-    <string name="singleTabFireDialogDeleteChat">Borrar chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">¿Borrar este chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Borrar este chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">«Eliminar todo» no borrará tu historial de chat de Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Eliminar datos del sitio puede hacer que cierres sesión en tus cuentas.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Esta acción cancelará las descargas en curso.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Kas kustutada vahekaardid, saidi andmed ja vestlused?</string>
     <string name="singleTabFireDialogDeleteAll">Kustuta kõik</string>
     <string name="singleTabFireDialogDeleteThisTab">Kustuta see vahekaart</string>
-    <string name="singleTabFireDialogDeleteChat">Kustuta vestlus</string>
-    <string name="singleTabFireDialogTitleDuckAi">Kustutada see vestlus?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Kustuta see vestlus</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">„Kustuta kõik” ei kustuta su Duck.ai vestlusajalugu.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Saidi andmete kustutamine võib sind kontodelt välja logida.</string>
     <string name="singleTabFireDialogSubtitleDownloads">See tühistab pooleliolevad allalaadimised.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Poistetaanko välilehdet, sivuston tiedot ja keskustelut?</string>
     <string name="singleTabFireDialogDeleteAll">Poista kaikki</string>
     <string name="singleTabFireDialogDeleteThisTab">Poista tämä välilehti</string>
-    <string name="singleTabFireDialogDeleteChat">Poista keskustelu</string>
-    <string name="singleTabFireDialogTitleDuckAi">Poistetaanko tämä keskustelu?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Poista tämä keskustelu</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Poista kaikki\" ei poista Duck.ai-keskusteluhistoriaasi.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Sivustotietojen poistaminen voi kirjata sinut ulos tileiltä.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tämä peruuttaa käynnissä olevat lataukset.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Supprimer les onglets, les données du site et les discussions ?</string>
     <string name="singleTabFireDialogDeleteAll">Tout supprimer</string>
     <string name="singleTabFireDialogDeleteThisTab">Supprimer cet onglet</string>
-    <string name="singleTabFireDialogDeleteChat">Supprimer la discussion</string>
-    <string name="singleTabFireDialogTitleDuckAi">Supprimer cette discussion ?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Supprimer cette discussion</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">« Tout supprimer » ne supprimera pas l\'historique de vos discussions Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">La suppression des données de site peut vous déconnecter des comptes.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Cela annulera les téléchargements en cours.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Izbrisati kartice, podatke mrežne lokacije i čavrljanja?</string>
     <string name="singleTabFireDialogDeleteAll">Izbriši sve</string>
     <string name="singleTabFireDialogDeleteThisTab">Izbriši ovu karticu</string>
-    <string name="singleTabFireDialogDeleteChat">Izbriši čavrljanje</string>
-    <string name="singleTabFireDialogTitleDuckAi">Izbrisati ovo čavrljanje?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Izbriši ovo čavrljanje</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Izbriši sve\" neće izbrisati tvoju Duck.ai povijest čavrljanja.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Brisanje podataka mrežnih lokacija može te odjaviti s računa.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Ovo će otkazati preuzimanja u tijeku.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Törlöd a lapokat, a webhelyadatokat és a csevegéseket?</string>
     <string name="singleTabFireDialogDeleteAll">Összes törlése</string>
     <string name="singleTabFireDialogDeleteThisTab">Lap törlése</string>
-    <string name="singleTabFireDialogDeleteChat">Csevegés törlése</string>
-    <string name="singleTabFireDialogTitleDuckAi">Csevegés törlése?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Csevegés törlése</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Az „Összes törlése” lehetőség választása esetén a Duck.ai csevegési előzményei nem törlődnek.</string>
     <string name="singleTabFireDialogSubtitleSiteData">A webhelyadatok törlése kijelentkeztethet a fiókjaidból.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Ez megszakítja a folyamatban lévő letöltéseket.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Eliminare schede, dati del sito e chat?</string>
     <string name="singleTabFireDialogDeleteAll">Elimina tutto</string>
     <string name="singleTabFireDialogDeleteThisTab">Elimina questa scheda</string>
-    <string name="singleTabFireDialogDeleteChat">Elimina chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Eliminare questa chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Elimina questa chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Elimina tutto\" non elimina la cronologia chat di Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">L\'eliminazione dei dati del sito può comportare la disconnessione dagli account.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Questa operazione annullerà i download in corso.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Ištrinti skirtukus, svetainės duomenis ir pokalbius?</string>
     <string name="singleTabFireDialogDeleteAll">Ištrinti viską</string>
     <string name="singleTabFireDialogDeleteThisTab">Ištrink šį skirtuką</string>
-    <string name="singleTabFireDialogDeleteChat">Ištrinti pokalbį</string>
-    <string name="singleTabFireDialogTitleDuckAi">Ištrinti šį pokalbį?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Ištrinti šį pokalbį</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">„Ištrinti viską“ neištrins tavo „Duck.ai“ pokalbių istorijos.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Ištrynus svetainės duomenis, galite būti atjungti nuo paskyrų.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tai atšauks vykdomus atsisiuntimus.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -267,8 +267,8 @@
     <string name="singleTabFireDialogTitleWithChats">Vai dzēst cilnes, vietnes datus un tērzēšanas sarunas?</string>
     <string name="singleTabFireDialogDeleteAll">Dzēst visus</string>
     <string name="singleTabFireDialogDeleteThisTab">Dzēst šo cilni</string>
-    <string name="singleTabFireDialogDeleteChat">Dzēst tērzēšanas sarunu</string>
-    <string name="singleTabFireDialogTitleDuckAi">Dzēst šo tērzēšanas sarunu?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Dzēst šo tērzēšanas sarunu</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Dzēst visu\" neizdzēsīs tavu Duck.ai tērzēšanas vēsturi.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Dzēšot vietnes datus, tu vari tikt izrakstīts no kontiem.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tas atcels notiekošās lejupielādes.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Vil du slette faner, nettstedsdata og chatter?</string>
     <string name="singleTabFireDialogDeleteAll">Slett alt</string>
     <string name="singleTabFireDialogDeleteThisTab">Slett denne fanen</string>
-    <string name="singleTabFireDialogDeleteChat">Slett chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Vil du slette denne chatten?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Slett denne chatten</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">«Slett alt» sletter ikke Duck.ai-chattehistorikken din.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Hvis du sletter nettstedsdata, kan du bli logget ut av kontoer.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dette avbryter pågående nedlastinger.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Tabbladen, sitegegevens en chats verwijderen?</string>
     <string name="singleTabFireDialogDeleteAll">Alles verwijderen</string>
     <string name="singleTabFireDialogDeleteThisTab">Dit tabblad verwijderen</string>
-    <string name="singleTabFireDialogDeleteChat">Chat verwijderen</string>
-    <string name="singleTabFireDialogTitleDuckAi">Deze chat verwijderen?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Deze chat verwijderen</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Als je \'Alles verwijderen\' kiest, wordt je Duck.ai-chatgeschiedenis niet verwijderd.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Als je sitegegevens verwijdert, kun je uitloggen bij je accounts.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Hiermee worden lopende downloads geannuleerd.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Usunąć karty, dane witryny i czaty?</string>
     <string name="singleTabFireDialogDeleteAll">Usuń wszystko</string>
     <string name="singleTabFireDialogDeleteThisTab">Usuń tę kartę</string>
-    <string name="singleTabFireDialogDeleteChat">Usuń czat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Usunąć ten czat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Usuń ten czat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Opcja „Usuń wszystkie” nie usunie Twojej historii czatów Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Usunięcie danych witryny może spowodować wylogowanie z kont.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Spowoduje to anulowanie trwającego pobierania.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Eliminar separadores, dados do site e chats?</string>
     <string name="singleTabFireDialogDeleteAll">Eliminar tudo</string>
     <string name="singleTabFireDialogDeleteThisTab">Eliminar este separador</string>
-    <string name="singleTabFireDialogDeleteChat">Eliminar conversa</string>
-    <string name="singleTabFireDialogTitleDuckAi">Eliminar esta conversa?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Eliminar esta conversa</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">“Apagar tudo” não apagará o histórico de conversas do Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Eliminar dados do site pode terminar a tua sessão nas contas.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Esta ação vai cancelar as transferências em curso.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -267,8 +267,8 @@
     <string name="singleTabFireDialogTitleWithChats">Dorești să ștergi filele, datele site-ului și chaturile?</string>
     <string name="singleTabFireDialogDeleteAll">Șterge toate</string>
     <string name="singleTabFireDialogDeleteThisTab">Șterge această filă</string>
-    <string name="singleTabFireDialogDeleteChat">Șterge chatul</string>
-    <string name="singleTabFireDialogTitleDuckAi">Ștergi acest chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Șterge acest chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">„Șterge tot” nu va șterge istoricul chaturilor tale Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Ștergerea datelor de pe site te poate deconecta de la conturi.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Aceasta va anula descărcările în desfășurare.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Удалить вкладки, данные сайта и чаты?</string>
     <string name="singleTabFireDialogDeleteAll">Удалить все</string>
     <string name="singleTabFireDialogDeleteThisTab">Удалить эту вкладку</string>
-    <string name="singleTabFireDialogDeleteChat">Удалить чат</string>
-    <string name="singleTabFireDialogTitleDuckAi">Удалить этот чат?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Удалить этот чат</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Функция «Удалить все» не стирает историю чатов с Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Удаление данных сайтов может сопровождаться выходом из учетных записей.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Текущие загрузки будут отменены.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Odstrániť karty, údaje stránok a chaty?</string>
     <string name="singleTabFireDialogDeleteAll">Odstrániť všetko</string>
     <string name="singleTabFireDialogDeleteThisTab">Vymazať túto záložku</string>
-    <string name="singleTabFireDialogDeleteChat">Zmazať chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Zmazať tento chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Zmazať tento čet</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Možnosť „Odstrániť všetko“ neodstráni tvoju históriu četu na Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Odstránením údajov z webových stránok sa môžeš odhlásiť z účtov.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tým sa zrušia prebiehajúce sťahovania.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -271,8 +271,8 @@
     <string name="singleTabFireDialogTitleWithChats">Izbrisati zavihke, podatke spletnega mesta in klepete?</string>
     <string name="singleTabFireDialogDeleteAll">Izbriši vse</string>
     <string name="singleTabFireDialogDeleteThisTab">Izbriši ta zavihek</string>
-    <string name="singleTabFireDialogDeleteChat">Izbriši klepet</string>
-    <string name="singleTabFireDialogTitleDuckAi">Želite izbrisati ta klepet?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Izbriši ta klepet</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">»Izbriši vse« ne bo izbrisalo vaše zgodovine klepetov na Duck.ai.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Brisanje podatkov o spletnem mestu vas lahko odjavi iz računov.</string>
     <string name="singleTabFireDialogSubtitleDownloads">S tem boste preklicali prenose v teku.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Vill du ta bort flikar, webbplatsdata och chattar?</string>
     <string name="singleTabFireDialogDeleteAll">Radera allt</string>
     <string name="singleTabFireDialogDeleteThisTab">Ta bort denna flik</string>
-    <string name="singleTabFireDialogDeleteChat">Radera chatt</string>
-    <string name="singleTabFireDialogTitleDuckAi">Radera den här chatten?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Radera den här chatten</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">Din Duck.ai-chatthistorik raderas inte om du väljer Radera alla.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Om du tar bort webbplatsdata kan du loggas ut från konton.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Detta kommer att avbryta pågående nerladdningar.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -263,8 +263,8 @@
     <string name="singleTabFireDialogTitleWithChats">Sekmeleri, site verilerini ve sohbetleri silmek mi istiyorsunuz?</string>
     <string name="singleTabFireDialogDeleteAll">Tümünü Sil</string>
     <string name="singleTabFireDialogDeleteThisTab">Bu Sekmeyi Sil</string>
-    <string name="singleTabFireDialogDeleteChat">Sohbeti Sil</string>
-    <string name="singleTabFireDialogTitleDuckAi">Bu sohbet silinsin mi?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Bu Sohbeti Sil</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Tümünü Sil\" seçeneği Duck.ai sohbet geçmişini silmeyecek.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Site verilerini silmek, hesaplarınızdan çıkış yapmanıza neden olabilir.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Bu işlem devam eden indirmeleri iptal edecektir.</string>
     <plurals name="tabsClearedSnackbarMessage">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,8 +262,8 @@
     <string name="singleTabFireDialogTitleWithChats">Delete tabs, site data, and chats?</string>
     <string name="singleTabFireDialogDeleteAll">Delete All</string>
     <string name="singleTabFireDialogDeleteThisTab">Delete This Tab</string>
-    <string name="singleTabFireDialogDeleteChat">Delete Chat</string>
-    <string name="singleTabFireDialogTitleDuckAi">Delete this chat?</string>
+    <string name="singleTabFireDialogDeleteThisChat">Delete This Chat</string>
+    <string name="singleTabFireDialogSubtitleDuckAi">\"Delete All\" will not delete your Duck.ai chat history.</string>
     <string name="singleTabFireDialogSubtitleSiteData">Deleting site data can sign you out of accounts.</string>
     <string name="singleTabFireDialogSubtitleDownloads">This will cancel downloads in progress.</string>
     <plurals name="tabsClearedSnackbarMessage">


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1213823667721707?focus=true

### Description

This reverts #8096, because of the string mismatch that didn't show up in the PR.

### Steps to test this PR

QA-optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Android string resource keys used by UI code; a mismatch would fail compilation or show incorrect text, but the change is localized to resource definitions only.
> 
> **Overview**
> Fixes a build-breaking string mismatch by **renaming/removing Duck.ai single-tab fire dialog string keys** across `values` and many localized `strings.xml` files.
> 
> Adds the new `singleTabFireDialogSubtitleDuckAi` message (explaining that "Delete All" doesn’t clear Duck.ai history) and standardizes the delete-chat label to `singleTabFireDialogDeleteThisChat`, while removing the old `singleTabFireDialogDeleteChat` and `singleTabFireDialogTitleDuckAi` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9064d72b4abe65502c74f4510c1f916e3e819fd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->