### PR TITLE
Instrument WebView errors with raw error code pixel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,39 @@ The `lint-rules` module enforces at compile time:
 
 ---
 
+## Pixel Definitions
+
+Every pixel name added to `AppPixelName.kt` (or any other `Pixel.PixelName` enum) **must** have a corresponding entry in `PixelDefinitions/pixels/definitions/`.
+
+**When you add a pixel:**
+1. Find or create a `.json5` file in `PixelDefinitions/pixels/definitions/` that matches the feature area (e.g. `error_page.json5`, `autofill.json5`).
+2. Add an entry using the pixel name string as the key:
+
+```json5
+{
+    "m_your_pixel_name": {
+        "description": "One sentence: what event this records",
+        "owners": ["your-github-handle"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "param_name",
+                "description": "What this parameter represents",
+                "type": "string"   // or "boolean", "integer"
+            }
+        ]
+    }
+}
+```
+
+- `suffixes` and `parameters` are optional — omit if the pixel sends none.
+- Standard params (`appVersion`, `atb`, etc.) are in `PixelDefinitions/pixels/params_dictionary.json` — reference them by key string rather than inlining.
+- See existing files in `PixelDefinitions/pixels/definitions/` for examples.
+
+---
+
 ## Key Dependencies
 
 | Category | Library |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,39 +175,6 @@ The `lint-rules` module enforces at compile time:
 
 ---
 
-## Pixel Definitions
-
-Every pixel name added to `AppPixelName.kt` (or any other `Pixel.PixelName` enum) **must** have a corresponding entry in `PixelDefinitions/pixels/definitions/`.
-
-**When you add a pixel:**
-1. Find or create a `.json5` file in `PixelDefinitions/pixels/definitions/` that matches the feature area (e.g. `error_page.json5`, `autofill.json5`).
-2. Add an entry using the pixel name string as the key:
-
-```json5
-{
-    "m_your_pixel_name": {
-        "description": "One sentence: what event this records",
-        "owners": ["your-github-handle"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": [
-            "appVersion",
-            {
-                "key": "param_name",
-                "description": "What this parameter represents",
-                "type": "string"   // or "boolean", "integer"
-            }
-        ]
-    }
-}
-```
-
-- `suffixes` and `parameters` are optional — omit if the pixel sends none.
-- Standard params (`appVersion`, `atb`, etc.) are in `PixelDefinitions/pixels/params_dictionary.json` — reference them by key string rather than inlining.
-- See existing files in `PixelDefinitions/pixels/definitions/` for examples.
-
----
-
 ## Key Dependencies
 
 | Category | Library |

--- a/PixelDefinitions/pixels/definitions/error_page.json5
+++ b/PixelDefinitions/pixels/definitions/error_page.json5
@@ -1,0 +1,23 @@
+{
+    "m_errorpageshown": {
+        "description": "A WebView error page was shown for a main-frame navigation failure",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_errorpageshown_code": {
+        "description": "A main-frame WebView error occurred (including errors that do not show an error page). Used to gather data on error code distribution before expanding error page coverage.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "error_code",
+                "description": "The raw WebView error code string, e.g. ERROR_HOST_LOOKUP, ERROR_FAILED_SSL_HANDSHAKE",
+                "type": "string"
+            }
+        ]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3801,20 +3801,18 @@ class BrowserTabViewModel @Inject constructor(
         url: String,
         rawErrorCode: String,
     ) {
-        if (errorType != OMITTED) {
-            browserViewState.value =
-                currentBrowserViewState().copy(
-                    browserError = errorType,
-                    showPrivacyShield = HighlightableButton.Visible(enabled = false),
-                )
-            if (androidBrowserConfig.errorPagePixel().isEnabled()) {
-                pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
-            }
-            command.value = WebViewError(errorType, url)
+        browserViewState.value =
+            currentBrowserViewState().copy(
+                browserError = errorType,
+                showPrivacyShield = HighlightableButton.Visible(enabled = false),
+            )
+        if (androidBrowserConfig.errorPagePixel().isEnabled()) {
+            pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
         }
         if (androidBrowserConfig.errorCodePixel().isEnabled()) {
             pixel.enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to rawErrorCode))
         }
+        command.value = WebViewError(errorType, url)
     }
 
     override fun onReceivedMaliciousSiteWarning(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3799,20 +3799,22 @@ class BrowserTabViewModel @Inject constructor(
     override fun onReceivedError(
         errorType: WebViewErrorResponse,
         url: String,
-        rawErrorCode: String,
+        errorCode: String,
     ) {
-        browserViewState.value =
-            currentBrowserViewState().copy(
-                browserError = errorType,
-                showPrivacyShield = HighlightableButton.Visible(enabled = false),
-            )
-        if (androidBrowserConfig.errorPagePixel().isEnabled()) {
-            pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
+        if (errorType != OMITTED) {
+            browserViewState.value =
+                currentBrowserViewState().copy(
+                    browserError = errorType,
+                    showPrivacyShield = HighlightableButton.Visible(enabled = false),
+                )
+            if (androidBrowserConfig.errorPagePixel().isEnabled()) {
+                pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
+            }
+            command.value = WebViewError(errorType, url)
         }
         if (androidBrowserConfig.errorCodePixel().isEnabled()) {
-            pixel.enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to rawErrorCode))
+            pixel.enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to errorCode))
         }
-        command.value = WebViewError(errorType, url)
     }
 
     override fun onReceivedMaliciousSiteWarning(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3799,16 +3799,22 @@ class BrowserTabViewModel @Inject constructor(
     override fun onReceivedError(
         errorType: WebViewErrorResponse,
         url: String,
+        rawErrorCode: String,
     ) {
-        browserViewState.value =
-            currentBrowserViewState().copy(
-                browserError = errorType,
-                showPrivacyShield = HighlightableButton.Visible(enabled = false),
-            )
-        if (androidBrowserConfig.errorPagePixel().isEnabled()) {
-            pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
+        if (errorType != OMITTED) {
+            browserViewState.value =
+                currentBrowserViewState().copy(
+                    browserError = errorType,
+                    showPrivacyShield = HighlightableButton.Visible(enabled = false),
+                )
+            if (androidBrowserConfig.errorPagePixel().isEnabled()) {
+                pixel.enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
+            }
+            command.value = WebViewError(errorType, url)
         }
-        command.value = WebViewError(errorType, url)
+        if (androidBrowserConfig.errorCodePixel().isEnabled()) {
+            pixel.enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to rawErrorCode))
+        }
     }
 
     override fun onReceivedMaliciousSiteWarning(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -832,8 +832,8 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         this.start = null
                     }
+                    webViewClientListener?.onReceivedError(parsedError, request.url.toString(), webResourceError.errorCode.asStringErrorCode())
                 }
-                webViewClientListener?.onReceivedError(parsedError, request.url.toString(), webResourceError.errorCode.asStringErrorCode())
                 logcat { "recordErrorCode for ${request.url}" }
                 webViewClientListener?.recordErrorCode(
                     "${webResourceError.errorCode.asStringErrorCode()} - ${webResourceError.description}",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -832,8 +832,8 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         this.start = null
                     }
-                    webViewClientListener?.onReceivedError(parsedError, request.url.toString(), webResourceError.errorCode.asStringErrorCode())
                 }
+                webViewClientListener?.onReceivedError(parsedError, request.url.toString(), webResourceError.errorCode.asStringErrorCode())
                 logcat { "recordErrorCode for ${request.url}" }
                 webViewClientListener?.recordErrorCode(
                     "${webResourceError.errorCode.asStringErrorCode()} - ${webResourceError.description}",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -832,8 +832,8 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         this.start = null
                     }
-                    webViewClientListener?.onReceivedError(parsedError, request.url.toString())
                 }
+                webViewClientListener?.onReceivedError(parsedError, request.url.toString(), webResourceError.errorCode.asStringErrorCode())
                 logcat { "recordErrorCode for ${request.url}" }
                 webViewClientListener?.recordErrorCode(
                     "${webResourceError.errorCode.asStringErrorCode()} - ${webResourceError.description}",

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -132,7 +132,7 @@ interface WebViewClientListener {
     fun onReceivedError(
         errorType: WebViewErrorResponse,
         url: String,
-        rawErrorCode: String,
+        errorCode: String,
     )
 
     fun onReceivedMaliciousSiteWarning(

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -132,6 +132,7 @@ interface WebViewClientListener {
     fun onReceivedError(
         errorType: WebViewErrorResponse,
         url: String,
+        rawErrorCode: String,
     )
 
     fun onReceivedMaliciousSiteWarning(

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -205,6 +205,8 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.FIRE_DIALOG_CLEAR_PRESSED_DAILY.pixelName to PixelParameter.removeAtb(),
             AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.FIRE_DIALOG_CLEAR_SINGLE_TAB_PRESSED_DAILY.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.ERROR_PAGE_SHOWN.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.ERROR_CODE_PIXEL.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -484,6 +484,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     PRODUCT_TELEMETRY_SURFACE_DAU_DAILY("m_product_telemetry_surface_usage_dau_daily"),
 
     ERROR_PAGE_SHOWN("m_errorpageshown"),
+    ERROR_CODE_PIXEL("m_errorpageshown_code"),
 
     APP_VERSION_AT_SEARCH_TIME("app_version_at_search_time"),
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -69,6 +69,14 @@ interface AndroidBrowserConfigFeature {
     fun errorPagePixel(): Toggle
 
     /**
+     * @return `true` when the remote config has the global "errorCodePixel" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun errorCodePixel(): Toggle
+
+    /**
      * @return `true` when the remote config has the global "featuresRequestHeader" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5371,7 +5371,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenWebViewRefreshedWithErrorThenBrowserErrorStateIsLoading() {
-        testee.onReceivedError(BAD_URL, exampleUrl)
+        testee.onReceivedError(BAD_URL, exampleUrl, "ERROR_HOST_LOOKUP")
         testee.onWebViewRefreshed()
 
         assertEquals(LOADING, browserViewState().browserError)
@@ -5379,7 +5379,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenResetBrowserErrorThenBrowserErrorStateIsLoading() {
-        testee.onReceivedError(BAD_URL, exampleUrl)
+        testee.onReceivedError(BAD_URL, exampleUrl, "ERROR_HOST_LOOKUP")
         assertEquals(BAD_URL, browserViewState().browserError)
         testee.resetBrowserError()
         assertEquals(OMITTED, browserViewState().browserError)
@@ -6870,7 +6870,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenPageIsChangedWithWebViewErrorResponseThenPixelIsFired() =
         runTest {
-            testee.onReceivedError(BAD_URL, "example2.com")
+            testee.onReceivedError(BAD_URL, "example2.com", "ERROR_HOST_LOOKUP")
 
             updateUrl(
                 originalUrl = "example.com",
@@ -6885,7 +6885,7 @@ class BrowserTabViewModelTest {
     fun givenErrorPageFeatureDisabledWhenPageIsChangedWithWebViewErrorResponseThenPixelIsNotFired() =
         runTest {
             fakeAndroidConfigBrowserFeature.errorPagePixel().setRawStoredState(State(enable = false))
-            testee.onReceivedError(BAD_URL, "example2.com")
+            testee.onReceivedError(BAD_URL, "example2.com", "ERROR_HOST_LOOKUP")
 
             updateUrl(
                 originalUrl = "example.com",
@@ -6894,6 +6894,54 @@ class BrowserTabViewModelTest {
             )
 
             verify(mockPixel, never()).enqueueFire(AppPixelName.ERROR_PAGE_SHOWN)
+        }
+
+    @Test
+    fun givenErrorCodePixelEnabledWhenNonOmittedErrorReceivedThenErrorCodePixelFiredWithCorrectCode() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = true))
+
+            testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
+
+            verify(mockPixel).enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to "ERROR_HOST_LOOKUP"))
+        }
+
+    @Test
+    fun givenErrorCodePixelEnabledWhenOmittedErrorReceivedThenErrorCodePixelStillFired() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = true))
+
+            testee.onReceivedError(OMITTED, "example.com", "ERROR_UNKNOWN")
+
+            verify(mockPixel).enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to "ERROR_UNKNOWN"))
+        }
+
+    @Test
+    fun givenErrorCodePixelDisabledWhenErrorReceivedThenErrorCodePixelNotFired() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = false))
+
+            testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
+
+            verify(mockPixel, never()).enqueueFire(AppPixelName.ERROR_CODE_PIXEL)
+        }
+
+    @Test
+    fun givenOmittedErrorWhenErrorReceivedThenBrowserErrorStateAndCommandNotUpdated() =
+        runTest {
+            testee.onReceivedError(OMITTED, "example.com", "ERROR_UNKNOWN")
+
+            assertEquals(OMITTED, browserViewState().browserError)
+            assertCommandNotIssued<Command.WebViewError>()
+        }
+
+    @Test
+    fun givenNonOmittedErrorWhenErrorReceivedThenBrowserErrorStateAndCommandUpdated() =
+        runTest {
+            testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
+
+            assertEquals(BAD_URL, browserViewState().browserError)
+            assertCommandIssued<Command.WebViewError>()
         }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -6897,23 +6897,13 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun givenErrorCodePixelEnabledWhenNonOmittedErrorReceivedThenErrorCodePixelFiredWithCorrectCode() =
+    fun givenErrorCodePixelEnabledWhenErrorReceivedThenErrorCodePixelFiredWithCorrectCode() =
         runTest {
             fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = true))
 
             testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
 
             verify(mockPixel).enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to "ERROR_HOST_LOOKUP"))
-        }
-
-    @Test
-    fun givenErrorCodePixelEnabledWhenOmittedErrorReceivedThenErrorCodePixelStillFired() =
-        runTest {
-            fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = true))
-
-            testee.onReceivedError(OMITTED, "example.com", "ERROR_UNKNOWN")
-
-            verify(mockPixel).enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to "ERROR_UNKNOWN"))
         }
 
     @Test
@@ -6927,16 +6917,7 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun givenOmittedErrorWhenErrorReceivedThenBrowserErrorStateAndCommandNotUpdated() =
-        runTest {
-            testee.onReceivedError(OMITTED, "example.com", "ERROR_UNKNOWN")
-
-            assertEquals(OMITTED, browserViewState().browserError)
-            assertCommandNotIssued<Command.WebViewError>()
-        }
-
-    @Test
-    fun givenNonOmittedErrorWhenErrorReceivedThenBrowserErrorStateAndCommandUpdated() =
+    fun givenErrorReceivedThenBrowserErrorStateAndCommandUpdated() =
         runTest {
             testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -6913,7 +6913,18 @@ class BrowserTabViewModelTest {
 
             testee.onReceivedError(BAD_URL, "example.com", "ERROR_HOST_LOOKUP")
 
-            verify(mockPixel, never()).enqueueFire(AppPixelName.ERROR_CODE_PIXEL)
+            verify(mockPixel, never()).enqueueFire(eq(AppPixelName.ERROR_CODE_PIXEL), any(), any(), any())
+        }
+
+    @Test
+    fun givenOmittedErrorAndErrorCodePixelEnabledWhenErrorReceivedThenPixelFiredButNoErrorPageShown() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.errorCodePixel().setRawStoredState(State(enable = true))
+
+            testee.onReceivedError(OMITTED, "example.com", "ERROR_UNKNOWN")
+
+            verify(mockPixel).enqueueFire(AppPixelName.ERROR_CODE_PIXEL, mapOf("error_code" to "ERROR_UNKNOWN"))
+            assertCommandNotIssued<Command.WebViewError>()
         }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -994,7 +994,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener)!!.onReceivedError(eq(OMITTED), anyString(), anyString())
+        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString(), anyString())
     }
 
     @Test
@@ -1006,7 +1006,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener)!!.onReceivedError(eq(OMITTED), anyString(), anyString())
+        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString(), anyString())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.anrs.api.CrashLogger.Crash
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.Web
 import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
+import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.WebViewErrorResponse.SSL_PROTOCOL_ERROR
 import com.duckduckgo.app.browser.applinks.AppSchemeInterceptionFeature
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
@@ -969,7 +970,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener)!!.onReceivedError(BAD_URL, "")
+        verify(testee.webViewClientListener)!!.onReceivedError(eq(BAD_URL), eq(""), anyString())
     }
 
     @Test
@@ -981,7 +982,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener)!!.onReceivedError(CONNECTION, "")
+        verify(testee.webViewClientListener)!!.onReceivedError(eq(CONNECTION), eq(""), anyString())
     }
 
     @Test
@@ -993,7 +994,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString())
+        verify(testee.webViewClientListener)!!.onReceivedError(eq(OMITTED), anyString(), anyString())
     }
 
     @Test
@@ -1005,7 +1006,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString())
+        verify(testee.webViewClientListener)!!.onReceivedError(eq(OMITTED), anyString(), anyString())
     }
 
     @Test
@@ -1017,7 +1018,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString())
+        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString(), anyString())
     }
 
     @Test
@@ -1031,7 +1032,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener)!!.onReceivedError(SSL_PROTOCOL_ERROR, requestUrl)
+        verify(testee.webViewClientListener)!!.onReceivedError(eq(SSL_PROTOCOL_ERROR), eq(requestUrl), anyString())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -40,7 +40,6 @@ import com.duckduckgo.anrs.api.CrashLogger.Crash
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.Web
 import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
-import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.WebViewErrorResponse.SSL_PROTOCOL_ERROR
 import com.duckduckgo.app.browser.applinks.AppSchemeInterceptionFeature
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.anrs.api.CrashLogger.Crash
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.Web
 import com.duckduckgo.app.browser.WebViewErrorResponse.BAD_URL
 import com.duckduckgo.app.browser.WebViewErrorResponse.CONNECTION
+import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.WebViewErrorResponse.SSL_PROTOCOL_ERROR
 import com.duckduckgo.app.browser.applinks.AppSchemeInterceptionFeature
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
@@ -993,7 +994,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString(), anyString())
+        verify(testee.webViewClientListener, times(1))!!.onReceivedError(eq(OMITTED), anyString(), anyString())
     }
 
     @Test
@@ -1005,7 +1006,7 @@ class BrowserWebViewClientTest {
 
         testee.onReceivedError(mockWebView, webResourceRequest, webResourceError)
 
-        verify(testee.webViewClientListener, times(0))!!.onReceivedError(any(), anyString(), anyString())
+        verify(testee.webViewClientListener, times(1))!!.onReceivedError(eq(OMITTED), anyString(), anyString())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1213831723087162

### Description

Adds a new `errorCodePixel` remote feature flag (defaulting to `false`) and `m_errorpageshown_code` pixel that fires for **all** main-frame WebView errors — including those previously silently discarded as `OMITTED`. The pixel sends the raw error code string as an `error_code` parameter.

This gives the team data on which error codes occur in the wild before expanding Yeti error page coverage to more error types. The existing `errorPagePixel` / `ERROR_PAGE_SHOWN` behaviour is completely unchanged. OMITTED errors continue to suppress the error page UI and `WebViewError` command.

Changes are confined to `:app`:
- `AndroidBrowserConfigFeature` — new `errorCodePixel()` toggle
- `AppPixelName` — new `ERROR_CODE_PIXEL("m_errorpageshown_code")` entry
- `WebViewClientListener` — `onReceivedError` gains a `rawErrorCode: String` param
- `BrowserWebViewClient` — calls listener for all main-frame errors (not just non-OMITTED)
- `BrowserTabViewModel` — gates UI/command on `errorType != OMITTED`; fires new pixel when flag enabled
- Tests updated and 5 new tests added

### Steps to test this PR

_Error code pixel (flag disabled by default)_
- [x] Enable the `errorCodePixel` sub-feature under `androidBrowserConfig` via remote config override
- [x] Navigate to an unreachable host — verify `m_errorpageshown_code` pixel fires with `error_code=ERROR_HOST_LOOKUP`
- [ ] Navigate to a URL with a bad SSL handshake — verify pixel fires with `error_code=ERROR_FAILED_SSL_HANDSHAKE`
- [ ] Navigate to a URL that returns an OMITTED error — verify pixel fires but Yeti error page is NOT shown
- [x] Disable the flag — verify pixel does not fire

_Existing error page behaviour (unchanged)_
- [x] Navigate to an unreachable host — verify Yeti error page still appears
- [x] Verify `m_errorpageshown` pixel still fires for BAD_URL / CONNECTION / SSL_PROTOCOL_ERROR errors

### UI changes

No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebView error handling and pixel firing paths (though gated by a default-off flag), so regressions could affect error UI signaling or telemetry if miswired.
> 
> **Overview**
> Introduces a new pixel definition `m_errorpageshown_code` (and `AppPixelName.ERROR_CODE_PIXEL`) to collect the *raw* main-frame WebView error code via an `error_code` parameter.
> 
> Plumbs the raw error code through `WebViewClientListener.onReceivedError` and updates `BrowserTabViewModel` to **keep existing error page/command behavior** (still suppressed for `OMITTED`), while optionally firing the new pixel behind the new `androidBrowserConfig.errorCodePixel` remote flag (default `false`). `PixelParamRemovalInterceptor` is updated to strip ATB from the new pixels, and tests are updated/added to cover the new instrumentation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed35d9b18f70afa610e6ded935030fa9763060bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->