### PR TITLE
change progress bar dark mode shimmer colors to be more subtle

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/PageLoadProgressBar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/PageLoadProgressBar.kt
@@ -18,12 +18,17 @@ package com.duckduckgo.app.browser.progressbar
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
 import android.os.SystemClock
 import android.util.AttributeSet
 import android.view.Choreographer
 import android.view.View
+import androidx.core.graphics.blue
+import androidx.core.graphics.green
+import androidx.core.graphics.red
 import androidx.core.view.isVisible
+import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.getColorFromAttr
 
 class PageLoadProgressBar @JvmOverloads constructor(
@@ -39,14 +44,26 @@ class PageLoadProgressBar @JvmOverloads constructor(
     }
 
     private val engine = ProgressPhaseEngine(config, timeProvider)
-    private val shimmerRenderer = ShimmerRenderer(config, resources.displayMetrics.density)
+
+    private val barColor = context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorAccentBlue)
+
+    private val shimmerRenderer = ShimmerRenderer(
+        config = config,
+        density = resources.displayMetrics.density,
+        shimmerColor = lighten(barColor, shimmerLightenFraction(config)),
+    )
 
     private val progressPaint = Paint().apply {
-        color = context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorAccentBlue)
+        color = barColor
         style = Paint.Style.FILL
     }
 
     private val barHeightPx = 1.5f * resources.displayMetrics.density
+
+    private fun shimmerLightenFraction(config: ProgressBarConfig): Float {
+        val isDark = (context as? DuckDuckGoActivity)?.isDarkThemeEnabled() ?: false
+        return if (isDark) config.shimmerLightenFractionDark else config.shimmerLightenFractionLight
+    }
 
     private var lastFrameTimeNanos = 0L
     private var _isStarted = false
@@ -170,5 +187,14 @@ class PageLoadProgressBar @JvmOverloads constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         reset()
+    }
+
+    companion object {
+        /** Blend [color] toward white by [fraction] (0 = original, 1 = white). */
+        private fun lighten(color: Int, fraction: Float): Int = Color.rgb(
+            (color.red + (255 - color.red) * fraction).toInt(),
+            (color.green + (255 - color.green) * fraction).toInt(),
+            (color.blue + (255 - color.blue) * fraction).toInt(),
+        )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarConfig.kt
@@ -31,4 +31,6 @@ data class ProgressBarConfig(
     val shimmerBandEndWidthDp: Float = 20f,
     val shimmerBandStartOpacity: Float = 0.4f,
     val shimmerBandEndOpacity: Float = 0.55f,
+    val shimmerLightenFractionLight: Float = 0.9f,
+    val shimmerLightenFractionDark: Float = 0.5f,
 )

--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/ShimmerRenderer.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/ShimmerRenderer.kt
@@ -28,6 +28,7 @@ import kotlin.math.roundToInt
 class ShimmerRenderer(
     private val config: ProgressBarConfig,
     private val density: Float,
+    private val shimmerColor: Int = Color.WHITE,
 ) {
 
     private val bandStartWidthPx = config.shimmerBandStartWidthDp * density
@@ -94,15 +95,18 @@ class ShimmerRenderer(
 
     private fun ensureGradientCached() {
         if (cachedGradients != null) return
+        val r = Color.red(shimmerColor)
+        val g = Color.green(shimmerColor)
+        val b = Color.blue(shimmerColor)
         cachedGradients = Array(bandCount) {
             LinearGradient(
                 0f, 0f, bandStartWidthPx, 0f,
                 intArrayOf(
-                    Color.argb(0, 255, 255, 255),
-                    Color.argb(204, 255, 255, 255), // 80%
-                    Color.argb(255, 255, 255, 255), // 100%
-                    Color.argb(204, 255, 255, 255), // 80%
-                    Color.argb(0, 255, 255, 255),
+                    Color.argb(0, r, g, b),
+                    Color.argb(204, r, g, b), // 80%
+                    Color.argb(255, r, g, b), // 100%
+                    Color.argb(204, r, g, b), // 80%
+                    Color.argb(0, r, g, b),
                 ),
                 floatArrayOf(0f, 0.25f, 0.5f, 0.75f, 1f),
                 Shader.TileMode.CLAMP,


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1213897873499582?focus=true

### Description

### Steps to test this PR
Open progress bar in dark mode and observe new colors


### UI changes
![output](https://github.com/user-attachments/assets/d9d84751-0b1c-4192-84bc-9f3436120b8b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: the progress bar shimmer color is now derived from the bar accent color and adjusted per light/dark theme, with no logic changes to navigation/progress calculation.
> 
> **Overview**
> Updates the page load progress bar shimmer to use a **theme-aware tinted gradient** instead of hardcoded white, making the effect more subtle in dark mode.
> 
> `PageLoadProgressBar` now computes a shimmer tint by lightening the bar’s accent color, with new `ProgressBarConfig` knobs (`shimmerLightenFractionLight`/`Dark`) controlling the amount per theme; `ShimmerRenderer` accepts this `shimmerColor` and builds its cached gradients from it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6533d67fb09b858c09a6d289ab5f8d7d0c551a95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->