### PR TITLE
Hatch: Translations

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -153,7 +153,7 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
         val labels = options.map { it.toTimeoutLabel() }
         val selectedIndex = options.indexOf(currentSelection).takeIf { it >= 0 }?.plus(1)
         RadioListAlertDialogBuilder(this)
-            .setTitle(R.string.afterInactivityOptionTitle)
+            .setTitle(R.string.afterInactivityDialogTitle)
             .setOptions(labels, selectedIndex)
             .setPositiveButton(com.duckduckgo.mobile.android.R.string.dialogSave)
             .setNegativeButton(R.string.cancel)

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Показване при стартиране на приложението</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Последно отворен раздел</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Страница с нов раздел</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Последно използван раздел</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Нов раздел</string>
     <string name="showOnAppLaunchOptionSpecificPage">Конкретна страница</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Търси анонимно с DuckDuckGo или попитай Duck.ai. Гласово търсене и Duck.ai са налични, ако са активирани.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Търсете или посещавайте любимите си сайтове анонимно с едно докосване. Гласово търсене и Duck.ai са налични, ако са активирани.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">След неактивност</string>
+    <string name="afterInactivityOptionTitle">Начален екран при отваряне</string>
+    <string name="afterInactivityTimeoutRowTitle">Изберете таймер за бездействие</string>
+    <string name="afterInactivityScreenSectionHeader">Изберете какво да виждате, когато се върнете в DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Няма</string>
+    <string name="afterInactivityTimeout1Minute">1 минута</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d минути</string>
+    <string name="afterInactivityTimeout1Hour">1 час</string>
+    <string name="afterInactivityTimeoutXHours">%1$d часа</string>
+
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Zobrazit při spuštění aplikace</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy otevřená karta</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Stránka Nová karta</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy použitá karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nová karta</string>
     <string name="showOnAppLaunchOptionSpecificPage">Konkrétní stránka</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Vyhledávej soukromě pomocí DuckDuckGo nebo se zeptej Duck.ai. Stačí povolit hlasové vyhledávání a Duck.ai.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Vyhledávej nebo navštěvuj své oblíbené weby soukromě jediným klepnutím. Stačí povolit hlasové vyhledávání a Duck.ai.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Po nečinnosti</string>
+    <string name="afterInactivityOptionTitle">Úvodní obrazovka</string>
+    <string name="afterInactivityTimeoutRowTitle">Vyber časovač nečinnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Vyber si, co uvidíš po návratu na DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Žádný</string>
+    <string name="afterInactivityTimeout1Minute">1 minuta</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minut(y)</string>
+    <string name="afterInactivityTimeout1Hour">1 hodina</string>
+    <string name="afterInactivityTimeoutXHours">%1$d hodin(y)</string>
+
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Vis ved app-start</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Sidst åbnede fane</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Ny faneside</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Sidst brugte fane</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny fane</string>
     <string name="showOnAppLaunchOptionSpecificPage">Specifik side</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Søg privat med DuckDuckGo, eller spørg Duck.ai. Stemmesøgning og Duck.ai er tilgængelige, hvis de er aktiveret.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Søg eller besøg dine yndlingssider privat med ét tryk. Stemmesøgning og Duck.ai er tilgængelige, hvis de er aktiveret.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Efter inaktivitet</string>
+    <string name="afterInactivityOptionTitle">Åbningsskærm</string>
+    <string name="afterInactivityTimeoutRowTitle">Vælg en inaktivitetstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Vælg, hvad du ser, når du vender tilbage til DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Ingen</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutter</string>
+    <string name="afterInactivityTimeout1Hour">1 time</string>
+    <string name="afterInactivityTimeoutXHours">%1$d timer</string>
+
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Beim App-Start anzeigen</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Zuletzt geöffneter Tab</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Neue Tab-Seite</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Zuletzt verwendeter Tab</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Neuer Tab</string>
     <string name="showOnAppLaunchOptionSpecificPage">Bestimmte Seite</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Privat suchen mit DuckDuckGo oder frag Duck.ai. Sprachsuche und Duck.ai sind verfügbar, wenn sie aktiviert sind.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Du kannst deine Lieblingswebsites mit nur einem Klick privat durchsuchen und anzeigen. Sprachsuche und Duck.ai sind verfügbar, wenn sie aktiviert sind.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Nach Inaktivität</string>
+    <string name="afterInactivityOptionTitle">Eröffnungsbildschirm</string>
+    <string name="afterInactivityTimeoutRowTitle">Wähle einen Inaktivitätstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Wähle aus, was dir angezeigt werden soll, wenn du zu DuckDuckGo zurückkehrst.</string>
+    <string name="afterInactivityTimeoutAlways">Gar nichts</string>
+    <string name="afterInactivityTimeout1Minute">1 Minute</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d Minuten</string>
+    <string name="afterInactivityTimeout1Hour">1 Stunde</string>
+    <string name="afterInactivityTimeoutXHours">%1$d Stunden</string>
+
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Εμφάνιση στην Εκκίνηση εφαρμογής</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Τελευταία καρτέλα που άνοιξε</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Σελίδα νέας καρτέλας</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Τελευταία καρτέλα που χρησιμοποιήθηκε</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Νέα καρτέλα</string>
     <string name="showOnAppLaunchOptionSpecificPage">Συγκεκριμένη σελίδα</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Πραγματοποιήστε αναζήτηση ιδιωτικά με το DuckDuckGo ή ρωτήστε το Duck.ai. Η φωνητική αναζήτηση και το Duck.ai είναι διαθέσιμα αν είναι ενεργοποιημένα.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Κάντε αναζήτηση ή επισκεφτείτε τους αγαπημένους ιστότοπούς σας ιδιωτικά, με ένα πάτημα. Η φωνητική αναζήτηση και το Duck.ai είναι διαθέσιμα αν είναι ενεργοποιημένα.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Μετά από αδράνεια</string>
+    <string name="afterInactivityOptionTitle">Οθόνη έναρξης</string>
+    <string name="afterInactivityTimeoutRowTitle">Επιλέξτε ένα χρονόμετρο αδράνειας</string>
+    <string name="afterInactivityScreenSectionHeader">Επιλέξτε τι βλέπετε όταν επιστρέψετε στο DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Κανένα</string>
+    <string name="afterInactivityTimeout1Minute">1 λεπτό</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d λεπτά</string>
+    <string name="afterInactivityTimeout1Hour">1 ώρα</string>
+    <string name="afterInactivityTimeoutXHours">%1$d ώρες</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Mostrar al abrir la aplicación</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Última pestaña abierta</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Página de nueva pestaña</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Última pestaña utilizada</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nueva pestaña</string>
     <string name="showOnAppLaunchOptionSpecificPage">Página específica</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Busca de manera privada con DuckDuckGo o pregúntale a Duck.ai. Búsqueda por voz y Duck.ai disponibles si están habilitados.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Busca o visita tus sitios web de forma privada con solo pulsar un botón. Búsqueda por voz y Duck.ai disponibles si están habilitados.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Después de inactividad</string>
+    <string name="afterInactivityOptionTitle">Pantalla de apertura</string>
+    <string name="afterInactivityTimeoutRowTitle">Elige un temporizador de inactividad</string>
+    <string name="afterInactivityScreenSectionHeader">Elige qué quieres ver cuando vuelvas a DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Ninguna</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutos</string>
+    <string name="afterInactivityTimeout1Hour">1 hora</string>
+    <string name="afterInactivityTimeoutXHours">%1$d horas</string>
+
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Kuva rakenduse käivitamisel</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Viimati avatud vahekaart</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Uue vahekaardi leht</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Viimati kasutatud vahekaart</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Uus vaheleht</string>
     <string name="showOnAppLaunchOptionSpecificPage">Konkreetne lehekülg</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Otsi privaatselt DuckDuckGo\'ga või küsi Duck.ai käest. Häälotsing ja Duck.ai on saadaval, kui need on lubatud.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Otsi või külasta oma lemmiksaite privaatselt ühe puudutusega. Häälotsing ja Duck.ai on saadaval, kui need on lubatud.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Pärast tegevusetust</string>
+    <string name="afterInactivityOptionTitle">Avakuva</string>
+    <string name="afterInactivityTimeoutRowTitle">Vali tegevusetusaja taimer</string>
+    <string name="afterInactivityScreenSectionHeader">Vali, mida näed DuckDuckGo-sse naastes</string>
+    <string name="afterInactivityTimeoutAlways">Puudub</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutit</string>
+    <string name="afterInactivityTimeout1Hour">1 tund</string>
+    <string name="afterInactivityTimeoutXHours">%1$d tundi</string>
+
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Näytä sovelluksen käynnistyksen yhteydessä</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Viimeksi avattu -välilehti</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Uusi välilehti -sivu</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Viimeksi käytetty välilehti</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Uusi välilehti</string>
     <string name="showOnAppLaunchOptionSpecificPage">Tietty sivu</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Tee yksityisiä hakuja DuckDuckGo:n avulla tai kysy Duck.ai:lta. Äänihaku ja Duck.ai ovat käytettävissä, jos ne on aktivoitu.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Tee hakuja ja käy lempisivustoillasi yhdellä napautuksella. Äänihaku ja Duck.ai ovat käytettävissä, jos ne on aktivoitu.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Toimettomuuden jälkeen</string>
+    <string name="afterInactivityOptionTitle">Aloitusnäyttö</string>
+    <string name="afterInactivityTimeoutRowTitle">Valitse passiivisuusajastin</string>
+    <string name="afterInactivityScreenSectionHeader">Valitse, mitä näet palatessasi DuckDuckGo-palveluun</string>
+    <string name="afterInactivityTimeoutAlways">Ei mitään</string>
+    <string name="afterInactivityTimeout1Minute">1 minuutti</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minuuttia</string>
+    <string name="afterInactivityTimeout1Hour">1 tunti</string>
+    <string name="afterInactivityTimeoutXHours">%1$d tuntia</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Afficher au lancement de l\'application</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Dernier onglet ouvert</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Nouvelle page d\'onglet</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Dernier onglet utilisé</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nouvel onglet</string>
     <string name="showOnAppLaunchOptionSpecificPage">Page spécifique</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Faites une recherche privée avec DuckDuckGo ou demandez à Duck.ai. La recherche vocale et Duck.ai sont disponibles si activés.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Faites une recherche ou visitez vos sites favoris en privé en un seul clic. La recherche vocale et Duck.ai sont disponibles si activés.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Après l\'inactivité</string>
+    <string name="afterInactivityOptionTitle">Écran d\'ouverture</string>
+    <string name="afterInactivityTimeoutRowTitle">Choisissez un minuteur d\'inactivité</string>
+    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez en revenant sur DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Aucune</string>
+    <string name="afterInactivityTimeout1Minute">1 minute</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutes</string>
+    <string name="afterInactivityTimeout1Hour">1 heure</string>
+    <string name="afterInactivityTimeoutXHours">%1$d heures</string>
+
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Prikaži pri pokretanju aplikacije</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Posljednja otvorena kartica</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Nova stranica kartice</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Posljednja korištena kartica</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nova kartica</string>
     <string name="showOnAppLaunchOptionSpecificPage">Specifična stranica</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Pretražuj privatno s DuckDuckGo-om ili pitaj Duck.ai. Glasovno pretraživanje i Duck.ai dostupni su ako su omogućeni.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Pretraži ili posjeti svoje omiljene mrežne lokacije privatno jednim dodirom. Glasovno pretraživanje i Duck.ai dostupni su ako su omogućeni.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Nakon neaktivnosti</string>
+    <string name="afterInactivityOptionTitle">Početni zaslon</string>
+    <string name="afterInactivityTimeoutRowTitle">Odaberi mjerač vremena neaktivnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Odaberi što ćeš vidjeti kada se vratiš na DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Nijedno</string>
+    <string name="afterInactivityTimeout1Minute">1 minutu</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minuta</string>
+    <string name="afterInactivityTimeout1Hour">1 sat</string>
+    <string name="afterInactivityTimeoutXHours">%1$d sati</string>
+
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Megjelenítés az alkalmazás indításakor</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Utoljára megnyitott lap</string>
-    <string name="showOnAppLaunchOptionNewTabPage">„Új lap” oldal</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Utoljára használt lap</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Új lap</string>
     <string name="showOnAppLaunchOptionSpecificPage">Speciális oldal</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Keress privát módon a DuckDuckGóval, vagy tegyél fel kérdést a Duck.ai számára. A hangalapú keresés és a Duck.ai akkor érhető el, ha engedélyezve van.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Látogasd meg a kedvenc weboldalaidat és keress rajtuk privát módon egyetlen koppintással. A hangalapú keresés és a Duck.ai akkor érhető el, ha engedélyezve van.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Inaktivitás után</string>
+    <string name="afterInactivityOptionTitle">Nyitóképernyő</string>
+    <string name="afterInactivityTimeoutRowTitle">Válaszd ki a tétlenségi időzítőt</string>
+    <string name="afterInactivityScreenSectionHeader">Válaszd ki, hogy mi jelenjen meg a DuckDuckGóba való visszatéréskor</string>
+    <string name="afterInactivityTimeoutAlways">Nincs</string>
+    <string name="afterInactivityTimeout1Minute">1 perc</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d perc</string>
+    <string name="afterInactivityTimeout1Hour">1 óra</string>
+    <string name="afterInactivityTimeoutXHours">%1$d óra</string>
+
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Mostra all\'avvio dell\'app</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima scheda aperta</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Pagina Nuova scheda</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima scheda usata</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nuova scheda</string>
     <string name="showOnAppLaunchOptionSpecificPage">Pagina specifica</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Cerca privatamente con DuckDuckGo o chiedi a Duck.ai. Ricerca vocale e Duck.ai disponibili se abilitati.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Cerca o visita i tuoi siti preferiti in privato con un tocco. Ricerca vocale e Duck.ai disponibili se abilitati.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Dopo l\'inattività</string>
+    <string name="afterInactivityOptionTitle">Schermata di apertura</string>
+    <string name="afterInactivityTimeoutRowTitle">Scegli un timer di inattività</string>
+    <string name="afterInactivityScreenSectionHeader">Scegli cosa visualizzare al tuo ritorno su DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Niente</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minuti</string>
+    <string name="afterInactivityTimeout1Hour">1 ora</string>
+    <string name="afterInactivityTimeoutXHours">%1$d ore</string>
+
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Rodyti paleidus programą</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Paskutinį kartą atidarytas skirtukas</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Naujas skirtuko puslapis</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Paskutinį kartą naudotas skirtukas</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nauja kortelė</string>
     <string name="showOnAppLaunchOptionSpecificPage">Konkretus puslapis</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Ieškokite privačiai naudodami „DuckDuckGo“ arba paklauskite „Duck.ai“. Jei įjungta, galima naudotis paieška balsu ir „Duck.ai“.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Ieškokite arba lankykitės savo mėgstamose svetainėse privačiai vienu spustelėjimu. Jei įjungta, galima naudotis paieška balsu ir „Duck.ai“.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Po neaktyvumo</string>
+    <string name="afterInactivityOptionTitle">Atidarymo ekranas</string>
+    <string name="afterInactivityTimeoutRowTitle">Pasirinkite neaktyvumo laikmatį</string>
+    <string name="afterInactivityScreenSectionHeader">Pasirinkite, ką matysite grįžę į „DuckDuckGo“</string>
+    <string name="afterInactivityTimeoutAlways">Jokie</string>
+    <string name="afterInactivityTimeout1Minute">1 min.</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d min.</string>
+    <string name="afterInactivityTimeout1Hour">1 val.</string>
+    <string name="afterInactivityTimeoutXHours">%1$d val.</string>
+
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -925,8 +925,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Rādīt lietotnes palaišanas laikā</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Pēdējā atvērtā cilne</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Jaunas cilnes lapa</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Pēdējā lietotā cilne</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Jauna cilne</string>
     <string name="showOnAppLaunchOptionSpecificPage">Konkrēta lapa</string>
 
     <!-- Privacy Dashboard -->
@@ -996,4 +996,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Meklē privāti ar DuckDuckGo vai jautā Duck.ai. Ja ir iespējota balss meklēšana un Duck.ai.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Savas iecienītākās vietnes meklē vai apmeklē privāti ar vienu pieskārienu. Balss meklēšana un Duck.ai ir pieejami, ja tie iespējoti.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Pēc neaktivitātes perioda</string>
+    <string name="afterInactivityOptionTitle">Ekrāna atvēršana</string>
+    <string name="afterInactivityTimeoutRowTitle">Izvēlies neaktivitātes taimeri</string>
+    <string name="afterInactivityScreenSectionHeader">Izvēlies, ko redzēsi, atgriežoties DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Nav</string>
+    <string name="afterInactivityTimeout1Minute">1 minūte</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minūtes</string>
+    <string name="afterInactivityTimeout1Hour">1 stunda</string>
+    <string name="afterInactivityTimeoutXHours">%1$d stundas</string>
+
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Vis ved lansering av appen</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Sist åpnet fane</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Ny faneside</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Sist brukte fane</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny fane</string>
     <string name="showOnAppLaunchOptionSpecificPage">Spesifikk side</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Søk privat med DuckDuckGo eller spør Duck.ai. Talesøk og Duck.ai er tilgjengelig hvis det er aktivert.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Søk eller besøk favorittsider privat med ett trykk. Talesøk og Duck.ai er tilgjengelig hvis det er aktivert.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Etter inaktivitet</string>
+    <string name="afterInactivityOptionTitle">Åpningsskjerm</string>
+    <string name="afterInactivityTimeoutRowTitle">Velg en inaktivitetstidtaker</string>
+    <string name="afterInactivityScreenSectionHeader">Velg hva du vil se når du kommer tilbake til DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Ingen</string>
+    <string name="afterInactivityTimeout1Minute">1 minutt</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutter</string>
+    <string name="afterInactivityTimeout1Hour">1 time</string>
+    <string name="afterInactivityTimeoutXHours">%1$d timer</string>
+
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Weergeven bij het starten van de app</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Laatst geopende tabblad</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Nieuwe tabbladpagina</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Laatst gebruikte tabblad</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nieuw tabblad</string>
     <string name="showOnAppLaunchOptionSpecificPage">Specifieke pagina</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Zoek privé met DuckDuckGo of vraag het aan Duck.ai. Voice Search en Duck.ai zijn beschikbaar indien ingeschakeld.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Zoek of bezoek je favoriete sites in de privémodus met één tik. Zoeken via spraak en Duck.ai zijn beschikbaar indien ingeschakeld.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Na inactiviteit</string>
+    <string name="afterInactivityOptionTitle">Openingsscherm</string>
+    <string name="afterInactivityTimeoutRowTitle">Kies een inactiviteitstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Kies wat je wilt zien als je terugkeert naar DuckDuckGo.</string>
+    <string name="afterInactivityTimeoutAlways">Geen</string>
+    <string name="afterInactivityTimeout1Minute">1 minuut</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minuten</string>
+    <string name="afterInactivityTimeout1Hour">1 uur</string>
+    <string name="afterInactivityTimeoutXHours">%1$d uur</string>
+
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Pokaż przy uruchomieniu aplikacji</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Ostatnio otwarta karta</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Strona nowej karty</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ostatnio używana karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nowa karta</string>
     <string name="showOnAppLaunchOptionSpecificPage">Określona strona</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Szukaj prywatnie z DuckDuckGo lub pytaj Duck.ai. Wyszukiwanie głosowe i Duck.ai są dostępne, jeśli są włączone.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Prywatnie przeszukuj lub odwiedzaj swoje ulubione witryny za pomocą jednego dotknięcia. Wyszukiwanie głosowe i Duck.ai są dostępne, jeśli są włączone.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Po braku aktywności</string>
+    <string name="afterInactivityOptionTitle">Ekran startowy</string>
+    <string name="afterInactivityTimeoutRowTitle">Ustaw czas bezczynności</string>
+    <string name="afterInactivityScreenSectionHeader">Wybierz, co zobaczysz po powrocie do DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Brak</string>
+    <string name="afterInactivityTimeout1Minute">1 minuta</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d min</string>
+    <string name="afterInactivityTimeout1Hour">1 godzina</string>
+    <string name="afterInactivityTimeoutXHours">%1$d godz.</string>
+
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Mostrar ao abrir a aplicação</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Último separador aberto</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Nova página de separador</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Último separador utilizado</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Novo separador</string>
     <string name="showOnAppLaunchOptionSpecificPage">Página específica</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Pesquisa em privado com o DuckDuckGo ou pergunta ao Duck.ai. Pesquisa por voz e Duck.ai disponíveis se ativados.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Pesquisa ou visita os teus sites favoritos de forma privada com um toque. Pesquisa por voz e Duck.ai disponíveis se ativados.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Após Inatividade</string>
+    <string name="afterInactivityOptionTitle">Ecrã de abertura</string>
+    <string name="afterInactivityTimeoutRowTitle">Escolher um temporizador de inatividade</string>
+    <string name="afterInactivityScreenSectionHeader">Escolhe o que vês quando voltares ao DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Nenhum</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutos</string>
+    <string name="afterInactivityTimeout1Hour">1 hora</string>
+    <string name="afterInactivityTimeoutXHours">%1$d horas</string>
+
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -925,7 +925,7 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Afișează la lansarea aplicației</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima filă deschisă</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima filă utilizată</string>
     <string name="showOnAppLaunchOptionNewTabPage">Filă nouă</string>
     <string name="showOnAppLaunchOptionSpecificPage">Pagină specifică</string>
 
@@ -996,4 +996,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Caută în mod privat cu DuckDuckGo sau întreabă Duck.ai. Căutarea vocală și Duck.ai sunt disponibile dacă sunt activate.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Caută sau vizitează site-urile preferate în mod privat, cu o singură atingere. Căutarea vocală și Duck.ai sunt disponibile dacă sunt activate.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">După inactivitate</string>
+    <string name="afterInactivityOptionTitle">Ecran de deschidere</string>
+    <string name="afterInactivityTimeoutRowTitle">Alege un cronometru de inactivitate</string>
+    <string name="afterInactivityScreenSectionHeader">Alege ce vezi când revii la DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Niciuna</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minute</string>
+    <string name="afterInactivityTimeout1Hour">1 oră</string>
+    <string name="afterInactivityTimeoutXHours">%1$d ore</string>
+
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Показывать при запуске приложения</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Последняя открытая вкладка</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Страница новой вкладки</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Последняя использованная вкладка</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Новая вкладка</string>
     <string name="showOnAppLaunchOptionSpecificPage">Конкретная страница</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Конфиденциальный поиск с DuckDuckGo или вопросы для Duck.ai. Голосовой поиск и Duck.ai можно включить по желанию.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Поиск или посещение любимых сайтов в приватном режиме одним касанием. По желанию можно включить голосовой поиск и Duck.ai.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">После бездействия</string>
+    <string name="afterInactivityOptionTitle">Начальный экран</string>
+    <string name="afterInactivityTimeoutRowTitle">Выберите таймер бездействия</string>
+    <string name="afterInactivityScreenSectionHeader">Что показывать при возвращении в DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Ничего</string>
+    <string name="afterInactivityTimeout1Minute">1 мин.</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d минут</string>
+    <string name="afterInactivityTimeout1Hour">1 ч.</string>
+    <string name="afterInactivityTimeoutXHours">%1$d ч.</string>
+
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Zobraziť pri spustení aplikácie</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy otvorená karta</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Stránka na novej karte</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy použitá karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nová karta</string>
     <string name="showOnAppLaunchOptionSpecificPage">Špecifická stránka</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Vyhľadávaj súkromne s DuckDuckGo alebo sa opýtaj Duck.ai. Hlasové vyhľadávanie a Duck.ai sú k dispozícii, ak sú povolené.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Jedným ťuknutím súkromne vyhľadávaj alebo navštív svoje obľúbené stránky. Hlasové vyhľadávanie a Duck.ai sú k dispozícii, ak sú povolené.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Po nečinnosti</string>
+    <string name="afterInactivityOptionTitle">Uvítacia obrazovka</string>
+    <string name="afterInactivityTimeoutRowTitle">Vyber časovač nečinnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Vyber si, čo uvidíš po návrate na DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Žiadne</string>
+    <string name="afterInactivityTimeout1Minute">1 min.</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minút</string>
+    <string name="afterInactivityTimeout1Hour">1 hod.</string>
+    <string name="afterInactivityTimeoutXHours">%1$d hodín</string>
+
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -945,8 +945,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Pokaži ob zagonu aplikacije</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Zadnji odprt zavihek</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Stran z novim zavihkom</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Nazadnje uporabljeni zavihek</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nov zavihek</string>
     <string name="showOnAppLaunchOptionSpecificPage">Določena stran</string>
 
     <!-- Privacy Dashboard -->
@@ -1016,4 +1016,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Zasebno iščite z DuckDuckGo ali vprašajte Duck.ai. Glasovno iskanje in Duck.ai sta na voljo, če sta omogočena.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Z enim dotikom zasebno poiščite ali obiščite svoja najljubša spletna mesta. Glasovno iskanje in Duck.ai sta na voljo, če sta omogočena.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Po neaktivnosti</string>
+    <string name="afterInactivityOptionTitle">Začetni zaslon</string>
+    <string name="afterInactivityTimeoutRowTitle">Izberite časovnik neaktivnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Izberite, kaj bo prikazano, ko se vrnete na DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Brez</string>
+    <string name="afterInactivityTimeout1Minute">1 minuti</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d min</string>
+    <string name="afterInactivityTimeout1Hour">1 uri</string>
+    <string name="afterInactivityTimeoutXHours">%1$d h</string>
+
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Visa vid app-start</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Senast öppnade flik</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Ny fliksida</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Senast använda flik</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny flik</string>
     <string name="showOnAppLaunchOptionSpecificPage">Specifik sida</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Sök privat med DuckDuckGo eller fråga Duck.ai. Röstsökning och Duck.ai kan användas efter aktivering.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Gör sökningar eller besök dina favoritwebbplatser privat med ett tryck. Röstsökning och Duck.ai kan användas efter aktivering.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Efter inaktivitet</string>
+    <string name="afterInactivityOptionTitle">Öppningsskärm</string>
+    <string name="afterInactivityTimeoutRowTitle">Välj en timer för inaktivitet</string>
+    <string name="afterInactivityScreenSectionHeader">Välj vad du ser när du återgår till DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">Inga</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minuter</string>
+    <string name="afterInactivityTimeout1Hour">1 timme</string>
+    <string name="afterInactivityTimeoutXHours">%1$d timmar</string>
+
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -905,8 +905,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Uygulama Başlatıldığında Göster</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Son Açılan Sekme</string>
-    <string name="showOnAppLaunchOptionNewTabPage">Yeni Sekme Sayfası</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Son Kullanılan Sekme</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Yeni Sekme</string>
     <string name="showOnAppLaunchOptionSpecificPage">Belirli Bir Sayfa</string>
 
     <!-- Privacy Dashboard -->
@@ -976,4 +976,16 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">DuckDuckGo ile gizli arama yapın veya Duck.ai\'a sorun. Etkinleştirildiğinde Sesli Arama ve Duck.ai kullanılabilir.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Tek dokunuşla favori sitelerinizi gizlice arayın veya ziyaret edin. Etkinleştirildiğinde Sesli Arama ve Duck.ai kullanılabilir.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">Hareketsizlik Sonrası</string>
+    <string name="afterInactivityOptionTitle">Açılış Ekranı</string>
+    <string name="afterInactivityTimeoutRowTitle">Bir hareketsizlik zamanlayıcısı seçin</string>
+    <string name="afterInactivityScreenSectionHeader">DuckDuckGo\'ya döndüğünüzde ne göreceğinizi seçin</string>
+    <string name="afterInactivityTimeoutAlways">Yok</string>
+    <string name="afterInactivityTimeout1Minute">1 dakika</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d dakika</string>
+    <string name="afterInactivityTimeout1Hour">1 saat</string>
+    <string name="afterInactivityTimeoutXHours">%1$d saat</string>
+
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -91,11 +91,12 @@
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
     <!-- Inactivity timeout -->
-    <string name="afterInactivityOptionTitle">After Inactivity</string>
+    <string name="afterInactivityDialogTitle">After Inactivity</string>
+    <string name="afterInactivityOptionTitle">Opening Screen</string>
     <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
-    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return after inactivity</string>
+    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return to DuckDuckGo</string>
     <string name="afterInactivityOptionMessage" translatable="false">Choose what you see when you return after %1$s minutes of inactivity.</string>
-    <string name="afterInactivityTimeoutAlways" translatable="false">Always</string>
+    <string name="afterInactivityTimeoutAlways" translatable="false">None</string>
     <string name="afterInactivityTimeout1Minute" translatable="false">1 minute</string>
     <string name="afterInactivityTimeoutXMinutes" translatable="false">%1$d minutes</string>
     <string name="afterInactivityTimeout1Hour" translatable="false">1 hour</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -90,18 +90,6 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
-    <!-- Inactivity timeout -->
-    <string name="afterInactivityDialogTitle">After Inactivity</string>
-    <string name="afterInactivityOptionTitle">Opening Screen</string>
-    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
-    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return to DuckDuckGo</string>
-    <string name="afterInactivityOptionMessage" translatable="false">Choose what you see when you return after %1$s minutes of inactivity.</string>
-    <string name="afterInactivityTimeoutAlways" translatable="false">None</string>
-    <string name="afterInactivityTimeout1Minute" translatable="false">1 minute</string>
-    <string name="afterInactivityTimeoutXMinutes" translatable="false">%1$d minutes</string>
-    <string name="afterInactivityTimeout1Hour" translatable="false">1 hour</string>
-    <string name="afterInactivityTimeoutXHours" translatable="false">%1$d hours</string>
-
     <!--Onboarding Rebrand Design Update-->
     <string name="preOnboardingWelcomeDialogTitle">Hi there!</string>
     <string name="preOnboardingWelcomeDialogBody">Ready for a faster browser that keeps you protected?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -904,8 +904,8 @@
 
     <!-- Show on App Launch Option -->
     <string name="showOnAppLaunchOptionTitle">Show on App Launch</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab">Last Opened Tab</string>
-    <string name="showOnAppLaunchOptionNewTabPage">New Tab Page</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Last Used Tab</string>
+    <string name="showOnAppLaunchOptionNewTabPage">New Tab</string>
     <string name="showOnAppLaunchOptionSpecificPage">Specific Page</string>
 
     <!-- Privacy Dashboard -->
@@ -985,5 +985,6 @@
     <string name="afterInactivityTimeout1Minute">1 minute</string>
     <string name="afterInactivityTimeoutXMinutes">%1$d minutes</string>
     <string name="afterInactivityTimeout1Hour">1 hour</string>
+    <string name="afterInactivityTimeoutXHours">%1$d hours</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -975,4 +975,15 @@
     <string name="searchWidgetDescription" instruction="Description for the search widget, which may include Duck.ai and voice search">Search privately with DuckDuckGo or ask Duck.ai. Voice Search and Duck.ai available if enabled.</string>
     <string name="searchAndFavoritesWidgetDescription" instruction="Description for the search and favorites widget">Search or visit your favorite sites privately with one tap. Voice Search and Duck.ai available if enabled.</string>
     <string name="duckAiOnlyPinShortcutLabel" instruction="Label for the Duck.ai pinned shortcut. Should be Duck.ai in all languages">Duck.ai</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityDialogTitle">After Inactivity</string>
+    <string name="afterInactivityOptionTitle">Opening Screen</string>
+    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
+    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return to DuckDuckGo</string>
+    <string name="afterInactivityTimeoutAlways">None</string>
+    <string name="afterInactivityTimeout1Minute">1 minute</string>
+    <string name="afterInactivityTimeoutXMinutes">%1$d minutes</string>
+    <string name="afterInactivityTimeout1Hour">1 hour</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1213800909789712?focus=true

### Description
Adds translations for the new Hatch screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk localization-only changes plus a minor UI string swap for the inactivity timeout dialog title; no behavioral or data-handling logic changes.
> 
> **Overview**
> Updates user-visible copy for **Show on App Launch** across locales (e.g., “Last Opened Tab” → “Last Used Tab”, “New Tab Page” → “New Tab”).
> 
> Adds localized string resources for the **inactivity timeout / Hatch** UI (titles, section headers, and timeout labels) across many languages, and moves the English inactivity-timeout strings out of `donottranslate.xml` into `values/strings.xml`. The inactivity timeout selection dialog in `ShowOnAppLaunchActivity` now uses the new `afterInactivityDialogTitle` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d476d67a44475256adc4fd98defa17b48ed3486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->