### PR TITLE
Update custom header tests to use UTC

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/trafficquality/CustomHeaderAllowedCheckerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/trafficquality/CustomHeaderAllowedCheckerTest.kt
@@ -26,7 +26,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset.UTC
 
 class CustomHeaderAllowedCheckerTest {
 
@@ -112,7 +112,7 @@ class CustomHeaderAllowedCheckerTest {
     }
 
     private fun givenBuildDateDaysAgo(days: Long) {
-        val daysAgo = LocalDateTime.now().minusDays(days).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val daysAgo = LocalDateTime.now(UTC).minusDays(days).atZone(UTC).toInstant().toEpochMilli()
         whenever(appBuildConfig.buildDateTimeMillis).thenReturn(daysAgo)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1213881885084184?focus=true

### Description
Fixes test helper to use UTC to prevent DST issue causing a failure if the test is run in some timezones.

### Steps to test this PR
 - [ ] QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that standardizes time calculations to UTC; no production behavior or data handling is modified.
> 
> **Overview**
> Updates `CustomHeaderAllowedCheckerTest` to generate the mocked `buildDateTimeMillis` using `ZoneOffset.UTC` rather than the device/system default timezone, aligning the test’s time calculations with production logic and avoiding timezone-dependent failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56896f97e3211bdb44fac337dcb347961f8e702d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->