### PR TITLE
Skip stale pageFinished and autoconsent callbacks when site is null

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2185,7 +2185,7 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         url: String?,
     ) {
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
+        if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             navigationStateChanged(webViewNavigationState)
             url?.let { prefetchFavicon(url) }
 
@@ -4880,7 +4880,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onAutoConsentPopUpHandled(isCosmetic: Boolean) {
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
+        if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             if (isCosmetic) {
                 autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_ANIMATION_SHOWN_COSMETIC_DAILY)
             } else {


### PR DESCRIPTION
Task/Issue URL: 

### Description

Added null checks for the `site` property in two conditional statements within `BrowserTabViewModel`. The conditions for `pageFinished` and `onAutoConsentPopUpHandled` methods now verify that both the malicious site is not blocked AND the site is not null before proceeding with their respective operations.

### Steps to test this PR
- [ ] Open app with search&duck.ai omnibar (although this issue happened for the saerch only omnibar as well)
- [ ] Go to any website 
- [ ] Quickly press back before the website has loaded or right when the website load has finised 
- [ ] The omnibar state should be the one for NTP (there should be no shield icon or “Cookies managed” animation)

### UI changes
Check in the following task: https://app.asana.com/1/137249556945/project/414730916066338/task/1213912716077779?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple guard conditions to skip work when the current `site` has been cleared (e.g., rapid back navigation), reducing chance of stale UI/pixel actions.
> 
> **Overview**
> Prevents stale WebView callbacks from mutating state after the tab has been reset.
> 
> `BrowserTabViewModel` now requires `site != null` (in addition to not being in a malicious-site block state) before running `pageFinished` follow-up work (navigation state update, favicon prefetch, SERP logo/duck.ai evaluation, page-context collection) and before handling `onAutoConsentPopUpHandled` (pixels and consent animation commands).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abb2bbfef4bbb6b70cb1033897f2f91897601aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->