### PR TITLE
feat: fire pixel for Duck.ai DAU users who never enabled the input screen toggle

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -405,6 +405,13 @@
             }
         ]
     },
+    "m_aichat_duckai_dau_toggle_never_enabled": {
+        "description": "Fired once per Duck.ai DAU day for users who have never enabled the Duck.ai input screen toggle. Used to identify heavy Duck.ai users who haven't discovered the feature.",
+        "owners": ["aitorvs"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_contextual_fire_button_tapped": {
         "description": "User tapped the fire button in the contextual Duck.ai sheet",
         "owners": ["aitorvs"],

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatInputScreenDauPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatInputScreenDauPlugin.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class DuckChatInputScreenDauPlugin @Inject constructor(
+    private val duckChatFeatureRepository: DuckChatFeatureRepository,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : AtbLifecyclePlugin {
+
+    override fun onDuckAiRetentionAtbRefreshed(
+        oldAtb: String,
+        newAtb: String,
+        metadata: Map<String, String?>,
+    ) {
+        if (oldAtb.atbAsNumber() == newAtb.atbAsNumber()) return
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (!duckChatFeatureRepository.isInputScreenEverEnabled()) {
+                pixel.fire(DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED)
+            }
+        }
+    }
+
+    /**
+     * Converts an ATB version string (e.g. "v123-2ma") to a monotonically increasing integer.
+     * The variant suffix (e.g. "ma") is intentionally ignored so that strings representing the
+     * same week/day but different cohort tags compare as equal.
+     */
+    internal fun String.atbAsNumber(): Int {
+        val startIndex = indexOf('v') + 1
+        val endIndex = indexOf('-', startIndex)
+        val week = if (endIndex > 0 && startIndex < endIndex) {
+            substring(startIndex, endIndex).toIntOrNull() ?: 0
+        } else {
+            substringAfter('v', "").toIntOrNull() ?: 0
+        }
+        val day = substringAfterLast('-', "").firstOrNull()?.digitToIntOrNull() ?: 0
+        return week * 7 + day - 1
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
 import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_BROWSER_MENU_IS_ENABLED_DAILY
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF
@@ -432,6 +433,7 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_KEYBOARD_RETURN_PRESSED("m_aichat_duckai_keyboard_return_pressed"),
     DUCK_CHAT_USER_ACCEPTED_TERMS_AND_CONDITIONS("m_aichat_duckai_accepted_terms_and_conditions"),
     DUCK_CHAT_EXPERIMENTAL_OMNIBAR_DAILY_RETENTION("m_aichat_experimental_omnibar_daily_retention"),
+    DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED("m_aichat_duckai_dau_toggle_never_enabled"),
     DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED("m_aichat_new_address_bar_picker_displayed"),
     DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED("m_aichat_new_address_bar_picker_confirmed"),
     DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW("m_aichat_new_address_bar_picker_not_now"),
@@ -583,6 +585,7 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_RETURN_PRESSED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_EXPERIMENTAL_LEGACY_OMNIBAR_BACK_BUTTON_PRESSED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_EXPERIMENTAL_OMNIBAR_DAILY_RETENTION.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -65,6 +65,8 @@ interface DuckChatFeatureRepository {
 
     suspend fun isInputScreenUserSettingEnabled(): Boolean
 
+    suspend fun isInputScreenEverEnabled(): Boolean
+
     suspend fun isFullScreenModeUserSettingEnabled(): Boolean
 
     suspend fun isAutomaticPageContextAttachmentUserSettingEnabled(): Boolean
@@ -168,6 +170,8 @@ class RealDuckChatFeatureRepository @Inject constructor(
     override suspend fun isDuckChatUserEnabled(): Boolean = duckChatDataStore.isDuckChatUserEnabled()
 
     override suspend fun isInputScreenUserSettingEnabled(): Boolean = duckChatDataStore.isInputScreenUserSettingEnabled()
+
+    override suspend fun isInputScreenEverEnabled(): Boolean = duckChatDataStore.isInputScreenEverEnabled()
 
     override suspend fun isFullScreenModeUserSettingEnabled(): Boolean = duckChatDataStore.isFullScreenUserSettingEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Key
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_CHAT_SUGGESTIONS_USER_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_DEFAULT_TOGGLE_POSITION
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING
+import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_EVER_ENABLED
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_INPUT_SCREEN_USER_SETTING
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_LAST_USED_TOGGLE_POSITION
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_AI_NATIVE_INPUT_FIELD_SETTING
@@ -57,6 +58,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 import kotlin.Boolean
 
@@ -102,6 +104,8 @@ interface DuckChatDataStore {
     suspend fun isDuckChatUserEnabled(): Boolean
 
     suspend fun isInputScreenUserSettingEnabled(): Boolean
+
+    suspend fun isInputScreenEverEnabled(): Boolean
 
     suspend fun isFullScreenUserSettingEnabled(): Boolean
 
@@ -173,6 +177,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_CHAT_USER_ENABLED = booleanPreferencesKey(name = "DUCK_CHAT_USER_ENABLED")
         val DUCK_AI_INPUT_SCREEN_USER_SETTING = booleanPreferencesKey(name = "DUCK_AI_INPUT_SCREEN_USER_SETTING")
         val DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING = booleanPreferencesKey(name = "DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING")
+        val DUCK_AI_INPUT_SCREEN_EVER_ENABLED = booleanPreferencesKey(name = "DUCK_AI_INPUT_SCREEN_EVER_ENABLED")
         val DUCK_CHAT_SHOW_IN_MENU = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_MENU")
         val DUCK_CHAT_SHOW_IN_ADDRESS_BAR = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_ADDRESS_BAR")
         val DUCK_CHAT_SHOW_IN_VOICE_SEARCH = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_VOICE_SEARCH")
@@ -288,6 +293,9 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         store.edit { prefs ->
             prefs[DUCK_AI_INPUT_SCREEN_USER_SETTING] = enabled
             prefs[DUCK_AI_INPUT_SCREEN_COSMETIC_SETTING] = enabled
+            if (enabled) {
+                prefs[DUCK_AI_INPUT_SCREEN_EVER_ENABLED] = true
+            }
         }
     }
 
@@ -342,6 +350,19 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
     override suspend fun isInputScreenUserSettingEnabled(): Boolean = store.data.firstOrNull()?.let {
         it[DUCK_AI_INPUT_SCREEN_USER_SETTING]
     } ?: false
+
+    override suspend fun isInputScreenEverEnabled(): Boolean {
+        val prefs = store.data.firstOrNull() ?: return false
+        if (prefs[DUCK_AI_INPUT_SCREEN_EVER_ENABLED] == true) return true
+        // Backfill: if the user setting key is present (true or false), the user explicitly
+        // interacted with the toggle at some point — treat that as "ever enabled".
+        val everInteracted = DUCK_AI_INPUT_SCREEN_USER_SETTING in prefs
+        logcat { "Did user change toggle settings? = $everInteracted" }
+        if (everInteracted) {
+            store.edit { it[DUCK_AI_INPUT_SCREEN_EVER_ENABLED] = true }
+        }
+        return everInteracted
+    }
 
     override suspend fun isFullScreenUserSettingEnabled(): Boolean = store.data.firstOrNull()?.let {
         it[DUCK_CHAT_FULLSCREEN_MODE_SETTING]

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatInputScreenDauPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatInputScreenDauPluginTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DuckChatInputScreenDauPluginTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val duckChatFeatureRepository: DuckChatFeatureRepository = mock()
+    private val pixel: Pixel = mock()
+
+    private val testee = DuckChatInputScreenDauPlugin(
+        duckChatFeatureRepository = duckChatFeatureRepository,
+        pixel = pixel,
+        coroutineScope = coroutineRule.testScope,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun `when new DAU day and toggle never enabled then fires pixel`() = runTest {
+        whenever(duckChatFeatureRepository.isInputScreenEverEnabled()).thenReturn(false)
+
+        testee.onDuckAiRetentionAtbRefreshed(
+            oldAtb = "v100-1",
+            newAtb = "v100-2",
+            metadata = emptyMap(),
+        )
+        advanceUntilIdle()
+
+        verify(pixel).fire(DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED)
+    }
+
+    @Test
+    fun `when new DAU day and toggle was ever enabled then does not fire pixel`() = runTest {
+        whenever(duckChatFeatureRepository.isInputScreenEverEnabled()).thenReturn(true)
+
+        testee.onDuckAiRetentionAtbRefreshed(
+            oldAtb = "v100-1",
+            newAtb = "v100-2",
+            metadata = emptyMap(),
+        )
+        advanceUntilIdle()
+
+        verify(pixel, never()).fire(DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED)
+    }
+
+    @Test
+    fun `when same DAU day (oldAtb equals newAtb) then does not fire pixel`() = runTest {
+        whenever(duckChatFeatureRepository.isInputScreenEverEnabled()).thenReturn(false)
+
+        testee.onDuckAiRetentionAtbRefreshed(
+            oldAtb = "v100-1",
+            newAtb = "v100-1",
+            metadata = emptyMap(),
+        )
+        advanceUntilIdle()
+
+        verify(pixel, never()).fire(DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED)
+    }
+
+    @Test
+    fun `when same DAU day but different cohort suffix then does not fire pixel`() = runTest {
+        whenever(duckChatFeatureRepository.isInputScreenEverEnabled()).thenReturn(false)
+
+        testee.onDuckAiRetentionAtbRefreshed(
+            oldAtb = "v100-1ma",
+            newAtb = "v100-1",
+            metadata = emptyMap(),
+        )
+        advanceUntilIdle()
+
+        verify(pixel, never()).fire(DUCK_CHAT_DUCKAI_DAU_TOGGLE_NEVER_ENABLED)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.test.core.app.ApplicationProvider
@@ -461,5 +463,45 @@ class SharedPreferencesDuckChatDataStoreTest {
         val result = testee.getSelectedModel()
         assertEquals("id2", result?.id)
         assertEquals("model2", result?.shortName)
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled returns false when setting was never changed`() = runTest {
+        assertFalse(testee.isInputScreenEverEnabled())
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled returns true after setInputScreenUserSetting enabled`() = runTest {
+        testee.setInputScreenUserSetting(enabled = true)
+        assertTrue(testee.isInputScreenEverEnabled())
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled stays true after setInputScreenUserSetting disabled again`() = runTest {
+        testee.setInputScreenUserSetting(enabled = true)
+        testee.setInputScreenUserSetting(enabled = false)
+        assertTrue(testee.isInputScreenEverEnabled())
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled returns true and backfills when user setting key is present and true (existing user who enabled)`() = runTest {
+        val inputScreenKey = booleanPreferencesKey("DUCK_AI_INPUT_SCREEN_USER_SETTING")
+        testDataStore.edit { it[inputScreenKey] = true }
+        assertTrue(testee.isInputScreenEverEnabled())
+        assertTrue(testee.isInputScreenEverEnabled()) // backfilled — second read also true
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled returns true and backfills when user setting key is present and false`() = runTest {
+        val inputScreenKey = booleanPreferencesKey("DUCK_AI_INPUT_SCREEN_USER_SETTING")
+        testDataStore.edit { it[inputScreenKey] = false }
+        assertTrue(testee.isInputScreenEverEnabled())
+        assertTrue(testee.isInputScreenEverEnabled()) // backfilled — second read also true
+    }
+
+    @Test
+    fun `isInputScreenEverEnabled returns false when user setting key is absent (user never touched the setting)`() = runTest {
+        // No writes at all — DUCK_AI_INPUT_SCREEN_USER_SETTING key is absent
+        assertFalse(testee.isInputScreenEverEnabled())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1213968881793540?focus=true

### Description

Adds a pixel (`m_aichat_duckai_dau_toggle_never_enabled`) that fires once per Duck.ai DAU day for users who have **never** enabled the Duck.ai input screen toggle (the AI/Search mode switch in the address bar).

**How it works:**

- A sticky boolean `DUCK_AI_INPUT_SCREEN_EVER_ENABLED` is stored in `DuckChatDataStore`. It is set to `true` the first time the user enables the input screen toggle (`setInputScreenUserSetting(true)`) and is never reset.
- A new `AtbLifecyclePlugin` (`DuckChatInputScreenDauPlugin`) listens for `onDuckAiRetentionAtbRefreshed`. When `oldAtb != newAtb` (indicating a new Duck.ai DAU day as recorded by the server), it checks the sticky flag and fires the pixel if the user has never enabled the toggle.
- Using `oldAtb != newAtb` rather than `Daily()` pixel type ensures the pixel fires on the same day boundary the server uses to count Duck.ai DAU, avoiding divergence at midnight vs. ATB day rollover.

### Steps to test this PR

**Setup:** In the internal build, go to Settings → Developer Features → **Duck AI ATB Override**. Enter an ATB value and tap **Start intercepting** to simulate a day rollover without waiting.

_Pixel fires for users who never enabled the toggle_
- [x] Fresh install (or clear app data) — input screen toggle has never been enabled
- [x] Open Duck.ai and submit a prompt to establish the initial ATB
- [x] Go to Settings → Developer Features → **Duck AI ATB Override**, set a different ATB (e.g. `v999-1`), tap **Start intercepting**
- [x] Open Duck.ai and submit another prompt — the retention call now returns `v999-1`, triggering the day rollover
- [x] Verify `m_aichat_duckai_dau_toggle_never_enabled` fires in the pixel log
- [x] Submit another prompt (same override ATB) — verify the pixel does **not** fire again (same DAU day)
- [x] Change the override to `v999-2` and submit again — verify the pixel fires once more (new DAU day)

_Pixel does not fire once toggle has been enabled_
- [x] Enable the Duck.ai input screen toggle in Settings
- [x] Use the ATB override to simulate a day rollover
- [x] Verify the pixel does **not** fire

_Existing users who previously interacted with the toggle (backfill)_
(This is very manual and probably covered by the first test case. So maybe skip)

- [ ] Simulate an existing user: manually write `DUCK_AI_INPUT_SCREEN_USER_SETTING` to the DataStore (e.g. via adb or a debug build with direct DataStore access)
- [ ] Trigger a day rollover via the ATB override tool
- [ ] Verify the pixel does **not** fire — key presence backfills `DUCK_AI_INPUT_SCREEN_EVER_ENABLED`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new retention-time pixel firing and persists a new sticky DataStore flag, which could affect analytics counts and introduces a small amount of additional DataStore I/O during ATB refreshes.
> 
> **Overview**
> Adds a new analytics event, `m_aichat_duckai_dau_toggle_never_enabled`, to track Duck.ai DAU users who have *never* enabled the input-screen toggle.
> 
> Implements a new `AtbLifecyclePlugin` that fires this pixel on Duck.ai retention ATB day changes (ignoring cohort suffixes), gated by a new sticky `DUCK_AI_INPUT_SCREEN_EVER_ENABLED` preference. Updates the DuckChat feature repository/data store to record and backfill this flag, and adds unit tests covering both the ATB day-change logic and the DataStore backfill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f668f96ce22d58437417e0ab24e41ee2e379a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->