### PR TITLE
Prevent crash if there was an exception getting login items for URL

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
@@ -135,21 +136,26 @@ class SecureStoreBackedAutofillStore @Inject constructor(
     override suspend fun getCredentials(rawUrl: String): List<LoginCredentials> {
         return withContext(dispatcherProvider.io()) {
             return@withContext if (autofillEnabled && autofillAvailable()) {
-                logcat(INFO) { "Querying secure store for stored credentials. rawUrl: $rawUrl" }
+                runCatching {
+                    logcat(INFO) { "Querying secure store for stored credentials. rawUrl: $rawUrl" }
 
-                val visitedSite = autofillUrlMatcher.extractUrlPartsForAutofill(rawUrl)
-                if (visitedSite.eTldPlus1 == null) return@withContext emptyList()
+                    val visitedSite = autofillUrlMatcher.extractUrlPartsForAutofill(rawUrl)
+                    if (visitedSite.eTldPlus1 == null) return@withContext emptyList()
 
-                // first part of domain matching happens at the DB level
-                val storedCredentials =
-                    secureStorage.websiteLoginDetailsWithCredentialsForDomain(visitedSite.eTldPlus1!!).firstOrNull() ?: emptyList()
+                    // first part of domain matching happens at the DB level
+                    val storedCredentials =
+                        secureStorage.websiteLoginDetailsWithCredentialsForDomain(visitedSite.eTldPlus1!!).firstOrNull() ?: emptyList()
 
-                // second part of domain matching requires filtering at code level
-                storedCredentials.filter {
-                    val storedDomain = it.details.domain ?: return@filter false
-                    val savedSite = autofillUrlMatcher.extractUrlPartsForAutofill(storedDomain)
-                    return@filter autofillUrlMatcher.matchingForAutofill(visitedSite, savedSite)
-                }.map { it.toLoginCredentials() }
+                    // second part of domain matching requires filtering at code level
+                    storedCredentials.filter {
+                        val storedDomain = it.details.domain ?: return@filter false
+                        val savedSite = autofillUrlMatcher.extractUrlPartsForAutofill(storedDomain)
+                        return@filter autofillUrlMatcher.matchingForAutofill(visitedSite, savedSite)
+                    }.map { it.toLoginCredentials() }
+                }.getOrElse {
+                    ensureActive()
+                    emptyList()
+                }
             } else {
                 emptyList()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1213886927706691?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] Fresh install
- [ ] Create a password for fill.dev
- [ ] Apply patch, install again
- [ ] Open fill.dev
- [ ] Check app doesn't crash


### Patches
```
Subject: [PATCH] Force exception on read
---
Index: autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt	(revision c626e494540a136b957a810912bb7e281aba5c3d)
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt	(date 1774962387460)
@@ -325,6 +325,9 @@
     }
 
     override suspend fun getKey(keyName: String): ByteArray? {
+        if (keyName != "KEY_L1KEY") {
+            throw SecureStorageException.InternalSecureStorageException("test")
+        }
         return withContext(dispatcherProvider.io()) {
             val harmonyFlags = harmonyFlags()
 
```

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is localized to `getCredentials` and only alters error handling by returning an empty result on unexpected exceptions while preserving coroutine cancellation.
> 
> **Overview**
> Prevents crashes during autofill credential lookup by wrapping `SecureStoreBackedAutofillStore.getCredentials` secure-storage reads/filtering in `runCatching`.
> 
> On failure it now calls `ensureActive()` (so cancellations still propagate) and returns an empty credentials list instead of throwing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c626e494540a136b957a810912bb7e281aba5c3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->