### PR TITLE
Skill: check status of the release board

### DIFF
--- a/.claude/skills/release-board-status/SKILL.md
+++ b/.claude/skills/release-board-status/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: release-board-status
+description: Combined release preview and board audit for Android. Shows what's in the next release cut, what's pending after LGC, and whether the "Waiting for Release" Asana board is accurate. Use whenever the user asks "what's in the next release?", "what will be released?", "preview release", "check the board", "any stale tasks?", "clean up the release board", "what PRs will be cut?", "what's pending after LGC?", or wants a combined release/board status view.
+allowed-tools:
+  Bash(bash .claude/skills/release-board-status/scripts/commits-to-release.sh),
+  Bash(bash .claude/skills/release-board-status/scripts/pending-commits.sh),
+  Bash(bash .claude/skills/release-board-status/scripts/audit-task.sh:*),
+  Bash(bash .claude/skills/release-board-status/scripts/check-lgc.sh:*),
+  Bash(bash .claude/skills/release-board-status/scripts/extract-gids.sh:*),
+---
+
+Show the full release picture: what's in the next cut, what's pending, and whether the Asana "Waiting for Release" board is accurate.
+
+**Requires:** Asana MCP (`asana_get_tasks`, `asana_get_task`)
+
+---
+
+## STEP 1: GET RELEASE CONTEXT AND BOARD TASKS
+
+Confirm the Asana MCP tools are available. If not, stop: "This skill requires the Asana MCP server."
+
+Run all three in parallel:
+
+**Release context:**
+```bash
+bash .claude/skills/release-board-status/scripts/commits-to-release.sh
+```
+Extract: `lgc_tag`, `latest_release`, `prs` block (PRs in this cut).
+
+**Pending commits (after LGC):**
+```bash
+bash .claude/skills/release-board-status/scripts/pending-commits.sh
+```
+Extract: `pending_prs` block.
+
+**Board tasks in "Waiting for Release":**
+Call `asana_get_tasks` with:
+- `section`: `614649293008196`
+- `opt_fields`: `gid,name`
+- `limit`: 100
+
+---
+
+## STEP 2: AUDIT BOARD TASKS + EXTRACT GIDS FOR PENDING PRS
+
+Run in the same turn (all in parallel as separate tool calls — do NOT combine with `&`):
+
+For each board task GID:
+```bash
+bash .claude/skills/release-board-status/scripts/audit-task.sh {GID}
+```
+
+Output format per task:
+- `result:NO_PR_FOUND`
+- `pr:N state:OPEN`
+- `pr:N state:CLOSED`
+- `pr:N state:MERGED released_in:5.X.Y` — stale
+- `pr:N state:MERGED released_in:PENDING commit:HASH` — genuinely waiting
+- `pr:N state:MERGED released_in:COMMIT_NOT_FOUND` — merged but commit not found in local history; treat as needing triage, not as already shipped
+
+Also run (one call, all pending PR numbers):
+```bash
+bash .claude/skills/release-board-status/scripts/extract-gids.sh {PR1} {PR2} ...
+```
+
+---
+
+## STEP 3: LOOK UP NAMES AND CHECK LGC
+
+Run in the same turn (all in parallel as separate tool calls):
+
+For each pending PR with a GID: call `asana_get_task` with `opt_fields: "name"`.
+For each pending PR without a GID: `gh pr view {N} --json title --jq '.title'`
+
+If any board tasks returned `released_in:PENDING commit:HASH`, check all at once:
+```bash
+bash .claude/skills/release-board-status/scripts/check-lgc.sh {lgc_tag} {commit1} {commit2} ...
+```
+Output: `{commit}:IN_LGC` or `{commit}:AFTER_LGC`.
+
+---
+
+## STEP 4: REPORT
+
+```
+## Release Board Status
+
+**LGC:** {lgc_tag}
+**Last release:** {latest_release}
+
+---
+
+### In this cut ({count})
+
+PRs between {latest_release} and LGC — shipping in the next release.
+
+**{Task name or PR title}**
+- PR: https://github.com/duckduckgo/Android/pull/{N}
+- Asana: https://app.asana.com/0/0/{GID}/f
+
+(If commits block is empty: "Nothing in this cut — {latest_release} is the current release.")
+
+---
+
+### Waiting for release ({count})
+
+Board tasks that are genuinely pending.
+
+**{Task name}**
+- PR: https://github.com/duckduckgo/Android/pull/{N}
+- Asana: https://app.asana.com/0/0/{GID}/f
+- Status: In next cut | Not included in latest LGC
+
+---
+
+### Not on board ({count})
+
+PRs merged after LGC that are not represented on the "Waiting for Release" board.
+
+**{Task name or PR title}**
+- PR: https://github.com/duckduckgo/Android/pull/{N}
+- Asana: https://app.asana.com/0/0/{GID}/f  (or "⚠️ No Asana task")
+
+---
+
+### Board correctness
+
+Always show this section. Use a one-line summary followed by detail only if there are issues:
+
+✅ Board looks clean — {count} tasks checked, all accounted for.
+
+Or, if there are issues, replace the summary line and list them:
+
+⚠️ {count} issue(s) found:
+
+#### Already shipped — stale ({count})
+These should be moved to Done.
+
+**{Task name}**
+- PR: https://github.com/duckduckgo/Android/pull/{N}
+- Asana: https://app.asana.com/0/0/{GID}/f
+- Released in: {version}
+
+#### PR not merged ({count})
+
+**{Task name}**
+- PR: https://github.com/duckduckgo/Android/pull/{N} (OPEN)
+- Asana: https://app.asana.com/0/0/{GID}/f
+
+#### Needs triage ({count})
+
+**{Task name}**
+- PR: https://github.com/duckduckgo/Android/pull/{N} (CLOSED) / No PR found
+- Asana: https://app.asana.com/0/0/{GID}/f
+```
+
+Omit subsections with 0 items. Keep output clean — no extra commentary.
+
+**"Not on board" logic:** a pending PR is "not on board" if none of the board task GIDs match the GID extracted from that PR's description.

--- a/.claude/skills/release-board-status/scripts/audit-task.sh
+++ b/.claude/skills/release-board-status/scripts/audit-task.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Usage: bash audit-task.sh GID
+# Finds PRs referencing an Asana GID and checks which release they landed in.
+GID=$1
+
+git fetch --tags 2>/dev/null
+
+# Search GitHub for PRs that reference this GID
+prs=$(gh pr list --search "$GID" --state all --json number,state --jq '.[] | "\(.number) \(.state)"' 2>/dev/null)
+
+if [ -z "$prs" ]; then
+  echo "result:NO_PR_FOUND"
+  exit 0
+fi
+
+echo "$prs" | while read -r number state; do
+  if [ "$state" = "MERGED" ]; then
+    commit=$(git log --oneline --all | grep -E "#${number}([^0-9]|$)" | head -1 | awk '{print $1}')
+    if [ -n "$commit" ]; then
+      first_release=$(git tag --sort=creatordate | grep -E "^5\.[0-9]+\.[0-9]+$" | while read -r tag; do
+        if git merge-base --is-ancestor "$commit" "$tag" 2>/dev/null; then
+          echo "$tag"
+          break
+        fi
+      done)
+      if [ -n "$first_release" ]; then
+        echo "pr:$number state:MERGED released_in:$first_release"
+      else
+        echo "pr:$number state:MERGED released_in:PENDING commit:$commit"
+      fi
+    else
+      echo "pr:$number state:MERGED released_in:COMMIT_NOT_FOUND"
+    fi
+  else
+    echo "pr:$number state:$state"
+  fi
+done

--- a/.claude/skills/release-board-status/scripts/check-lgc.sh
+++ b/.claude/skills/release-board-status/scripts/check-lgc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Usage: bash check-lgc.sh <lgc_tag> <commit1> <commit2> ...
+# Outputs one line per commit: "<commit>:IN_LGC" or "<commit>:AFTER_LGC"
+lgc_tag=$1
+shift
+for commit in "$@"; do
+  git merge-base --is-ancestor "$commit" "$lgc_tag" 2>/dev/null && echo "$commit:IN_LGC" || echo "$commit:AFTER_LGC"
+done

--- a/.claude/skills/release-board-status/scripts/commits-to-release.sh
+++ b/.claude/skills/release-board-status/scripts/commits-to-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Outputs release context: LGC tag, latest release, commits and PRs between them.
+set -euo pipefail
+
+git fetch --tags -q 2>/dev/null || true
+
+lgc_tag=$(git tag -l 'LGC-*' | sort -r | head -1)
+latest_release=$(git tag -l | grep -E '^5\.[0-9]+\.[0-9]+$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+
+echo "lgc_tag:${lgc_tag}"
+echo "latest_release:${latest_release}"
+
+if [ -z "$lgc_tag" ] || [ -z "$latest_release" ]; then
+  echo "commits:START"
+  echo "commits:END"
+  echo "prs:START"
+  echo "prs:END"
+  exit 0
+fi
+
+commits=$(git log "${latest_release}..${lgc_tag}" --oneline \
+  | grep -vE "Merge branch 'release/|Updated .* for new release|Merge pull request .* from .*release" \
+  || true)
+
+echo "commits:START"
+echo "$commits"
+echo "commits:END"
+
+echo "prs:START"
+if [ -n "$commits" ]; then
+  echo "$commits" | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+fi
+echo "prs:END"

--- a/.claude/skills/release-board-status/scripts/extract-gids.sh
+++ b/.claude/skills/release-board-status/scripts/extract-gids.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Usage: bash extract-gids.sh PR1 PR2 ...
+# Outputs one line per PR: "pr:N gid:M" (gid empty if not found)
+for pr in "$@"; do
+  body=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null || echo "")
+  gid=""
+  if [ -n "$body" ]; then
+    gid=$(echo "$body" | grep -i "Task/Issue URL:" | head -1 | grep -oE '/task/[0-9]+' | head -1 | grep -oE '[0-9]+')
+    if [ -z "$gid" ]; then
+      gid=$(echo "$body" | grep -i "Task/Issue URL:" | head -1 | grep -oE 'app\.asana\.com/0/[0-9]+/[0-9]+' | head -1 | sed 's|.*/||')
+    fi
+  fi
+  echo "pr:${pr} gid:${gid}"
+done

--- a/.claude/skills/release-board-status/scripts/pending-commits.sh
+++ b/.claude/skills/release-board-status/scripts/pending-commits.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Outputs commits merged after the LGC tag (will miss the next cut).
+set -euo pipefail
+
+git fetch --tags -q 2>/dev/null || true
+
+lgc_tag=$(git tag -l 'LGC-*' | sort -r | head -1)
+
+echo "pending:START"
+if [ -n "$lgc_tag" ]; then
+  git log "${lgc_tag}..HEAD" --oneline \
+    | grep -vE "Merge branch 'release/|Updated .* for new release|Merge pull request .* from .*release" \
+    || true
+fi
+echo "pending:END"
+
+echo "pending_prs:START"
+if [ -n "$lgc_tag" ]; then
+  git log "${lgc_tag}..HEAD" --oneline \
+    | grep -vE "Merge branch 'release/|Updated .* for new release|Merge pull request .* from .*release" \
+    | grep -oE '#[0-9]+' | tr -d '#' | sort -u \
+    || true
+fi
+echo "pending_prs:END"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213833143588232?focus=true

### Description
Adds a `/release-board-status`skill that gives a combined release preview and Asana board audit in one command.

When invoked, the skill:
1. Identifies the current LGC tag and latest release
2. Lists PRs merged between the last release and LGC ("in this cut")
3. Lists PRs merged after LGC that aren't yet released ("pending")
4. Audits every task on the Asana "Waiting for Release" board and flags stale, unmerged, or orphaned tasks

Scripts live in `.claude/skills/release-board-status/scripts/` and are orchestrated by the `SKILL.md` prompt file.

### Steps to test this PR
- [ ] In Claude Code, run `/release-board-status`
- [ ] Verify the output shows the current LGC tag and latest release version
- [ ] Verify "In this cut" lists PRs between the last release and LGC (or says nothing is in the cut)
- [ ] Verify "Waiting for release" lists genuinely pending merged PRs
- [ ] Verify "Board correctness" correctly flags any stale/closed/orphaned tasks on the Asana board

### UI changes
N/A — internal tooling only (Claude Code skill)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds internal Claude skill prompt and helper shell scripts; no production app/runtime code changes. Main risk is brittle parsing/tag assumptions affecting the report output only.
> 
> **Overview**
> Adds a new Claude Code skill, `release-board-status`, that generates a combined view of **what’s in the next Android release cut** (PRs between latest `5.x.y` tag and latest `LGC-*` tag) and **what’s pending after LGC**.
> 
> Includes helper scripts to (1) compute release/pending PR lists from git history, (2) extract Asana task GIDs from PR bodies, and (3) audit the Asana “Waiting for Release” section by mapping tasks to PRs and flagging stale/shipped, unmerged, or missing-PR items, with optional LGC inclusion checks for pending merged commits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38a181cf126ffa3b7ce6d6d290ba07514ae8a4b4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->