### PR TITLE
Fix contextual Duck AI header button alignment

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
@@ -55,9 +55,9 @@
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
             android:layout_marginEnd="@dimen/keyline_2"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_expand_24" />
 
         <ImageView
@@ -68,15 +68,16 @@
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
             app:layout_constraintStart_toEndOf="@+id/contextualFullScreen"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_ai_chat_add_24" />
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/contextualTitle"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_4"
             android:drawableStart="@drawable/ic_duck_ai_color_24"
             android:drawablePadding="@dimen/keyline_2"
@@ -95,9 +96,10 @@
             android:contentDescription="@string/duckAIContextualFireButtonContentDescription"
             android:scaleType="center"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+            tools:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
             app:layout_constraintEnd_toStartOf="@+id/contextualClose"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_fire_24" />
 
         <ImageView
@@ -108,9 +110,9 @@
             android:background="@drawable/selectable_item_rounded_corner_background"
             android:contentDescription="@string/browserMenuChatHistory"
             android:scaleType="center"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/contextualTitle"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@id/contextualTitle"
             app:srcCompat="@drawable/ic_close_24_small" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1213919632313899?focus=true

### Description

The header buttons (`contextualFullScreen`, `contextualNewChat`, `contextualFire`, `contextualClose`) in the contextual Duck AI bottom sheet were constrained top/bottom to `parent` instead of `contextualTitle`, causing them to be vertically centered on the full ConstraintLayout rather than aligned with the title row. Additionally, `contextualTitle` had `layout_height="0dp"` with no bottom constraint, collapsing it to zero height.

Fixed by setting `layout_height="wrap_content"` on `contextualTitle` and constraining all four buttons top/bottom to `@id/contextualTitle`.

### Steps to test this PR

_Contextual Duck AI bottom sheet_
- [x] Open the contextual Duck AI bottom sheet from a browser tab
- [x] Verify the Duck AI logo/title and the close button are vertically centred on the same row
- [x] Verify the expand (full screen) button is also aligned to the same row
- [x] Long-press or trigger states that show the fire/new-chat buttons and verify they are also aligned

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak in a single XML layout; main risk is minor visual regression across device sizes/densities.
> 
> **Overview**
> Fixes misaligned header controls in the contextual Duck AI bottom sheet by anchoring the header buttons’ top/bottom constraints (`contextualFullScreen`, `contextualNewChat`, `contextualFire`, `contextualClose`) to `contextualTitle` instead of the parent container.
> 
> Updates `contextualTitle` to `layout_height="wrap_content"` (preventing it from collapsing) and adds `tools:visibility="visible"` for previewing the normally-gone `contextualNewChat`/`contextualFire` buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb66067cb13fc55a9a00cb5d6118ac42852ebd92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->