### PR TITLE
Restore the tab pager adapter state after populating the list of tabs and avoid navigating to input screen on fragment restoration

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1340,14 +1340,14 @@ open class BrowserActivity : DuckDuckGoActivity() {
                         tabPagerAdapter.restore(it)
                     }
                 }
+
+                // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
+                // flows only once, so a separate initialization is necessary
+                configureFlowCollectors()
             }
 
             binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
             tabPager.isVisible = swipingTabsFeature.isEnabled
-
-            // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
-            // flows only once, so a separate initialization is necessary
-            configureFlowCollectors()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1340,14 +1340,16 @@ open class BrowserActivity : DuckDuckGoActivity() {
                         tabPagerAdapter.restore(it)
                     }
                 }
-
-                // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
-                // flows only once, so a separate initialization is necessary
-                configureFlowCollectors()
             }
 
             binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
             tabPager.isVisible = swipingTabsFeature.isEnabled
+
+            if (swipingTabsFeature.isEnabled) {
+                // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
+                // flows only once, so a separate initialization is necessary
+                configureFlowCollectors()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1332,9 +1332,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
             configureViewPagerForSystemAutofill(tabPager)
 
-            // savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-            //     tabPagerAdapter.restore(it)
-            // }
+            if (!androidBrowserConfigFeature.tabStateRestorationFix().isEnabled()) {
+                savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+                    tabPagerAdapter.restore(it)
+                }
+            }
         }
 
         binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
@@ -1487,10 +1489,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private fun onTabsUpdated(updatedTabIds: List<TabModel>, savedInstanceState: Bundle?) {
         tabPagerAdapter.onTabsUpdated(updatedTabIds)
-        savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-            tabPagerAdapter.restore(it)
+
+        if (androidBrowserConfigFeature.tabStateRestorationFix().isEnabled()) {
+            savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+                tabPagerAdapter.restore(it)
+            }
+            savedInstanceState?.remove(KEY_TAB_PAGER_STATE)
         }
-        savedInstanceState?.remove(KEY_TAB_PAGER_STATE)
     }
 
     fun launchNewTab(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -358,9 +358,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         initializeTabs(savedInstanceState)
 
-        // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
-        // flows only once, so a separate initialization is necessary
-        configureFlowCollectors()
         setupFireDialogListener()
 
         viewModel.viewState
@@ -401,27 +398,23 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun configureFlowCollectors() {
-        if (swipingTabsFeature.isEnabled) {
-            lifecycleScope.launch {
-                repeatOnLifecycle(STARTED) {
-                    launch {
-                        viewModel.tabsFlow.collectLatest {
-                            tabManager.onTabsChanged(it)
-                        }
-                    }
+    private suspend fun configureFlowCollectors() {
+        repeatOnLifecycle(STARTED) {
+            launch {
+                viewModel.tabsFlow.collectLatest {
+                    tabManager.onTabsChanged(it)
+                }
+            }
 
-                    launch {
-                        viewModel.selectedTabFlow.collectLatest {
-                            tabManager.onSelectedTabChanged(it)
-                        }
-                    }
+            launch {
+                viewModel.selectedTabFlow.collectLatest {
+                    tabManager.onSelectedTabChanged(it)
+                }
+            }
 
-                    launch {
-                        viewModel.selectedTabIndex.collectLatest {
-                            onMoveToTabRequested(it)
-                        }
-                    }
+            launch {
+                viewModel.selectedTabIndex.collectLatest {
+                    onMoveToTabRequested(it)
                 }
             }
         }
@@ -1319,28 +1312,43 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun initializeTabs(savedInstanceState: Bundle?) {
-        if (swipingTabsFeature.isEnabled) {
-            tabManager.registerCallbacks(
-                onTabsUpdated = {
-                    onTabsUpdated(it, savedInstanceState)
-                },
-            )
+        lifecycleScope.launch {
+            val tabRestorationFixEnabled = withContext(dispatcherProvider.io()) {
+                androidBrowserConfigFeature.tabStateRestorationFix().isEnabled()
+            }
+            if (swipingTabsFeature.isEnabled) {
+                tabManager.registerCallbacks(
+                    onTabsUpdated = {
+                        onTabsUpdated(it, savedInstanceState, tabRestorationFixEnabled)
+                    },
+                )
 
-            tabPager.adapter = tabPagerAdapter
-            tabPager.registerOnPageChangeCallback(onTabPageChangeListener)
-            tabPager.setPageTransformer(MarginPageTransformer(resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1).toPx().toInt()))
+                tabPager.adapter = tabPagerAdapter
+                tabPager.registerOnPageChangeCallback(onTabPageChangeListener)
+                tabPager.setPageTransformer(
+                    MarginPageTransformer(
+                        resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1)
+                            .toPx()
+                            .toInt(),
+                    ),
+                )
 
-            configureViewPagerForSystemAutofill(tabPager)
+                configureViewPagerForSystemAutofill(tabPager)
 
-            if (!androidBrowserConfigFeature.tabStateRestorationFix().isEnabled()) {
-                savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-                    tabPagerAdapter.restore(it)
+                if (!tabRestorationFixEnabled) {
+                    savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+                        tabPagerAdapter.restore(it)
+                    }
                 }
             }
-        }
 
-        binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
-        tabPager.isVisible = swipingTabsFeature.isEnabled
+            binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
+            tabPager.isVisible = swipingTabsFeature.isEnabled
+
+            // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
+            // flows only once, so a separate initialization is necessary
+            configureFlowCollectors()
+        }
     }
 
     private fun configureViewPagerForSystemAutofill(viewPager: ViewPager2) {
@@ -1487,10 +1495,14 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun onTabsUpdated(updatedTabIds: List<TabModel>, savedInstanceState: Bundle?) {
+    private fun onTabsUpdated(
+        updatedTabIds: List<TabModel>,
+        savedInstanceState: Bundle?,
+        tabRestorationFixEnabled: Boolean,
+    ) {
         tabPagerAdapter.onTabsUpdated(updatedTabIds)
 
-        if (androidBrowserConfigFeature.tabStateRestorationFix().isEnabled()) {
+        if (tabRestorationFixEnabled) {
             savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
                 tabPagerAdapter.restore(it)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1321,7 +1321,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private fun initializeTabs(savedInstanceState: Bundle?) {
         if (swipingTabsFeature.isEnabled) {
             tabManager.registerCallbacks(
-                onTabsUpdated = ::onTabsUpdated,
+                onTabsUpdated = {
+                    onTabsUpdated(it, savedInstanceState)
+                },
             )
 
             tabPager.adapter = tabPagerAdapter
@@ -1330,9 +1332,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
             configureViewPagerForSystemAutofill(tabPager)
 
-            savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-                tabPagerAdapter.restore(it)
-            }
+            // savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+            //     tabPagerAdapter.restore(it)
+            // }
         }
 
         binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
@@ -1483,8 +1485,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun onTabsUpdated(updatedTabIds: List<TabModel>) {
+    private fun onTabsUpdated(updatedTabIds: List<TabModel>, savedInstanceState: Bundle?) {
         tabPagerAdapter.onTabsUpdated(updatedTabIds)
+        savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+            tabPagerAdapter.restore(it)
+        }
+        savedInstanceState?.remove(KEY_TAB_PAGER_STATE)
     }
 
     fun launchNewTab(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1011,6 +1011,8 @@ class BrowserTabFragment :
         }
         viewModel.handleExternalLaunch(isLaunchedFromExternalApp)
 
+        viewModel.observeSelectedTab(savedInstanceState != null)
+
         observeSubscriptionEventDataChannel()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -898,7 +898,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
-        var isTabRestored = isRestored
         val isTabRestorationFixEnabled = androidBrowserConfig.tabStateRestorationFix().isEnabled()
         selectedTabObserver?.cancel()
         // auto-launch input screen for new, empty tabs (New Tab Page)
@@ -912,13 +911,24 @@ class BrowserTabViewModel @Inject constructor(
                 val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
                 showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
             }.flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
+            .let {
+                if (isRestored && isTabRestorationFixEnabled) {
+                    // Skip the first matching emission on restore to avoid a loop
+                    // where closing InputScreenActivity would return to a restored NTP,
+                    // which would restart this flow and reopen InputScreenActivity again.
+                    // This happens when memory pressure destroys BrowserActivity while
+                    // InputScreenActivity is in the foreground.
+                    it.drop(1)
+                } else {
+                    it
+                }
+            }
             .onEach {
                 val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
                 val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
                 val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
-                val hasRestoredTabAndFlagIsEnabled = isTabRestored && isTabRestorationFixEnabled
 
-                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar && !hasRestoredTabAndFlagIsEnabled) {
+                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar) {
                     viewModelScope.launch {
                         // whenever an event fires, so the user switched to a new tab page, launch the input screen
                         // unless an onboarding promo message is displayed
@@ -928,7 +938,6 @@ class BrowserTabViewModel @Inject constructor(
                         }
                     }
                 }
-                isTabRestored = false
             }.launchIn(viewModelScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -563,8 +563,6 @@ class BrowserTabViewModel @Inject constructor(
     private var ctaChangedTicker = MutableStateFlow("")
     val hiddenIds = MutableStateFlow(HiddenBookmarksIds())
 
-    private var isTabRestored = false
-
     private var activeExperiments: List<Toggle>? = null
 
     private val _subscriptionEventDataChannel = Channel<SubscriptionEventData>(capacity = Channel.BUFFERED)
@@ -900,7 +898,8 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
-        isTabRestored = isRestored
+        var isTabRestored = isRestored
+        val isTabRestorationFixEnabled = androidBrowserConfig.tabStateRestorationFix().isEnabled()
         selectedTabObserver?.cancel()
         // auto-launch input screen for new, empty tabs (New Tab Page)
         selectedTabObserver = tabRepository.flowSelectedTab
@@ -917,8 +916,9 @@ class BrowserTabViewModel @Inject constructor(
                 val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
                 val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
                 val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
+                val hasRestoredTabAndFlagIsEnabled = isTabRestored && isTabRestorationFixEnabled
 
-                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar && !isTabRestored) {
+                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar && !hasRestoredTabAndFlagIsEnabled) {
                     viewModelScope.launch {
                         // whenever an event fires, so the user switched to a new tab page, launch the input screen
                         // unless an onboarding promo message is displayed

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -624,6 +624,7 @@ class BrowserTabViewModel @Inject constructor(
     private var faviconPrefetchJob: Job? = null
     private var deferredBlankSite: Job? = null
     private var accessibilityObserver: Job? = null
+    private var selectedTabObserver: Job? = null
     private var isProcessingTrackingLink = false
     private var isLinkOpenedInNewTab = false
     private var hasExitedFixedProgress = false
@@ -900,8 +901,9 @@ class BrowserTabViewModel @Inject constructor(
 
     fun observeSelectedTab(isRestored: Boolean) {
         isTabRestored = isRestored
+        selectedTabObserver?.cancel()
         // auto-launch input screen for new, empty tabs (New Tab Page)
-        tabRepository.flowSelectedTab
+        selectedTabObserver = tabRepository.flowSelectedTab
             .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
             .filter { selectedTab ->
                 // fire event when activating a new, empty tab

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -898,12 +898,12 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
-        selectedTabObserver?.cancel()
         viewModelScope.launch {
             val isTabRestorationFixEnabled = withContext(dispatchers.io()) {
                 androidBrowserConfig.tabStateRestorationFix().isEnabled()
             }
             // auto-launch input screen for new, empty tabs (New Tab Page)
+            selectedTabObserver?.cancel()
             selectedTabObserver = tabRepository.flowSelectedTab
                 .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
                 .let {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -898,47 +898,51 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
-        val isTabRestorationFixEnabled = androidBrowserConfig.tabStateRestorationFix().isEnabled()
         selectedTabObserver?.cancel()
-        // auto-launch input screen for new, empty tabs (New Tab Page)
-        selectedTabObserver = tabRepository.flowSelectedTab
-            .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
-            .filter { selectedTab ->
-                // fire event when activating a new, empty tab
-                // (has no URL and wasn't opened from another tab)
-                val showInputScreenAutomatically = duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value
-                val isActiveTab = ::tabId.isInitialized && selectedTab?.tabId == tabId
-                val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
-                showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
-            }.flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
-            .let {
-                if (isRestored && isTabRestorationFixEnabled) {
-                    // Skip the first matching emission on restore to avoid a loop
-                    // where closing InputScreenActivity would return to a restored NTP,
-                    // which would restart this flow and reopen InputScreenActivity again.
-                    // This happens when memory pressure destroys BrowserActivity while
-                    // InputScreenActivity is in the foreground.
-                    it.drop(1)
-                } else {
-                    it
-                }
+        viewModelScope.launch {
+            val isTabRestorationFixEnabled = withContext(dispatchers.io()) {
+                androidBrowserConfig.tabStateRestorationFix().isEnabled()
             }
-            .onEach {
-                val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
-                val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
-                val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
-
-                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar) {
-                    viewModelScope.launch {
-                        // whenever an event fires, so the user switched to a new tab page, launch the input screen
-                        // unless an onboarding promo message is displayed
-                        val hasPendingOnboardingPromo = ctaViewModel.isPromoOnboardingDialogShowing()
-                        if (!hasPendingOnboardingPromo) {
-                            command.value = LaunchInputScreen
-                        }
+            // auto-launch input screen for new, empty tabs (New Tab Page)
+            selectedTabObserver = tabRepository.flowSelectedTab
+                .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
+                .let {
+                    if (isRestored && isTabRestorationFixEnabled) {
+                        // Skip the first emission on restore to avoid a loop
+                        // where closing InputScreenActivity would return to a restored NTP,
+                        // which would restart this flow and reopen InputScreenActivity again.
+                        // This happens when memory pressure destroys BrowserActivity while
+                        // InputScreenActivity is in the foreground.
+                        it.drop(1)
+                    } else {
+                        it
                     }
                 }
-            }.launchIn(viewModelScope)
+                .filter { selectedTab ->
+                    // fire event when activating a new, empty tab
+                    // (has no URL and wasn't opened from another tab)
+                    val showInputScreenAutomatically = duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value
+                    val isActiveTab = ::tabId.isInitialized && selectedTab?.tabId == tabId
+                    val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
+                    showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
+                }.flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
+                .onEach {
+                    val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
+                    val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
+                    val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
+
+                    if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar) {
+                        viewModelScope.launch {
+                            // whenever an event fires, so the user switched to a new tab page, launch the input screen
+                            // unless an onboarding promo message is displayed
+                            val hasPendingOnboardingPromo = ctaViewModel.isPromoOnboardingDialogShowing()
+                            if (!hasPendingOnboardingPromo) {
+                                command.value = LaunchInputScreen
+                            }
+                        }
+                    }
+                }.launchIn(viewModelScope)
+        }
     }
 
     fun observeAccessibilitySettings() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -563,6 +563,8 @@ class BrowserTabViewModel @Inject constructor(
     private var ctaChangedTicker = MutableStateFlow("")
     val hiddenIds = MutableStateFlow(HiddenBookmarksIds())
 
+    private var isTabRestored = false
+
     private var activeExperiments: List<Toggle>? = null
 
     private val _subscriptionEventDataChannel = Channel<SubscriptionEventData>(capacity = Channel.BUFFERED)
@@ -846,34 +848,6 @@ class BrowserTabViewModel @Inject constructor(
                 browserViewState.value = currentBrowserViewState().copy(showSelectDefaultBrowserMenuItem = it)
             }.launchIn(viewModelScope)
 
-        // auto-launch input screen for new, empty tabs (New Tab Page)
-        tabRepository.flowSelectedTab
-            .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
-            .filter { selectedTab ->
-                // fire event when activating a new, empty tab
-                // (has no URL and wasn't opened from another tab)
-                val showInputScreenAutomatically = duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value
-                val isActiveTab = ::tabId.isInitialized && selectedTab?.tabId == tabId
-                val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
-                showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
-            }.flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
-            .onEach {
-                val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
-                val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
-                val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
-
-                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar) {
-                    viewModelScope.launch {
-                        // whenever an event fires, so the user switched to a new tab page, launch the input screen
-                        // unless an onboarding promo message is displayed
-                        val hasPendingOnboardingPromo = ctaViewModel.isPromoOnboardingDialogShowing()
-                        if (!hasPendingOnboardingPromo) {
-                            command.value = LaunchInputScreen
-                        }
-                    }
-                }
-            }.launchIn(viewModelScope)
-
         isFullUrlEnabled
             .onEach {
                 command.value = Command.RefreshOmnibar
@@ -922,6 +896,38 @@ class BrowserTabViewModel @Inject constructor(
 
     fun onViewRecreated() {
         observeAccessibilitySettings()
+    }
+
+    fun observeSelectedTab(isRestored: Boolean) {
+        isTabRestored = isRestored
+        // auto-launch input screen for new, empty tabs (New Tab Page)
+        tabRepository.flowSelectedTab
+            .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
+            .filter { selectedTab ->
+                // fire event when activating a new, empty tab
+                // (has no URL and wasn't opened from another tab)
+                val showInputScreenAutomatically = duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value
+                val isActiveTab = ::tabId.isInitialized && selectedTab?.tabId == tabId
+                val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
+                showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
+            }.flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
+            .onEach {
+                val hasPendingTabLaunch = externalIntentProcessingState.hasPendingTabLaunch
+                val hasPendingDuckAiOpen = externalIntentProcessingState.hasPendingDuckAiOpen
+                val hasPendingSnackbar = externalIntentProcessingState.hasPendingSnackbar
+
+                if (!hasPendingTabLaunch && !hasPendingDuckAiOpen && !hasPendingSnackbar && !isTabRestored) {
+                    viewModelScope.launch {
+                        // whenever an event fires, so the user switched to a new tab page, launch the input screen
+                        // unless an onboarding promo message is displayed
+                        val hasPendingOnboardingPromo = ctaViewModel.isPromoOnboardingDialogShowing()
+                        if (!hasPendingOnboardingPromo) {
+                            command.value = LaunchInputScreen
+                        }
+                    }
+                }
+                isTabRestored = false
+            }.launchIn(viewModelScope)
     }
 
     fun observeAccessibilitySettings() {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -579,8 +579,10 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         if (fragment.isAdded() && fragment.isHidden()) {
             mFragmentManager.beginTransaction().show(fragment).commitNow();
         }
-        if (fragment.getView() != null && fragment.getView().getVisibility() != View.VISIBLE) {
-            fragment.getView().setVisibility(View.VISIBLE);
+
+        View fragmentView = fragment.getView();
+        if (fragmentView != null && fragmentView.getVisibility() != View.VISIBLE) {
+            fragmentView.setVisibility(View.VISIBLE);
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -579,6 +579,9 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         if (fragment.isAdded() && fragment.isHidden()) {
             mFragmentManager.beginTransaction().show(fragment).commitNow();
         }
+        if (fragment.getView() != null && fragment.getView().getVisibility() != View.VISIBLE) {
+            fragment.getView().setVisibility(View.VISIBLE);
+        }
     }
 
     @SuppressWarnings("WeakerAccess") // to avoid creation of a synthetic accessor

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -356,4 +356,16 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun serpLogoInMenu(): Toggle
+
+    /**
+     * Controls whether the tab state restoration fix is enabled for swiping tabs.
+     * When enabled, the adapter populates tabs before restoring state to prevent
+     * garbage collection.
+     * @return `true` when the remote config has the global "tabStateRestorationFix" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.InternalAlwaysEnabled
+    fun tabStateRestorationFix(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -363,9 +363,8 @@ interface AndroidBrowserConfigFeature {
      * garbage collection.
      * @return `true` when the remote config has the global "tabStateRestorationFix" androidBrowserConfig
      * sub-feature flag enabled
-     * If the remote feature is not present defaults to `false`
+     * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    @Toggle.InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun tabStateRestorationFix(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8370,28 +8370,15 @@ class BrowserTabViewModelTest {
     @Test
     fun whenInputScreenEnabledAndTabRestoredAndRestorationFixEnabledThenLaunchInputScreenCommandSuppressed() =
         runTest {
-            val initialTabId = "initial-tab"
-            val initialTab =
-                TabEntity(
-                    tabId = initialTabId,
-                    url = "https://example.com",
-                    title = "EX",
-                    skipHome = false,
-                    viewed = true,
-                    position = 0,
-                )
             val ntpTabId = "ntp-tab"
             val ntpTab = TabEntity(tabId = ntpTabId, url = null, title = "", skipHome = false, viewed = true, position = 0)
-            whenever(mockTabRepository.getTab(initialTabId)).thenReturn(initialTab)
             whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
-            flowSelectedTab.emit(initialTab)
+            flowSelectedTab.emit(ntpTab)
 
             fakeAndroidConfigBrowserFeature.tabStateRestorationFix().setRawStoredState(State(enable = true))
+            mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
             testee.observeSelectedTab(isRestored = true)
-            mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
-
-            flowSelectedTab.emit(ntpTab)
 
             verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
             val commands = commandCaptor.allValues

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8019,6 +8019,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(ntpTab)
@@ -8051,6 +8052,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(false)
 
             flowSelectedTab.emit(ntpTab)
@@ -8091,6 +8093,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = targetTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(targetTab)
@@ -8123,6 +8126,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = initialTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(ntpTab)
@@ -8155,6 +8159,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(false)
 
             flowSelectedTab.emit(ntpTab)
@@ -8198,6 +8203,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(ntpTab)
@@ -8239,6 +8245,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(ntpTab)
@@ -8271,6 +8278,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
             whenever(mockExternalIntentProcessingState.hasPendingTabLaunch).thenReturn(true)
 
@@ -8304,6 +8312,7 @@ class BrowserTabViewModelTest {
             flowSelectedTab.emit(initialTab)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
             whenever(mockExternalIntentProcessingState.hasPendingDuckAiOpen).thenReturn(true)
 
@@ -8345,6 +8354,7 @@ class BrowserTabViewModelTest {
             whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = false)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
             flowSelectedTab.emit(ntpTab)
@@ -8353,6 +8363,39 @@ class BrowserTabViewModelTest {
             val commands = commandCaptor.allValues
             assertFalse(
                 "LaunchInputScreen command should be suppressed when Privacy Pro skipped-onboarding dialog is showing",
+                commands.any { it is Command.LaunchInputScreen },
+            )
+        }
+
+    @Test
+    fun whenInputScreenEnabledAndTabRestoredThenLaunchInputScreenCommandSuppressed() =
+        runTest {
+            val initialTabId = "initial-tab"
+            val initialTab =
+                TabEntity(
+                    tabId = initialTabId,
+                    url = "https://example.com",
+                    title = "EX",
+                    skipHome = false,
+                    viewed = true,
+                    position = 0,
+                )
+            val ntpTabId = "ntp-tab"
+            val ntpTab = TabEntity(tabId = ntpTabId, url = null, title = "", skipHome = false, viewed = true, position = 0)
+            whenever(mockTabRepository.getTab(initialTabId)).thenReturn(initialTab)
+            whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
+            flowSelectedTab.emit(initialTab)
+
+            testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = true)
+            mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
+
+            flowSelectedTab.emit(ntpTab)
+
+            verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+            val commands = commandCaptor.allValues
+            assertFalse(
+                "LaunchInputScreen command should be suppressed when tab is restored from saved state",
                 commands.any { it is Command.LaunchInputScreen },
             )
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8368,7 +8368,7 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenInputScreenEnabledAndTabRestoredThenLaunchInputScreenCommandSuppressed() =
+    fun whenInputScreenEnabledAndTabRestoredAndRestorationFixEnabledThenLaunchInputScreenCommandSuppressed() =
         runTest {
             val initialTabId = "initial-tab"
             val initialTab =
@@ -8386,6 +8386,7 @@ class BrowserTabViewModelTest {
             whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
             flowSelectedTab.emit(initialTab)
 
+            fakeAndroidConfigBrowserFeature.tabStateRestorationFix().setRawStoredState(State(enable = true))
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
             testee.observeSelectedTab(isRestored = true)
             mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
@@ -8396,6 +8397,40 @@ class BrowserTabViewModelTest {
             val commands = commandCaptor.allValues
             assertFalse(
                 "LaunchInputScreen command should be suppressed when tab is restored from saved state",
+                commands.any { it is Command.LaunchInputScreen },
+            )
+        }
+
+    @Test
+    fun whenInputScreenEnabledAndTabRestoredAndRestorationFixDisabledThenLaunchInputScreenCommandNotSuppressed() =
+        runTest {
+            val initialTabId = "initial-tab"
+            val initialTab =
+                TabEntity(
+                    tabId = initialTabId,
+                    url = "https://example.com",
+                    title = "EX",
+                    skipHome = false,
+                    viewed = true,
+                    position = 0,
+                )
+            val ntpTabId = "ntp-tab"
+            val ntpTab = TabEntity(tabId = ntpTabId, url = null, title = "", skipHome = false, viewed = true, position = 0)
+            whenever(mockTabRepository.getTab(initialTabId)).thenReturn(initialTab)
+            whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
+            flowSelectedTab.emit(initialTab)
+
+            fakeAndroidConfigBrowserFeature.tabStateRestorationFix().setRawStoredState(State(enable = false))
+            testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
+            testee.observeSelectedTab(isRestored = true)
+            mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
+
+            flowSelectedTab.emit(ntpTab)
+
+            verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+            val commands = commandCaptor.allValues
+            assertTrue(
+                "LaunchInputScreen command should not be suppressed when tab restoration fix is disabled",
                 commands.any { it is Command.LaunchInputScreen },
             )
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1213836390603173?focus=true

### Description

Fixed 2 issues:

1. FragmentStateAdapter GC'd restored fragments: In BrowserActivity.initializeTabs(), tabPagerAdapter.restore() was called before the adapter's tabs list was populated. The gcFragments() call inside restoreState() checks containsItem() for each restored fragment, but with tabs empty, every fragment failed this check and was removed. The adapter then created a brand-new fragment via createFragment() with null savedInstanceState.
2. ViewModel flow re-emitted on recreation: The flowSelectedTab subscription in the ViewModel's init block re-evaluated on every new ViewModel instance. Since the tab still had no URL, the filter passed and LaunchInputScreen was emitted again, causing the loop

Fix:

1. Populate adapter tabs before restoring state — ensures containsItem() returns true during GC, so restored fragments survive with their savedInstanceState.
2. Extract the flow subscription to observeSelectedTab(isRestored) — the fragment calls this method, passing whether it was restored from saved state. The first emission is skipped when isRestored is true, preventing the re-launch. The flag resets after the first emission so subsequent tab switches work normally.

### Steps to test this PR

_Tab Restoration Behavior_

- [ ] Enable "Don't keep activities" in Developer Options
- [ ] Enable “Search&[Duck.ai](http://Duck.ai)” omnibar
- [ ] Go to new tab page
- [ ] Click on the omnibar
- [ ] Click on the menu icon
- [ ] The menu should be opened

### UI changes

| Before | After |
| --- | --- |
|  |  |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tab restoration and lifecycle-driven flow collection in core browsing UI; ordering/remote-config gating changes could affect tab switching or state restore on low-memory/rotation scenarios.
> 
> **Overview**
> Fixes swiping-tabs state restoration by adding a remote-configed `tabStateRestorationFix` that restores `TabPagerAdapter` state **after** `onTabsUpdated` populates the tab list (instead of during `initializeTabs`), avoiding restored fragments being GC’d; state is removed from the bundle after applying.
> 
> Prevents an Input Screen relaunch loop on fragment/viewmodel recreation by moving the selected-tab flow logic out of `BrowserTabViewModel` init into `observeSelectedTab(isRestored)`, called from `BrowserTabFragment`, and skipping the first emission on restore when the fix is enabled. Also ensures shown fragments’ root views are explicitly made `VISIBLE` in `FragmentStateAdapter.showFragment`, and updates/adds unit tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f60d2771ddcda083db9839a14f7cab0c555183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->