### PR TITLE
Control animation on search and chat selection

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -343,9 +343,9 @@ class RealNativeInputManager @Inject constructor(
             },
         )
         val previousOnChatSelected = widget.onChatSelected
-        widget.onChatSelected = {
+        widget.onChatSelected = { animate ->
             callbacks.onClearAutocomplete()
-            previousOnChatSelected?.invoke()
+            previousOnChatSelected?.invoke(animate)
         }
         widget.onClearTextTapped = {
             if (!widget.isChatTabSelected()) {
@@ -420,11 +420,11 @@ class RealNativeInputManager @Inject constructor(
     ) {
         val widget = widgetFrom(widgetView) ?: return
         val previousOnSearchSelected = widget.onSearchSelected
-        widget.onSearchSelected = {
+        widget.onSearchSelected = { animate ->
             if (widget.text.isBlank()) {
                 onClearAutocomplete()
             }
-            previousOnSearchSelected?.invoke()
+            previousOnSearchSelected?.invoke(animate)
         }
     }
 
@@ -440,8 +440,8 @@ class RealNativeInputManager @Inject constructor(
             rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return
         val focusedView = rootView.findViewById<View?>(R.id.focusedView)
         val previousOnChatSelected = widget.onChatSelected
-        widget.onChatSelected = {
-            previousOnChatSelected?.invoke()
+        widget.onChatSelected = { animate ->
+            previousOnChatSelected?.invoke(animate)
             autoCompleteList.gone()
             focusedView?.gone()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -290,9 +290,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             params?.launchOnChat ?: false
         }
         if (launchOnChat) {
-            inputModeWidget.initOnChat()
+            inputModeWidget.initOnChat(animate = false)
         } else {
-            inputModeWidget.initOnSearch()
+            inputModeWidget.initOnSearch(animate = false)
         }
         updateMenuIconButton(params?.useBottomSheetMenu ?: false)
 
@@ -464,13 +464,13 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             onBack = {
                 requireActivity().onBackPressed()
             }
-            onSearchSelected = {
-                binding.viewPager.setCurrentItem(0, true)
+            onSearchSelected = { animate ->
+                binding.viewPager.setCurrentItem(0, animate)
                 viewModel.onSearchSelected()
                 viewModel.onSearchInputTextChanged(inputModeWidget.text)
             }
-            onChatSelected = {
-                binding.viewPager.setCurrentItem(1, true)
+            onChatSelected = { animate ->
+                binding.viewPager.setCurrentItem(1, animate)
                 viewModel.onChatSelected()
                 viewModel.onChatInputTextChanged(inputModeWidget.text)
                 if (!useTopBar) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -101,8 +101,8 @@ open class InputModeWidget @JvmOverloads constructor(
     var onBack: (() -> Unit)? = null
     var onSearchSent: ((String) -> Unit)? = null
     var onChatSent: ((String) -> Unit)? = null
-    var onSearchSelected: (() -> Unit)? = null
-    var onChatSelected: (() -> Unit)? = null
+    var onSearchSelected: ((animate: Boolean) -> Unit)? = null
+    var onChatSelected: ((animate: Boolean) -> Unit)? = null
     var onSubmitMessageAvailable: ((Boolean) -> Unit)? = null
         set(value) {
             field = value
@@ -203,12 +203,12 @@ open class InputModeWidget @JvmOverloads constructor(
         }
     }
 
-    fun initOnSearch() {
-        onSearchSelected?.invoke()
+    fun initOnSearch(animate: Boolean = true) {
+        onSearchSelected?.invoke(animate)
     }
 
-    fun initOnChat() {
-        onChatSelected?.invoke()
+    fun initOnChat(animate: Boolean = true) {
+        onChatSelected?.invoke(animate)
     }
 
     fun clearInputFocus() {
@@ -349,8 +349,8 @@ open class InputModeWidget @JvmOverloads constructor(
                     val isSearchTab = tab.position == 0
                     applyModeSpecificInputBehaviour(isSearchTab = isSearchTab)
                     when (tab.position) {
-                        0 -> onSearchSelected?.invoke()
-                        1 -> onChatSelected?.invoke()
+                        0 -> onSearchSelected?.invoke(true)
+                        1 -> onChatSelected?.invoke(true)
                     }
                 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -56,8 +56,8 @@ import javax.inject.Inject
 interface NativeInputWidget {
 
     var text: String
-    var onSearchSelected: (() -> Unit)?
-    var onChatSelected: (() -> Unit)?
+    var onSearchSelected: ((animate: Boolean) -> Unit)?
+    var onChatSelected: ((animate: Boolean) -> Unit)?
     var onClearTextTapped: (() -> Unit)?
     var onStopTapped: (() -> Unit)?
     var onVoiceClick: (() -> Unit)?
@@ -297,7 +297,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onChatSubmitted: (String) -> Unit,
     ) {
         this.onSearchTextChanged = onSearchTextChanged
-        this.onSearchSelected = {
+        this.onSearchSelected = { _ ->
             onSearchTextChanged(text)
         }
         this.onSearchSent = onSearchSubmitted
@@ -342,14 +342,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
 
         val previousOnSearchSelected = this.onSearchSelected
-        this.onSearchSelected = {
+        this.onSearchSelected = { animate ->
             hideChatSuggestions(hideList = false)
-            previousOnSearchSelected?.invoke()
+            previousOnSearchSelected?.invoke(animate)
         }
 
         val previousOnChatSelected = this.onChatSelected
-        this.onChatSelected = {
-            previousOnChatSelected?.invoke()
+        this.onChatSelected = { animate ->
+            previousOnChatSelected?.invoke(animate)
             showSuggestions(text)
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213839968417665?focus=true 

### Description
When selecting “Duck.ai” as default, the toggle is playing a small animation on init, the sliding animation from “Search” to “Duck.ai”. This doesn’t look good especially since the page just loaded and is not transitioning.
We need to improve the way we load the input screen to make it load the default without animation.

This PR makes the "smoothScroll" a parameter instead of hard coding it to true, and pass it from both the input widget and the native input widget.

### Steps to test this PR

- Turn on "rememberTogglePosition" FF
- Go to AI Features setting, select "Search & Duck.ai"
- Set the "Default Toggle Position" to "Duck.ai"
- go to a website, then create a new tab
- Expectation: New tab defaults to "Duck.ai" toggle without any sliding animation. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-behavior change limited to tab selection and `ViewPager` smooth scrolling; main risk is mismatched callback signatures causing missed tab-change side effects.
> 
> **Overview**
> Prevents the input screen toggle from animating on initial load by **threading an `animate` boolean through search/chat tab selection callbacks**.
> 
> `InputModeWidget` and the native widget interface now pass this flag through to callers, and `InputScreenFragment` uses it to control `ViewPager.setCurrentItem(..., animate)` while initializing the default tab with `animate = false`. Related wrappers in `NativeInputManager`/`NativeInputModeWidget` forward the flag while preserving existing side effects (autocomplete clearing, suggestions visibility).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4ba3ef865ae40a285316f80c7b2ef6f94e4379d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->