### PR TITLE
Display back history with a long press on back button

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1698,6 +1698,9 @@ class BrowserTabFragment :
             onMenuItemClicked(backMenuItem) {
                 onBackArrowClicked()
             }
+            onMenuItemLongClicked(backMenuItem) {
+                onBackArrowLongClicked()
+            }
             onMenuItemClicked(forwardMenuItem) {
                 onForwardArrowClicked()
             }

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -184,6 +184,14 @@ class BrowserMenuBottomSheet(
         }
     }
 
+    fun onMenuItemLongClicked(menuView: View, onClick: () -> Unit) {
+        menuView.setOnLongClickListener {
+            onClick()
+            dismiss()
+            true
+        }
+    }
+
     private fun hideAllMenuItems() {
         menuItemsContainer.children.forEach { menuItem ->
             menuItem.gone()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213860477517943?focus=true
GitHub issue: https://github.com/duckduckgo/Android/issues/8151 

### Description

Display back history with a long press on the back button with new bottom sheet menu.

### Steps to test this PR

- [ ] Open the browser, navigate in two different websites
- [ ] Open the browser menu in sheet mode (enable the new browser menu in Appearance settings if necessary)
- [ ] Make a long press on the back button and check the back history is displayed in a new bottom sheet 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI interaction change limited to the new bottom-sheet menu; main risk is unintended long-press behavior or missing menu-usage pixels for that path.
> 
> **Overview**
> Enables **long-press on the Back button** in the new bottom-sheet browser menu to invoke the existing back-history flow (`onBackArrowLongClicked`).
> 
> Adds a reusable `onMenuItemLongClicked` helper to `BrowserMenuBottomSheet` that wires a `setOnLongClickListener` and dismisses the sheet after handling the action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf975ec29f40dfc8190d93aa32021c0aa4dd668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->