### PR TITLE
DuckAi/Voice: Hide when url is pre-filled

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -322,9 +322,14 @@ class InputScreenViewModel @AssistedInject constructor(
     val inputFieldCommand: Flow<InputFieldCommand> = _inputFieldCommand.receiveAsFlow()
 
     init {
-        combine(voiceServiceAvailable, voiceInputAllowed, isSearchModeFlow) { serviceAvailable, inputAllowed, isSearchMode ->
+        combine(
+            voiceServiceAvailable,
+            voiceInputAllowed,
+            isSearchModeFlow,
+            chatInputTextState,
+        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText ->
             val newEntryPointActive = !isSearchMode && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
-            if (newEntryPointActive) inputAllowed else serviceAvailable && inputAllowed
+            if (newEntryPointActive) chatInputText.isEmpty() else serviceAvailable && inputAllowed
         }.onEach { voiceInputPossible ->
             _visibilityState.update {
                 it.copy(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -2775,6 +2775,7 @@ class InputScreenViewModelTest {
             val viewModel = createViewModel()
             viewModel.onActivityResume()
             viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("")
 
             assertTrue(viewModel.visibilityState.value.voiceInputButtonVisible)
         }
@@ -2788,7 +2789,7 @@ class InputScreenViewModelTest {
             val viewModel = createViewModel()
             viewModel.onActivityResume()
             viewModel.onChatSelected()
-            viewModel.onVoiceInputAllowedChange(false)
+            viewModel.onChatInputTextChanged("Test")
 
             assertFalse(viewModel.visibilityState.value.voiceInputButtonVisible)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/492600419927320/task/1213980797394365?focus=true 

### Description
Before this change: The voice entry is visible when the Duck.ai tab is opened when a site has been loaded. The requirement is that we only show the voice icon when the input field is empty (aligns with iOS).
Cause: `voiceInputAllowed` default state is `true` and does not take into account the pre-filled value on the Duck.AI tab.

After this change: Instead on relying on `voiceInputAllowed`, we directly check `chatInputTextState` instead.

### Steps to test this PR

- [ ] Ensure that `Setting for Duck.ai` is `ENABLED` and `Search & Duck.ai` is `ENABLED`.
- [ ] FF: Enable `duckAiVoiceEntryPoint` and ensure that `nativeInputField` is `DISABLED`.
- [ ] Set top bar / split bar
- [ ] Open cnn.com
- [ ] Click on address bar and switch to Duck.ai tab
- [ ] Verify that url is still pre-filled
- [ ] Verify that voice chat entry is NOT visible
- [ ] Clear the chat by pressing x
- [ ] Verify that voice chat entry is visible
- [ ] Type something
- [ ] Verify that voice chat entry is NOT visible
- [ ] Delete everything manually
- [ ] Verify that voice chat entry is NOT visible
- [ ] open a new tab and switch to Duck.ai tab
- [ ] Verify that voice chat entry is visible
- [ ] Type something
- [ ] Verify that voice chat entry is NOT visible

### UI changes
Before:
https://github.com/user-attachments/assets/2b0ca945-8ac4-4bcf-b7fd-d466471a468e


After:
https://github.com/user-attachments/assets/0c0ecdf4-5d75-4d6b-8097-012591729453

