### PR TITLE
Add allow list to Agentic Workflow

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -14,6 +14,11 @@
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.53.0",
       "sha": "8c53fd1f95aad591c003b39360b2ec16237b373f"
+    },
+    "microsoft/apm-action@v1.4.1": {
+      "repo": "microsoft/apm-action",
+      "version": "v1.4.1",
+      "sha": "a190b0b1a91031057144dc136acf9757a59c9e4d"
     }
   }
 }

--- a/.github/workflows/action-agentic-maintenance-pr.yaml
+++ b/.github/workflows/action-agentic-maintenance-pr.yaml
@@ -1,0 +1,30 @@
+name: 'Agentic Maintenance PR -> Move Asana task to In Review'
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  move-task-to-in-review:
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'agentic-maintenance') ||
+      (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'agentic-maintenance'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Asana Task ID from PR body
+        id: find-asana-task
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          trigger-phrase: "Task/Issue URL:"
+          action: 'find-asana-task-id'
+
+      - name: Move task to In Review in Agentic Backlog
+        if: ${{ steps.find-asana-task.outputs.asanaTaskId != '' }}
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_AGENTIC_BACKLOG_PROJECT_ID }}
+          asana-section: ${{ vars.GH_AGENTIC_BACKLOG_IN_REVIEW_SECTION_ID }}
+          asana-task-id: ${{ steps.find-asana-task.outputs.asanaTaskId }}
+          action: 'add-task-asana-project'

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -267,9 +267,11 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
+          {
+            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
+            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
+            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
+          } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"64d1b8f75efd5f22f36d062cc3a72a71f90d3458e306dde2b92d7bc02aa1b3ac","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e21a1434b3e7ae4897fe22790c465540087c8d927c7bd933d6a5181fe6c37be7","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -76,7 +76,6 @@ jobs:
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.4"
           GH_AW_INFO_AWMG_VERSION: ""
-          GH_AW_INFO_APM_VERSION: "v0.8.6"
           GH_AW_INFO_FIREWALL_TYPE: "squid"
           GH_AW_COMPILED_STRICT: "true"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -126,19 +125,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
+          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
           <system>
-          GH_AW_PROMPT_c35e7d19849c39f2_EOF
+          GH_AW_PROMPT_b54754da127a4ddf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
+          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_c35e7d19849c39f2_EOF
+          GH_AW_PROMPT_b54754da127a4ddf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
+          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -168,14 +167,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c35e7d19849c39f2_EOF
+          GH_AW_PROMPT_b54754da127a4ddf_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
+          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
           </system>
-          GH_AW_PROMPT_c35e7d19849c39f2_EOF
-          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
+          GH_AW_PROMPT_b54754da127a4ddf_EOF
+          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_c35e7d19849c39f2_EOF
+          GH_AW_PROMPT_b54754da127a4ddf_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -241,9 +240,7 @@ jobs:
           retention-days: 1
 
   agent:
-    needs:
-      - activation
-      - apm
+    needs: activation
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -254,7 +251,6 @@ jobs:
       GH_AW_ASSETS_ALLOWED_EXTS: ""
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
-      GH_AW_INFO_APM_VERSION: v0.8.6
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
       GH_AW_WORKFLOW_ID_SANITIZED: androidmaintenanceworker
     outputs:
@@ -324,21 +320,6 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh v0.25.4
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@latest
-      - name: Download APM bundle artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: apm
-          path: /tmp/gh-aw/apm-bundle
-      - name: Restore APM dependencies
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          APM_BUNDLE_DIR: /tmp/gh-aw/apm-bundle
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/apm_unpack.cjs');
-            await main();
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -356,12 +337,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_97fb4eb05d204443_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c34c1c44db695221_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_97fb4eb05d204443_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c34c1c44db695221_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_8b576310303b933d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c434bcbe1360ce23_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
@@ -369,8 +350,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_8b576310303b933d_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2e3dc3dd6bbe9325_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_c434bcbe1360ce23_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_cebe0ec333daa8c7_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -466,7 +447,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_2e3dc3dd6bbe9325_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_cebe0ec333daa8c7_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -534,7 +515,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_dda0ecc6108fc2c2_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_111d197aea35aa59_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "asana": {
@@ -594,7 +575,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dda0ecc6108fc2c2_EOF
+          GH_AW_MCP_CONFIG_111d197aea35aa59_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -834,61 +815,10 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/audit/
           if-no-files-found: ignore
 
-  apm:
-    needs: activation
-    runs-on: ubuntu-slim
-    permissions: {}
-    env:
-      GH_AW_INFO_APM_VERSION: v0.8.6
-    steps:
-      - name: Generate GitHub App token for APM dependencies
-        id: apm-app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
-        with:
-          app-id: ${{ vars.GH_AW_APP_ID }}
-          private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ddg-ai-config
-          github-api-url: ${{ github.api_url }}
-      - name: Install and pack APM dependencies
-        id: apm_pack
-        uses: microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
-        env:
-          GITHUB_TOKEN: ${{ steps.apm-app-token.outputs.token }}
-        with:
-          dependencies: |
-            - duckduckgo/ddg-ai-config
-          isolated: 'true'
-          pack: 'true'
-          archive: 'true'
-          target: claude
-          working-directory: /tmp/gh-aw/apm-workspace
-          apm-version: ${{ env.GH_AW_INFO_APM_VERSION }}
-      - name: Upload APM bundle artifact
-        if: success()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: apm
-          path: ${{ steps.apm_pack.outputs.bundle-path }}
-          retention-days: 1
-      - name: Invalidate GitHub App token for APM
-        if: always() && steps.apm-app-token.outputs.token != ''
-        env:
-          TOKEN: ${{ steps.apm-app-token.outputs.token }}
-        run: |
-          echo "Revoking GitHub App installation token for APM..."
-          # GitHub CLI will auth with the token being revoked.
-          gh api \
-            --method DELETE \
-            -H "Authorization: token $TOKEN" \
-            /installation/token || echo "Token revocation failed (token may be expired or invalid)."
-          echo "Token invalidation step complete."
-
   conclusion:
     needs:
       - activation
       - agent
-      - apm
       - detection
       - safe_outputs
     if: always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true')

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96dacff6faa87f6b07776bcefbf1fe202f5a1dc2ce1866a1ac571d85f971ad28","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"99f297c54064491392e4a0190a287f202acd0816396f654436e2241a357b74ff","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -76,6 +76,7 @@ jobs:
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.4"
           GH_AW_INFO_AWMG_VERSION: ""
+          GH_AW_INFO_APM_VERSION: "v0.8.6"
           GH_AW_INFO_FIREWALL_TYPE: "squid"
           GH_AW_COMPILED_STRICT: "true"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -125,19 +126,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
+          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
           <system>
-          GH_AW_PROMPT_d7e76342434132de_EOF
+          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
+          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d7e76342434132de_EOF
+          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
+          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -167,14 +168,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d7e76342434132de_EOF
+          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
+          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
           </system>
-          GH_AW_PROMPT_d7e76342434132de_EOF
-          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
+          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
+          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_d7e76342434132de_EOF
+          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -240,7 +241,9 @@ jobs:
           retention-days: 1
 
   agent:
-    needs: activation
+    needs:
+      - activation
+      - apm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -251,6 +254,7 @@ jobs:
       GH_AW_ASSETS_ALLOWED_EXTS: ""
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
+      GH_AW_INFO_APM_VERSION: v0.8.6
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
       GH_AW_WORKFLOW_ID_SANITIZED: androidmaintenanceworker
     outputs:
@@ -274,6 +278,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
       - name: Create gh-aw temp directory
         run: bash ${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure gh CLI for GitHub Enterprise
@@ -315,6 +324,21 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh v0.25.4
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code@latest
+      - name: Download APM bundle artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: apm
+          path: /tmp/gh-aw/apm-bundle
+      - name: Restore APM dependencies
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          APM_BUNDLE_DIR: /tmp/gh-aw/apm-bundle
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/apm_unpack.cjs');
+            await main();
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -332,12 +356,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_327971c7768ed2ce_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e46639915be48fe_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_327971c7768ed2ce_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5e46639915be48fe_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_02100db191aa61eb_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_923032c6dddb2107_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
@@ -345,8 +369,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_02100db191aa61eb_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7ca0beec96cd7b56_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_923032c6dddb2107_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_30756a7c51621d3b_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -442,7 +466,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_7ca0beec96cd7b56_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_30756a7c51621d3b_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -485,6 +509,7 @@ jobs:
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
@@ -507,11 +532,31 @@ jobs:
           export DEBUG="*"
           
           export GH_AW_ENGINE="claude"
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_d37cf855fa8bb226_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_ea8ac4d54e6afcf6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
+              "asana": {
+                "type": "stdio",
+                "container": "node:lts-alpine",
+                "entrypoint": "npx",
+                "entrypointArgs": [
+                  "npx",
+                  "-y",
+                  "@anthropic/asana-mcp-server"
+                ],
+                "env": {
+                  "ASANA_ACCESS_TOKEN": "${{ secrets.ASANA_ACCESS_TOKEN }}"
+                },
+                "guard-policies": {
+                  "write-sink": {
+                    "accept": [
+                      "*"
+                    ]
+                  }
+                }
+              },
               "github": {
                 "container": "ghcr.io/github/github-mcp-server:v0.32.0",
                 "env": {
@@ -549,7 +594,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d37cf855fa8bb226_EOF
+          GH_AW_MCP_CONFIG_ea8ac4d54e6afcf6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -688,8 +733,9 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/redact_secrets.cjs');
             await main();
         env:
-          GH_AW_SECRET_NAMES: 'ANTHROPIC_API_KEY,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN,GT_DAXMOBILE'
+          GH_AW_SECRET_NAMES: 'ANTHROPIC_API_KEY,ASANA_ACCESS_TOKEN,GH_AW_GITHUB_MCP_SERVER_TOKEN,GH_AW_GITHUB_TOKEN,GITHUB_TOKEN,GT_DAXMOBILE'
           SECRET_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SECRET_ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
           SECRET_GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
           SECRET_GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -788,10 +834,40 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/audit/
           if-no-files-found: ignore
 
+  apm:
+    needs: activation
+    runs-on: ubuntu-slim
+    permissions: {}
+    env:
+      GH_AW_INFO_APM_VERSION: v0.8.6
+    steps:
+      - name: Install and pack APM dependencies
+        id: apm_pack
+        uses: microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          dependencies: |
+            - duckduckgo/ddg-ai-config
+          isolated: 'true'
+          pack: 'true'
+          archive: 'true'
+          target: claude
+          working-directory: /tmp/gh-aw/apm-workspace
+          apm-version: ${{ env.GH_AW_INFO_APM_VERSION }}
+      - name: Upload APM bundle artifact
+        if: success()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: apm
+          path: ${{ steps.apm_pack.outputs.bundle-path }}
+          retention-days: 1
+
   conclusion:
     needs:
       - activation
       - agent
+      - apm
       - detection
       - safe_outputs
     if: always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true')

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c551f29dce5aba37f42fc7d8aaa8f1176154b6f121aadb97f308efff3d1108fc","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5a7bb651e791cb46e7337ff931b11c4a8227e813482c52387ffc94f405159ccc","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -125,19 +125,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
+          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
           <system>
-          GH_AW_PROMPT_80117f6f3511644d_EOF
+          GH_AW_PROMPT_afec543437c1b42e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
+          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_80117f6f3511644d_EOF
+          GH_AW_PROMPT_afec543437c1b42e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
+          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -167,14 +167,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_80117f6f3511644d_EOF
+          GH_AW_PROMPT_afec543437c1b42e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
+          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
           </system>
-          GH_AW_PROMPT_80117f6f3511644d_EOF
-          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
+          GH_AW_PROMPT_afec543437c1b42e_EOF
+          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_80117f6f3511644d_EOF
+          GH_AW_PROMPT_afec543437c1b42e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -332,21 +332,21 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8dea9d394ea7c471_EOF'
-          {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8dea9d394ea7c471_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_876e01d037e1f83a_EOF'
+          {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","labels":["agentic-maintenance"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_876e01d037e1f83a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_cada4f3a55f37b37_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_726465ae7b1cd2e5_EOF'
           {
             "description_suffixes": {
-              "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
+              "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". Labels [\"agentic-maintenance\"] will be automatically added. PRs will be created as drafts."
             },
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_cada4f3a55f37b37_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f129dde43f1507fd_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_726465ae7b1cd2e5_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_123dce1ba763f353_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -442,7 +442,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f129dde43f1507fd_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_123dce1ba763f353_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -485,7 +485,7 @@ jobs:
       - name: Setup MCP Scripts Config
         run: |
           mkdir -p ${RUNNER_TEMP}/gh-aw/mcp-scripts/logs
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/tools.json << 'GH_AW_MCP_SCRIPTS_TOOLS_7cb15393c1dd3629_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/tools.json << 'GH_AW_MCP_SCRIPTS_TOOLS_6ac70dc439f1c7ce_EOF'
           {
             "serverName": "mcpscripts",
             "version": "1.0.0",
@@ -535,8 +535,8 @@ jobs:
               }
             ]
           }
-          GH_AW_MCP_SCRIPTS_TOOLS_7cb15393c1dd3629_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs << 'GH_AW_MCP_SCRIPTS_SERVER_a39f908265bcbc70_EOF'
+          GH_AW_MCP_SCRIPTS_TOOLS_6ac70dc439f1c7ce_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs << 'GH_AW_MCP_SCRIPTS_SERVER_a8f553e77d0c0043_EOF'
             const path = require("path");
             const { startHttpServer } = require("./mcp_scripts_mcp_server_http.cjs");
             const configPath = path.join(__dirname, "tools.json");
@@ -550,12 +550,12 @@ jobs:
               console.error("Failed to start mcp-scripts HTTP server:", error);
               process.exit(1);
             });
-          GH_AW_MCP_SCRIPTS_SERVER_a39f908265bcbc70_EOF
+          GH_AW_MCP_SCRIPTS_SERVER_a8f553e77d0c0043_EOF
           chmod +x ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs
           
       - name: Setup MCP Scripts Tool Files
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_section_tasks.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_a13f1dde1af51f7e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_section_tasks.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_4235e5ec5c32c200_EOF'
             async function execute(inputs) {
               const { section_gid } = inputs || {};
               const token = process.env.ASANA_ACCESS_TOKEN;
@@ -570,8 +570,8 @@ jobs:
             if (require.main === module) {
               require("./mcp-scripts-runner.cjs")(execute);
             }
-          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_a13f1dde1af51f7e_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_task.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_ceb625ab7cee88ba_EOF'
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_4235e5ec5c32c200_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_task.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_6e08296a0bed75f2_EOF'
             async function execute(inputs) {
               const { task_gid } = inputs || {};
               const token = process.env.ASANA_ACCESS_TOKEN;
@@ -586,7 +586,7 @@ jobs:
             if (require.main === module) {
               require("./mcp-scripts-runner.cjs")(execute);
             }
-          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_ceb625ab7cee88ba_EOF
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_6e08296a0bed75f2_EOF
           
       - name: Generate MCP Scripts Server Config
         id: mcp-scripts-config
@@ -651,7 +651,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_MCP_SCRIPTS_PORT -e GH_AW_MCP_SCRIPTS_API_KEY -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_cb668b13a1eef447_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_f91eb0717a15e5df_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -705,7 +705,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cb668b13a1eef447_EOF
+          GH_AW_MCP_CONFIG_f91eb0717a15e5df_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1324,7 +1324,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"develop\",\"draft\":true,\"github-token\":\"${{ secrets.GT_DAXMOBILE }}\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"CLAUDE.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".claude/\"],\"title_prefix\":\"[Android Maintenance] \"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"develop\",\"draft\":true,\"github-token\":\"${{ secrets.GT_DAXMOBILE }}\",\"labels\":[\"agentic-maintenance\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"CLAUDE.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".claude/\"],\"title_prefix\":\"[Android Maintenance] \"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GT_DAXMOBILE }}
         with:

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f601b0c8c32a9a38372467298a7237f440e270f5ec836d0c763377845713fa98","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96dacff6faa87f6b07776bcefbf1fe202f5a1dc2ce1866a1ac571d85f971ad28","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -72,7 +72,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","app.asana.com"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.4"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -125,19 +125,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a628829c24530aed_EOF'
+          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
           <system>
-          GH_AW_PROMPT_a628829c24530aed_EOF
+          GH_AW_PROMPT_d7e76342434132de_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a628829c24530aed_EOF'
+          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a628829c24530aed_EOF
+          GH_AW_PROMPT_d7e76342434132de_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a628829c24530aed_EOF'
+          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -167,14 +167,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a628829c24530aed_EOF
+          GH_AW_PROMPT_d7e76342434132de_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a628829c24530aed_EOF'
+          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
           </system>
-          GH_AW_PROMPT_a628829c24530aed_EOF
-          cat << 'GH_AW_PROMPT_a628829c24530aed_EOF'
+          GH_AW_PROMPT_d7e76342434132de_EOF
+          cat << 'GH_AW_PROMPT_d7e76342434132de_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_a628829c24530aed_EOF
+          GH_AW_PROMPT_d7e76342434132de_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -267,11 +267,9 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          {
-            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
-            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
-            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
-          } >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -334,12 +332,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_2296db12b12f006f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_327971c7768ed2ce_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2296db12b12f006f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_327971c7768ed2ce_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_988027fbf7c31a5a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_02100db191aa61eb_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
@@ -347,8 +345,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_988027fbf7c31a5a_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b2b84c01fd9fba50_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_02100db191aa61eb_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7ca0beec96cd7b56_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -444,7 +442,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_b2b84c01fd9fba50_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_7ca0beec96cd7b56_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -511,7 +509,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_1f49724a1b98b261_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d37cf855fa8bb226_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -551,7 +549,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1f49724a1b98b261_EOF
+          GH_AW_MCP_CONFIG_d37cf855fa8bb226_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -635,7 +633,7 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.4 --skip-pull --enable-api-proxy \
+          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.4 --skip-pull --enable-api-proxy \
             -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && claude --print --disable-slash-commands --no-chrome --mcp-config /tmp/gh-aw/mcp-config/mcp-servers.json --allowed-tools Bash,BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_label,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__issue_read,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_label,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__pull_request_read,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users --debug-file /tmp/gh-aw/agent-stdio.log --verbose --permission-mode bypassPermissions --output-format stream-json "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_CLAUDE:+ --model "$GH_AW_MODEL_AGENT_CLAUDE"}' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -659,7 +657,6 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           MCP_TIMEOUT: 120000
           MCP_TOOL_TIMEOUT: 60000
-          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -713,7 +710,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GH_AW_ALLOWED_GITHUB_REFS: ""
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
@@ -1156,7 +1153,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
           GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"develop\",\"draft\":true,\"github-token\":\"${{ secrets.GT_DAXMOBILE }}\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"CLAUDE.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".claude/\"],\"title_prefix\":\"[Android Maintenance] \"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e21a1434b3e7ae4897fe22790c465540087c8d927c7bd933d6a5181fe6c37be7","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c551f29dce5aba37f42fc7d8aaa8f1176154b6f121aadb97f308efff3d1108fc","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -125,19 +125,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
+          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
           <system>
-          GH_AW_PROMPT_b54754da127a4ddf_EOF
+          GH_AW_PROMPT_80117f6f3511644d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
+          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_b54754da127a4ddf_EOF
+          GH_AW_PROMPT_80117f6f3511644d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
+          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -167,14 +167,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b54754da127a4ddf_EOF
+          GH_AW_PROMPT_80117f6f3511644d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
+          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
           </system>
-          GH_AW_PROMPT_b54754da127a4ddf_EOF
-          cat << 'GH_AW_PROMPT_b54754da127a4ddf_EOF'
+          GH_AW_PROMPT_80117f6f3511644d_EOF
+          cat << 'GH_AW_PROMPT_80117f6f3511644d_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_b54754da127a4ddf_EOF
+          GH_AW_PROMPT_80117f6f3511644d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -274,11 +274,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '24'
-          package-manager-cache: false
       - name: Create gh-aw temp directory
         run: bash ${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Configure gh CLI for GitHub Enterprise
@@ -337,12 +332,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c34c1c44db695221_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8dea9d394ea7c471_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c34c1c44db695221_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8dea9d394ea7c471_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c434bcbe1360ce23_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_cada4f3a55f37b37_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
@@ -350,8 +345,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_c434bcbe1360ce23_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_cebe0ec333daa8c7_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_cada4f3a55f37b37_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f129dde43f1507fd_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -447,7 +442,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_cebe0ec333daa8c7_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f129dde43f1507fd_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -487,10 +482,151 @@ jobs:
           
           bash ${RUNNER_TEMP}/gh-aw/actions/start_safe_outputs_server.sh
           
+      - name: Setup MCP Scripts Config
+        run: |
+          mkdir -p ${RUNNER_TEMP}/gh-aw/mcp-scripts/logs
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/tools.json << 'GH_AW_MCP_SCRIPTS_TOOLS_7cb15393c1dd3629_EOF'
+          {
+            "serverName": "mcpscripts",
+            "version": "1.0.0",
+            "logDir": "${RUNNER_TEMP}/gh-aw/mcp-scripts/logs",
+            "tools": [
+              {
+                "name": "asana_get_section_tasks",
+                "description": "List tasks in a given section of an Asana project. Returns task GIDs, names, and URLs.",
+                "inputSchema": {
+                  "properties": {
+                    "section_gid": {
+                      "description": "The GID of the Asana section to list tasks from",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "section_gid"
+                  ],
+                  "type": "object"
+                },
+                "handler": "asana_get_section_tasks.cjs",
+                "env": {
+                  "ASANA_ACCESS_TOKEN": "ASANA_ACCESS_TOKEN"
+                },
+                "timeout": 60
+              },
+              {
+                "name": "asana_get_task",
+                "description": "Get full details of an Asana task by GID. Returns name, notes (description), and URL.",
+                "inputSchema": {
+                  "properties": {
+                    "task_gid": {
+                      "description": "The GID of the Asana task to fetch",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "task_gid"
+                  ],
+                  "type": "object"
+                },
+                "handler": "asana_get_task.cjs",
+                "env": {
+                  "ASANA_ACCESS_TOKEN": "ASANA_ACCESS_TOKEN"
+                },
+                "timeout": 60
+              }
+            ]
+          }
+          GH_AW_MCP_SCRIPTS_TOOLS_7cb15393c1dd3629_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs << 'GH_AW_MCP_SCRIPTS_SERVER_a39f908265bcbc70_EOF'
+            const path = require("path");
+            const { startHttpServer } = require("./mcp_scripts_mcp_server_http.cjs");
+            const configPath = path.join(__dirname, "tools.json");
+            const port = parseInt(process.env.GH_AW_MCP_SCRIPTS_PORT || "3000", 10);
+            const apiKey = process.env.GH_AW_MCP_SCRIPTS_API_KEY || "";
+            startHttpServer(configPath, {
+              port: port,
+              stateless: true,
+              logDir: "${RUNNER_TEMP}/gh-aw/mcp-scripts/logs"
+            }).catch(error => {
+              console.error("Failed to start mcp-scripts HTTP server:", error);
+              process.exit(1);
+            });
+          GH_AW_MCP_SCRIPTS_SERVER_a39f908265bcbc70_EOF
+          chmod +x ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs
+          
+      - name: Setup MCP Scripts Tool Files
+        run: |
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_section_tasks.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_a13f1dde1af51f7e_EOF'
+            async function execute(inputs) {
+              const { section_gid } = inputs || {};
+              const token = process.env.ASANA_ACCESS_TOKEN;
+              const res = await fetch(
+                `https://app.asana.com/api/1.0/sections/${section_gid}/tasks?opt_fields=name,permalink_url`,
+                { headers: { Authorization: `Bearer ${token}` } }
+              );
+              if (!res.ok) throw new Error(`Asana API error: ${res.status}`);
+              return await res.json();
+            }
+            module.exports = { execute };
+            if (require.main === module) {
+              require("./mcp-scripts-runner.cjs")(execute);
+            }
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_a13f1dde1af51f7e_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_task.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_ceb625ab7cee88ba_EOF'
+            async function execute(inputs) {
+              const { task_gid } = inputs || {};
+              const token = process.env.ASANA_ACCESS_TOKEN;
+              const res = await fetch(
+                `https://app.asana.com/api/1.0/tasks/${task_gid}?opt_fields=name,notes,permalink_url,memberships.section.name`,
+                { headers: { Authorization: `Bearer ${token}` } }
+              );
+              if (!res.ok) throw new Error(`Asana API error: ${res.status}`);
+              return await res.json();
+            }
+            module.exports = { execute };
+            if (require.main === module) {
+              require("./mcp-scripts-runner.cjs")(execute);
+            }
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_ceb625ab7cee88ba_EOF
+          
+      - name: Generate MCP Scripts Server Config
+        id: mcp-scripts-config
+        run: |
+          # Generate a secure random API key (360 bits of entropy, 40+ chars)
+          # Mask immediately to prevent timing vulnerabilities
+          API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
+          echo "::add-mask::${API_KEY}"
+          
+          PORT=3000
+          
+          # Set outputs for next steps
+          {
+            echo "mcp_scripts_api_key=${API_KEY}"
+            echo "mcp_scripts_port=${PORT}"
+          } >> "$GITHUB_OUTPUT"
+          
+          echo "MCP Scripts server will run on port ${PORT}"
+          
+      - name: Start MCP Scripts HTTP Server
+        id: mcp-scripts-start
+        env:
+          DEBUG: '*'
+          GH_AW_MCP_SCRIPTS_PORT: ${{ steps.mcp-scripts-config.outputs.mcp_scripts_port }}
+          GH_AW_MCP_SCRIPTS_API_KEY: ${{ steps.mcp-scripts-config.outputs.mcp_scripts_api_key }}
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        run: |
+          # Environment variables are set above to prevent template injection
+          export DEBUG
+          export GH_AW_MCP_SCRIPTS_PORT
+          export GH_AW_MCP_SCRIPTS_API_KEY
+          
+          bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_scripts_server.sh
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GH_AW_MCP_SCRIPTS_API_KEY: ${{ steps.mcp-scripts-start.outputs.api_key }}
+          GH_AW_MCP_SCRIPTS_PORT: ${{ steps.mcp-scripts-start.outputs.port }}
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
@@ -513,31 +649,11 @@ jobs:
           export DEBUG="*"
           
           export GH_AW_ENGINE="claude"
-          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
+          export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_MCP_SCRIPTS_PORT -e GH_AW_MCP_SCRIPTS_API_KEY -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_111d197aea35aa59_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_cb668b13a1eef447_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
-              "asana": {
-                "type": "stdio",
-                "container": "node:lts-alpine",
-                "entrypoint": "npx",
-                "entrypointArgs": [
-                  "npx",
-                  "-y",
-                  "@anthropic/asana-mcp-server"
-                ],
-                "env": {
-                  "ASANA_ACCESS_TOKEN": "${{ secrets.ASANA_ACCESS_TOKEN }}"
-                },
-                "guard-policies": {
-                  "write-sink": {
-                    "accept": [
-                      "*"
-                    ]
-                  }
-                }
-              },
               "github": {
                 "container": "ghcr.io/github/github-mcp-server:v0.32.0",
                 "env": {
@@ -550,6 +666,20 @@ jobs:
                   "allow-only": {
                     "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
                     "repos": "$GITHUB_MCP_GUARD_REPOS"
+                  }
+                }
+              },
+              "mcpscripts": {
+                "type": "http",
+                "url": "http://host.docker.internal:$GH_AW_MCP_SCRIPTS_PORT",
+                "headers": {
+                  "Authorization": "$GH_AW_MCP_SCRIPTS_API_KEY"
+                },
+                "guard-policies": {
+                  "write-sink": {
+                    "accept": [
+                      "*"
+                    ]
                   }
                 }
               },
@@ -575,7 +705,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_111d197aea35aa59_EOF
+          GH_AW_MCP_CONFIG_cb668b13a1eef447_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -659,10 +789,11 @@ jobs:
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
           # shellcheck disable=SC1003
-          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.4 --skip-pull --enable-api-proxy \
+          sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --tty --env-all --exclude-env ANTHROPIC_API_KEY --exclude-env ASANA_ACCESS_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,app.asana.com,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --image-tag 0.25.4 --skip-pull --enable-api-proxy \
             -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && claude --print --disable-slash-commands --no-chrome --mcp-config /tmp/gh-aw/mcp-config/mcp-servers.json --allowed-tools Bash,BashOutput,Edit,ExitPlanMode,Glob,Grep,KillBash,LS,MultiEdit,NotebookEdit,NotebookRead,Read,Task,TodoWrite,Write,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_label,mcp__github__get_latest_release,mcp__github__get_me,mcp__github__get_notification_details,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_release_by_tag,mcp__github__get_secret_scanning_alert,mcp__github__get_tag,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__get_workflow_run_usage,mcp__github__issue_read,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_discussion_categories,mcp__github__list_discussions,mcp__github__list_issue_types,mcp__github__list_issues,mcp__github__list_label,mcp__github__list_notifications,mcp__github__list_pull_requests,mcp__github__list_releases,mcp__github__list_secret_scanning_alerts,mcp__github__list_starred_repositories,mcp__github__list_tags,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__pull_request_read,mcp__github__search_code,mcp__github__search_issues,mcp__github__search_orgs,mcp__github__search_pull_requests,mcp__github__search_repositories,mcp__github__search_users --debug-file /tmp/gh-aw/agent-stdio.log --verbose --permission-mode bypassPermissions --output-format stream-json "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"${GH_AW_MODEL_AGENT_CLAUDE:+ --model "$GH_AW_MODEL_AGENT_CLAUDE"}' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
           BASH_DEFAULT_TIMEOUT_MS: 60000
           BASH_MAX_TIMEOUT_MS: 60000
           DISABLE_BUG_COMMAND: 1
@@ -758,6 +889,15 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_claude_log.cjs');
             await main();
+      - name: Parse MCP Scripts logs for step summary
+        if: always()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_mcp_scripts_logs.cjs');
+            await main();
       - name: Parse MCP Gateway logs for step summary
         if: always()
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -797,6 +937,7 @@ jobs:
           path: |
             /tmp/gh-aw/aw-prompts/prompt.txt
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/mcp-scripts/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,7 +24,7 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"99f297c54064491392e4a0190a287f202acd0816396f654436e2241a357b74ff","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"64d1b8f75efd5f22f36d062cc3a72a71f90d3458e306dde2b92d7bc02aa1b3ac","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
@@ -126,19 +126,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
+          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
           <system>
-          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
+          GH_AW_PROMPT_c35e7d19849c39f2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
+          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
+          GH_AW_PROMPT_c35e7d19849c39f2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
+          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -168,14 +168,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
+          GH_AW_PROMPT_c35e7d19849c39f2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
+          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
           </system>
-          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
-          cat << 'GH_AW_PROMPT_a1b1f1bef7042e20_EOF'
+          GH_AW_PROMPT_c35e7d19849c39f2_EOF
+          cat << 'GH_AW_PROMPT_c35e7d19849c39f2_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_a1b1f1bef7042e20_EOF
+          GH_AW_PROMPT_c35e7d19849c39f2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -356,12 +356,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5e46639915be48fe_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_97fb4eb05d204443_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5e46639915be48fe_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_97fb4eb05d204443_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_923032c6dddb2107_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_8b576310303b933d_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". PRs will be created as drafts."
@@ -369,8 +369,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_923032c6dddb2107_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_30756a7c51621d3b_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_8b576310303b933d_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2e3dc3dd6bbe9325_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -466,7 +466,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_30756a7c51621d3b_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_2e3dc3dd6bbe9325_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -534,7 +534,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_ea8ac4d54e6afcf6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_dda0ecc6108fc2c2_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "asana": {
@@ -594,7 +594,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ea8ac4d54e6afcf6_EOF
+          GH_AW_MCP_CONFIG_dda0ecc6108fc2c2_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -841,11 +841,20 @@ jobs:
     env:
       GH_AW_INFO_APM_VERSION: v0.8.6
     steps:
+      - name: Generate GitHub App token for APM dependencies
+        id: apm-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ vars.GH_AW_APP_ID }}
+          private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ddg-ai-config
+          github-api-url: ${{ github.api_url }}
       - name: Install and pack APM dependencies
         id: apm_pack
         uses: microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.apm-app-token.outputs.token }}
         with:
           dependencies: |
             - duckduckgo/ddg-ai-config
@@ -862,6 +871,18 @@ jobs:
           name: apm
           path: ${{ steps.apm_pack.outputs.bundle-path }}
           retention-days: 1
+      - name: Invalidate GitHub App token for APM
+        if: always() && steps.apm-app-token.outputs.token != ''
+        env:
+          TOKEN: ${{ steps.apm-app-token.outputs.token }}
+        run: |
+          echo "Revoking GitHub App installation token for APM..."
+          # GitHub CLI will auth with the token being revoked.
+          gh api \
+            --method DELETE \
+            -H "Authorization: token $TOKEN" \
+            /installation/token || echo "Token revocation failed (token may be expired or invalid)."
+          echo "Token invalidation step complete."
 
   conclusion:
     needs:

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -29,6 +29,7 @@ safe-outputs:
   allowed-github-references: []
   create-pull-request:
     title-prefix: "[Android Maintenance] "
+    labels: [agentic-maintenance]
     base-branch: develop
     draft: true
     github-token: ${{ secrets.GT_DAXMOBILE }}

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -102,12 +102,22 @@ PR against live data before acting on memory.
 
 ### Step 1: Check for in-progress work
 
-1. Read memory for any task marked in_progress
-2. If found, fetch the current state of that task and its PR from live data
-3. If the PR has CI failures caused by your changes → fix them, push an update, and stop
-4. If the PR has merge conflicts → resolve them, push an update, and stop
-5. If the PR is in "In Review" with no issues → nothing to do, stop
-6. If no in-progress task exists → proceed to Step 2
+**Before doing anything else, check live state — do not rely on memory alone.**
+
+1. Use the `asana_get_section_tasks` tool to list tasks in the "In Progress" section
+   (section GID: `1213746476312672`).
+2. List open GitHub PRs whose title starts with `[Android Maintenance]`
+   (use the GitHub MCP tool `list_pull_requests` with state `open`).
+3. If EITHER check returns results → in-progress work exists. Go to step 5.
+4. If BOTH checks are empty → no in-progress work. Proceed to Step 2.
+5. Inspect the in-progress work:
+   - If the PR has CI failures caused by your changes → fix them, push an update, and **stop**.
+   - If the PR has merge conflicts → resolve them, push an update, and **stop**.
+   - Otherwise (PR is open and healthy, or no PR exists yet) → **stop**. Do not start a new task.
+
+**Never proceed to Step 2 when step 3 applies.**
+Use memory (`in_progress_task`, `in_progress_pr`) only as a hint to locate the task and PR
+faster — it is not the source of truth.
 
 ### Step 2: Select a task
 

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -40,7 +40,13 @@ mcp-servers:
       ASANA_ACCESS_TOKEN: "${{ secrets.ASANA_ACCESS_TOKEN }}"
 imports:
   apm-packages:
-    - duckduckgo/ddg-ai-config
+    github-app:
+      app-id: ${{ vars.GH_AW_APP_ID }}
+      private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
+      repositories:
+        - ddg-ai-config
+    packages:
+      - duckduckgo/ddg-ai-config
 engine: claude
 ---
 

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -32,10 +32,40 @@ safe-outputs:
     base-branch: develop
     draft: true
     github-token: ${{ secrets.GT_DAXMOBILE }}
-mcp-servers:
-  asana:
-    command: npx
-    args: ["-y", "@anthropic/asana-mcp-server"]
+mcp-scripts:
+  asana_get_section_tasks:
+    description: "List tasks in a given section of an Asana project. Returns task GIDs, names, and URLs."
+    inputs:
+      section_gid:
+        type: string
+        required: true
+        description: "The GID of the Asana section to list tasks from"
+    script: |
+      const token = process.env.ASANA_ACCESS_TOKEN;
+      const res = await fetch(
+        `https://app.asana.com/api/1.0/sections/${section_gid}/tasks?opt_fields=name,permalink_url`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!res.ok) throw new Error(`Asana API error: ${res.status}`);
+      return await res.json();
+    env:
+      ASANA_ACCESS_TOKEN: "${{ secrets.ASANA_ACCESS_TOKEN }}"
+
+  asana_get_task:
+    description: "Get full details of an Asana task by GID. Returns name, notes (description), and URL."
+    inputs:
+      task_gid:
+        type: string
+        required: true
+        description: "The GID of the Asana task to fetch"
+    script: |
+      const token = process.env.ASANA_ACCESS_TOKEN;
+      const res = await fetch(
+        `https://app.asana.com/api/1.0/tasks/${task_gid}?opt_fields=name,notes,permalink_url,memberships.section.name`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!res.ok) throw new Error(`Asana API error: ${res.status}`);
+      return await res.json();
     env:
       ASANA_ACCESS_TOKEN: "${{ secrets.ASANA_ACCESS_TOKEN }}"
 engine: claude
@@ -80,13 +110,11 @@ PR against live data before acting on memory.
 
 ### Step 2: Select a task
 
-1. Use the Asana API to fetch tasks in the "Ready" section of the Android Agentic Maintenance Backlog
-   - Project GID: `1213746476312668`
+1. Use the `asana_get_section_tasks` tool to fetch tasks in the "Ready" section
    - "Ready" section GID: `1213746476312669`
 2. Pick the first task listed
-3. Move the task to "In Progress" (section GID: `1213746476312672`) via the Asana API
-4. Leave a comment: "🤖 Android Maintenance Worker: starting work on this task."
-5. Save the task GID and URL to memory as in_progress_task
+3. Use the `asana_get_task` tool to fetch the full task details (name, notes, URL)
+4. Save the task GID and URL to memory as in_progress_task
 
 ### Step 3: Read project conventions
 
@@ -149,19 +177,15 @@ Body (follow the template exactly — replace the placeholder sections):
     | No UI changes | No UI changes |
 
 After opening the PR:
-- Move the Asana task to "In Review" (section GID: `1213746476312674`) via the Asana API
-- Leave a comment on the Asana task with the PR link
 - Update memory: in_progress_pr → PR number and branch
 
 ### Step 7: If stuck
 
 If at any point you cannot proceed (the task is ambiguous, the approach does not work,
 verification fails in a way you cannot resolve):
-1. Comment on the Asana task tagging the original task owner
-2. Describe specifically what is blocking you
-3. Move the task back to "Ready"
-4. Do NOT open a partial PR
-5. Update memory: clear in_progress_task and in_progress_pr
+1. Do NOT open a partial PR
+2. Update memory: clear in_progress_task and in_progress_pr
+3. Stop and explain what blocked you in the workflow output
 
 ## Guidelines
 
@@ -173,5 +197,5 @@ verification fails in a way you cannot resolve):
 - No breaking changes: if a change could break existing behavior, stop and comment instead
 - Format before committing: always run spotlessApply before committing
 - One task per run: never pick up a second task even if the first completes quickly
-- Asana API: use the Asana MCP server tools (mcp__asana__*) for all Asana operations
-- AI transparency: every PR description and Asana comment must include the 🤖 Android Maintenance Worker disclosure
+- Asana API: use the `asana_get_section_tasks` and `asana_get_task` tools for all Asana reads; do not attempt Asana writes
+- AI transparency: every PR description must include the 🤖 Android Maintenance Worker disclosure

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -32,6 +32,15 @@ safe-outputs:
     base-branch: develop
     draft: true
     github-token: ${{ secrets.GT_DAXMOBILE }}
+mcp-servers:
+  asana:
+    command: npx
+    args: ["-y", "@anthropic/asana-mcp-server"]
+    env:
+      ASANA_ACCESS_TOKEN: "${{ secrets.ASANA_ACCESS_TOKEN }}"
+imports:
+  apm-packages:
+    - duckduckgo/ddg-ai-config
 engine: claude
 ---
 
@@ -167,5 +176,5 @@ verification fails in a way you cannot resolve):
 - No breaking changes: if a change could break existing behavior, stop and comment instead
 - Format before committing: always run spotlessApply before committing
 - One task per run: never pick up a second task even if the first completes quickly
-- Asana API: use bash with curl and the ASANA_ACCESS_TOKEN secret for all Asana operations
+- Asana API: use the Asana MCP server tools (mcp__asana__*) for all Asana operations
 - AI transparency: every PR description and Asana comment must include the 🤖 Android Maintenance Worker disclosure

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -38,15 +38,6 @@ mcp-servers:
     args: ["-y", "@anthropic/asana-mcp-server"]
     env:
       ASANA_ACCESS_TOKEN: "${{ secrets.ASANA_ACCESS_TOKEN }}"
-imports:
-  apm-packages:
-    github-app:
-      app-id: ${{ vars.GH_AW_APP_ID }}
-      private-key: ${{ secrets.GH_AW_APP_PRIVATE_KEY }}
-      repositories:
-        - ddg-ai-config
-    packages:
-      - duckduckgo/ddg-ai-config
 engine: claude
 ---
 

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -12,7 +12,10 @@ permissions:
   issues: read
   pull-requests: read
 
-network: defaults
+network:
+  allowed:
+    - defaults
+    - app.asana.com
 
 tools:
   github:

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -272,9 +272,11 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
+          {
+            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
+            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
+            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
+          } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -272,11 +272,9 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          {
-            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
-            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
-            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
-          } >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1213883965463238?focus=true

### Description
Updated the maintenance worker workflow (android-maintenance-worker.md) to unblock Asana access from the GitHub Actions sandbox:

- Allowlisted `app.asana.com` in the network config so the agent can reach the Asana API
- Replaced the Asana MCP server with `mcp-scripts` that expose two read-only Asana tools (`asana_get_section_tasks`, `asana_get_task`) — lighter weight and no extra dependency
- Removed the `ddg-ai-config` APM dependency that was no longer needed
- Added GitHub App auth for `ddg-ai-config` APM package access
- Auto-labels PRs created by the maintenance worker with `agentic-maintenance`
- Added a new workflow (`action-agentic-maintenance-pr.yaml`) that moves the Asana task to "In Review" when a PR is opened or labeled with `agentic-maintenance` — this overcomes the agent's lack of Asana write permissions

### Steps to test this PR
Worked in https://github.com/duckduckgo/Android/actions/runs/23839305109

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies GitHub Actions agent sandbox/networking and introduces new Asana-integrated automation using `ASANA_ACCESS_TOKEN`, which can affect CI behavior and external side effects if misconfigured.
> 
> **Overview**
> Unblocks the Android agentic maintenance worker from reading Asana by allowlisting `app.asana.com` and wiring in a lightweight `mcp-scripts` HTTP server that exposes two read-only Asana tools (`asana_get_section_tasks`, `asana_get_task`) through the MCP gateway.
> 
> Maintenance PRs created by the worker are now automatically labeled `agentic-maintenance`, and a new `action-agentic-maintenance-pr` workflow reacts to that label/PR open to move the referenced Asana task to *In Review* using `duckduckgo/native-github-asana-sync`.
> 
> Updates the compiled `android-maintenance-worker.lock.yml` accordingly (MCP scripts startup, env/secret redaction, artifact upload) and adds `microsoft/apm-action@v1.4.1` to the actions lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd997914f25ec5b8b69200dc43fcead1cd26ee8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->