### PR TITLE
Remove v1/offer-status request

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -405,15 +405,10 @@ class RealSubscriptionsManager @Inject constructor(
     override suspend fun canSupportEncryption(): Boolean = authRepository.canSupportEncryption()
 
     override suspend fun isFreeTrialEligible(): Boolean {
-        val userHadFreeTrial = try {
-            subscriptionsService.offerStatus().hadTrial
-        } catch (e: Exception) {
-            false
-        }
         val freeTrialProductsAvailableInGooglePlay = getSubscriptionOffer().any {
             it.offerId in SubscriptionsConstants.LIST_OF_FREE_TRIAL_OFFERS
         }
-        return !userHadFreeTrial && privacyProFeature.get().privacyProFreeTrial().isEnabled() && freeTrialProductsAvailableInGooglePlay
+        return privacyProFeature.get().privacyProFreeTrial().isEnabled() && freeTrialProductsAvailableInGooglePlay
     }
 
     override suspend fun blackFridayOfferAvailable(): Boolean = withContext(dispatcherProvider.io()) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
@@ -36,10 +36,6 @@ interface SubscriptionsService {
     suspend fun portal(): PortalResponse
 
     @AuthRequired
-    @GET("https://subscriptions.duckduckgo.com/api/v1/offer-status")
-    suspend fun offerStatus(): OfferStatusResponse
-
-    @AuthRequired
     @POST("https://subscriptions.duckduckgo.com/api/purchase/confirm/google")
     suspend fun confirm(
         @Body confirmationBody: ConfirmationBody,
@@ -98,8 +94,4 @@ fun List<ConfirmationEntitlement>.toEntitlements(): List<Entitlement> {
 
 data class FeaturesResponse(
     val features: List<String>,
-)
-
-data class OfferStatusResponse(
-    val hadTrial: Boolean,
 )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209991789468715/task/1213982969677093?focus=true

### Description
Remove backend check for hadTrial since we limited usage on Play Console

### Steps to test this PR (subscriptions smoke test)
_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Free trial eligible_
- [x] Go to Play Billing Lab and enable introductory offer in Configuration Settings
- [x] Fresh install from branch
- [x] Once in the browser, open the menu in the new tab page and check you se VPN menu item with 'Try for Free' yellow pill

_Subscription expired_
- [x] Purchase a test subscription
- [x] Remove it from device
- [x] Add it back with 'I have a subscription flow'
- [x] Wait until it expires and check expired status looks correct in Settings screen and Subscription Settings screen

_VPN menu item_
- [x] Remove Free trial eligibility in Play Billing Lab
- [x] Open a new tap page
- [x] Check VPN menu doesnt have yellow pill
- [x] Go to Subscription Settings (still in expired status)
- [x] Tab on View plans
- [x] Verify no free trial is offered
- [x] Purchase a new plan with no free trial

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant backend call and simplifies free-trial eligibility gating; behavior changes only in cases where the backend previously reported `hadTrial` but Play Console still exposes an intro offer.
> 
> **Overview**
> Removes the `v1/offer-status` API from `SubscriptionsService` and deletes the associated `OfferStatusResponse` model.
> 
> `RealSubscriptionsManager.isFreeTrialEligible` no longer queries the backend for `hadTrial`; free-trial eligibility is now determined solely by the `privacyProFreeTrial` feature flag and whether a matching free-trial offer is available from Google Play.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b50cb048ea35eb104654691081785b5d4d158c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->