### PR TITLE
Make Asana URL matching more lenient in asana_release_utils

### DIFF
--- a/scripts/release/asana_release_utils.py
+++ b/scripts/release/asana_release_utils.py
@@ -35,12 +35,26 @@ def get_commits_between(repo_path: str, start_commit: str, end_commit: str) -> L
     return commits
 
 
+def _build_flexible_prefix_pattern(prefix: str) -> str:
+    """
+    Build a flexible regex pattern from a prefix string.
+    Allows flexible whitespace (including newlines) between words and around "/".
+    """
+    # Split prefix by whitespace, escape each part, join with \s+ to allow flexible whitespace
+    prefix_parts = prefix.split()
+    flexible = r"\s+".join(re.escape(part) for part in prefix_parts)
+    # Allow optional whitespace around "/" (e.g., "Task / Issue" or "Task/ Issue")
+    flexible = flexible.replace("/", r"\s*/\s*")
+    return flexible
+
+
 def extract_asana_task_links(commits: List[git.Commit], url_prefix: str) -> List[AsanaTaskLink]:
     """
     Extract Asana task links from commit messages.
     """
     task_links = []
-    url_pattern = re.compile(rf"{re.escape(url_prefix)}\s*(https://app\.asana\.com/\S*)")
+    prefix_pattern = _build_flexible_prefix_pattern(url_prefix)
+    url_pattern = re.compile(rf"(?:{prefix_pattern})\s*(https://app\.asana\.com/\S*)")
     
     for commit in commits:
         message = commit.message

--- a/scripts/release/test_asana_release_utils.py
+++ b/scripts/release/test_asana_release_utils.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Tests for asana_release_utils and lgc-asana-tasks."""
+"""Tests for asana_release_utils and lgc-asana-tasks, extract_asana_task_links and _build_flexible_prefix_pattern."""
 
 from unittest.mock import MagicMock, patch
+import pytest
 from asana_release_utils import (
     get_public_release_tags,
     get_latest_public_release_tag,
     get_public_release_tag_before,
+    extract_asana_task_links,
+    _build_flexible_prefix_pattern,
+    AsanaTaskLink,
 )
 
 def _mock_git_tags_result(tags: list[str]):
@@ -86,3 +90,129 @@ class TestGetPublicReleaseTagBefore:
             "5.264.0",
         ])
         assert get_public_release_tag_before(".", "5.264.0") == "5.262.0"
+
+# --- extract_asana_task_links ---
+
+STANDARD_PREFIX = "Task/Issue URL:"
+
+def _fake_commit(hexsha: str, message: str):
+    commit = MagicMock()
+    commit.hexsha = hexsha
+    commit.message = message
+    return commit
+
+class TestExtractAsanaTaskLinks:
+    def test_standard_prefix(self):
+        commits = [_fake_commit("aaa", "Task/Issue URL: https://app.asana.com/0/123/456")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result == [AsanaTaskLink(url="https://app.asana.com/0/123/456", commit_hash="aaa")]
+
+    def test_no_url_returns_none(self):
+        commits = [_fake_commit("bbb", "Fix a bug\n\nNo link here")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result == [AsanaTaskLink(url=None, commit_hash="bbb")]
+
+    def test_multiple_commits(self):
+        commits = [
+            _fake_commit("c1", "Task/Issue URL: https://app.asana.com/0/111/222"),
+            _fake_commit("c2", "No link"),
+            _fake_commit("c3", "Task/Issue URL: https://app.asana.com/0/333/444"),
+        ]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result == [
+            AsanaTaskLink(url="https://app.asana.com/0/111/222", commit_hash="c1"),
+            AsanaTaskLink(url=None, commit_hash="c2"),
+            AsanaTaskLink(url="https://app.asana.com/0/333/444", commit_hash="c3"),
+        ]
+
+    def test_url_with_query_params(self):
+        url = "https://app.asana.com/1/137249556945/project/12345/task/67890?focus=true"
+        commits = [_fake_commit("ddd", f"Task/Issue URL: {url}")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == url
+
+    def test_url_with_trailing_f(self):
+        url = "https://app.asana.com/0/123/456/f"
+        commits = [_fake_commit("eee", f"Task/Issue URL: {url}")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == url
+
+    def test_new_style_url(self):
+        url = "https://app.asana.com/1/137249556945/project/1209107918776641/task/1210066941136479"
+        commits = [_fake_commit("fff", f"Task/Issue URL: {url}")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == url
+
+    def test_prefix_on_separate_line_from_url(self):
+        message = "Some title\n\nTask/Issue URL:\nhttps://app.asana.com/0/123/456"
+        commits = [_fake_commit("ggg", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+    def test_flexible_whitespace_between_prefix_words(self):
+        message = "Task/Issue  URL:  https://app.asana.com/0/123/456"
+        commits = [_fake_commit("hhh", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+    def test_flexible_whitespace_around_slash(self):
+        message = "Task / Issue URL: https://app.asana.com/0/123/456"
+        commits = [_fake_commit("iii", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+    def test_spaces_around_slash_and_extra_whitespace(self):
+        message = "Task  /  Issue   URL: https://app.asana.com/0/123/456"
+        commits = [_fake_commit("jjj", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+    def test_prefix_in_multiline_commit_message(self):
+        message = (
+            "feat: Add new feature\n"
+            "\n"
+            "This adds a great feature.\n"
+            "\n"
+            "Task/Issue URL: https://app.asana.com/0/999/888"
+        )
+        commits = [_fake_commit("kkk", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/999/888"
+
+    def test_wrong_domain_not_matched(self):
+        commits = [_fake_commit("nnn", "Task/Issue URL: https://app.example.com/0/1/2")]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url is None
+
+    def test_empty_commit_list(self):
+        result = extract_asana_task_links([], STANDARD_PREFIX)
+        assert result == []
+
+    def test_url_stops_at_whitespace(self):
+        message = "Task/Issue URL: https://app.asana.com/0/123/456 some trailing text"
+        commits = [_fake_commit("ooo", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+    def test_prefix_newline_between_words(self):
+        message = "Task/Issue\nURL: https://app.asana.com/0/123/456"
+        commits = [_fake_commit("ppp", message)]
+        result = extract_asana_task_links(commits, STANDARD_PREFIX)
+        assert result[0].url == "https://app.asana.com/0/123/456"
+
+
+# --- _build_flexible_prefix_pattern ---
+
+
+class TestBuildFlexiblePrefixPattern:
+    def test_single_word(self):
+        pattern = _build_flexible_prefix_pattern("URL:")
+        assert pattern == "URL:"
+
+    def test_words_joined_with_flexible_whitespace(self):
+        pattern = _build_flexible_prefix_pattern("Task URL:")
+        assert r"\s+" in pattern
+
+    def test_slash_gets_flexible_whitespace(self):
+        pattern = _build_flexible_prefix_pattern("Task/Issue URL:")
+        assert r"\s*/\s*" in pattern


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1213833143588238?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] Run `pip install pytest GitPython`
- [ ] Run [test_asana_release_utils.py‎](https://github.com/duckduckgo/Android/pull/8130/changes#diff-218195acbd891729d9b08705b526d10a894af7d435f3ff7fd7f107521d70dbfb) - `python -m pytest test_asana_release_utils.py -v`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release helper scripts’ regex matching and add tests; the match is still constrained to `https://app.asana.com/`, so the blast radius is small.
> 
> **Overview**
> Asana task URL extraction in `asana_release_utils.extract_asana_task_links` is now **more lenient** by building a flexible regex for the trigger prefix (tolerating extra spaces/newlines between words and optional whitespace around the `/` in `Task/Issue`).
> 
> Adds `_build_flexible_prefix_pattern` and expands `test_asana_release_utils.py` with coverage for multiline prefixes/URLs, varied whitespace, multiple URL formats (including query params and trailing `/f`), and negative cases (wrong domain / no match).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc45649a8a7a1017d66d4829916fef6b2e18d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->