### PR TITLE
Update copy for sync screen in recovery code flow

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncSetupIntroFragment.kt
@@ -109,11 +109,11 @@ class SyncSetupIntroFragment : DuckDuckGoFragment(R.layout.fragment_intro_sync) 
             }
 
             is RecoverAccountIntro -> {
-                binding.contentTitle.text = getString(R.string.sync_intro_recover_title)
-                binding.contentBody.text = getString(R.string.sync_intro_recover_content)
+                binding.contentTitle.text = getString(R.string.sync_recover_synced_data_title)
+                binding.contentBody.text = getString(R.string.sync_recover_synced_data_content)
                 binding.contentIllustration.setImageResource(R.drawable.ic_sync_recover_128)
                 binding.syncIntroFooter.hide()
-                binding.syncIntroCta.text = getString(R.string.sync_intro_recover_cta)
+                binding.syncIntroCta.text = getString(R.string.sync_recover_synced_data_cta)
                 binding.syncIntroCta.setOnClickListener {
                     viewModel.onStartRecoverDataClicked()
                 }

--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Създава криптирано резервно копие на Вашите отметки, пароли и чатове с Duck.ai на защитения сървър на DuckDuckGo, което може да бъде синхронизирано с други Ваши устройства. \n\n Ключът за криптиране се съхранява само на Вашето устройство и DuckDuckGo няма достъп до него.</string>
     <string name="sync_intro_enable_footer">Можете да синхронизирате с други устройства по-късно.</string>
     <string name="sync_intro_enable_cta">Включване на Синхронизиране и архивиране</string>
-    <string name="sync_intro_recover_title">Възстановяване на синхронизирани данни</string>
-    <string name="sync_intro_recover_content">За възстановяване на синхронизираните данни е необходим Кодът за възстановяване, който сте запазили при първата настройка на функцията за синхронизиране. Този код може да е запазен като PDF файл на устройството, което първоначално сте използвали за настройка на функцията за синхронизиране.</string>
-    <string name="sync_intro_recover_cta">Първи стъпки</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Сканиране на QR код</string>
     <string name="login_screen_enter_code_cta">Ръчно въвеждане на код</string>

--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Създава криптирано резервно копие на Вашите отметки, пароли и чатове с Duck.ai на защитения сървър на DuckDuckGo, което може да бъде синхронизирано с други Ваши устройства. \n\n Ключът за криптиране се съхранява само на Вашето устройство и DuckDuckGo няма достъп до него.</string>
     <string name="sync_intro_enable_footer">Можете да синхронизирате с други устройства по-късно.</string>
     <string name="sync_intro_enable_cta">Включване на Синхронизиране и архивиране</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Възстановяване на синхронизираните данни</string>
+    <string name="sync_recover_synced_data_content">Ще трябва да въведете кода за възстановяване, който сет получили при настройка на Sync &amp; Backup. Може да сте го запазили като PDF файл на устройството, което сте използвали.</string>
+    <string name="sync_recover_synced_data_cta">Възстановяване на синхронизирани данни</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Сканиране на QR код</string>
     <string name="login_screen_enter_code_cta">Ръчно въвеждане на код</string>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Na zabezpečeném serveru DuckDuckGo se vytvoří šifrovaná záloha záložek, hesel a chatů Duck.ai, kterou můžeš synchronizovat s ostatními zařízeními.\n\n Šifrovací klíč se ukládá jenom na tvé zařízení, DuckDuckGo k němu nemá přístup.</string>
     <string name="sync_intro_enable_footer">Synchronizaci s dalšími zařízeními můžeš provést později.</string>
     <string name="sync_intro_enable_cta">Zapnout synchronizaci a zálohování</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Obnovení synchronizovaných dat</string>
+    <string name="sync_recover_synced_data_content">Budeš potřebovat kód pro obnovení, který ti přišel při aktivaci funkce Sync &amp; Backup. Možná ho máš uložený jako PDF na svém zařízení.</string>
+    <string name="sync_recover_synced_data_cta">Obnovit synchronizovaná data</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skenování QR kódu</string>
     <string name="login_screen_enter_code_cta">Ruční zadání kódu</string>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Na zabezpečeném serveru DuckDuckGo se vytvoří šifrovaná záloha záložek, hesel a chatů Duck.ai, kterou můžeš synchronizovat s ostatními zařízeními.\n\n Šifrovací klíč se ukládá jenom na tvé zařízení, DuckDuckGo k němu nemá přístup.</string>
     <string name="sync_intro_enable_footer">Synchronizaci s dalšími zařízeními můžeš provést později.</string>
     <string name="sync_intro_enable_cta">Zapnout synchronizaci a zálohování</string>
-    <string name="sync_intro_recover_title">Obnovit synchronizovaná data</string>
-    <string name="sync_intro_recover_content">K obnovení synchronizovaných dat budeš potřebovat kód pro obnovení, který máš uložený od prvního nastavení synchronizace. Je možné, že tenhle kód se uložil ve formátu PDF na zařízení původně použitém k nastavení synchronizace.</string>
-    <string name="sync_intro_recover_cta">Začínáme</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skenování QR kódu</string>
     <string name="login_screen_enter_code_cta">Ruční zadání kódu</string>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dette opretter en krypteret sikkerhedskopi af dine bogmærker, adgangskoder og Duck.ai-chats på DuckDuckGos sikre server, som kan synkroniseres med dine andre enheder. \n\n Krypteringsnøglen gemmes kun på din enhed. DuckDuckGo har ikke adgang til den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisere med dine andre enheder senere.</string>
     <string name="sync_intro_enable_cta">Slå synkronisering og sikkerhedskopiering til</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Gendan dine synkroniserede data</string>
+    <string name="sync_recover_synced_data_content">Du skal bruge den gendannelseskode, du fik, da du konfigurerede Sync &amp; Backup. Du har muligvis gemt den som en PDF-fil på den enhed, du brugte.</string>
+    <string name="sync_recover_synced_data_cta">Gendan synkroniserede data</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Scan QR-kode</string>
     <string name="login_screen_enter_code_cta">Indtast kode manuelt</string>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dette opretter en krypteret sikkerhedskopi af dine bogmærker, adgangskoder og Duck.ai-chats på DuckDuckGos sikre server, som kan synkroniseres med dine andre enheder. \n\n Krypteringsnøglen gemmes kun på din enhed. DuckDuckGo har ikke adgang til den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisere med dine andre enheder senere.</string>
     <string name="sync_intro_enable_cta">Slå synkronisering og sikkerhedskopiering til</string>
-    <string name="sync_intro_recover_title">Gendan synkroniserede data</string>
-    <string name="sync_intro_recover_content">For at gendanne dine synkroniserede data skal du bruge den gendannelseskode, du gemte, da du opsatte Synkronisering første gang. Denne kode kan være blevet gemt som en PDF-fil på den enhed, du oprindeligt brugte til at konfigurere Synkronisering.</string>
-    <string name="sync_intro_recover_cta">Kom igang</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Scan QR-kode</string>
     <string name="login_screen_enter_code_cta">Indtast kode manuelt</string>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dadurch wird ein verschlüsseltes Backup deiner Lesezeichen, Passwörter und Duck.ai-Chats auf dem sicheren Server von DuckDuckGo erstellt, das mit deinen anderen Geräten synchronisiert werden kann. Der Verschlüsselungsschlüssel wird nur auf deinem Gerät gespeichert, DuckDuckGo kann nicht darauf zugreifen.</string>
     <string name="sync_intro_enable_footer">Du kannst später mit deinen anderen Geräten synchronisieren.</string>
     <string name="sync_intro_enable_cta">„Synchronisieren und sichern“ aktivieren</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Stelle deine synchronisierten Daten wieder her</string>
+    <string name="sync_recover_synced_data_content">Du benötigst den Wiederherstellungscode, den du bei der Einrichtung von Sync &amp; Backup erhalten hast. Möglicherweise hast du ihn auf dem verwendeten Gerät als PDF gespeichert.</string>
+    <string name="sync_recover_synced_data_cta">Synchronisierte Daten wiederherstellen</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-Code scannen</string>
     <string name="login_screen_enter_code_cta">Code manuell eingeben</string>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dadurch wird ein verschlüsseltes Backup deiner Lesezeichen, Passwörter und Duck.ai-Chats auf dem sicheren Server von DuckDuckGo erstellt, das mit deinen anderen Geräten synchronisiert werden kann. Der Verschlüsselungsschlüssel wird nur auf deinem Gerät gespeichert, DuckDuckGo kann nicht darauf zugreifen.</string>
     <string name="sync_intro_enable_footer">Du kannst später mit deinen anderen Geräten synchronisieren.</string>
     <string name="sync_intro_enable_cta">„Synchronisieren und sichern“ aktivieren</string>
-    <string name="sync_intro_recover_title">Synchronisierte Daten wiederherstellen</string>
-    <string name="sync_intro_recover_content">Um deine synchronisierten Daten wiederherzustellen, benötigst du den Wiederherstellungscode, den du bei der Einrichtung von Synchronisieren und sichern gespeichert hast. Dieser Code wurde möglicherweise als PDF auf dem Gerät gespeichert, das du zum Einrichten von Synchronisieren und sichern verwendet hast.</string>
-    <string name="sync_intro_recover_cta">Los geht\'s!</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-Code scannen</string>
     <string name="login_screen_enter_code_cta">Code manuell eingeben</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Αυτό δημιουργεί ένα κρυπτογραφημένο αντίγραφο ασφάλειας των σελιδοδεικτών, των κωδικών πρόσβασής σας και των συνομιλιών στο Duck.ai στον ασφαλή διακομιστή του DuckDuckGo, το οποίο μπορεί να συγχρονιστεί με τις άλλες συσκευές σας. \n\n Το κλειδί κρυπτογράφησης αποθηκεύεται μόνο στη συσκευή σας. Δεν μπορεί να έχει πρόσβαση σε αυτό το DuckDuckGo.</string>
     <string name="sync_intro_enable_footer">Μπορείτε να προβείτε σε συγχρονισμό με τις άλλες συσκευές σας αργότερα.</string>
     <string name="sync_intro_enable_cta">Ενεργοποίηση συγχρονισμού και δημιουργίας αντιγράφων ασφαλείας</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Ανακτήστε τα συγχρονισμένα δεδομένα σας</string>
+    <string name="sync_recover_synced_data_content">Θα χρειαστείτε τον Κωδικό ανάκτησης που λάβατε κατά τη ρύθμιση του Sync &amp; Backup. Ενδέχεται να το έχετε αποθηκεύσει ως PDF στη συσκευή που χρησιμοποιήσατε.</string>
+    <string name="sync_recover_synced_data_cta">Ανάκτηση συγχρονισμένων δεδομένων</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Σάρωση κώδικα QR</string>
     <string name="login_screen_enter_code_cta">Μη αυτόματη εισαγωγή κωδικού</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Αυτό δημιουργεί ένα κρυπτογραφημένο αντίγραφο ασφάλειας των σελιδοδεικτών, των κωδικών πρόσβασής σας και των συνομιλιών στο Duck.ai στον ασφαλή διακομιστή του DuckDuckGo, το οποίο μπορεί να συγχρονιστεί με τις άλλες συσκευές σας. \n\n Το κλειδί κρυπτογράφησης αποθηκεύεται μόνο στη συσκευή σας. Δεν μπορεί να έχει πρόσβαση σε αυτό το DuckDuckGo.</string>
     <string name="sync_intro_enable_footer">Μπορείτε να προβείτε σε συγχρονισμό με τις άλλες συσκευές σας αργότερα.</string>
     <string name="sync_intro_enable_cta">Ενεργοποίηση συγχρονισμού και δημιουργίας αντιγράφων ασφαλείας</string>
-    <string name="sync_intro_recover_title">Ανάκτηση συγχρονισμένων δεδομένων</string>
-    <string name="sync_intro_recover_content">Για να κάνετε επαναφορά των συγχρονισμένων δεδομένων σας, θα χρειαστείτε τον Κωδικό ανάκτησης που αποθηκεύσατε κατά την πρώτη ρύθμιση του Συγχρονισμού. Αυτός ο κωδικός ενδέχεται να έχει αποθηκευτεί ως PDF στη συσκευή που χρησιμοποιήσατε αρχικά για ρύθμιση του Συγχρονισμού.</string>
-    <string name="sync_intro_recover_cta">Ξεκινήστε</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Σάρωση κώδικα QR</string>
     <string name="login_screen_enter_code_cta">Μη αυτόματη εισαγωγή κωδικού</string>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Esto crea una copia de seguridad encriptada de tus marcadores, contraseñas y chats de Duck.ai en el servidor seguro de DuckDuckGo que se puede sincronizar con tus otros dispositivos.\n\n La clave de encriptación solo se almacena en tu dispositivo, DuckDuckGo no puede acceder a ella.</string>
     <string name="sync_intro_enable_footer">Puedes sincronizar con tus otros dispositivos más tarde.</string>
     <string name="sync_intro_enable_cta">Activar sincronización y copia de seguridad</string>
-    <string name="sync_intro_recover_title">Recuperar datos sincronizados</string>
-    <string name="sync_intro_recover_content">Para restaurar tus datos sincronizados, necesitarás el código de recuperación que guardaste cuando configuraste la sincronización por primera vez. Es posible que este código se haya guardado como PDF en el dispositivo que utilizaste originalmente para configurar la sincronización.</string>
-    <string name="sync_intro_recover_cta">Empezar</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Escanear código QR</string>
     <string name="login_screen_enter_code_cta">Introducir código manualmente</string>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Esto crea una copia de seguridad encriptada de tus marcadores, contraseñas y chats de Duck.ai en el servidor seguro de DuckDuckGo que se puede sincronizar con tus otros dispositivos.\n\n La clave de encriptación solo se almacena en tu dispositivo, DuckDuckGo no puede acceder a ella.</string>
     <string name="sync_intro_enable_footer">Puedes sincronizar con tus otros dispositivos más tarde.</string>
     <string name="sync_intro_enable_cta">Activar sincronización y copia de seguridad</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Recupera tus datos sincronizados</string>
+    <string name="sync_recover_synced_data_content">Necesitarás el código de recuperación que recibiste cuando configuraste Sync &amp; Backup. Puede que lo hayas guardado como PDF en el dispositivo que usaste.</string>
+    <string name="sync_recover_synced_data_cta">Recuperar datos sincronizados</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Escanear código QR</string>
     <string name="login_screen_enter_code_cta">Introducir código manualmente</string>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">See loob DuckDuckGo turvalises serveris krüptitud varukoopia sinu järjehoidjatest, paroolidest ja Duck.ai vestlustest, mida saab sünkroonida sinu teiste seadmetega. \n\n Krüptimisvõti salvestatakse ainult sinu seadmesse, DuckDuckGo ei pääse sellele ligi.</string>
     <string name="sync_intro_enable_footer">Saad hiljem sünkroonida teiste seadmetega.</string>
     <string name="sync_intro_enable_cta">Lülita sünkroonimine ja varundamine sisse</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Oma sünkroonitud andmete taastamine</string>
+    <string name="sync_recover_synced_data_content">Sul on vaja taastamiskoodi, mille said funktsiooni Sync &amp; Backup seadistamisel. Võimalik, et salvestasid selle PDF-failina seadmesse, mida kasutasid.</string>
+    <string name="sync_recover_synced_data_cta">Taasta sünkroonitud andmed</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-koodi skannimine</string>
     <string name="login_screen_enter_code_cta">Sisesta kood käsitsi</string>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">See loob DuckDuckGo turvalises serveris krüptitud varukoopia sinu järjehoidjatest, paroolidest ja Duck.ai vestlustest, mida saab sünkroonida sinu teiste seadmetega. \n\n Krüptimisvõti salvestatakse ainult sinu seadmesse, DuckDuckGo ei pääse sellele ligi.</string>
     <string name="sync_intro_enable_footer">Saad hiljem sünkroonida teiste seadmetega.</string>
     <string name="sync_intro_enable_cta">Lülita sünkroonimine ja varundamine sisse</string>
-    <string name="sync_intro_recover_title">Taasta sünkroonitud andmed</string>
-    <string name="sync_intro_recover_content">Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid.</string>
-    <string name="sync_intro_recover_cta">Alustage</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-koodi skannimine</string>
     <string name="login_screen_enter_code_cta">Sisesta kood käsitsi</string>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tämä luo salatun varmuuskopion kirjanmerkeistäsi, salasanoistasi ja Duck.ai -keskusteluistasi DuckDuckGon suojatulle palvelimelle, ja se voidaan synkronoida muiden laitteidesi kanssa. \n\n Salausavain tallennetaan vain laitteellesi. DuckDuckGo ei pääse siihen käsiksi.</string>
     <string name="sync_intro_enable_footer">Voit synkronoiden muiden laitteittesi kanssa myöhemmin.</string>
     <string name="sync_intro_enable_cta">Ota käyttöön synkronointi ja varmuuskopiointi</string>
-    <string name="sync_intro_recover_title">Palauta synkronoidut tiedot</string>
-    <string name="sync_intro_recover_content">Jos haluat palauttaa synkronoidut tietosi, tarvitset palautuskoodin, jonka tallensit ottaessasi synkronoinnin käyttöön. Koodi on voitu tallentaa PDF-tiedostona laitteelle, jolla määritit synkronoinnin.</string>
-    <string name="sync_intro_recover_cta">Aloita</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skannaa QR-koodi</string>
     <string name="login_screen_enter_code_cta">Syötä koodi manuaalisesti</string>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tämä luo salatun varmuuskopion kirjanmerkeistäsi, salasanoistasi ja Duck.ai -keskusteluistasi DuckDuckGon suojatulle palvelimelle, ja se voidaan synkronoida muiden laitteidesi kanssa. \n\n Salausavain tallennetaan vain laitteellesi. DuckDuckGo ei pääse siihen käsiksi.</string>
     <string name="sync_intro_enable_footer">Voit synkronoiden muiden laitteittesi kanssa myöhemmin.</string>
     <string name="sync_intro_enable_cta">Ota käyttöön synkronointi ja varmuuskopiointi</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Palauta synkronoidut tiedot</string>
+    <string name="sync_recover_synced_data_content">Tarvitset palautuskoodin, jonka sait Sync &amp; Backup -ominaisuuden käyttöönoton yhteydessä. Olet saattanut tallentaa sen PDF-tiedostona käyttämällesi laitteelle.</string>
+    <string name="sync_recover_synced_data_cta">Palauta synkronoidut tiedot</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skannaa QR-koodi</string>
     <string name="login_screen_enter_code_cta">Syötä koodi manuaalisesti</string>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Cela crée une sauvegarde cryptée de vos favoris, mots de passe et discussions Duck.ai sur le serveur sécurisé de DuckDuckGo, qui peut être synchronisée avec vos autres appareils. \n\n La clé de cryptage n\'est stockée que sur votre appareil ; DuckDuckGo ne peut pas y accéder.</string>
     <string name="sync_intro_enable_footer">Vous pourrez effectuer une synchronisation avec vos autres appareils ultérieurement.</string>
     <string name="sync_intro_enable_cta">Activer Synchronisation et sauvegarde</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Récupérer vos données synchronisées</string>
+    <string name="sync_recover_synced_data_content">Il vous faudra le code de récupération obtenu lors de la configuration de Sync &amp; Backup. Peut-être l\'avez-vous enregistré au format PDF sur l\'appareil utilisé.</string>
+    <string name="sync_recover_synced_data_cta">Récupérer les données synchronisées</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Scanner le code QR</string>
     <string name="login_screen_enter_code_cta">Saisir manuellement le code</string>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Cela crée une sauvegarde cryptée de vos favoris, mots de passe et discussions Duck.ai sur le serveur sécurisé de DuckDuckGo, qui peut être synchronisée avec vos autres appareils. \n\n La clé de cryptage n\'est stockée que sur votre appareil ; DuckDuckGo ne peut pas y accéder.</string>
     <string name="sync_intro_enable_footer">Vous pourrez effectuer une synchronisation avec vos autres appareils ultérieurement.</string>
     <string name="sync_intro_enable_cta">Activer Synchronisation et sauvegarde</string>
-    <string name="sync_intro_recover_title">Récupérer les données synchronisées</string>
-    <string name="sync_intro_recover_content">Pour restaurer vos données synchronisées, il vous faudra le code de récupération que vous aurez enregistré lors de la première configuration de Synchronisation. Ce code peut avoir été enregistré au format PDF sur l\'appareil utilisé initialement pour configurer Synchronisation.</string>
-    <string name="sync_intro_recover_cta">Commencer</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Scanner le code QR</string>
     <string name="login_screen_enter_code_cta">Saisir manuellement le code</string>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Time se stvara šifrirana sigurnosna kopija tvojih oznaka, lozinki i Duck.ai čavrljanja na sigurnom poslužitelju DuckDuckGo, koja se može sinkronizirati s tvojim drugim uređajima. \n\n Ključ za šifriranje pohranjen je samo na tvom uređaju, DuckDuckGo mu ne može pristupiti.</string>
     <string name="sync_intro_enable_footer">Kasnije možeš sinkronizirati s drugim uređajima.</string>
     <string name="sync_intro_enable_cta">Uključi sinkronizaciju i sigurnosno kopiranje</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Oporavi sinkronizirane podatke</string>
+    <string name="sync_recover_synced_data_content">Trebat će ti šifra za oporavak dobivena prilikom postavljanja Sync &amp; Backupa. Možda si je spremio kao PDF na uređaju koji si koristio.</string>
+    <string name="sync_recover_synced_data_cta">Oporavak sinkroniziranih podataka</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skeniraj QR kôd</string>
     <string name="login_screen_enter_code_cta">Ručno unesi šifru</string>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Time se stvara šifrirana sigurnosna kopija tvojih oznaka, lozinki i Duck.ai čavrljanja na sigurnom poslužitelju DuckDuckGo, koja se može sinkronizirati s tvojim drugim uređajima. \n\n Ključ za šifriranje pohranjen je samo na tvom uređaju, DuckDuckGo mu ne može pristupiti.</string>
     <string name="sync_intro_enable_footer">Kasnije možeš sinkronizirati s drugim uređajima.</string>
     <string name="sync_intro_enable_cta">Uključi sinkronizaciju i sigurnosno kopiranje</string>
-    <string name="sync_intro_recover_title">Oporavak sinkroniziranih podataka</string>
-    <string name="sync_intro_recover_content">Za vraćanje sinkroniziranih podataka, trebat će ti šifra za oporavak koju si spremio prilikom prvog postavljanja sinkronizacije. Ta je šifra možda spremljena kao PDF na uređaju koji je izvorno korišten za postavljanje sinkronizacije.</string>
-    <string name="sync_intro_recover_cta">Započnite</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skeniraj QR kôd</string>
     <string name="login_screen_enter_code_cta">Ručno unesi šifru</string>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Ez egy titkosított biztonsági másolatot hoz létre a könyvjelzőidről, a jelszavaidról és a Duck.ai-csevegéseidről a DuckDuckGo biztonságos szerverén, amely szinkronizálható a többi eszközöddel. \n\n A titkosítási kulcs csak az eszközödön kerül eltárolásra, a DuckDuckGo nem fér hozzá.</string>
     <string name="sync_intro_enable_footer">Később szinkronizálhatod más eszközeidet.</string>
     <string name="sync_intro_enable_cta">Szinkronizálás és biztonsági mentés bekapcsolása</string>
-    <string name="sync_intro_recover_title">Szinkronizált adatok helyreállítása</string>
-    <string name="sync_intro_recover_content">A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt eszközre.</string>
-    <string name="sync_intro_recover_cta">Első lépések</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-kód beolvasása</string>
     <string name="login_screen_enter_code_cta">Kód manuális megadása</string>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Ez egy titkosított biztonsági másolatot hoz létre a könyvjelzőidről, a jelszavaidról és a Duck.ai-csevegéseidről a DuckDuckGo biztonságos szerverén, amely szinkronizálható a többi eszközöddel. \n\n A titkosítási kulcs csak az eszközödön kerül eltárolásra, a DuckDuckGo nem fér hozzá.</string>
     <string name="sync_intro_enable_footer">Később szinkronizálhatod más eszközeidet.</string>
     <string name="sync_intro_enable_cta">Szinkronizálás és biztonsági mentés bekapcsolása</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">A szinkronizált adataid helyreállítása</string>
+    <string name="sync_recover_synced_data_content">Szükséged lesz a Sync &amp; Backup beállításakor kapott helyreállítási kódra. Lehetséges, hogy PDF formátumban mentetted el azon az eszközön, amelyet használtál.</string>
+    <string name="sync_recover_synced_data_cta">Szinkronizált adatok helyreállítása</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-kód beolvasása</string>
     <string name="login_screen_enter_code_cta">Kód manuális megadása</string>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">In questo modo viene creato un backup crittografato dei tuoi segnalibri, delle tue password e delle chat di Duck.ai sul server sicuro di DuckDuckGo, che può essere sincronizzato con gli altri tuoi dispositivi. \n\n La chiave di crittografia viene memorizzata solo sul tuo dispositivo e DuckDuckGo non può accedervi.</string>
     <string name="sync_intro_enable_footer">Potrai effettuare la sincronizzazione con gli altri dispositivi in un secondo momento.</string>
     <string name="sync_intro_enable_cta">Attiva Sincronizzazione e backup</string>
-    <string name="sync_intro_recover_title">Recupera i dati sincronizzati</string>
-    <string name="sync_intro_recover_content">Per ripristinare i dati sincronizzati avrai bisogno del codice di ripristino che hai salvato quando hai configurato Sync per la prima volta. Questo codice potrebbe essere stato salvato in formato PDF sul dispositivo che hai usato originariamente per impostare la sincronizzazione.</string>
-    <string name="sync_intro_recover_cta">Iniziamo</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Scansiona il codice QR</string>
     <string name="login_screen_enter_code_cta">Inserisci manualmente il codice</string>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">In questo modo viene creato un backup crittografato dei tuoi segnalibri, delle tue password e delle chat di Duck.ai sul server sicuro di DuckDuckGo, che può essere sincronizzato con gli altri tuoi dispositivi. \n\n La chiave di crittografia viene memorizzata solo sul tuo dispositivo e DuckDuckGo non può accedervi.</string>
     <string name="sync_intro_enable_footer">Potrai effettuare la sincronizzazione con gli altri dispositivi in un secondo momento.</string>
     <string name="sync_intro_enable_cta">Attiva Sincronizzazione e backup</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Recupera i tuoi dati sincronizzati</string>
+    <string name="sync_recover_synced_data_content">Ti servirà il codice di ripristino che hai ricevuto quando hai configurato Sync &amp; Backup. Potresti averlo salvato in formato PDF sul dispositivo che hai utilizzato.</string>
+    <string name="sync_recover_synced_data_cta">Recupera i dati sincronizzati</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Scansiona il codice QR</string>
     <string name="login_screen_enter_code_cta">Inserisci manualmente il codice</string>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tai sukuria užšifruotą jūsų žymių, slaptažodžių ir Duck.ai pokalbių atsarginę kopiją “DuckDuckGo” saugiame serveryje, kurią galima sinchronizuoti su kitais jūsų įrenginiais. \n\n Šifravimo raktas saugomas tik jūsų įrenginyje, „DuckDuckGo“ negali jo pasiekti.</string>
     <string name="sync_intro_enable_footer">Vėliau galėsite sinchronizuoti su kitais įrenginiais.</string>
     <string name="sync_intro_enable_cta">Įjunkite sinchronizavimą ir atsarginės kopijos kūrimą</string>
-    <string name="sync_intro_recover_title">Atkurti sinchronizuotus duomenis</string>
-    <string name="sync_intro_recover_content">Norėdami atkurti sinchronizuotus duomenis, turėsite naudoti atkūrimo kodą, kurį išsaugojote pirmą kartą nustatydami sinchronizavimą. Šis kodas galėjo būti išsaugotas kaip PDF failas įrenginyje, kurį iš pradžių naudojote sinchronizavimui nustatyti.</string>
-    <string name="sync_intro_recover_cta">Pradėti</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Nuskaityti QR kodą</string>
     <string name="login_screen_enter_code_cta">Įveskite kodą ranka</string>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tai sukuria užšifruotą jūsų žymių, slaptažodžių ir Duck.ai pokalbių atsarginę kopiją “DuckDuckGo” saugiame serveryje, kurią galima sinchronizuoti su kitais jūsų įrenginiais. \n\n Šifravimo raktas saugomas tik jūsų įrenginyje, „DuckDuckGo“ negali jo pasiekti.</string>
     <string name="sync_intro_enable_footer">Vėliau galėsite sinchronizuoti su kitais įrenginiais.</string>
     <string name="sync_intro_enable_cta">Įjunkite sinchronizavimą ir atsarginės kopijos kūrimą</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Sinchronizuotų duomenų atkūrimas</string>
+    <string name="sync_recover_synced_data_content">Reikės atkūrimo kodo, kurį gavai, kai nustatei „Sync &amp; Backup\". Galbūt išsaugojai jį kaip PDF failą naudojamame įrenginyje.</string>
+    <string name="sync_recover_synced_data_cta">Atkurti sinchronizuotus duomenis</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Nuskaityti QR kodą</string>
     <string name="login_screen_enter_code_cta">Įveskite kodą ranka</string>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tas izveido šifrētu tavu grāmatzīmju, paroļu un Duck.ai tērzēšanas dublējumu DuckDuckGo drošajā serverī, ko vari sinhronizēt ar citām tavām ierīcēm. \n\n Šifrēšanas atslēga tiek saglabāta tikai tavā ierīcē – DuckDuckGo tai nevar piekļūt.</string>
     <string name="sync_intro_enable_footer">Vēlāk vari sinhronizēt ar citām ierīcēm.</string>
     <string name="sync_intro_enable_cta">Ieslēgt sinhronizāciju un dublēšanu</string>
-    <string name="sync_intro_recover_title">Sinhronizēto datu atgūšana</string>
-    <string name="sync_intro_recover_content">Lai atjaunotu sinhronizētos datus, ir nepieciešams atgūšanas kods, ko saglabāji, kad pirmo reizi iestatīji sinhronizāciju. Šis kods, iespējams, ir saglabāts PDF formātā ierīcē, kuru sākotnēji izmantoji sinhronizācijas iestatīšanai.</string>
-    <string name="sync_intro_recover_cta">Sākt darbu</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Kvadrātkoda skenēšana</string>
     <string name="login_screen_enter_code_cta">Manuāla koda ievadīšana</string>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tas izveido šifrētu tavu grāmatzīmju, paroļu un Duck.ai tērzēšanas dublējumu DuckDuckGo drošajā serverī, ko vari sinhronizēt ar citām tavām ierīcēm. \n\n Šifrēšanas atslēga tiek saglabāta tikai tavā ierīcē – DuckDuckGo tai nevar piekļūt.</string>
     <string name="sync_intro_enable_footer">Vēlāk vari sinhronizēt ar citām ierīcēm.</string>
     <string name="sync_intro_enable_cta">Ieslēgt sinhronizāciju un dublēšanu</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Sinhronizēto datu atgūšana</string>
+    <string name="sync_recover_synced_data_content">Tev būs nepieciešams atkopšanas kods, ko saņēmi, iestatot Sync &amp; Backup. Iespējams, esi saglabājis to PDF formātā izmantotajā ierīcē.</string>
+    <string name="sync_recover_synced_data_cta">Sinhronizēto datu atgūšana</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Kvadrātkoda skenēšana</string>
     <string name="login_screen_enter_code_cta">Manuāla koda ievadīšana</string>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dette oppretter en kryptert sikkerhetskopi av bokmerkene, passordene og Duck.ai-chattene dine på DuckDuckGos sikre server, som kan synkroniseres med dine andre enheter. \n\n Krypteringsnøkkelen lagres bare på enheten din. DuckDuckGo har ikke tilgang til den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisere med de andre enhetene dine senere.</string>
     <string name="sync_intro_enable_cta">Slå på Synkronisering og sikkerhetskopiering</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Gjenopprett synkroniserte data</string>
+    <string name="sync_recover_synced_data_content">Du trenger gjenopprettingskoden du fikk, da du konfigurerte Sync &amp; Backup. Du kan ha lagret den som en PDF på enheten du brukte.</string>
+    <string name="sync_recover_synced_data_cta">Gjenopprett synkroniserte data</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skann QR-kode</string>
     <string name="login_screen_enter_code_cta">Skriv inn koden manuelt</string>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Dette oppretter en kryptert sikkerhetskopi av bokmerkene, passordene og Duck.ai-chattene dine på DuckDuckGos sikre server, som kan synkroniseres med dine andre enheter. \n\n Krypteringsnøkkelen lagres bare på enheten din. DuckDuckGo har ikke tilgang til den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisere med de andre enhetene dine senere.</string>
     <string name="sync_intro_enable_cta">Slå på Synkronisering og sikkerhetskopiering</string>
-    <string name="sync_intro_recover_title">Gjenopprett synkroniserte data</string>
-    <string name="sync_intro_recover_content">For å gjenopprette synkroniserte data trenger du gjenopprettingskoden du lagret, da du først satte opp synkronisering. Denne koden kan ha blitt lagret som en PDF-fil på enheten du opprinnelig brukte til å sette opp synkronisering.</string>
-    <string name="sync_intro_recover_cta">Kom i gang</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skann QR-kode</string>
     <string name="login_screen_enter_code_cta">Skriv inn koden manuelt</string>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Hiermee maak je een versleutelde back-up van je bladwijzers, wachtwoorden en Duck.ai-chats op de beveiligde server van DuckDuckGo. Deze back-up kan met je andere apparaten worden gesynchroniseerd. \n\n De versleutelingscode wordt alleen op je apparaat opgeslagen. DuckDuckGo heeft er geen toegang toe.</string>
     <string name="sync_intro_enable_footer">Je kunt later synchroniseren met je andere apparaten.</string>
     <string name="sync_intro_enable_cta">\'Synchronisatie en back-up\' inschakelen</string>
-    <string name="sync_intro_recover_title">Gesynchroniseerde gegevens herstellen</string>
-    <string name="sync_intro_recover_content">Om je gesynchroniseerde gegevens te herstellen, heb je de herstelcode nodig die je hebt opgeslagen tijdens het instellen van \'Synchronisatie\'. Deze code is mogelijk als PDF opgeslagen op het apparaat dat je gebruikte om \'Synchronisatie\' in te stellen.</string>
-    <string name="sync_intro_recover_cta">Aan de slag</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-code scannen</string>
     <string name="login_screen_enter_code_cta">Code handmatig invoeren</string>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Hiermee maak je een versleutelde back-up van je bladwijzers, wachtwoorden en Duck.ai-chats op de beveiligde server van DuckDuckGo. Deze back-up kan met je andere apparaten worden gesynchroniseerd. \n\n De versleutelingscode wordt alleen op je apparaat opgeslagen. DuckDuckGo heeft er geen toegang toe.</string>
     <string name="sync_intro_enable_footer">Je kunt later synchroniseren met je andere apparaten.</string>
     <string name="sync_intro_enable_cta">\'Synchronisatie en back-up\' inschakelen</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Herstel je gesynchroniseerde gegevens</string>
+    <string name="sync_recover_synced_data_content">Je hebt de herstelcode nodig die je kreeg toen je Sync &amp; Backup instelde. Je hebt deze mogelijk als PDF opgeslagen op het apparaat dat je gebruikte.</string>
+    <string name="sync_recover_synced_data_cta">Gesynchroniseerde gegevens herstellen</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">QR-code scannen</string>
     <string name="login_screen_enter_code_cta">Code handmatig invoeren</string>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tworzy na bezpiecznym serwerze DuckDuckGo zaszyfrowaną kopię zapasową zakładek, haseł i czatów Duck.ai, którą można zsynchronizować z innymi urządzeniami. \n\n Klucz szyfrowania jest przechowywany tylko na urządzeniu użytkownika, DuckDuckGo nie może uzyskać do niego dostępu.</string>
     <string name="sync_intro_enable_footer">Możesz później przeprowadzić synchronizację z innymi urządzeniami.</string>
     <string name="sync_intro_enable_cta">Włącz synchronizację i kopię zapasową</string>
-    <string name="sync_intro_recover_title">Odzyskaj zsynchronizowane dane</string>
-    <string name="sync_intro_recover_content">Aby przywrócić zsynchronizowane dane, będziesz potrzebować kodu odzyskiwania zapisanego podczas pierwszej konfiguracji synchronizacji. Ten kod mógł zostać zapisany jako plik PDF na urządzeniu wykorzystanym do skonfigurowania synchronizacji.</string>
-    <string name="sync_intro_recover_cta">Rozpocznij</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Zeskanuj kod QR</string>
     <string name="login_screen_enter_code_cta">Wprowadź kod ręcznie</string>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tworzy na bezpiecznym serwerze DuckDuckGo zaszyfrowaną kopię zapasową zakładek, haseł i czatów Duck.ai, którą można zsynchronizować z innymi urządzeniami. \n\n Klucz szyfrowania jest przechowywany tylko na urządzeniu użytkownika, DuckDuckGo nie może uzyskać do niego dostępu.</string>
     <string name="sync_intro_enable_footer">Możesz później przeprowadzić synchronizację z innymi urządzeniami.</string>
     <string name="sync_intro_enable_cta">Włącz synchronizację i kopię zapasową</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Odzyskaj zsynchronizowane dane</string>
+    <string name="sync_recover_synced_data_content">Będziesz potrzebować kodu odzyskiwania otrzymanego podczas konfigurowania funkcji Sync &amp; Backup. Możliwe, że został on zapisany jako plik PDF na urządzeniu, które było używane.</string>
+    <string name="sync_recover_synced_data_cta">Odzyskaj zsynchronizowane dane</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Zeskanuj kod QR</string>
     <string name="login_screen_enter_code_cta">Wprowadź kod ręcznie</string>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Isto cria uma cópia de segurança encriptada dos marcadores, palavras-passe e chats do Duck.ai no servidor seguro da DuckDuckGo, que pode ser sincronizado com os teus outros dispositivos. \n\n A chave de encriptação é armazenada apenas no teu dispositivo. O DuckDuckGo não consegue aceder à chave.</string>
     <string name="sync_intro_enable_footer">Podes sincronizar com outros dispositivos mais tarde.</string>
     <string name="sync_intro_enable_cta">Ativar a sincronização e cópia de segurança</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Recuperar os teus dados sincronizados</string>
+    <string name="sync_recover_synced_data_content">Vais precisar do código de recuperação que recebeste quando configuraste o Sync &amp; Backup. Podes ter guardado como um PDF no dispositivo que utilizaste.</string>
+    <string name="sync_recover_synced_data_cta">Recuperar dados sincronizados</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Ler código QR</string>
     <string name="login_screen_enter_code_cta">Introduzir manualmente o código</string>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Isto cria uma cópia de segurança encriptada dos marcadores, palavras-passe e chats do Duck.ai no servidor seguro da DuckDuckGo, que pode ser sincronizado com os teus outros dispositivos. \n\n A chave de encriptação é armazenada apenas no teu dispositivo. O DuckDuckGo não consegue aceder à chave.</string>
     <string name="sync_intro_enable_footer">Podes sincronizar com outros dispositivos mais tarde.</string>
     <string name="sync_intro_enable_cta">Ativar a sincronização e cópia de segurança</string>
-    <string name="sync_intro_recover_title">Recuperar dados sincronizados</string>
-    <string name="sync_intro_recover_content">Para restaurares os teus dados sincronizados, precisas do código de recuperação que guardaste quando configuraste a sincronização. Este código pode ter sido guardado como um PDF no dispositivo usado para configurar a sincronização.</string>
-    <string name="sync_intro_recover_cta">Comece</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Ler código QR</string>
     <string name="login_screen_enter_code_cta">Introduzir manualmente o código</string>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Aceasta creează o copie de rezervă criptată a marcajelor, parolelor și chaturilor Duck.ai pe serverul securizat DuckDuckGo, care poate fi sincronizată cu celelalte dispozitive ale tale. \n\n Cheia de criptare este stocată doar pe dispozitivul tău, DuckDuckGo nu o poate accesa.</string>
     <string name="sync_intro_enable_footer">Poți sincroniza mai târziu cu celelalte dispozitive ale tale.</string>
     <string name="sync_intro_enable_cta">Activează Sincronizare și backup</string>
-    <string name="sync_intro_recover_title">Recuperează datele sincronizate</string>
-    <string name="sync_intro_recover_content">Pentru a restabili datele sincronizate, vei avea nevoie de codul de recuperare pe care l-ai salvat atunci când ai configurat prima dată Sincronizarea. Este posibil ca acest cod să fi fost salvat ca PDF pe dispozitivul pe care l-ai folosit inițial pentru a configura Sincronizarea.</string>
-    <string name="sync_intro_recover_cta">Să începem</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Scanează codul QR</string>
     <string name="login_screen_enter_code_cta">Completează manual codul</string>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Aceasta creează o copie de rezervă criptată a marcajelor, parolelor și chaturilor Duck.ai pe serverul securizat DuckDuckGo, care poate fi sincronizată cu celelalte dispozitive ale tale. \n\n Cheia de criptare este stocată doar pe dispozitivul tău, DuckDuckGo nu o poate accesa.</string>
     <string name="sync_intro_enable_footer">Poți sincroniza mai târziu cu celelalte dispozitive ale tale.</string>
     <string name="sync_intro_enable_cta">Activează Sincronizare și backup</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Recuperează-ți datele sincronizate</string>
+    <string name="sync_recover_synced_data_content">Vei avea nevoie de codul de recuperare pe care l-ai primit când ai configurat Sync &amp; Backup. Este posibil să-l fi salvat ca PDF pe dispozitivul pe care l-ai folosit.</string>
+    <string name="sync_recover_synced_data_cta">Recuperează datele sincronizate</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Scanează codul QR</string>
     <string name="login_screen_enter_code_cta">Completează manual codul</string>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">DuckDuckGo создаст зашифрованную резервную копию ваших закладок, паролей и чатов Duck.ai на надежном сервере. Копию можно синхронизировать с другими устройствами. \n\n Ключ шифрования хранится только на вашем устройстве. У DuckDuckGo нет к нему доступа.</string>
     <string name="sync_intro_enable_footer">Синхронизацию с другими устройствами можно выполнить позже.</string>
     <string name="sync_intro_enable_cta">Включить синхронизацию и копирование</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Восстановление синхронизированных данных</string>
+    <string name="sync_recover_synced_data_content">Вам потребуется код восстановления, полученный при настройке синхронизации и резервного копирования. Возможно, вы сохранили его в виде PDF на устройстве, где выполнялась настройка.</string>
+    <string name="sync_recover_synced_data_cta">Восстановить синхронизированные данные</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Сканирование QR-кода</string>
     <string name="login_screen_enter_code_cta">Ручной ввод кода</string>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">DuckDuckGo создаст зашифрованную резервную копию ваших закладок, паролей и чатов Duck.ai на надежном сервере. Копию можно синхронизировать с другими устройствами. \n\n Ключ шифрования хранится только на вашем устройстве. У DuckDuckGo нет к нему доступа.</string>
     <string name="sync_intro_enable_footer">Синхронизацию с другими устройствами можно выполнить позже.</string>
     <string name="sync_intro_enable_cta">Включить синхронизацию и копирование</string>
-    <string name="sync_intro_recover_title">Восстановить синхронизированные данные</string>
-    <string name="sync_intro_recover_content">Чтобы восстановить синхронизированные данные, потребуется код восстановления, который вы сохранили при первой настройке синхронизации. Возможно, он сохранен в файле PDF на устройстве, где изначально настраивалась синхронизация.</string>
-    <string name="sync_intro_recover_cta">Приступим!</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Сканирование QR-кода</string>
     <string name="login_screen_enter_code_cta">Ручной ввод кода</string>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tým sa na zabezpečenom serveri DuckDuckGo vytvorí šifrovaná záloha tvojich záložiek, hesiel a četov Duck.ai, ktorú môžeš synchronizovať s tvojimi ostatnými zariadeniami. \n\n Šifrovací kľúč je uložený iba v tvojom zariadení - DuckDuckGo k nemu nemá prístup.</string>
     <string name="sync_intro_enable_footer">S ostatnými zariadeniami môžete synchronizovať neskôr.</string>
     <string name="sync_intro_enable_cta">Zapnite synchronizáciu a zálohovanie</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Obnov svoje synchronizované údaje</string>
+    <string name="sync_recover_synced_data_content">Budeš potrebovať kód na obnovenie, ktorý si dostal/-a pri nastavovaní Sync &amp; Backup. Možno ho máš uložený v podobe PDF súboru na zariadení, ktoré si použil/-a.</string>
+    <string name="sync_recover_synced_data_cta">Obnovenie synchronizovaných údajov</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skenovanie kódu QR</string>
     <string name="login_screen_enter_code_cta">Manuálne zadajte kód</string>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Tým sa na zabezpečenom serveri DuckDuckGo vytvorí šifrovaná záloha tvojich záložiek, hesiel a četov Duck.ai, ktorú môžeš synchronizovať s tvojimi ostatnými zariadeniami. \n\n Šifrovací kľúč je uložený iba v tvojom zariadení - DuckDuckGo k nemu nemá prístup.</string>
     <string name="sync_intro_enable_footer">S ostatnými zariadeniami môžete synchronizovať neskôr.</string>
     <string name="sync_intro_enable_cta">Zapnite synchronizáciu a zálohovanie</string>
-    <string name="sync_intro_recover_title">Obnovenie synchronizovaných údajov</string>
-    <string name="sync_intro_recover_content">Na obnovenie synchronizovaných údajov budete potrebovať kód na obnovenie, ktorý ste uložili pri prvom nastavení funkcie Sync. Tento kód mohol byť uložený vo formáte PDF v zariadení, ktoré ste pôvodne použili na nastavenie funkcie Sync.</string>
-    <string name="sync_intro_recover_cta">Začnite</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skenovanie kódu QR</string>
     <string name="login_screen_enter_code_cta">Manuálne zadajte kód</string>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">S tem ustvarite šifrirano varnostno kopijo zaznamkov, gesel in klepetov Duck.ai v varnem strežniku DuckDuckGo, ki jo lahko sinhronizirate z drugimi napravami. \n\n Šifrirni ključ je shranjen samo v vaši napravi, DuckDuckGo ne more dostopati do njega.</string>
     <string name="sync_intro_enable_footer">Pozneje lahko sinhronizirate z drugimi napravami.</string>
     <string name="sync_intro_enable_cta">Vklopite sinhronizacijo in varnostno kopiranje</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Obnovi sinhronizirane podatke</string>
+    <string name="sync_recover_synced_data_content">Potrebovali boste obnovitveno kodo, ki ste jo prejeli ob nastavitvi funkcije Sync &amp; Backup. To kodo ste morda shranili kot PDF v napravi, ki ste jo takrat uporabili.</string>
+    <string name="sync_recover_synced_data_cta">Obnovitev sinhroniziranih podatkov</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skeniranje kode QR</string>
     <string name="login_screen_enter_code_cta">Ročno vnesite kodo</string>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">S tem ustvarite šifrirano varnostno kopijo zaznamkov, gesel in klepetov Duck.ai v varnem strežniku DuckDuckGo, ki jo lahko sinhronizirate z drugimi napravami. \n\n Šifrirni ključ je shranjen samo v vaši napravi, DuckDuckGo ne more dostopati do njega.</string>
     <string name="sync_intro_enable_footer">Pozneje lahko sinhronizirate z drugimi napravami.</string>
     <string name="sync_intro_enable_cta">Vklopite sinhronizacijo in varnostno kopiranje</string>
-    <string name="sync_intro_recover_title">Obnovitev sinhroniziranih podatkov</string>
-    <string name="sync_intro_recover_content">Za obnovitev sinhroniziranih podatkov potrebujete kodo za obnovitev, ki ste jo shranili ob prvi nastavitvi sinhronizacije. Ta koda je bila morda shranjena kot PDF v napravi, ki ste jo prvotno uporabili za nastavitev sinhronizacije.</string>
-    <string name="sync_intro_recover_cta">Začni</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skeniranje kode QR</string>
     <string name="login_screen_enter_code_cta">Ročno vnesite kodo</string>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Detta skapar en krypterad säkerhetskopia av dina bokmärken, lösenord och Duck.ai-chattar på DuckDuckGos säkra server, som kan synkroniseras med dina andra enheter. \n\n Krypteringsnyckeln lagras endast på din enhet. DuckDuckGo har inte åtkomst till den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisera med dina andra enheter senare.</string>
     <string name="sync_intro_enable_cta">Aktivera synkronisering och säkerhetskopiering</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Återställ dina synkroniserade data</string>
+    <string name="sync_recover_synced_data_content">Du behöver den återställningskod som du fick när du konfigurerade Sync &amp; Backup. Du kan ha sparat koden som en PDF-fil på enheten du använde.</string>
+    <string name="sync_recover_synced_data_cta">Återställ synkroniserade data</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">Skanna QR-kod</string>
     <string name="login_screen_enter_code_cta">Ange kod manuellt</string>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Detta skapar en krypterad säkerhetskopia av dina bokmärken, lösenord och Duck.ai-chattar på DuckDuckGos säkra server, som kan synkroniseras med dina andra enheter. \n\n Krypteringsnyckeln lagras endast på din enhet. DuckDuckGo har inte åtkomst till den.</string>
     <string name="sync_intro_enable_footer">Du kan synkronisera med dina andra enheter senare.</string>
     <string name="sync_intro_enable_cta">Aktivera synkronisering och säkerhetskopiering</string>
-    <string name="sync_intro_recover_title">Återställ synkroniserade data</string>
-    <string name="sync_intro_recover_content">För att återställa dina synkroniserade data behöver du den återställningskod som du sparade när du konfigurerade synkronisering första gången. Koden kan ha sparats som en PDF-fil på den enhet du använde för att konfigurera synkronisering första gången.</string>
-    <string name="sync_intro_recover_cta">Kom igång</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">Skanna QR-kod</string>
     <string name="login_screen_enter_code_cta">Ange kod manuellt</string>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -56,6 +56,11 @@
     <string name="sync_intro_enable_content_with_ai_chat">Bu işlem, yer işaretleri, şifreler ve Duck.ai sohbetlerinin şifrelenmiş bir yedeğini DuckDuckGo\'nun güvenli sunucusunda oluşturur ve bunlar diğer cihazlarınızla senkronize edilebilir. \n\n Şifreleme anahtarı sadece cihazınızda saklanır ve DuckDuckGo bu anahtara erişemez.</string>
     <string name="sync_intro_enable_footer">Daha sonra diğer cihazlarınızla senkronize edebilirsiniz.</string>
     <string name="sync_intro_enable_cta">Senkronizasyon ve Yedekleme\'yi açın</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Senkronize edilmiş verilerinizi kurtarın</string>
+    <string name="sync_recover_synced_data_content">Sync &amp; Backup kurulumunda verilen Kurtarma Koduna ihtiyacınız olacak. Kullandığınız cihazda PDF olarak kaydetmiş olabilirsiniz.</string>
+    <string name="sync_recover_synced_data_cta">Senkronize Edilen Verileri Kurtar</string>
+
     <!-- Recover data screen -->
     <string name="login_screen_title">QR Kodunu Tara</string>
     <string name="login_screen_enter_code_cta">Kodu Manuel Olarak Yaz</string>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -56,10 +56,6 @@
     <string name="sync_intro_enable_content_with_ai_chat">Bu işlem, yer işaretleri, şifreler ve Duck.ai sohbetlerinin şifrelenmiş bir yedeğini DuckDuckGo\'nun güvenli sunucusunda oluşturur ve bunlar diğer cihazlarınızla senkronize edilebilir. \n\n Şifreleme anahtarı sadece cihazınızda saklanır ve DuckDuckGo bu anahtara erişemez.</string>
     <string name="sync_intro_enable_footer">Daha sonra diğer cihazlarınızla senkronize edebilirsiniz.</string>
     <string name="sync_intro_enable_cta">Senkronizasyon ve Yedekleme\'yi açın</string>
-    <string name="sync_intro_recover_title">Senkronize Edilen Verileri Kurtar</string>
-    <string name="sync_intro_recover_content">Senkronize edilmiş verilerinizi geri yüklemek için Senkronizasyonu ilk ayarlarken belirlediğiniz Kurtarma Koduna ihtiyacınız olacaktır. Bu kod, Senkronizasyonu yapmak üzere kullandığınız cihaza PDF olarak kaydedilmiş olabilir.</string>
-    <string name="sync_intro_recover_cta">Başlayın</string>
-
     <!-- Recover data screen -->
     <string name="login_screen_title">QR Kodunu Tara</string>
     <string name="login_screen_enter_code_cta">Kodu Manuel Olarak Yaz</string>

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -56,9 +56,10 @@
     <string name="sync_intro_enable_content_with_ai_chat">This creates an encrypted backup of your bookmarks, passwords, and Duck.ai chats on DuckDuckGo’s secure server, which can be synced with your other devices. \n\n The encryption key is only stored on your device, DuckDuckGo cannot access it.</string>
     <string name="sync_intro_enable_footer">You can sync with your other devices later.</string>
     <string name="sync_intro_enable_cta">Turn on Sync &amp; Backup</string>
-    <string name="sync_intro_recover_title">Recover Synced Data</string>
-    <string name="sync_intro_recover_content">To restore your synced data, you\'ll need the Recovery Code you saved when you first set up Sync. This code may have been saved as a PDF on the device you originally used to set up Sync.</string>
-    <string name="sync_intro_recover_cta">Get Started</string>
+    <!-- Recover Synced Data Intro Screen -->
+    <string name="sync_recover_synced_data_title">Recover your synced data</string>
+    <string name="sync_recover_synced_data_content">You\'ll need the Recovery Code you got when you set up Sync &amp; Backup. You may have saved it as a PDF on the device you used.</string>
+    <string name="sync_recover_synced_data_cta">Recover Synced Data</string>
 
     <!-- Recover data screen -->
     <string name="login_screen_title">Scan QR Code</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211766481496467?focus=true

### Description
Update copy on the sync recovery screen

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change; main risk is missing/incorrect localization keys causing fallback/missing text on the recovery intro screen.
> 
> **Overview**
> Updates the *Sync recovery intro* screen copy by switching `RecoverAccountIntro` to new string resources (`sync_recover_synced_data_*`) and updating the CTA/title/body text.
> 
> Replaces the old `sync_intro_recover_*` strings with newly worded equivalents across the base `strings-sync.xml` and multiple localized `strings-sync.xml` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8ed1be68da4615b63ec0b2d9da1f18b43ecae42. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->