### PR TITLE
Show chat URL suggestions when no recent chats matches

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -772,7 +772,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 autoCompleteTargetVisibility = false
                 hideOverlayImmediately(binding.autoCompleteOverlay, ::invalidateAutoCompleteBlurView)
             }
-            updateChatSuggestionsVisibility(viewModel.chatSuggestions.value.isNotEmpty())
+            updateChatSuggestionsVisibility(
+                viewModel.chatSuggestions.value.isNotEmpty() || viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty(),
+            )
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -29,6 +29,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.FragmentViewModelFactory
@@ -41,6 +43,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAd
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
@@ -64,14 +67,19 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
 
     private var chatSuggestionsRecyclerView: SwipeableRecyclerView? = null
     private lateinit var chatSuggestionsAdapter: ChatSuggestionsAdapter
+    private var chatUrlSuggestionsAdapter: BrowserAutoCompleteSuggestionsAdapter? = null
     private var bottomBlurView: BottomBlurView? = null
     private var bottomBlurLayoutListener: View.OnLayoutChangeListener? = null
     private var bottomBlurDataObserver: RecyclerView.AdapterDataObserver? = null
+    private var bottomBlurObserverAdapter: RecyclerView.Adapter<*>? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (!duckChatFeature.aiChatSuggestions().isEnabled()) return
         configureChatSuggestions()
+        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
+            configureChatUrlSuggestions()
+        }
         configureObservers()
         configureBottomBlur()
     }
@@ -101,6 +109,39 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     private fun configureObservers() {
         val parentFragment = requireParentFragment() as InputScreenFragment
 
+        if (!duckChatFeature.rememberTogglePosition().isEnabled()) {
+            configureLegacyObservers(parentFragment)
+            return
+        }
+
+        combine(
+            viewModel.chatSuggestions,
+            viewModel.chatUrlSuggestions,
+        ) { chatSuggestions, urlSuggestions ->
+            Pair(chatSuggestions, urlSuggestions)
+        }.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach { (chatSuggestions, urlSuggestions) ->
+                if (viewModel.visibilityState.value.searchMode) return@onEach
+                val hasChatSuggestions = chatSuggestions.isNotEmpty()
+                val hasUrlSuggestions = urlSuggestions.suggestions.isNotEmpty()
+
+                if (hasChatSuggestions) {
+                    chatSuggestionsRecyclerView?.adapter = chatSuggestionsAdapter
+                    chatSuggestionsAdapter.submitList(chatSuggestions)
+                    parentFragment.updateChatSuggestionsVisibility(true)
+                } else if (hasUrlSuggestions) {
+                    chatSuggestionsRecyclerView?.adapter = chatUrlSuggestionsAdapter
+                    chatUrlSuggestionsAdapter?.updateData(urlSuggestions.query, urlSuggestions.suggestions)
+                    parentFragment.updateChatSuggestionsVisibility(true)
+                } else {
+                    chatSuggestionsRecyclerView?.adapter = chatSuggestionsAdapter
+                    chatSuggestionsAdapter.submitList(emptyList())
+                    parentFragment.updateChatSuggestionsVisibility(false)
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun configureLegacyObservers(parentFragment: InputScreenFragment) {
         viewModel.chatSuggestions
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach { suggestions ->
@@ -109,6 +150,17 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
                     parentFragment.updateChatSuggestionsVisibility(suggestions.isNotEmpty())
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun configureChatUrlSuggestions() {
+        chatUrlSuggestionsAdapter = BrowserAutoCompleteSuggestionsAdapter(
+            immediateSearchClickListener = { viewModel.userSelectedAutocomplete(it, fromChatUrlSuggestions = true) },
+            editableSearchClickListener = { viewModel.onUserSelectedToEditQuery(it.phrase) },
+            autoCompleteInAppMessageDismissedListener = { },
+            autoCompleteOpenSettingsClickListener = { },
+            autoCompleteLongPressClickListener = { },
+            omnibarType = if (inputScreenConfigResolver.useTopBar()) OmnibarType.SINGLE_TOP else OmnibarType.SINGLE_BOTTOM,
+        )
     }
 
     private fun configureBottomBlur() {
@@ -150,7 +202,8 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
                     recyclerView.post { bottomBlurView?.invalidate() }
                 }
             }
-            recyclerView.adapter?.registerAdapterDataObserver(bottomBlurDataObserver!!)
+            bottomBlurObserverAdapter = recyclerView.adapter
+            bottomBlurObserverAdapter?.registerAdapterDataObserver(bottomBlurDataObserver!!)
         }
     }
 
@@ -161,8 +214,9 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         }
         bottomBlurLayoutListener = null
         bottomBlurDataObserver?.let { observer ->
-            chatSuggestionsRecyclerView?.adapter?.unregisterAdapterDataObserver(observer)
+            bottomBlurObserverAdapter?.unregisterAdapterDataObserver(observer)
         }
+        bottomBlurObserverAdapter = null
         bottomBlurDataObserver = null
         (bottomBlurView?.parent as? FrameLayout)?.removeView(bottomBlurView)
         bottomBlurView = null

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -105,6 +105,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -277,6 +278,38 @@ class InputScreenViewModel @AssistedInject constructor(
             .catch { t: Throwable? -> logcat(WARN) { "Failed to get search results: ${t?.asLog()}" } }
             .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
 
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+    val chatUrlSuggestions: StateFlow<AutoCompleteResult> =
+        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
+            combine(
+                chatInputTextState.debounceExceptFirst(timeoutMillis = 100),
+                _chatSuggestions,
+                autoCompleteSuggestionsEnabled,
+            ) { chatInput, chatSuggestions, autoCompleteEnabled ->
+                if (autoCompleteEnabled && chatInput.isNotEmpty() && chatSuggestions.isEmpty()) chatInput else null
+            }.distinctUntilChanged()
+                .flatMapLatest { query ->
+                    if (query != null) {
+                        autoComplete.autoComplete(query).map { result ->
+                            result.copy(
+                                suggestions = result.suggestions.filter {
+                                    it is AutoCompleteBookmarkSuggestion ||
+                                        it is AutoCompleteSwitchToTabSuggestion ||
+                                        it is AutoCompleteHistorySuggestion ||
+                                        (it is AutoCompleteSearchSuggestion && it.isUrl)
+                                },
+                            )
+                        }
+                    } else {
+                        flowOf(AutoCompleteResult("", emptyList()))
+                    }
+                }.flowOn(dispatchers.io())
+                .catch { t -> logcat(WARN) { "Failed to get chat URL suggestions: ${t.asLog()}" } }
+                .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
+        } else {
+            MutableStateFlow(AutoCompleteResult("", emptyList()))
+        }
+
     private val _inputFieldState = MutableStateFlow(InputFieldState(canExpand = false))
     val inputFieldState: StateFlow<InputFieldState> = _inputFieldState.asStateFlow()
 
@@ -338,10 +371,13 @@ class InputScreenViewModel @AssistedInject constructor(
             }
         }.launchIn(viewModelScope)
 
-        _chatSuggestions.onEach { suggestions ->
-            val hasChatSuggestions = suggestions.isNotEmpty()
+        combine(_chatSuggestions, chatUrlSuggestions) { chatSuggestions, urlSuggestions ->
+            Pair(chatSuggestions, urlSuggestions)
+        }.onEach { (chatSuggestions, urlSuggestions) ->
+            val hasChatSuggestions = chatSuggestions.isNotEmpty()
+            val hasUrlSuggestions = urlSuggestions.suggestions.isNotEmpty()
             _visibilityState.update {
-                it.copy(showChatLogo = !hasChatSuggestions, chatSuggestionsVisible = hasChatSuggestions)
+                it.copy(showChatLogo = !hasChatSuggestions && !hasUrlSuggestions, chatSuggestionsVisible = hasChatSuggestions || hasUrlSuggestions)
             }
         }.launchIn(viewModelScope)
 
@@ -374,9 +410,14 @@ class InputScreenViewModel @AssistedInject constructor(
         voiceServiceAvailable.value = voiceSearchAvailability.isVoiceSearchAvailable
     }
 
-    fun userSelectedAutocomplete(suggestion: AutoCompleteSuggestion) {
+    fun userSelectedAutocomplete(suggestion: AutoCompleteSuggestion, fromChatUrlSuggestions: Boolean = false) {
         appCoroutineScope.launch(dispatchers.io()) {
-            autoComplete.fireAutocompletePixel(autoCompleteSuggestionResults.value.suggestions, suggestion, true)
+            val suggestions = if (duckChatFeature.rememberTogglePosition().isEnabled() && fromChatUrlSuggestions) {
+                chatUrlSuggestions.value.suggestions
+            } else {
+                autoCompleteSuggestionResults.value.suggestions
+            }
+            autoComplete.fireAutocompletePixel(suggestions, suggestion, true)
             withContext(dispatchers.main()) {
                 when (suggestion) {
                     is AutoCompleteDefaultSuggestion -> onUserSubmittedQuery(suggestion.phrase)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -3033,4 +3033,144 @@ class InputScreenViewModelTest {
         }
 
     // endregion
+
+    // region chat URL suggestions
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions is empty and autocomplete not called when feature flag is off`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
+
+            val viewModel = createViewModel()
+
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
+            verify(autoComplete, never()).autoComplete(any())
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions filters out non-URL suggestions when feature flag is on`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+            val bookmarkSuggestion = AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion(
+                phrase = "example.com",
+                title = "Example",
+                url = "https://example.com",
+            )
+            val searchSuggestion = AutoCompleteSearchSuggestion(
+                phrase = "example",
+                isUrl = false,
+                isAllowedInTopHits = false,
+            )
+            val urlSearchSuggestion = AutoCompleteSearchSuggestion(
+                phrase = "example.com",
+                isUrl = true,
+                isAllowedInTopHits = false,
+            )
+            whenever(autoComplete.autoComplete(any())).thenReturn(
+                flowOf(AutoCompleteResult("example", listOf(searchSuggestion, bookmarkSuggestion, urlSearchSuggestion))),
+            )
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("example")
+            advanceUntilIdle()
+
+            val result = viewModel.chatUrlSuggestions.value
+            assertEquals(2, result.suggestions.size)
+            assertTrue(result.suggestions[0] is AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion)
+            assertTrue(result.suggestions[1] is AutoCompleteSearchSuggestion)
+            assertTrue((result.suggestions[1] as AutoCompleteSearchSuggestion).isUrl)
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions is empty when chat input is empty`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
+            verify(autoComplete, never()).autoComplete("")
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions is empty when chat suggestions exist`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(
+                listOf(ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false)),
+            )
+            whenever(autoComplete.autoComplete(any())).thenReturn(
+                flowOf(AutoCompleteResult("test", listOf(AutoCompleteSearchSuggestion("test.com", isUrl = true, isAllowedInTopHits = false)))),
+            )
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("test")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions is empty when autocomplete suggestions disabled`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+            whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("example")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatSuggestionsVisible is true when only URL suggestions exist`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+            whenever(autoComplete.autoComplete(any())).thenReturn(
+                flowOf(
+                    AutoCompleteResult(
+                        "example",
+                        listOf(AutoCompleteSearchSuggestion("example.com", isUrl = true, isAllowedInTopHits = false)),
+                    ),
+                ),
+            )
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("example")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty())
+            assertTrue(viewModel.visibilityState.value.chatSuggestionsVisible)
+            assertFalse(viewModel.visibilityState.value.showChatLogo)
+        }
+
+    // endregion
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213824415440423?focus=true 

### Description
- When typing on the Duck.ai tab and no recent chats match, shows URL-based autocomplete suggestions (bookmarks, history, open tabs, URL search results). Filters out plain search suggestions, default suggestions, "Ask Duck.ai" prompts, and in-app messages
- URL suggestion navigates the same way as on the Search tab
- The logo behavior was updated accordingly
- Respects the "Search Suggestions" user setting. If disabled, no URL suggestions appear
- Gated behind the `rememberTogglePosition` feature flag
- ChatTabFragment owns the URL suggestions adapter independently. No changes to Search tab or InputScreenFragment overlay logic

### Steps to test this PR
- Enable "rememberTogglePosition" FF, select "Search & Duck.ai" mode
- Switch to Duck.ai tab, verify recents chats are showing and filter correctly
- Type in a URL that do not match any recent chats -> Verify URL suggestions are visible
- Verify Bookmarks, favorites, other tabs are also visible
- Verify if no direct URL match, nothing is shown. Logo should be visible. (We don't show plain autocomplete suggestions
- Type text that matches recent chats, keep typing until no chats match -> verify URL suggestions replace chat suggestions 
- Switch between Search and Duck.ai tabs -> verify both work independently, no interference
- Disable "Search Suggestions" in settings -> verify no URL suggestions appear on Duck.ai tab
- Disable "rememberTogglePosition" FF -> verify no URL suggestions appear, chat tab behaves as before

### Video demo


https://github.com/user-attachments/assets/9da4edf2-7dfd-482e-a316-85c804f08372



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new suggestion flow and adapter-swapping behavior on the Duck.ai tab (including pixel attribution changes), though it’s gated behind `rememberTogglePosition` and covered by new unit tests.
> 
> **Overview**
> When on the Duck.ai tab and **no recent chat suggestions are available**, the UI can now fall back to showing URL-based autocomplete suggestions (bookmarks/history/switch-to-tab/URL search suggestions), gated by the `rememberTogglePosition` feature flag.
> 
> This adds a new `chatUrlSuggestions` stream in `InputScreenViewModel` that queries autocomplete only when chat input is non-empty, chat suggestions are empty, and search suggestions are enabled, and updates logo/overlay visibility based on either suggestion source.
> 
> `ChatTabFragment` now swaps the recycler view adapter between chat suggestions and the new URL suggestions adapter, and fixes bottom-blur observer registration by tracking/unregistering against the original adapter. New tests verify gating, filtering, and visibility behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb59da07bcf3eb773ecbe423f201fc17ad20d71c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->