### PR TITLE
Prevent NTP from being added if we're already on it

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -51,7 +51,12 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     override suspend fun handleAppLaunchOption() {
         when (val option = showOnAppLaunchOptionDataStore.optionFlow.first()) {
             LastOpenedTab -> Unit
-            NewTabPage -> tabRepository.add()
+            NewTabPage -> {
+                val selectedTab = tabRepository.getSelectedTab()
+                if (selectedTab == null || !selectedTab.url.isNullOrBlank()) {
+                    tabRepository.add()
+                }
+            }
             is SpecificPage -> handleSpecificPageOption(option)
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -77,7 +77,24 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     }
 
     @Test
-    fun whenOptionIsNewTabPageOpenedThenNewTabPageIsAdded() = runTest {
+    fun whenOptionIsNewTabPageAndSelectedTabHasUrlThenNewTabPageIsAdded() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = "https://example.com", position = 0)
+
+        testee.handleAppLaunchOption()
+
+        fakeTabRepository.flowTabs.test {
+            val tabs = awaitItem()
+            awaitComplete()
+
+            assertTrue(tabs.size == 1)
+            assertTrue(tabs.last().url == "")
+        }
+    }
+
+    @Test
+    fun whenOptionIsNewTabPageAndNoSelectedTabThenNewTabPageIsAdded() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
 
         testee.handleAppLaunchOption()
@@ -88,6 +105,38 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "")
+        }
+    }
+
+    @Test
+    fun whenOptionIsNewTabPageAndSelectedTabIsAlreadyNtpThenNoTabIsAdded() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = null, position = 0)
+
+        testee.handleAppLaunchOption()
+
+        fakeTabRepository.flowTabs.test {
+            val tabs = awaitItem()
+            awaitComplete()
+
+            assertTrue(tabs.isEmpty())
+        }
+    }
+
+    @Test
+    fun whenOptionIsNewTabPageAndSelectedTabHasBlankUrlThenNoTabIsAdded() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = "", position = 0)
+
+        testee.handleAppLaunchOption()
+
+        fakeTabRepository.flowTabs.test {
+            val tabs = awaitItem()
+            awaitComplete()
+
+            assertTrue(tabs.isEmpty())
         }
     }
 
@@ -844,8 +893,10 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             TODO("Not yet implemented")
         }
 
+        var selectedTab: TabEntity? = null
+
         override suspend fun getSelectedTab(): TabEntity? {
-            return null
+            return selectedTab
         }
 
         override suspend fun getLastAccessedTab(): TabEntity? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213975902898664?focus=true 

### Description
After a period of inactivity (idle return), if the user has selected "New Tab Page" in the settings, we are creating a NTP via `tabRepository.add()`. This tab creation runs through an asynch chain and can race with the user input. Which can cause the following scenario:
- User was already on NTP
- App is put in the background until inactivity time triggers 
- User reopens the app, we triggered the flow to add a NTP (setting selected by the user)
- Before the NTP is added the user perform a search quickly or click on the return hatch
- Search starts, but then a NTP is added (from the triggered flow) overriding the user action and putting them back on the NTP

This fix skips adding redundant NTP if we're already there, for that particular setting

Note: This does not fix the case where the user was on a website and the NTP takes time to load. They will still see the website briefly before being redirected to the NTP. Resolving that will require a re-architecture of the whoel feature.

### Steps to test this PR

**I could not reproduce. This was only reproduced by adding artifical delays to the code to force the race condition**

But theoretically this is how we could reproduce:
- Settings -> General -> After Inactivity -> Select Inactivity Timer "Always" and  "New Tab Page"
- Perform a search
- Open a new tab
- Put the app in the background
- Wait for few seconds for the inactivity timer to kick in
- Open the app again and QUICKLY click on the hatch or perform a search (You have to be really quick) <-- This is where I couldn't reproduce so I added artificial code delay
- If you're quick enough, the search will start loading and then take you back to the NTP <-- THis is the bug

With this fix that scenario should no longer happen
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-launch tab creation behavior, which can affect navigation state and edge cases around tab selection. Risk is moderate but scoped, with new unit tests covering the added conditions.
> 
> **Overview**
> Prevents creating a redundant New Tab Page when the user’s *Show on app launch* setting is `NewTabPage` and the currently selected tab is already an NTP (blank/null URL), reducing races where a late-added NTP can override user actions.
> 
> Updates `ShowOnAppLaunchOptionHandlerImpl.handleAppLaunchOption` to only call `tabRepository.add()` when there is no selected tab or the selected tab has a non-blank URL, and expands unit tests plus the fake repository to model `getSelectedTab()` for these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9be851ff74c5ed0beca87ce02f676d06935b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->