### PR TITLE
Add PrivacyDashboardOpenedPlugin

### DIFF
--- a/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/PrivacyDashboardOpenedPlugin.kt
+++ b/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/PrivacyDashboardOpenedPlugin.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.dashboard.api
+
+interface PrivacyDashboardOpenedPlugin {
+    /**
+     * Executed when the Privacy Dashboard screen is opened.
+     */
+    suspend fun onPrivacyDashboardOpened()
+}

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/di/PrivacyDashboardOpenedPluginPoint.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/di/PrivacyDashboardOpenedPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.dashboard.impl.di
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.dashboard.api.PrivacyDashboardOpenedPlugin
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = PrivacyDashboardOpenedPlugin::class,
+)
+@Suppress("unused")
+private interface PrivacyDashboardOpenedPluginTrigger

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.privacy.dashboard.api.PrivacyDashboardOpenedPlugin
 import com.duckduckgo.privacy.dashboard.api.PrivacyProtectionTogglePlugin
 import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin
 import com.duckduckgo.privacy.dashboard.api.ui.DashboardOpener
@@ -94,6 +95,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
     private val brokenSiteSender: BrokenSiteSender,
     private val moshi: Moshi,
     private val privacyProtectionTogglePlugin: PluginPoint<PrivacyProtectionTogglePlugin>,
+    private val privacyDashboardOpenedPlugin: PluginPoint<PrivacyDashboardOpenedPlugin>,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -238,6 +240,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 parameters = mapOf("daysSinceInstall" to userBrowserProperties.daysSinceInstalled().toString(), "from_onboarding" to "false"),
                 type = Unique(),
             )
+            privacyDashboardOpenedPlugin.getPlugins().forEach { it.onPrivacyDashboardOpened() }
         }
 
         site.filterNotNull()

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -37,13 +37,18 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import com.duckduckgo.privacy.dashboard.api.PrivacyDashboardOpenedPlugin
 import com.duckduckgo.privacy.dashboard.api.PrivacyProtectionTogglePlugin
 import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin
 import com.duckduckgo.privacy.dashboard.api.ui.DashboardOpener
 import com.duckduckgo.privacy.dashboard.api.ui.ToggleReports
 import com.duckduckgo.privacy.dashboard.impl.di.JsonModule
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardCustomTabPixelNames
-import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.*
+import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.BROKEN_SITE_ALLOWLIST_ADD
+import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.BROKEN_SITE_ALLOWLIST_REMOVE
+import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.PRIVACY_DASHBOARD_ALLOWLIST_ADD
+import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.PRIVACY_DASHBOARD_ALLOWLIST_REMOVE
+import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.REPORT_BROKEN_SITE_SENT
 import com.duckduckgo.privacy.dashboard.impl.ui.PrivacyDashboardHybridViewModel.Command.GoBack
 import com.nhaarman.mockitokotlin2.mock
 import com.squareup.moshi.Moshi
@@ -90,6 +95,7 @@ class PrivacyDashboardHybridViewModelTest {
     private val brokenSiteSender: BrokenSiteSender = mock()
     private val protectionTogglePlugin = FakePrivacyProtectionTogglePlugin()
     private val pluginPoint = FakePluginPoint(protectionTogglePlugin)
+    private val dashboardOpenedPluginPoint = FakeDashboardOpenedPluginPoint()
 
     private val toggleReports: ToggleReports = mock {
         runBlocking { whenever(mock.shouldPrompt()).thenReturn(false) }
@@ -108,6 +114,7 @@ class PrivacyDashboardHybridViewModelTest {
             userBrowserProperties = mockUserBrowserProperties,
             brokenSiteSender = brokenSiteSender,
             privacyProtectionTogglePlugin = pluginPoint,
+            privacyDashboardOpenedPlugin = dashboardOpenedPluginPoint,
             toggleReports = toggleReports,
             moshi = Moshi.Builder().build(),
         )
@@ -562,6 +569,10 @@ private class FakeUserAllowListRepository : UserAllowListRepository {
     override suspend fun addDomainToUserAllowList(domain: String) = domains.update { it + domain }
 
     override suspend fun removeDomainFromUserAllowList(domain: String) = domains.update { it - domain }
+}
+
+class FakeDashboardOpenedPluginPoint : PluginPoint<PrivacyDashboardOpenedPlugin> {
+    override fun getPlugins(): Collection<PrivacyDashboardOpenedPlugin> = emptyList()
 }
 
 class FakePluginPoint(val plugin: FakePrivacyProtectionTogglePlugin) : PluginPoint<PrivacyProtectionTogglePlugin> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213915853420988?focus=true

### Description
Add new plugin for when users open privacy dashboard

### Steps to test this PR
- [ ] CI checks are successful

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new extension point and invokes it on dashboard open; primary impact is any added plugin side effects or startup latency in `PrivacyDashboardHybridViewModel`.
> 
> **Overview**
> Adds a new `PrivacyDashboardOpenedPlugin` API to allow modules to run custom logic when the Privacy Dashboard is opened.
> 
> `PrivacyDashboardHybridViewModel` now injects a `PluginPoint<PrivacyDashboardOpenedPlugin>` and invokes `onPrivacyDashboardOpened()` for all registered plugins during initialization alongside the existing “dashboard opened” pixel firing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 815b1fa2c8783b0ffc2e0756d268cfcb04f735d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->