### PR TITLE
Add PDF pixel definitions and ATB removal plugin

### DIFF
--- a/PixelDefinitions/pixels/definitions/pdf_viewer.json5
+++ b/PixelDefinitions/pixels/definitions/pdf_viewer.json5
@@ -1,0 +1,38 @@
+{
+    "m_pdf_viewer_opened": {
+        "description": "Fired when a PDF is successfully rendered inline in a browser tab",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_pdf_render_failure": {
+        "description": "Fired when a PDF fails to render inline (malformed file, unsupported format, or other error)",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "error_type",
+                "type": "string",
+                "description": "The category of error that caused the render failure",
+                "enum": ["io_error", "security_error", "unknown"]
+            }
+        ]
+    },
+    "m_nav_pdf_download_menu_item_pressed": {
+        "description": "Fired when the user taps the Download PDF item in the browser menu",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_pdf_fallback": {
+        "description": "Fired when inline PDF rendering is not available (unsupported device, API < 31) and the standard download flow is used instead",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelName.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class PdfPixelName(override val pixelName: String) : Pixel.PixelName {
+    PDF_VIEWER_OPENED("m_pdf_viewer_opened"),
+    PDF_RENDER_FAILURE("m_pdf_render_failure"),
+    PDF_DOWNLOAD_MENU_ITEM_PRESSED("m_nav_pdf_download_menu_item_pressed"),
+    PDF_FALLBACK("m_pdf_fallback"),
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelParamRemovalPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class PdfPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return PdfPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/69071770703008/task/1213897912537813?focus=true 

### Description

Adds formal pixel definitions and ATB removal for the inline PDF rendering feature, as requested during the privacy triage review.

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new analytics pixel definitions and a DI-registered param-removal plugin; no functional PDF rendering logic or data processing paths are changed.
> 
> **Overview**
> Adds formal pixel definitions for the inline PDF experience (`m_pdf_viewer_opened`, `m_pdf_render_failure` with `error_type`, download menu tap, and fallback-to-download).
> 
> Introduces `PdfPixelName` plus an `AppScope` `PdfPixelParamRemovalPlugin` that registers these pixels to have the ATB parameter removed before sending.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 054d8d6c5771474e9bac2977835de31f0b301254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->