### PR TITLE
Fix m_aichat_settings_auto_context pixel definition

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -300,7 +300,13 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_enabled",
+                "description": "whether automatic page context collection is enabled or not"
+            }
+        ]
     },
     "m_aichat_settings_chat_suggestions_turned_on_count": {
         "description": "User enabled the Chat Suggestions toggle in General Settings",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1213752150879203?focus=true

### Description
The pixel `m_aichat_settings_auto_context` was failing live validation because it is fired with an `is_enabled` parameter in `DuckChatDailyPixelSender` but the pixel definition was missing this parameter.

Added `is_enabled` to the parameters list in the pixel definition to match what is actually being sent.

### Steps to test this PR
- [ ] Pixel validation report no longer flags `m_aichat_settings_auto_context` for an extra `is_enabled` property

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small analytics schema change that only affects pixel validation/metadata and does not modify runtime logic.
> 
> **Overview**
> Fixes the Duck Chat daily pixel definition for `m_aichat_settings_auto_context` by adding the missing `is_enabled` parameter (with description) alongside `appVersion`, aligning the schema with the event payload sent in production.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00a2d2e118f2b00f40d6374e8d3cd3758eaba94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->