### PR TITLE
PIR: Add additional params for foreground pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1208,6 +1208,11 @@
                 "key": "profile_queries",
                 "description": "The number of profile queries used in the scan",
                 "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -99,10 +99,12 @@ interface PirPixelSender {
      *
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      * @param profileQueryCount - the number of profile queries used in the scan
+     * @param brokerCount - the number of active brokers at the start of the scan
      */
     fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
+        brokerCount: Int,
     )
 
     /**
@@ -619,10 +621,12 @@ class RealPirPixelSender @Inject constructor(
     override fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
+        brokerCount: Int,
     ) {
         val params = mapOf(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
+            PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
         )
         fire(PIR_FOREGROUND_RUN_STARTED, params)
     }
@@ -1519,6 +1523,7 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_BATTERY_OPTIMIZATIONS = "battery-optimizations"
         private const val PARAM_KEY_TOTAL_SCAN = "total_scan"
         private const val PARAM_KEY_TOTAL_OPTOUT = "total_optout"
+        private const val PARAM_KEY_BROKER_COUNT = "broker_count"
         private const val PARAM_KEY_TRACKER_BLOCKING = "tracker_blocking_state"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -77,7 +77,8 @@ class RealPirJobsRunner @Inject constructor(
 
         // Multiple profile support (includes deprecated profiles as we need to process opt-out for them if there are extracted profiles)
         val profileQueries = obtainProfiles()
-        emitStartPixel(context, executionType, profileQueries.size)
+        val activeBrokers = pirRepository.getAllActiveBrokers().toHashSet()
+        emitStartPixel(context, executionType, profileQueries.size, activeBrokers.size)
 
         // Clean up any already running scan jobs before starting new ones as this function can be called
         // while previous instance is still running in case of profile edits.
@@ -89,8 +90,6 @@ class RealPirJobsRunner @Inject constructor(
         // and creating opt-out jobs for them, which we don't want.
         // We only want to continue running opt-outs and confirmation scans for extracted profiles that were found up until the point of profile edit.
         pirScan.stop()
-
-        val activeBrokers = pirRepository.getAllActiveBrokers().toHashSet()
 
         if (profileQueries.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No profile queries available. Completing run." }
@@ -154,12 +153,13 @@ class RealPirJobsRunner @Inject constructor(
         context: Context,
         executionType: PirExecutionType,
         profileQueryCount: Int,
+        brokerCount: Int,
     ) {
         if (executionType == MANUAL) {
             val isPowerSavingEnabled = runCatching {
                 (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
             }.getOrDefault(false)
-            pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount)
+            pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount)
         } else {
             pixelSender.reportScheduledScanStarted()
         }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -46,7 +46,7 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportManualScanStartedThenFiresPixelWithPowerSavingParam() = runTest {
-        testee.reportManualScanStarted(isPowerSavingEnabled = true, profileQueryCount = 3)
+        testee.reportManualScanStarted(isPowerSavingEnabled = true, profileQueryCount = 3, brokerCount = 10)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender, times(2)).fire(
@@ -60,6 +60,8 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["power_saving"] == "true")
         assert(paramsCaptor.firstValue.containsKey("profile_queries"))
         assert(paramsCaptor.firstValue["profile_queries"] == "3")
+        assert(paramsCaptor.firstValue.containsKey("broker_count"))
+        assert(paramsCaptor.firstValue["broker_count"] == "10")
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -162,7 +162,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
@@ -183,7 +183,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         assertTrue(result.isSuccess)
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -203,7 +203,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
@@ -253,7 +253,7 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
@@ -304,7 +304,7 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(0L, 2)
@@ -482,7 +482,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirScan).stop()
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
@@ -634,7 +634,7 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213818964638875?focus=true 

### Description
See attached taskd description

### Steps to test this PR

_Feature 1_
- [x] Filter “PIR-LOGGING:"
- [x] Start scan
- [x] Verify that `m_dbp_foreground-run_started` is emitted with `profile_queries` set to how much profiles you have
- [x] Wait for scan to complete
- [x] Verify that `m_dbp_foreground-run_completed` is emitted with `total_scan` and `total_optout` set to a reasonable number


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes foreground-run telemetry payloads and alters job-runner behavior when no user profiles exist (no longer falling back to default profile queries), which can affect when scans/opt-outs execute and what metrics are reported.
> 
> **Overview**
> Adds new parameters to PIR foreground run pixels: `m_dbp_foreground-run_started` now includes `profile_queries` and `broker_count`, and `m_dbp_foreground-run_completed` includes `total_scan` and `total_optout` (with matching updates to `PirPixelSender`/`RealPirPixelSender` and pixel definitions).
> 
> Updates `RealPirJobsRunner` to compute and pass these counts by returning the number of eligible scan/opt-out jobs executed, and changes empty-profile handling to **finish early** when `getAllUserProfileQueries()` is empty instead of using `DEFAULT_PROFILE_QUERIES`; tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6c4bdb513d533422d9a3e3864d453da30140786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->