### PR TITLE
Add default toggle position for new and existing users

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -341,6 +342,7 @@ class RealDuckChat @Inject constructor(
     private val duckChatSyncRepository: DuckChatSyncRepository,
     private val syncEngine: SyncEngine,
     private val duckAiHostProvider: DuckAiHostProvider,
+    private val appBuildConfig: AppBuildConfig,
 ) : DuckChatInternal,
     DuckAiFeatureState,
     PrivacyConfigCallbackPlugin {
@@ -905,6 +907,11 @@ class RealDuckChat @Inject constructor(
                     .isEnabled() && duckChatFeatureRepository.isAutomaticPageContextAttachmentUserSettingEnabled()
 
             areMultipleContentAttachmentsEnabled = isContextualModeEnabled && duckChatFeature.supportsMultipleContexts().isEnabled()
+
+            if (duckChatFeature.rememberTogglePosition().isEnabled() && duckChatFeatureRepository.getDefaultTogglePosition() == null) {
+                val default = if (appBuildConfig.isNewInstall()) DefaultTogglePosition.LAST_USED else DefaultTogglePosition.SEARCH
+                duckChatFeatureRepository.setDefaultTogglePosition(default.name)
+            }
         }
 
     companion object {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -108,6 +109,7 @@ class RealDuckChatTest {
     private val mockDuckChatSyncRepository: DuckChatSyncRepository = mock()
     private val mockSyncEngine: SyncEngine = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
+    private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private lateinit var testee: RealDuckChat
 
@@ -149,6 +151,7 @@ class RealDuckChatTest {
                 mockDuckChatSyncRepository,
                 mockSyncEngine,
                 mockDuckAiHostProvider,
+                mockAppBuildConfig,
             ),
         )
         coroutineRule.testScope.advanceUntilIdle()
@@ -1578,5 +1581,55 @@ class RealDuckChatTest {
         val result = testee.observeLastUsedTogglePosition().first()
 
         assertEquals("SEARCH", result)
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when new user then default toggle position is set to LAST_USED`() = runTest {
+        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        verify(mockDuckChatFeatureRepository).setDefaultTogglePosition(DefaultTogglePosition.LAST_USED.name)
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when existing user then default toggle position is set to SEARCH`() = runTest {
+        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        verify(mockDuckChatFeatureRepository).setDefaultTogglePosition(DefaultTogglePosition.SEARCH.name)
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when default toggle position already set then do not overwrite`() = runTest {
+        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn("DUCK_AI")
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        verify(mockDuckChatFeatureRepository, never()).setDefaultTogglePosition(any())
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when feature flag off then default toggle position is not set`() = runTest {
+        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+        whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        verify(mockDuckChatFeatureRepository, never()).setDefaultTogglePosition(any())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213800808542015?focus=true 

### Description

- New users (installed today) default to "Last Used" for the toggle position setting
- Existing users (installed before today) default to "Search" (preserving current behaviour)
- Detection runs once at app startup in cacheUserSettings(). If no default is stored yet, checks daysSinceInstalled() to determine user type and persists the appropriate default
- Includes a workaround for a race condition where the install timestamp may not be recorded yet, causing daysSinceInstalled() to return days since epoch (~20,000). Values outside a valid range (1 to days-since-epoch minus 1 year buffer) are treated as new users.
- All gated behind the rememberTogglePosition feature flag

### Steps to test this PR                       
- Existing install (1 day or more ago) --> enable FF --> verify setting defaults to "Search"
- Fresh instal -> enable FF --> verify setting defaults to "Last Used"                                              
- Change the setting manually → kill app → verify it persists and is not overwritten on next launch                   


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: gated behind `rememberTogglePosition` and only initializes a missing preference, but it changes startup-time settings initialization and could affect default UX if the install-type check is wrong.
> 
> **Overview**
> Adds one-time initialization of the Duck.ai input-mode default toggle position during `cacheUserSettings()`.
> 
> When `rememberTogglePosition` is enabled and no default is stored, the app now sets the default to `LAST_USED` for new installs and `SEARCH` for existing installs (using `AppBuildConfig.isNewInstall()`), and avoids overwriting if already set. Tests were updated to inject `AppBuildConfig` and cover the new initialization/guard cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f77f45bf6ed69bf3583932ed9bbbc33b81706bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->