### PR TITLE
Add pixels for tracking default toggle position

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -371,5 +371,32 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_aichat_settings_default_toggle_position_changed": {
+        "description": "User changed the default toggle position setting in AI Features settings",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            { "key": "value", "type": "string", "description": "The selected toggle position", "enum": ["search", "duckAI", "lastUsed"] }
+        ]
+    },
+    "m_aichat_experimental_omnibar_mode_switched": {
+        "description": "User switched between Search and Duck.ai toggle in the input screen",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            { "key": "direction", "type": "string", "description": "Direction of the toggle switch", "enum": ["to_search", "to_duckai"] },
+            { "key": "had_text", "type": "string", "description": "Whether the input field had text", "enum": ["true", "false"] },
+            {
+                "key": "default_position",
+                "type": "string",
+                "description": "The user's default toggle position setting",
+                "enum": ["search", "duckAI", "lastUsed"]
+            }
+        ]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -747,16 +747,16 @@ class InputScreenViewModel @AssistedInject constructor(
             } else {
                 searchInputTextState.value.isNotBlank()
             }
-        val params =
-            mapOf(
-                "direction" to
-                    if (directionToSearch) {
-                        "to_search"
-                    } else {
-                        "to_duckai"
-                    },
-                "had_text" to hadText.toString(),
+        val params = buildMap {
+            put(
+                "direction",
+                if (directionToSearch) "to_search" else "to_duckai",
             )
+            put("had_text", hadText.toString())
+            if (duckChatFeature.rememberTogglePosition().isEnabled()) {
+                put(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION, defaultTogglePosition.value.pixelValue)
+            }
+        }
         pixel.fire(pixel = DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, parameters = params)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -484,6 +484,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
 
     DUCK_CHAT_TERMS_ACCEPTED_DUPLICATE_SYNC_ON("m_aichat_terms_accepted_duplicate_sync_on"),
     DUCK_CHAT_TERMS_ACCEPTED_DUPLICATE_SYNC_OFF("m_aichat_terms_accepted_duplicate_sync_off"),
+    DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT("m_aichat_settings_default_toggle_position_changed_count"),
+    DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY("m_aichat_settings_default_toggle_position_changed_daily"),
 }
 
 object DuckChatPixelParameters {
@@ -492,6 +494,8 @@ object DuckChatPixelParameters {
     const val INPUT_SCREEN_MODE = "mode"
     const val TEXT_LENGTH_BUCKET = "text_length_bucket"
     const val NEW_ADDRESS_BAR_SELECTION = "selection"
+    const val DEFAULT_TOGGLE_POSITION = "default_position"
+    const val DEFAULT_TOGGLE_POSITION_VALUE = "value"
 }
 
 @ContributesMultibinding(AppScope::class)
@@ -617,6 +621,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DefaultTogglePosition.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DefaultTogglePosition.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.duckchat.impl.store
 
-enum class DefaultTogglePosition {
-    SEARCH,
-    DUCK_AI,
-    LAST_USED,
+enum class DefaultTogglePosition(val pixelValue: String) {
+    SEARCH("search"),
+    DUCK_AI("duckAI"),
+    LAST_USED("lastUsed"),
     ;
 
     fun getOptionIndex(): Int {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -28,7 +28,9 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.impl.pixel.fireCountAndDaily
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLink
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLinkInNewTab
@@ -280,6 +282,11 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         viewModelScope.launch {
             duckChat.setDefaultTogglePosition(position)
         }
+        pixel.fireCountAndDaily(
+            countPixel = DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT,
+            dailyPixel = DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY,
+            parameters = mapOf(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION_VALUE to position.pixelValue),
+        )
     }
 
     fun duckAiInputScreenShareFeedbackClicked() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -2988,4 +2988,49 @@ class InputScreenViewModelTest {
         }
 
     // endregion
+
+    // region mode switched pixel
+
+    @Test
+    fun `mode switched pixel includes default_position when feature flag is on`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+
+            val viewModel = createViewModel()
+            viewModel.onSearchSelected()
+            viewModel.onChatSelected()
+
+            verify(pixel).fire(
+                pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED,
+                parameters = mapOf(
+                    "direction" to "to_duckai",
+                    "had_text" to "false",
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "duckAI",
+                ),
+            )
+        }
+
+    @Test
+    fun `mode switched pixel excludes default_position when feature flag is off`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+
+            val viewModel = createViewModel()
+            viewModel.onSearchSelected()
+            viewModel.onChatSelected()
+
+            verify(pixel).fire(
+                pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED,
+                parameters = mapOf(
+                    "direction" to "to_duckai",
+                    "had_text" to "false",
+                ),
+            )
+        }
+
+    // endregion
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.LaunchFeedback
@@ -988,5 +989,21 @@ class DuckChatSettingsViewModelTest {
         runTest {
             testee.onDefaultTogglePositionSelected(DefaultTogglePosition.LAST_USED)
             verify(duckChat).setDefaultTogglePosition(DefaultTogglePosition.LAST_USED)
+        }
+
+    @Test
+    fun `when default toggle position selected then count and daily pixels fired with correct value`() =
+        runTest {
+            testee.onDefaultTogglePositionSelected(DefaultTogglePosition.DUCK_AI)
+
+            verify(mockPixel).fire(
+                pixel = DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT,
+                parameters = mapOf(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION_VALUE to "duckAI"),
+            )
+            verify(mockPixel).fire(
+                pixel = DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY,
+                parameters = mapOf(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION_VALUE to "duckAI"),
+                type = Pixel.PixelType.Daily(),
+            )
         }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213800808542017?focus=true

### Description

- Adds `pixel m_aichat_settings_default_toggle_position_changed` (count + daily) fired when user changes the setting, with value param (search/duckAI/lastUsed)
- Adds `default_position` param to existing `m_aichat_experimental_omnibar_mode_switched` pixel to correlate toggle switches with the user's setting
- Added pixel definition for both (m_aichat_experimental_omnibar_mode_switche was missing so I added it)
- Pixels are FF gated

### Steps to test this PR
- Change the setting → verify m_aichat_settings_default_toggle_position_changed_count pixel fires with correct value
- Change the setting → verify m_aichat_settings_default_toggle_position_changed_daily pixel fires
- Switch toggle between Search and Duck.ai with FF on → verify m_aichat_experimental_omnibar_mode_switched includes default_position param

I verifine on Graphana. Example query:

```
m.aichat.settings.default.toggle.position.changed.count.android.*
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics/pixel definitions and parameter plumbing, with behavior gated behind an existing feature flag.
> 
> **Overview**
> Adds new `m_aichat_settings_default_toggle_position_changed` count/daily pixels fired when the user updates the default Search/Duck.ai toggle position, including a `value` parameter (`search`/`duckAI`/`lastUsed`).
> 
> Extends `m_aichat_experimental_omnibar_mode_switched` to optionally include `default_position` (derived from the user setting) when `rememberTogglePosition` is enabled, and updates `DefaultTogglePosition` to provide canonical pixel values. Unit tests cover both the new pixels and the conditional parameter inclusion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86489ca00c6bafd48ca54315edcdfa4f6d243fd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->