### PR TITLE
Update content scope scripts to version 13.37.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -600,7 +600,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -619,7 +620,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -2135,7 +2135,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -2154,7 +2155,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2107,7 +2107,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -2126,7 +2127,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1465,7 +1465,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -1484,7 +1485,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -582,7 +582,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -601,7 +602,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -582,7 +582,8 @@
       "pageObserver",
       "hover",
       "browserUiLock",
-      "trackerProtection"
+      "trackerProtection",
+      "tabSuspension"
     ]
   );
   var platformSupport = {
@@ -601,7 +602,8 @@
       "webEvents",
       "webInterferenceDetection",
       "pageObserver",
-      "hover"
+      "hover",
+      "tabSuspension"
     ],
     "apple-ai-clear": ["duckAiDataClearing"],
     "apple-ai-history": ["duckAiChatHistory"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.67.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.36.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.37.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8d1143e86e05ef16a3eec2d53e4ea488aee1dca8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#56754c6e0fd58a76a78f2241b6e811d08cfbee84",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.67.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.36.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.37.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213914528070501/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a bundled third-party script package that runs in the browser context, which could change in-page behavior across multiple features. Diff is small and primarily adds a new `tabSuspension` feature flag, but regressions would surface at runtime.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `13.36.0` to `13.37.0` (package.json + lockfile resolved commit).
> 
> Updates the bundled Android build outputs to include the new `tabSuspension` feature in the supported feature lists (including `apple-isolated` support), enabling it to be toggled/used by the content-scope runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cffe2fc0910e01427d29418704be7dccf844d962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->