### PR TITLE
Fix blank NTP after Switch to Tab and press back

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2183,6 +2183,7 @@ class BrowserTabFragment :
         viewModel.onHomeShown()
         dismissAppLinkSnackBar()
         errorSnackbar.dismiss()
+        renderer.recreateNewTabPageContent()
         newBrowserTab.newTabLayout.show()
         newBrowserTab.newTabRootLayout.show()
         binding.browserLayout.gone()
@@ -5456,8 +5457,12 @@ class BrowserTabFragment :
             viewModel.onCtaShown()
         }
 
-        fun showNewTab() {
-            logcat { "New tab: Show new tab" }
+        fun recreateNewTabPageContent() {
+            newBrowserTab.newTabContainerLayout.removeAllViews()
+            addNewTabPageContent()
+        }
+
+        fun addNewTabPageContent() {
             newTabPageProvider
                 .provideNewTabPageVersion()
                 .onEach { newTabPage ->
@@ -5470,7 +5475,12 @@ class BrowserTabFragment :
                             ),
                         )
                     }
-                }.launchIn(lifecycleScope)
+                }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }
+
+        fun showNewTab() {
+            logcat { "New tab: Show new tab" }
+            addNewTabPageContent()
             newBrowserTab.newTabRootLayout.show()
             newBrowserTab.newTabLayout.show()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213917443311978?focus=true

### Description
Refer to [Investigation + Root cause ](https://app.asana.com/1/137249556945/project/715106103902962/task/1213917443311977?focus=true) task for details on the bug.

Fix: Recreate NTP content in showHome()
This is the first fix proposal. 

What it does: When showHome() is called (from navigating back), remove the existing NTP content view and create a fresh one via recreateNewTabPageContent(). Also scopes the addNewTabPageContent() flow to viewLifecycleOwner.lifecycleScope to prevent    
stale flows from surviving view destruction.

Files changed:                                            
BrowserTabFragment.kt: added recreateNewTabPageContent() call in showHome(), extracted addNewTabPageContent() from showNewTab(), and changed flow scope from lifecycleScope to `viewLifecycleOwner.lifecycleScope`

Why this works: Instead of relying on the existing NTP view (which may have a RecyclerView that missed its layout pass while the container was GONE), a fresh view is created at the moment showHome() is about to make the container visible. The new view initializes with a fresh adapter and gets its layout pass at the right time.

### Steps to test this PR
- Add websites to your favourites
- Start on a new tab (existing tabs might not be reliable to reproduce)
- Navigate to a website 
- click on the tab picker and open a new tab
- Switch back to the previous tab using the Hatch or by typing bbc and choosing the “Switch tab” row
- Click on the back button (or swipe to go back)
- Verify Favourites are showing 

### Video links

Before (With bug)

https://github.com/user-attachments/assets/bf2b4c79-e9ae-4843-9068-8b3261caccc5

After (Fixed)


https://github.com/user-attachments/assets/e9d2f720-de8d-48ed-b93d-ca2e2fd36588



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/lifecycle change limited to New Tab Page rendering, but it alters when the NTP view is rebuilt and how its Flow is scoped, which could affect NTP initialization timing.
> 
> **Overview**
> Fixes a blank New Tab Page when navigating back to home by **recreating the NTP content** in `showHome()` (clearing the container and re-adding a fresh NTP view).
> 
> Extracts NTP creation into `addNewTabPageContent()` and scopes the provider Flow to `viewLifecycleOwner.lifecycleScope` so collection is cancelled with the view, reducing the chance of stale emissions after view destruction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6cce0a8aa00928aed8a952d8e732f0704151564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->