### PR TITLE
Update PIR broker bundle - 2026-04-06

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/anywho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/anywho.com.json
@@ -1,0 +1,84 @@
+{
+  "name": "AnyWho",
+  "url": "anywho.com",
+  "version": "0.1.0",
+  "parent": "spokeo.com",
+  "addedDatetime": 1768780800000,
+  "optOutUrl": "https://www.spokeo.com/optout",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "a1b2c3d4-e5f6-4789-0123-456789abcdef",
+          "url": "https://www.anywho.com/people/${firstName}+${lastName}/${state|stateFull|downcase}/${city|downcase}?age_range=${age|ageRange}",
+          "ageRange": [
+            "0-30",
+            "31-60",
+            "61-80",
+            "80+"
+          ]
+        },
+        {
+          "actionType": "expectation",
+          "id": "e5f6a7b8-c9d0-4123-4567-890123abcdef",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#name-search-results, h1.text-display-md"
+            }
+          ]
+        },
+        {
+          "actionType": "extract",
+          "id": "f6a7b8c9-d0e1-4234-5678-901234abcdef",
+          "selector": "#name-search-results > div.bg-white",
+          "noResultsSelector": "//h1[contains(text(), \"Sorry, we couldn't find results\")]",
+          "profile": {
+            "name": {
+              "selector": "h2.font-bold"
+            },
+            "age": {
+              "selector": ".//span[contains(text(), 'Age')]",
+              "afterText": "Age "
+            },
+            "alternativeNamesList": {
+              "selector": ".//h3[contains(text(), 'AKA')]/following-sibling::div[not(contains(@class, 'h-px'))]",
+              "findElements": true
+            },
+            "addressFull": {
+              "selector": ".//h3[contains(text(), 'Lives in')]/following-sibling::div[@class='text-body-md'][1]"
+            },
+            "addressFullList": {
+              "selector": ".//h3[contains(text(), 'Used to live in')]/following-sibling::div[@class='text-body-md']",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//h3[contains(text(), 'May be related to')]/following-sibling::div[@class='text-body-md']/a",
+              "findElements": true
+            },
+            "profileUrl": {
+              "selector": "a[href*='/people/']",
+              "identifierType": "path",
+              "identifier": "https://www.anywho.com/people/${firstName}+${lastName}/${state|downcase}/${city|downcase}/${id}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
@@ -1,0 +1,115 @@
+{
+  "name": "SpyFly",
+  "url": "spyfly.com",
+  "version": "0.3.0",
+  "addedDatetime": 1775214750818,
+  "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "url": "https://www.spyfly.com/help-center/privacy-requests",
+          "id": "scan-navigate-to-privacy-page"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".main"
+            }
+          ],
+          "id": "scan-expect-page-loaded"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": ".form-contact-help form",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "firstName",
+              "selector": "#firstName"
+            },
+            {
+              "type": "lastName",
+              "_comment": "This input doesn't follow the same id pattern as the rest",
+              "selector": ".//input[@placeholder='Last Name']"
+            },
+            {
+              "type": "city",
+              "selector": "#city"
+            },
+            {
+              "type": "fullState",
+              "selector": "#states"
+            },
+            {
+              "type": "$generated_zip_code$",
+              "selector": "#zip"
+            },
+            {
+              "type": "age",
+              "selector": "#age"
+            }
+          ],
+          "id": "scan-fill-user-profile"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "_comment": "Ensure the Turnstile captcha is solved before proceeding",
+              "selector": ".//input[@name='cf-turnstile-response' and @value and @value != '']",
+              "parent": ".form__captcha"
+            }
+          ],
+          "id": "scan-expect-turnstile-solved"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": ".//button[@type='submit']"
+            }
+          ],
+          "id": "scan-click-submit"
+        },
+        {
+          "_comment": "Last supported action. If we reach here, Cloudflare did not block us. The scan will fail after this because generateEmail is not yet implemented.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#email-address"
+            }
+          ],
+          "id": "scan-expect-email-page-loaded"
+        },
+        {
+          "_comment": "Terminal action. We are on the email page, not results. noResultsSelector matches #email-address so extract returns empty results cleanly.",
+          "actionType": "extract",
+          "selector": ".result-item",
+          "noResultsSelector": "#email-address",
+          "profile": {
+            "name": {
+              "selector": "h2"
+            }
+          },
+          "id": "scan-extract-terminal"
+        }
+      ]
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/414730916066338/task/1213965665740964?focus=true

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Added (2):**
- anywho.com.json
- spyfly.com.json

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds two new broker JSON configs that will change which sites PIR scans/opts out from; the SpyFly flow depends on Cloudflare Turnstile/UI selectors and is explicitly incomplete (stops before results), which could cause scan failures or no-op behavior if enabled.
> 
> **Overview**
> Adds new PIR broker configurations for **AnyWho** and **SpyFly**.
> 
> `anywho.com.json` introduces a templated people-search scan and delegates opt-out to its parent (`spokeo.com`) via `parentSiteOptOut`. `spyfly.com.json` adds a scan workflow that navigates to the privacy request form, fills user data, gates on Turnstile completion, and then terminates on the email step (extracting no results), with no opt-out step defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9d46f17b9d990f67c2a0bba36ffef7357f26ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->