### PR TITLE
Fix data clearing product surface telemetry pixels accumulating in pending queue

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/surface/MobileBrowserSurfacePixelInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/surface/MobileBrowserSurfacePixelInterceptor.kt
@@ -45,7 +45,7 @@ class MobileBrowserSurfacePixelInterceptor @Inject constructor(
         }
 
         if (shouldCheckFeatureFlag) {
-            if (!productSurfaceTelemetryFeature.feature().isEnabled()) {
+            if (!productSurfaceTelemetryFeature.enableTelemetry().isEnabled()) {
                 logcat { "Mobile surfaces pixel dropped: $pixelName (feature disabled)" }
                 return dummyResponse(chain)
             } else {

--- a/app/src/main/java/com/duckduckgo/app/pixels/surface/ProductSurfaceTelemetryFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/surface/ProductSurfaceTelemetryFeature.kt
@@ -33,5 +33,5 @@ interface ProductSurfaceTelemetryFeature {
 
     @DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
-    fun feature(): Toggle
+    fun enableTelemetry(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/pixels/surface/MobileBrowserSurfacePixelInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/surface/MobileBrowserSurfacePixelInterceptorTest.kt
@@ -39,7 +39,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsDisabledAndPixelMatchesThenPixelIsDropped() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = false))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = false))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -57,7 +57,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsEnabledAndPixelMatchesThenPixelProceeds() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = true))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = true))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -73,7 +73,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsEnabledAndPixelDoesNotMatchThenPixelProceeds() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = true))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = true))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -89,7 +89,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsDisabledAndPixelDoesNotMatchThenPixelProceeds() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = false))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = false))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -105,7 +105,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenNoPluginsRegisteredThenPixelAlwaysProceeds() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = false))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = false))
 
         val startUrl = "$URL_PIXEL_BASE/m_product_telemetry_surface_usage_serp_phone"
         val response = interceptor.intercept(FakeChain(startUrl))
@@ -115,7 +115,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenPixelStartsWithRegisteredNameThenItMatches() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = false))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = false))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -132,7 +132,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenPixelNameIsExactMatchThenItMatches() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = true))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = true))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_dau",
@@ -147,7 +147,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsDisabledAndPixelHasQueryParamsThenPixelIsDropped() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = false))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = false))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_serp",
@@ -163,7 +163,7 @@ class MobileBrowserSurfacePixelInterceptorTest {
 
     @Test
     fun whenFeatureIsEnabledAndPixelHasQueryParamsThenPixelProceeds() {
-        productSurfaceTelemetryFeature.feature().setRawStoredState(Toggle.State(enable = true))
+        productSurfaceTelemetryFeature.enableTelemetry().setRawStoredState(Toggle.State(enable = true))
         whenever(surfacePixelPlugin.names()).thenReturn(
             listOf(
                 "m_product_telemetry_surface_usage_website",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1121803137609221/task/1213900190090146?focus=true

### Description

This PR introduces a new `feature()` toggle method to the `ProductSurfaceTelemetryFeature` interface and updates the `MobileBrowserSurfacePixelInterceptor` to use this new method instead of the existing `self()` method for feature flag checks (to support incremental rollouts and rollouts to a smaller subset of users). 
Additionally, the dummy response code for dropped pixels has been changed from 500 to 200 to better represent successful interception rather than an error state, which would prevent the pixel from being cleared from the databse in case it was not being sent. This would lead to a high number of data clearing pixels accumulating in the database and getting sent all at once

### Steps to test this PR
- [ ] Filter the logcat for "Mobile surfaces pixel"
- [ ] Disable the `feature` under `ProductSurfaceTelemetryFeature`
- [ ] Navigate through the app (NTP, website, SERP, menu etc), the logcat should mentioned that the pixels are dropped becasue the feature is disabled 
- [ ] Use the fire button a coupld of times (again the pixels are dropped)
- [ ] Enable the feature` under `ProductSurfaceTelemetryFeature`
- [ ] Use the fire button
- [ ] Only one data clearing event should be sent (`m_product_telemetry_surface_usage_data_clearing`)

_Response Handling_
- [ ] Validate that dropped pixels return a 200 response code instead of 500
- [ ] Ensure the response body and message remain unchanged for dropped pixels

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-flag gating and HTTP response semantics for intercepted telemetry pixels; misconfiguration could unintentionally drop or allow telemetry and affect pixel queue clearing behavior.
> 
> **Overview**
> Updates the mobile surface pixel interceptor to gate matching telemetry pixels on a new `ProductSurfaceTelemetryFeature.enableTelemetry()` toggle (instead of `self()`), enabling more granular rollout control.
> 
> When telemetry is disabled and a pixel is dropped, the interceptor now returns a **successful `200` dummy response** (previously `500`) so the client treats the pixel as handled and doesn’t leave it queued. Unit tests were updated to reflect the new toggle and response code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 679c7bdf8173457414eac0a9d61af2b5aec4860f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->