### PR TITLE
Fix stale WebView callbacks updating UI state after navigating home

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2191,6 +2191,7 @@ class BrowserTabFragment :
         binding.browserLayout.gone()
         webViewContainer.gone()
         omnibar.setViewMode(ViewMode.NewTab)
+        webView?.stopLoading()
         webView?.onPause()
         webView?.hide()
         errorView.errorLayout.gone()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2197,7 +2197,7 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         url: String?,
     ) {
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
+        if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             navigationStateChanged(webViewNavigationState)
             url?.let { prefetchFavicon(url) }
 
@@ -2249,7 +2249,7 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         url: String,
     ) {
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
+        if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             navigationStateChanged(webViewNavigationState)
             onPageContentStart(url)
         }
@@ -2259,6 +2259,8 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         activeExperiments: List<Toggle>,
     ) {
+        if (!currentBrowserViewState().browserShowing) return
+
         this.activeExperiments = activeExperiments
 
         browserViewState.value =
@@ -4892,7 +4894,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onAutoConsentPopUpHandled(isCosmetic: Boolean) {
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
+        if (!currentBrowserViewState().maliciousSiteBlocked && site != null) {
             if (isCosmetic) {
                 autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_ANIMATION_SHOWN_COSMETIC_DAILY)
             } else {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5744,6 +5744,7 @@ class BrowserTabViewModelTest {
     fun whenPageFinishedAndStorePageContextEnabledThenCollectPageContext() =
         runTest {
             fakeAndroidConfigBrowserFeature.storePageContext().setRawStoredState(State(enable = true))
+            givenCurrentSite("https://example.com")
             val webViewNavState = WebViewNavigationState(mockStack, 100)
 
             testee.pageFinished(mockWebView, webViewNavState, "https://example.com")
@@ -7480,6 +7481,48 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenPageFinishedWithNullSiteThenDoNotUpdateState() {
+        testee.browserViewState.value =
+            testee.browserViewState.value?.copy(
+                browserShowing = false,
+                maliciousSiteBlocked = false,
+            )
+
+        testee.pageFinished(mockWebView, WebViewNavigationState(mockStack, 100), exampleUrl)
+
+        assertNull(testee.siteLiveData.value)
+        assertFalse(browserViewState().browserShowing)
+    }
+
+    @Test
+    fun whenPageCommitVisibleWithNullSiteThenDoNotUpdateState() {
+        testee.browserViewState.value =
+            testee.browserViewState.value?.copy(
+                browserShowing = false,
+                maliciousSiteBlocked = false,
+            )
+
+        testee.onPageCommitVisible(WebViewNavigationState(mockStack, 100), exampleUrl)
+
+        assertNull(testee.siteLiveData.value)
+        assertFalse(browserViewState().browserShowing)
+    }
+
+    @Test
+    fun whenAutoConsentPopupHandledWithNullSiteThenDoNotPostCommand() {
+        testee.browserViewState.value =
+            testee.browserViewState.value?.copy(
+                browserShowing = true,
+                maliciousSiteBlocked = false,
+            )
+
+        testee.onAutoConsentPopUpHandled(true)
+
+        assertCommandNotIssued<ShowAutoconsentAnimation>()
+        assertCommandNotIssued<EnqueueCookiesAnimation>()
+    }
+
+    @Test
     fun whenAutoConsentPopupHandledWithMaliciousSiteBlockedThenDoNotPostCommand() {
         testee.browserViewState.value =
             testee.browserViewState.value?.copy(
@@ -7495,6 +7538,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenAutoConsentPopupHandledWithNotMaliciousSiteBlockedThenPostCommand() {
+        givenCurrentSite("https://example.com")
         testee.browserViewState.value =
             testee.browserViewState.value?.copy(
                 browserShowing = true,
@@ -7533,6 +7577,7 @@ class BrowserTabViewModelTest {
     fun whenAutoConsentPopupHandledWithFeatureToggleDisabledThenShowAutoconsentAnimation() {
         runBlocking { whenever(mockAddressBarTrackersAnimationManager.isFeatureEnabled()).thenReturn(false) }
 
+        givenCurrentSite("https://example.com")
         testee.browserViewState.value =
             testee.browserViewState.value?.copy(
                 browserShowing = true,
@@ -7567,6 +7612,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenAutoConsentPopupHandledAndCosmeticTrueThenFireAnimationShownCosmeticPixel() {
+        givenCurrentSite("https://example.com")
         testee.browserViewState.value =
             testee.browserViewState.value?.copy(
                 browserShowing = true,
@@ -7581,6 +7627,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenAutoConsentPopupHandledAndCosmeticFalseThenFireAnimationShownPixel() {
+        givenCurrentSite("https://example.com")
         testee.browserViewState.value =
             testee.browserViewState.value?.copy(
                 browserShowing = true,
@@ -8447,6 +8494,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenEvaluateSerpLogoStateCalledWithDuckDuckGoUrlThenExtractSerpLogoCommandIssued() {
         whenever(mockDuckAiFeatureState.showFullScreenMode).thenReturn(mockDuckAiFullScreenMode)
+        givenCurrentSite("https://duckduckgo.com/?q=test")
         val ddgUrl = "https://duckduckgo.com/?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -8479,6 +8527,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenEvaluateSerpLogoStateCalledWithNonDuckDuckGoUrlThenSerpLogoIsCleared() {
         whenever(mockDuckAiFeatureState.showFullScreenMode).thenReturn(mockDuckAiFullScreenMode)
+        givenCurrentSite("https://example.com/search?q=test")
         val nonDdgUrl = "https://example.com/search?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -8525,6 +8574,7 @@ class BrowserTabViewModelTest {
         val favouriteUrl = "https://example.com/favourite-logo.png"
         favouriteLogoFlow.value = favouriteUrl
 
+        givenCurrentSite("https://duckduckgo.com/?q=test")
         val ddgUrl = "https://duckduckgo.com/?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -8543,6 +8593,7 @@ class BrowserTabViewModelTest {
         whenever(mockSetFavouriteToggle.isEnabled()).thenReturn(false)
         favouriteLogoFlow.value = "https://example.com/favourite-logo.png"
 
+        givenCurrentSite("https://duckduckgo.com/?q=test")
         val ddgUrl = "https://duckduckgo.com/?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -8563,6 +8614,7 @@ class BrowserTabViewModelTest {
         setFavouriteEnabledFlow.value = true
         favouriteLogoFlow.value = null
 
+        givenCurrentSite("https://duckduckgo.com/?q=test")
         val ddgUrl = "https://duckduckgo.com/?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -9165,6 +9217,7 @@ class BrowserTabViewModelTest {
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
         whenever(mockDuckAiFeatureState.showFullScreenMode).thenReturn(mockDuckAiFullScreenModeEnabled)
 
+        givenCurrentSite("https://example.com/search?q=test")
         val nonDdgUrl = "https://example.com/search?q=test"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 
@@ -9182,6 +9235,7 @@ class BrowserTabViewModelTest {
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         whenever(mockDuckAiFeatureState.showFullScreenMode).thenReturn(mockDuckAiFullScreenModeEnabled)
 
+        givenCurrentSite("https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
         val nonDdgUrl = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
         val webViewNavState = WebViewNavigationState(mockStack, 100)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1213977577223794?focus=true

### Description

When navigating to a site from the new tab page and pressing back while the page is still loading (e.g. during the tracker animation), the privacy shield icon incorrectly appears on the new tab page. Tapping it shows the privacy dashboard for the previous site or fails to load. Similarly, the escape hatch UI can show mismatched data. The new site's icon with the old site's link.

### Details

- When navigating to a site from new tab and pressing back mid-load, late WebView callbacks (pageFinished, onPageCommitVisible, onAutoConsentPopUpHandled, pageStarted) could fire after the user returned to the new tab page, causing the privacy shield icon and escape hatch to show stale data from the previous site
- Added `site != null` guard to pageFinished, onPageCommitVisible, and onAutoConsentPopUpHandled so they are ignored once navigateHome() has cleared the site
- Added `browserShowing` guard to pageStarted to prevent it from setting browserShowing = true and reviving the browser view on the NTP
- Added webView?.stopLoading() in showHome() to stop the WebView from generating further callbacks after the user navigates back to the new tab page (onPause is not enough)

### Steps to test this PR

Shield icon on new tab:
1. Open a new tab
2. Navigate to a site that has trackers (e.g., a news site)
3. As soon as the page starts loading and the tracker animation begins to appear, press back
4. Observe on the new tab page the privacy shield icon is visible when it shouldn't be
5. Tap the shield icon --> it shows the privacy dashboard for the site you just left, or fails to load

Escape hatch showing wrong data:
1. Follow the same steps as above
2. If the escape hatch UI appears on the new tab page, observe that the icon shows the new site but the link still points to the old one

### Videos
https://github.com/user-attachments/assets/849d7068-46d3-4c39-aede-0883ea1ea363

https://github.com/user-attachments/assets/42a49d61-658c-40f6-bf11-5d9681d58756








<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebView/navigation lifecycle and view-model state updates, which can cause subtle regressions in UI state if the new guards are too broad. Changes are localized to callback handling and add test coverage, lowering overall risk.
> 
> **Overview**
> Prevents late WebView callbacks from updating UI/state after the user has navigated back to the New Tab page.
> 
> `BrowserTabViewModel` now ignores `pageFinished`, `onPageCommitVisible`, and `onAutoConsentPopUpHandled` when there is no active `site`, and `pageStarted` returns early if the browser UI is not currently showing. `BrowserTabFragment.showHome` additionally calls `webView.stopLoading()` when switching to Home.
> 
> Updates unit tests to ensure state/commands are not updated/emitted when `site` is `null`, and to set up a current site in tests that depend on these callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c252d1a2ba5aab42d00c5ec6ce5d7a47ce141cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->