### PR TITLE
Fix blank NTP favourites/shortcuts after tab switch

### DIFF
--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
@@ -21,6 +21,7 @@ import android.content.res.Configuration
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import androidx.core.view.isEmpty
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
@@ -94,6 +95,16 @@ class ShortcutsNewTabSectionView @JvmOverloads constructor(
     override fun onDetachedFromWindow() {
         conflatedJob.cancel()
         super.onDetachedFromWindow()
+    }
+
+    // When this view is re-attached while its parent is GONE (e.g. during tab switching),
+    // the RecyclerView misses its initial layout pass after submitList(). Force a layout
+    // when the view becomes visible so the adapter data is actually rendered.
+    override fun onVisibilityAggregated(isVisible: Boolean) {
+        super.onVisibilityAggregated(isVisible)
+        if (isVisible && binding.quickAccessRecyclerView.isEmpty() && (binding.quickAccessRecyclerView.adapter?.itemCount ?: 0) > 0) {
+            binding.quickAccessRecyclerView.requestLayout()
+        }
     }
 
     private fun render(viewState: ViewState) {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -29,6 +29,7 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.core.text.HtmlCompat
 import androidx.core.text.toSpannable
+import androidx.core.view.isEmpty
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -336,6 +337,16 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
     private fun submitUrl(url: String) {
         viewModel.onFavoriteClicked(placement)
         context.startActivity(browserNav.openInCurrentTab(context, url))
+    }
+
+    // When this view is re-attached while its parent is GONE (e.g. during tab switching),
+    // the RecyclerView misses its initial layout pass after submitList().
+    // Force a layout when the view becomes visible so the adapter data is actually rendered.
+    override fun onVisibilityAggregated(isVisible: Boolean) {
+        super.onVisibilityAggregated(isVisible)
+        if (isVisible && binding.quickAccessRecyclerView.isEmpty() && (binding.quickAccessRecyclerView.adapter?.itemCount ?: 0) > 0) {
+            binding.quickAccessRecyclerView.requestLayout()
+        }
     }
 
     private fun render(viewState: ViewState) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213917443311979?focus=true 

### Description

Refer to [Investigation + Root cause](https://app.asana.com/1/137249556945/project/715106103902962/task/1213917443311977?focus=true) task for details on the bug.

This is the second fix proposal. 

Fix: Handle RecyclerView missed layout after GONE→VISIBLE transition           
When the favourites and shortcuts grids are set up while their container is hidden, they never get the chance to draw their items. This fix detects that situation when the container becomes visible again and tells the grids to draw themselves.                                           

What it does: Override onVisibilityAggregated() in FavouritesNewTabSectionView and ShortcutsNewTabSectionView. When the view becomes visible and the RecyclerView has adapter data but zero children (missed its layout pass while the parent was GONE), request a layout.                                        

Files changed:
FavouritesNewTabSectionView.kt — added onVisibilityAggregated override
ShortcutsNewTabSectionView.kt — same                                                                                      
                                        
Why this works: The root cause is that adapter.submitList() runs while the NTP container is GONE (browser is showing). The RecyclerView's diff completes but it never creates child views because no layout pass occurs while GONE. When showHome() makes the container visible, no new render() fires (ViewModel state unchanged), so the RecyclerView stays empty. The onVisibilityAggregated callback detects this state and triggers the missing layout

### Steps to test this PR
- Add websites to your favourites
- Start on a new tab (existing tabs might not be reliable to reproduce)
- Navigate to a website 
- click on the tab picker and open a new tab
- Switch back to the previous tab using the Hatch or by typing bbc and choosing the “Switch tab” row
- Click on the back button (or swipe to go back)
- Verify Favourites are showing 

### Video links

Before (With bug)

https://github.com/user-attachments/assets/bf2b4c79-e9ae-4843-9068-8b3261caccc5

After (Fixed)


https://github.com/user-attachments/assets/e9d2f720-de8d-48ed-b93d-ca2e2fd36588

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI lifecycle change: it only forces a `RecyclerView` layout when the view becomes visible but has adapter items with no rendered children; main risk is minor extra layout work on visibility changes.
> 
> **Overview**
> Fixes cases where New Tab Page **Favourites** and **Shortcuts** grids appear blank after tab switching by detecting a missed `RecyclerView` layout pass.
> 
> Both `FavouritesNewTabSectionView` and `ShortcutsNewTabSectionView` now override `onVisibilityAggregated`; when the view becomes visible and the `RecyclerView` has adapter data but no children, they call `requestLayout()` to force rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b25adce206806f17215c70055d8fca651e30a1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->