### PR TITLE
Show info Panel to inform about downgrade

### DIFF
--- a/app/src/main/res/values-fr/strings-settings.xml
+++ b/app/src/main/res/values-fr/strings-settings.xml
@@ -22,8 +22,8 @@
     <!-- Inactivity timeout -->
     <string name="afterInactivityOptionTitle">Après l\'inactivité</string>
     <string name="afterInactivityTimeoutRowTitle">Choisissez un minuteur d\'inactivité</string>
-    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d\'inactivité.</string>
-    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d\'inactivité.</string>
+    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d’inactivité.</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d’inactivité.</string>
     <string name="afterInactivityTimeoutAlways">Toujours</string>
     <string name="afterInactivityTimeout1Minute">1 minute</string>
     <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutes</string>

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
@@ -171,6 +171,7 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
         binding.viewAllPlansTop.isVisible = false
         binding.upgradeToProContainer.isVisible = false
         binding.verticalTierDivider.isVisible = false
+        binding.pendingDowngradeInfoPanel.gone()
 
         if (viewState.status in listOf(INACTIVE, EXPIRED)) {
             binding.viewPlans.isVisible = true
@@ -419,6 +420,23 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
             binding.changePlan.setSecondaryText(
                 getString(changeTypeString, pendingPlanDisplayName, viewState.pendingEffectiveDate),
             )
+            if (viewState.isPendingDowngrade == true &&
+                viewState.pendingTierNameResId != null &&
+                viewState.pendingEffectiveDateShort != null
+            ) {
+                binding.pendingDowngradeInfoPanel.show()
+                binding.pendingDowngradeInfoPanel.setText(
+                    getString(
+                        string.subscriptionPendingPlanChangeDowngradePanel,
+                        getString(viewState.pendingTierNameResId),
+                        viewState.pendingEffectiveDateShort,
+                    ),
+                )
+            } else {
+                binding.pendingDowngradeInfoPanel.gone()
+            }
+        } else {
+            binding.pendingDowngradeInfoPanel.gone()
         }
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModel.kt
@@ -122,6 +122,12 @@ class SubscriptionSettingsViewModel @Inject constructor(
         val pendingPlanDisplayNameResId = pendingPlan?.let {
             getPendingPlanDisplayName(it.tier, it.billingPeriod)
         }
+        val pendingEffectiveDateShort = pendingPlan?.let {
+            DateFormat.getInstanceForSkeleton("MMMMd").format(Date(it.effectiveAt))
+        }
+        val pendingTierNameResId = pendingPlan?.let {
+            getPendingTierNameResId(it.tier)
+        }
 
         val effectiveTier = if (subscriptionsFeature.showPendingPlanHint().isEnabled()) {
             pendingPlan?.tier ?: subscription.tier
@@ -144,6 +150,8 @@ class SubscriptionSettingsViewModel @Inject constructor(
                 pendingEffectiveDate = pendingEffectiveDate,
                 isPendingDowngrade = isPendingDowngrade,
                 pendingPlanDisplayNameResId = pendingPlanDisplayNameResId,
+                pendingEffectiveDateShort = pendingEffectiveDateShort,
+                pendingTierNameResId = pendingTierNameResId,
                 effectiveTier = effectiveTier,
             ),
         )
@@ -215,6 +223,14 @@ class SubscriptionSettingsViewModel @Inject constructor(
         }
     }
 
+    private fun getPendingTierNameResId(tier: SubscriptionTier): Int {
+        return when (tier) {
+            SubscriptionTier.PLUS -> R.string.planTierNamePlus
+            SubscriptionTier.PRO -> R.string.planTierNamePro
+            SubscriptionTier.UNKNOWN -> R.string.planTierNamePlus // fallback
+        }
+    }
+
     sealed class SubscriptionDuration {
         data object Monthly : SubscriptionDuration()
         data object Yearly : SubscriptionDuration()
@@ -244,6 +260,8 @@ class SubscriptionSettingsViewModel @Inject constructor(
             val pendingEffectiveDate: String? = null,
             val isPendingDowngrade: Boolean? = null,
             val pendingPlanDisplayNameResId: Int? = null,
+            val pendingEffectiveDateShort: String? = null,
+            val pendingTierNameResId: Int? = null,
             val effectiveTier: SubscriptionTier,
         ) : ViewState()
     }

--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_settings.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_settings.xml
@@ -129,6 +129,16 @@
 
             </LinearLayout>
 
+            <com.duckduckgo.common.ui.view.InfoPanel
+                android:id="@+id/pendingDowngradeInfoPanel"
+                style="@style/Widget.DuckDuckGo.InfoPanel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:layout_marginHorizontal="@dimen/keyline_5"
+                android:visibility="gone"
+                app:panelBackground="@drawable/info_panel_tooltip_background" />
+
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Управлявай плащането или отмени</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Планът ще бъде намален до %1$s на %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Планът ще бъде надграден до %1$s на %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Планът ще бъде намален до %1$s на %2$s.</string>
     <string name="planNamePlusMonthly">Месечен план Plus</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Správa platby nebo zrušení akce</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="planNamePlusMonthly">Plus měsíčně</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Administrer betaling eller annullér</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Dit abonnement nedgraderes til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dit abonnement opgraderes til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dit abonnement nedgraderes til %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus månedligt</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Zahlung verwalten oder stornieren</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Dein Abo wird am %2$s auf %1$s herabgestuft.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dein Abo wird am %2$s auf %1$s hochgestuft.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dein Abo wird am %2$s auf %1$s herabgestuft.</string>
     <string name="planNamePlusMonthly">Plus monatlich</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Διαχείριση πληρωμής ή ακύρωση</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Το πρόγραμμά σας θα υποβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Το πρόγραμμά σας θα αναβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Το πρόγραμμά σας θα υποβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="planNamePlusMonthly">Plus Μηνιαίο</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestionar el pago o cancelar</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tu plan se revertirá a %1$s el %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tu plan se actualizará a %1$s el %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tu plan se revertirá a %1$s el %2$s.</string>
     <string name="planNamePlusMonthly">Plus mensual</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Makse haldamine või tühistamine</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Sinu pakett alandatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sinu plaan uuendatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sinu pakett alandatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="planNamePlusMonthly">Plus Monthly</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Hallitse maksua tai peruuta</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Sopimuksesi alenee tasolle %1$s alkaen %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sopimuksesi päivittyy sopimukseen %1$s %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sopimuksesi alenee tasolle %1$s alkaen %2$s.</string>
     <string name="planNamePlusMonthly">Plus kuukausittain</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gérer le paiement ou annuler</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Le %2$s, vous passerez à un forfait inférieur : %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Le %2$s, vous passerez à un forfait supérieur : %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Le %2$s, vous passerez à un forfait inférieur : %1$s.</string>
     <string name="planNamePlusMonthly">Plus Mensuel</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Upravljanje plaćanjem ili otkazivanje</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvoj će se plan smanjiti na %1$s dana %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj će se plan nadograditi na %1$s dana %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj će se plan smanjiti na %1$s dana %2$s.</string>
     <string name="planNamePlusMonthly">mjesečni Plus</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Fizetés kezelése vagy lemondása</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">A csomagod %2$s dátummal erre vált vissza: %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">A csomagod %2$s dátummal erre frissül: %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">A csomagod %2$s dátummal erre vált vissza: %1$s.</string>
     <string name="planNamePlusMonthly">Plus – havi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestisci il pagamento o Annulla</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Il tuo piano passerà a %1$s il giorno %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Il tuo piano verrà aggiornato a %1$s il %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Il tuo piano passerà a %1$s il giorno %2$s.</string>
     <string name="planNamePlusMonthly">Plus Mensile</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Tvarkyti mokėjimą arba atšaukti</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">%2$s tavo planas pasikeis į žemesnio lygio %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s tavo planas atsinaujins į %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s tavo planas pasikeis į žemesnio lygio %1$s.</string>
     <string name="planNamePlusMonthly">Mėnesinis „Plus“</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Pārvaldīt maksājumu vai atcelt</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tavs plāns tiks pazemināts uz %1$s šādā datumā: %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tavs plāns tiks jaunināts uz %1$s šādā datumā: %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tavs plāns tiks pazemināts uz %1$s šādā datumā: %2$s.</string>
     <string name="planNamePlusMonthly">Plus ik mēnesi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Administrer betaling eller si opp</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Abonnementet ditt blir nedgradert til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Abonnementet ditt blir oppgradert til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Abonnementet ditt blir nedgradert til %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus månedlig</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Betaling beheren of annuleren</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Je abonnement wordt op %2$s gedowngraded naar %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Je abonnement wordt op %2$s geüpgraded naar %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Je abonnement wordt op %2$s gedowngraded naar %1$s.</string>
     <string name="planNamePlusMonthly">Plus Maandelijks</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Zarządzaj płatnością lub anuluj</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">W dniu %2$s Twój plan zostanie obniżony do poziomu %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Twój plan zostanie zaktualizowany do %1$s w dniu %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">W dniu %2$s Twój plan zostanie obniżony do poziomu %1$s.</string>
     <string name="planNamePlusMonthly">Plus Miesięczny</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gerir pagamento ou Cancelar</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Será feito o downgrade do teu plano para %1$s a %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">O teu plano será atualizado para %1$s a %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Será feito o downgrade do teu plano para %1$s a %2$s.</string>
     <string name="planNamePlusMonthly">Plus Mensal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestionează plata sau anulează</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Planul tău va fi retrogradat la %1$s la data de %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planul tău va fi actualizat la %1$s la data de %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planul tău va fi retrogradat la %1$s la data de %2$s.</string>
     <string name="planNamePlusMonthly">Plus lunar</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Управление оплатой или Отмена</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">%2$s ваш план будет понижен до %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s ваш план будет повышен до %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s ваш план будет понижен до %1$s.</string>
     <string name="planNamePlusMonthly">Plus с оплатой раз в месяц</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Spravovať platbu alebo zrušiť</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvoj plán prejde na nižšiu úroveň %1$s dňa %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj plán prejde na vyššiu úroveň %1$s dňa %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj plán prejde na nižšiu úroveň %1$s dňa %2$s.</string>
     <string name="planNamePlusMonthly">Plus mesačne</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Upravljanje plačila ali preklic</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Vaša naročnina se bo znižala na %1$s dne %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Vaša naročnina bo nadgrajena na %1$s dne %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Vaša naročnina se bo znižala na %1$s dne %2$s.</string>
     <string name="planNamePlusMonthly">Plus – mesečno</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Hantera betalning eller avbryt</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Din plan kommer att nedgraderas till %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Din plan kommer att uppgraderas till %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Din plan kommer att nedgraderas till %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus – månadsvis</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Ödemeyi Yönetin veya İptal Edin</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Planınız %2$s tarihinde %1$s planına düşürülecek.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planın %2$s tarihinde %1$s planına yükseltilecek.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planınız %2$s tarihinde %1$s planına düşürülecek.</string>
     <string name="planNamePlusMonthly">Plus Aylık</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -21,6 +21,11 @@
     <string name="pirStorageUnavailableDialogMessage">Please restart the DuckDuckGo app and try again.</string>
     <string name="pirStorageUnavailableDialogButton">Got It</string>
 
+    <!-- Pending downgrade info panel - move to strings-subscriptions.xml once translations are requested -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Your plan will downgrade to %1$s on %2$s.</string>
+    <string name="planTierNamePlus">Plus</string>
+    <string name="planTierNamePro">Pro</string>
+
     <!-- Black Friday offer-->
     <string name="subscriptionSettingBlackFridayOffer">Save 40% on First Year</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -20,9 +20,6 @@
     <string name="pirStorageUnavailableDialogTitle">Temporary issue with Personal Information Removal</string>
     <string name="pirStorageUnavailableDialogMessage">Please restart the DuckDuckGo app and try again.</string>
     <string name="pirStorageUnavailableDialogButton">Got It</string>
-
-    <!-- Pending downgrade info panel - move to strings-subscriptions.xml once translations are requested -->
-    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="planTierNamePlus">Plus</string>
     <string name="planTierNamePro">Pro</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
@@ -188,6 +188,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Manage Payment or Cancel</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Your plan will upgrade to %1$s on %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="planNamePlusMonthly">Plus Monthly</string>

--- a/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/CancelPendingPlanChangeView.kt
+++ b/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/CancelPendingPlanChangeView.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.internal.settings
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.Toast
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.subscriptions.impl.CurrentPurchase
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
+import com.duckduckgo.subscriptions.internal.SubsSettingPlugin
+import com.duckduckgo.subscriptions.internal.databinding.SubsSimpleViewBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * PoC dev setting to validate whether a deferred PRO → PLUS plan change can be cancelled via
+ * the Billing Library by re-subscribing to the current (non-pending) plan with WITHOUT_PRORATION.
+ *
+ * Requires an active subscription with a pending plan change (hasPendingChange == true).
+ * No backend changes are needed — the purchase confirmation flow handles it.
+ */
+@InjectWith(ViewScope::class)
+class CancelPendingPlanChangeView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var subscriptionsManager: SubscriptionsManager
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private val binding: SubsSimpleViewBinding by viewBinding()
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        binding.root.setPrimaryText("Cancel Pending Plan Change (PoC)")
+        binding.root.setSecondaryText("Attempt to revert a deferred downgrade by re-subscribing to the current plan with WITHOUT_PRORATION")
+
+        val lifecycleOwner = findViewTreeLifecycleOwner()
+        lifecycleOwner?.lifecycleScope?.launch(dispatcherProvider.io()) {
+            subscriptionsManager.currentPurchaseState.collect {
+                when (it) {
+                    is CurrentPurchase.Success -> {
+                        launch(dispatcherProvider.main()) {
+                            Toast.makeText(context, "Pending plan change cancelled successfully", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                    is CurrentPurchase.Failure -> {
+                        launch(dispatcherProvider.main()) {
+                            Toast.makeText(context, "Failed to cancel pending change: ${it.message}", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                    is CurrentPurchase.Canceled -> {
+                        launch(dispatcherProvider.main()) {
+                            Toast.makeText(context, "Cancellation flow dismissed by user", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                    else -> {}
+                }
+            }
+        }
+
+        checkStatusAndConfigureView()
+    }
+
+    private fun checkStatusAndConfigureView() {
+        val lifecycleOwner = findViewTreeLifecycleOwner() ?: run {
+            configureDisabledState("Unable to check subscription status")
+            return
+        }
+
+        lifecycleOwner.lifecycleScope.launch(dispatcherProvider.io()) {
+            val subscription = subscriptionsManager.getSubscription()
+            launch(dispatcherProvider.main()) {
+                when {
+                    subscription == null -> configureDisabledState("No active subscription found")
+                    !subscription.hasPendingChange -> configureDisabledState("No pending plan change to cancel (hasPendingChange = false)")
+                    else -> {
+                        val pendingTier = subscription.pendingPlans.firstOrNull()?.tier?.value ?: "unknown"
+                        configureEnabledState(
+                            currentPlanId = subscription.productId,
+                            pendingTier = pendingTier,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun configureEnabledState(currentPlanId: String, pendingTier: String) {
+        binding.root.setSecondaryText(
+            "Current: $currentPlanId | Pending change to: $pendingTier — tap to cancel",
+        )
+        binding.root.setEnabled(true)
+        binding.root.setClickListener {
+            triggerCancellation(currentPlanId)
+        }
+    }
+
+    private fun configureDisabledState(reason: String) {
+        binding.root.setSecondaryText(reason)
+        binding.root.alpha = 0.5f
+        binding.root.setClickListener {
+            Toast.makeText(context, reason, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun triggerCancellation(currentPlanId: String) {
+        val lifecycleOwner = findViewTreeLifecycleOwner() ?: return
+        val activity = context as? android.app.Activity ?: run {
+            Toast.makeText(context, "Error: Activity context required for billing flow", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        lifecycleOwner.lifecycleScope.launch(dispatcherProvider.io()) {
+            val offer = subscriptionsManager.getSubscriptionOffer().find {
+                it.planId == currentPlanId && it.offerId == null
+            }
+
+            if (offer == null) {
+                launch(dispatcherProvider.main()) {
+                    Toast.makeText(context, "Could not find offer for plan: $currentPlanId", Toast.LENGTH_LONG).show()
+                }
+                return@launch
+            }
+
+            launch(dispatcherProvider.main()) {
+                Toast.makeText(context, "Launching billing flow to cancel pending change...", Toast.LENGTH_SHORT).show()
+            }
+
+            subscriptionsManager.switchSubscriptionPlan(
+                activity = activity,
+                planId = offer.planId,
+                offerId = null,
+                replacementMode = SubscriptionReplacementMode.WITHOUT_PRORATION,
+                origin = "dev_settings_cancel_pending",
+            )
+        }
+    }
+}
+
+@ContributesMultibinding(ActivityScope::class)
+class CancelPendingPlanChangeViewPlugin @Inject constructor() : SubsSettingPlugin {
+    override fun getView(context: Context): View = CancelPendingPlanChangeView(context)
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213983089199776?focus=true 

### Description
Shows downgrade information at top of subscription settings for more visibility

Also adds an internal setting to perform "cancel downgrade" when available, as a PoC in case we need to revisit.

### Steps to test this PR

_Feature 1_
- [x] Apply patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] fresh install
- [x] purchase pro
- [x] downgrade to plus
- [x] Ensure in subscription settings appears an info panel with downgrade information
- [x] Wait until subscription downgrades, ensure the info panel is gone

_Feature 2_
- [x] purchase pro
- [x] downgrade to plus
- [x] Ensure in subscription settings appears an info panel with downgrade information
- [x] Go to manage subscription in play store, and cancel subscription
- [x] go back to subscription settings
- [x] Ensure downgrade information is gone
- [x] Wait until subscription expires, ensure the info panel is gone 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes subscription-settings UI state based on pending plan data and introduces an internal dev action that triggers a billing plan switch using `WITHOUT_PRORATION`. Main production impact is UI/strings, but incorrect pending-state handling could confuse users.
> 
> **Overview**
> **Improves visibility of pending downgrades in Subscription Settings.** When a deferred downgrade is detected, the settings screen now shows a new top-of-page `InfoPanel` with a short tier+date message, and ensures the panel is reliably hidden/reset when the pending change is absent.
> 
> Adds supporting view-model fields for a short effective date and tier display name, plus new localized strings (and new non-translatable tier name resources). Also includes a new internal dev setting (`CancelPendingPlanChangeView`) that attempts to cancel a pending downgrade by re-subscribing to the current plan via Billing with `WITHOUT_PRORATION`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6375e7c91c57deda993a17ab72d70361a161cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->