### PR TITLE
Change setting title for toggle position

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -17,7 +17,7 @@
 <resources>
     <string name="duckAiNativeInputFieldTitle">Native Input Field</string>
     <string name="duckAiNativeInputFieldMessage">Use the native input field for Duck.ai</string>
-    <string name="duckAiDefaultTogglePositionTitle">Default Toggle Position</string>
+    <string name="duckAiDefaultTogglePositionTitle">New tab toggle position</string>
     <string name="duckAiDefaultTogglePositionSearch">Search</string>
     <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
     <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213908962566543?focus=true

### Description
Small string update for the setting title

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="334" height="196" alt="Screenshot 2026-04-02 at 1 02 06 AM" src="https://github.com/user-attachments/assets/03728935-f03c-4ab3-b66a-bfc9914327d5" />|<img width="344" height="197" alt="Screenshot 2026-04-02 at 12 49 14 AM" src="https://github.com/user-attachments/assets/f1a4b7ff-569c-4762-9ff8-da2d8b7e7ac9" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only changes a single settings display string with no logic, data, or security impact.
> 
> **Overview**
> Updates the Duck.ai settings label `duckAiDefaultTogglePositionTitle` from “Default Toggle Position” to “New tab toggle position” in `donottranslate.xml` to better describe the toggle’s behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6afd08e393d78bfc42b31a8ff742454e2d42a82b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->