### PR TITLE
Increase perputual creep speed, and track in pageload wide event when users pass 95%.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2163,9 +2163,10 @@ class BrowserTabViewModel @Inject constructor(
             if (newProgress < FIXED_PROGRESS || isProcessingTrackingLink) FIXED_PROGRESS else newProgress
         }
 
-        // Track the first time we escape from fixed progress for Wide Events
+        // Track the first time we escape from max progress threshold for Wide Events
         val currentUrl = webViewNavigationState.currentUrl
-        if (!hasExitedFixedProgress && currentUrl != null && newProgress > FIXED_PROGRESS) {
+        val progressThreshold = if (progressBarUpgradeFeature.self().isEnabled()) UPGRADED_PROGRESS_THRESHOLD else FIXED_PROGRESS
+        if (!hasExitedFixedProgress && currentUrl != null && newProgress > progressThreshold) {
             hasExitedFixedProgress = true
             pageLoadWideEvent.onProgressChanged(tabId, currentUrl)
         }
@@ -4955,6 +4956,7 @@ class BrowserTabViewModel @Inject constructor(
 
     companion object {
         private const val FIXED_PROGRESS = 50
+        private const val UPGRADED_PROGRESS_THRESHOLD = 95
 
         // Minimum progress to show web content again after decided to hide web content (possible spoofing attack).
         // We think that progress is enough to assume next site has already loaded new content.

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -46,7 +46,7 @@ import kotlin.time.toJavaDuration
 
 /**
  * Tracks page load events as Wide Event flows with multi-phase tracking.
- * Manages flow lifecycle: page_start → page_visible → page_escaped_fixed_progress → page_finish
+ * Manages flow lifecycle: page_start → page_visible → page_escaped_max_progress → page_finish
  */
 interface PageLoadWideEvent {
     /**
@@ -65,7 +65,7 @@ interface PageLoadWideEvent {
     fun onPageVisible(tabId: String, url: String, progress: Int)
 
     /**
-     * Called when page progress changes and escapes the fixed progress state.
+     * Called when page progress changes and escapes the max progress threshold state.
      * @param tabId The unique identifier for the tab
      * @param url The URL of the page being loaded
      */
@@ -191,7 +191,7 @@ class RealPageLoadWideEvent @Inject constructor(
                 wideEventId = flowId,
                 stepName = STEP_PAGE_ESCAPED_FIXED_PROGRESS,
             )
-            logcat { "Exited fixed progress: flowId=$flowId" }
+            logcat { "Exited max progress threshold: flowId=$flowId" }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarConfig.kt
@@ -21,7 +21,7 @@ data class ProgressBarConfig(
     val fastStartDuration: Long = 600L,
     val springStiffness: Float = 2.0f,
     val dampingRatio: Float = 8.5f,
-    val creepVelocity: Float = 0.004f,
+    val creepVelocity: Float = 0.04f,
     val endDuration: Long = 300L,
     val fadeInDuration: Long = 100L,
     val fadeOutDuration: Long = 100L,

--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressPhaseEngine.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressPhaseEngine.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.app.browser.progressbar
 
-import kotlin.math.abs
-
 enum class Phase {
     IDLE, FAST_START, TRACKING, COMPLETING, DONE
 }
@@ -45,6 +43,7 @@ class ProgressPhaseEngine(
     private var realProgress: Float = 0f
     private var velocity: Float = 0f
     private var phaseStartTime: Long = 0L
+    private var creepProgress: Float = 0f
 
     private var completionFrom: Float = 0f
 
@@ -60,6 +59,7 @@ class ProgressPhaseEngine(
         displayProgress = 0f
         realProgress = 0f
         velocity = 0f
+        creepProgress = 0f
 
         phaseStartTime = timeProvider.elapsedRealtime()
     }
@@ -83,6 +83,7 @@ class ProgressPhaseEngine(
         displayProgress = 0f
         realProgress = 0f
         velocity = 0f
+        creepProgress = 0f
     }
 
     fun tick(dtSeconds: Float): FrameState {
@@ -109,13 +110,20 @@ class ProgressPhaseEngine(
             displayProgress = config.fastStartTarget
             phase = Phase.TRACKING
             velocity = 0f
+            creepProgress = config.fastStartTarget
         }
     }
 
     private fun tickTracking(dt: Float) {
         val floor = config.fastStartTarget
+
+        // Perpetual creep accumulates independently
+        if (config.creepVelocity > 0f) {
+            creepProgress = (creepProgress + config.creepVelocity * dt * 100f).coerceAtMost(95f)
+        }
+
         val target = realProgress.coerceAtMost(95f)
-        val effectiveTarget = maxOf(target, floor)
+        val effectiveTarget = maxOf(target, floor, creepProgress)
 
         // Spring dynamics (semi-implicit Euler)
         val displacement = effectiveTarget - displayProgress
@@ -127,11 +135,6 @@ class ProgressPhaseEngine(
         if (displayProgress > effectiveTarget) {
             displayProgress = effectiveTarget
             velocity = 0f
-        }
-
-        // Perpetual creep
-        if (displayProgress < 95f && abs(velocity) < 0.5f && config.creepVelocity > 0f) {
-            displayProgress += config.creepVelocity * dt * 100f
         }
 
         displayProgress = displayProgress.coerceIn(floor, 95f)


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213910819896364?focus=true

### Description
- Increase perputual creep speed, 
- Track in pageload wide event when users pass 95%.

### Steps to test this PR
- open a slow loading site
- observe continuous progress which stops at 95% until real completion.
- it should take ~20s to reach 95% if the site is still loading, then it waits until it receives actual 100% done signal from webview.

### UI changes


https://github.com/user-attachments/assets/3d3026fe-46c1-481b-850d-0794e297e779


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes progress-bar animation behavior and the threshold used to fire page-load Wide Events, which could affect perceived load UX and analytics timing on slow pages.
> 
> **Overview**
> Improves the upgraded progress bar’s *perpetual creep* behavior by increasing `creepVelocity` and refactoring `ProgressPhaseEngine` so creep accumulates independently and drives `displayProgress` up to a 95% cap while awaiting real completion.
> 
> Updates page-load Wide Event instrumentation to treat “escape” as passing a configurable max-progress threshold: `BrowserTabViewModel` now fires `PageLoadWideEvent.onProgressChanged` when progress exceeds 95% (when `ProgressBarUpgradeFeature` is enabled) instead of the legacy fixed 50%, with corresponding naming/logging tweaks in `PageLoadWideEvent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4aa87b72aa1b0265fe53022164ad715f7340c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->