### PR TITLE
Sanitize intent fallback URLs to prevent javascript execution.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -212,7 +212,7 @@ class SpecialUrlDetectorImpl(
                     androidBrowserConfigFeature.validateIntentResolution().isEnabled()
                 ) {
                     // If the intent has a fallback URL, still return NonHttpAppLink so the caller can use the fallback
-                    val fallbackUrl = intent?.getStringExtra(EXTRA_FALLBACK_URL)
+                    val fallbackUrl = sanitizeFallbackUrl(intent?.getStringExtra(EXTRA_FALLBACK_URL))
                     if (fallbackUrl != null && appSchemeInterceptionFeature.self().isEnabled()) {
                         if (externalAppIntentFlagsFeature.self().isEnabled()) {
                             intent.addCategory(Intent.CATEGORY_BROWSABLE)
@@ -234,7 +234,7 @@ class SpecialUrlDetectorImpl(
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }
 
-                val fallbackUrl = intent.getStringExtra(EXTRA_FALLBACK_URL)
+                val fallbackUrl = sanitizeFallbackUrl(intent.getStringExtra(EXTRA_FALLBACK_URL))
                 val fallbackIntent = buildFallbackIntent(fallbackUrl)
                 UrlType.NonHttpAppLink(uriString = uriString, intent = intent, fallbackUrl = fallbackUrl, fallbackIntent = fallbackIntent)
             } catch (e: URISyntaxException) {
@@ -249,6 +249,12 @@ class SpecialUrlDetectorImpl(
         }
 
         return UrlType.SearchQuery(uriString)
+    }
+
+    private fun sanitizeFallbackUrl(fallbackUrl: String?): String? {
+        if (fallbackUrl == null) return null
+        val scheme = Uri.parse(fallbackUrl).scheme?.lowercase() ?: return null
+        return if (scheme == HTTP_SCHEME || scheme == HTTPS_SCHEME) fallbackUrl else null
     }
 
     private fun buildFallbackIntent(fallbackUrl: String?): Intent? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213822170345436?focus=true

### Description
The browser blocks direct `javascript:` navigations in normal URL handling, but the same payload can still execute via `intent://...#Intent;S.browser_fallback_url=...;end`.

When a non-HTTP app link fails to resolve, the app loads `browser_fallback_url` directly with `webView.loadUrl(fallbackUrl, headers)` without scheme validation. This allows `javascript:` fallback URLs to execute.

This is a scheme-validation bypass. In high-impact contexts, it can become UXSS-like script execution on a trusted origin if an attacker can inject a clickable `intent://` link into that origin.

I propose we sanitize these fallback URLs to prevent script execution.

### Steps to test this PR
1. visit https://tespach.duck.co/poc/android-js-intent.html
2. ensure no alert box appears when button is tapped

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches intent/app-link handling and changes when `browser_fallback_url` is honored, which could affect deep-link fallback behavior. The change is small and constrained, but in a security-sensitive URL loading path.
> 
> **Overview**
> Prevents `intent://` links from using non-web `browser_fallback_url` values by sanitizing fallback URLs to only allow `http`/`https` schemes before they are returned in `UrlType.NonHttpAppLink`.
> 
> This blocks `javascript:` (and other non-HTTP) fallback navigation paths when an intent cannot be resolved, reducing the risk of script execution via intent fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d16f5009ef8105ec2d0830e7d88ebbf5e8cd80f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->