### PR TITLE
Disable autofill instead of crashing on exceptions

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+import logcat.logcat
 import javax.inject.Inject
 
 interface InBrowserImportPromo {
@@ -73,7 +74,12 @@ class RealInBrowserImportPromo @Inject constructor(
                 return@withContext false
             }
 
-            if ((autofillStore.getCredentialCount().firstOrNull() ?: 0) >= MAX_CREDENTIALS_FOR_PROMO) {
+            runCatching {
+                if ((autofillStore.getCredentialCount().firstOrNull() ?: 0) >= MAX_CREDENTIALS_FOR_PROMO) {
+                    return@withContext false
+                }
+            }.getOrElse {
+                logcat { "InSettingsPasswordImportPromoRules - Couldn't retrieve credentials count" }
                 return@withContext false
             }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InSettingsPasswordImportPromoRules.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InSettingsPasswordImportPromoRules.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+import logcat.logcat
 import javax.inject.Inject
 
 interface InSettingsPasswordImportPromoRules {
@@ -52,7 +53,12 @@ class RealInSettingsPasswordImportPromoRules @Inject constructor(
                 return@withContext false
             }
 
-            if ((autofillStore.getCredentialCount().firstOrNull() ?: 0) >= MAX_CREDENTIALS_FOR_PROMO) {
+            runCatching {
+                if ((autofillStore.getCredentialCount().firstOrNull() ?: 0) >= MAX_CREDENTIALS_FOR_PROMO) {
+                    return@withContext false
+                }
+            }.getOrElse {
+                logcat { "InSettingsPasswordImportPromoRules - Couldn't retrieve credentials count" }
                 return@withContext false
             }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
@@ -103,6 +103,8 @@ import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -324,7 +326,15 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
             return
         }
 
-        val credentialCount = autofillStore.getCredentialCount().firstOrNull()
+        val credentialCount = runCatching {
+            autofillStore.getCredentialCount().firstOrNull()
+        }.getOrElse {
+            currentCoroutineContext().ensureActive()
+            logcat { "Error accessing secure storage so can't offer autofill functionality" }
+            deviceUnsupported()
+            return
+        }
+
         val shouldAskAuth = credentialCount == null || credentialCount == 0
         if (shouldAskAuth) {
             logcat(VERBOSE) { "No credentials; can skip showing device auth" }
@@ -433,17 +443,23 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
                 prioritizeDomainMatchesOnSearch = autofillFeature.prioritizeDomainMatchesOnSearch().isEnabled(),
             )
 
-            val allCredentials = autofillStore.getAllCredentials().distinctUntilChanged()
-            val combined = allCredentials.combine(searchQueryFilter) { credentials, filter ->
-                credentialListFilter.filter(credentials, filter)
-            }
-            combined.collect { credentials ->
-                val updatedBreakageState = _viewState.value.reportBreakageState.copy(allowBreakageReporting = isBreakageReportingAllowed())
-                _viewState.value = _viewState.value.copy(
-                    logins = credentials,
-                    reportBreakageState = updatedBreakageState,
-                )
-                showPromotionIfEligible()
+            runCatching {
+                val allCredentials = autofillStore.getAllCredentials().distinctUntilChanged()
+                val combined = allCredentials.combine(searchQueryFilter) { credentials, filter ->
+                    credentialListFilter.filter(credentials, filter)
+                }
+                combined.collect { credentials ->
+                    val updatedBreakageState = _viewState.value.reportBreakageState.copy(allowBreakageReporting = isBreakageReportingAllowed())
+                    _viewState.value = _viewState.value.copy(
+                        logins = credentials,
+                        reportBreakageState = updatedBreakageState,
+                    )
+                    showPromotionIfEligible()
+                }
+            }.getOrElse {
+                logcat { "Error accessing secure storage so can't offer autofill functionality" }
+                deviceUnsupported()
+                return@launch
             }
         }
 
@@ -681,10 +697,17 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
             logcat(VERBOSE) { "Opened autofill management screen from from $launchSource" }
 
             val source = launchSource.asString()
-            val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
-            pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source, "has_credentials_saved" to hasCredentialsSaved.toBinaryString()))
-            pixel.fire(AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED)
-            pixel.fire(AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+            runCatching {
+                val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
+                pixel.fire(
+                    AUTOFILL_MANAGEMENT_SCREEN_OPENED,
+                    mapOf("source" to source, "has_credentials_saved" to hasCredentialsSaved.toBinaryString()),
+                )
+                pixel.fire(AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED)
+                pixel.fire(AutofillPixelNames.PRODUCT_TELEMETRY_SURFACE_PASSWORDS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+            }.getOrElse {
+                logcat { "Couldn't get credential count" }
+            }
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -52,6 +53,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 
 @ContributesViewModel(ActivityScope::class)
@@ -107,21 +109,30 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun sendLaunchPixel(autofillScreenLaunchSource: AutofillScreenLaunchSource) {
         viewModelScope.launch {
-            val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
-            pixel.fire(
-                AUTOFILL_SETTINGS_OPENED,
-                parameters = mapOf(
-                    "source" to autofillScreenLaunchSource.asString(),
-                    "has_credentials_saved" to hasCredentialsSaved.toBinaryString(),
-                ),
-            )
+            runCatching {
+                val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
+                pixel.fire(
+                    AUTOFILL_SETTINGS_OPENED,
+                    parameters = mapOf(
+                        "source" to autofillScreenLaunchSource.asString(),
+                        "has_credentials_saved" to hasCredentialsSaved.toBinaryString(),
+                    ),
+                )
+            }.getOrElse {
+                ensureActive()
+                logcat { "Autofill-settings: Can't get credential count" }
+            }
         }
     }
 
     private fun onViewStateFlowStart() {
         viewModelScope.launch(dispatchers.io()) {
-            autofillStore.getCredentialCount().collect { count ->
-                _viewState.value = _viewState.value.copy(loginsCount = count)
+            runCatching {
+                autofillStore.getCredentialCount().collect { count ->
+                    _viewState.value = _viewState.value.copy(loginsCount = count)
+                }
+            }.getOrElse {
+                _viewState.value = _viewState.value.copy(autofillUnsupported = true)
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1213571673775022?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] Fresh install
- [ ] Create a password for fill.dev
- [ ] Apply patch, install again
- [ ] Open fill.dev
- [ ] Check app doesn't crash


### Patches
```
Subject: [PATCH] Force exception on read
---
Index: autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt	(revision c626e494540a136b957a810912bb7e281aba5c3d)
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt	(date 1774962387460)
@@ -325,6 +325,9 @@
     }
 
     override suspend fun getKey(keyName: String): ByteArray? {
+        if (keyName != "KEY_L1KEY") {
+            throw SecureStorageException.InternalSecureStorageException("test")
+        }
         return withContext(dispatcherProvider.io()) {
             val harmonyFlags = harmonyFlags()
 
```

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
