### PR TITLE
Make adding labels a separate step

### DIFF
--- a/.github/workflows/update-pir-broker-bundle.yml
+++ b/.github/workflows/update-pir-broker-bundle.yml
@@ -57,7 +57,6 @@ jobs:
           author: daxmobile <daxmobile@users.noreply.github.com>
           token: ${{ secrets.GT_DAXMOBILE }}
           commit-message: "Update PIR broker bundle - ${{ env.current_date }}"
-          labels: pir, automated pr
           branch: automated/update-pir-broker-bundle-${{ env.current_date }}
           add-paths: pir/pir-impl/src/main/assets/brokers
           body: |
@@ -73,6 +72,12 @@ jobs:
 
             - [ ] Verify broker changes look correct
             - [ ] All tests must pass
+
+      - name: Apply labels to PR
+        if: ${{ steps.broker-check.outputs.has_changes == 'true' && steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
+        run: gh pr edit ${{ steps.create-pr.outputs.pull-request-number }} --add-label "pir" --add-label "automated pr"
 
       - name: Create Asana task
         if: ${{ steps.broker-check.outputs.has_changes == 'true' }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213875032793224?focus=true

### Description
Moves adding labels to automatically created PR a separate step to avoid timing issue with PR not being fully created when labels are added via the GH action.

### Steps to test this PR
No QA needed, will be tested on next run of the workflow.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts PR labeling to avoid timing issues; main risk is requiring `gh` CLI availability and correct token permissions in the runner.
> 
> **Overview**
> **Separates PR labeling from PR creation** in `update-pir-broker-bundle.yml` by removing labels from the `peter-evans/create-pull-request` step.
> 
> Adds a follow-up step that runs `gh pr edit ... --add-label` (gated on `pull-request-number`) to apply the `pir` and `automated pr` labels after the PR is created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de03c8d62e3abba45fe7cb7b9e06b5fd43e0ba61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->