### PR TITLE
Translations: downgrade info panel

### DIFF
--- a/app/src/main/res/values-fr/strings-settings.xml
+++ b/app/src/main/res/values-fr/strings-settings.xml
@@ -22,8 +22,8 @@
     <!-- Inactivity timeout -->
     <string name="afterInactivityOptionTitle">Après l\'inactivité</string>
     <string name="afterInactivityTimeoutRowTitle">Choisissez un minuteur d\'inactivité</string>
-    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d\'inactivité.</string>
-    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d\'inactivité.</string>
+    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d’inactivité.</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d’inactivité.</string>
     <string name="afterInactivityTimeoutAlways">Toujours</string>
     <string name="afterInactivityTimeout1Minute">1 minute</string>
     <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutes</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Управлявай плащането или отмени</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Планът ще бъде намален до %1$s на %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Планът ще бъде надграден до %1$s на %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Планът ще бъде намален до %1$s на %2$s.</string>
     <string name="planNamePlusMonthly">Месечен план Plus</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Správa platby nebo zrušení akce</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvůj tarif se dne %2$s změní na %1$s.</string>
     <string name="planNamePlusMonthly">Plus měsíčně</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Administrer betaling eller annullér</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Dit abonnement nedgraderes til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dit abonnement opgraderes til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dit abonnement nedgraderes til %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus månedligt</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Zahlung verwalten oder stornieren</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Dein Abo wird am %2$s auf %1$s herabgestuft.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dein Abo wird am %2$s auf %1$s hochgestuft.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Dein Abo wird am %2$s auf %1$s herabgestuft.</string>
     <string name="planNamePlusMonthly">Plus monatlich</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Διαχείριση πληρωμής ή ακύρωση</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Το πρόγραμμά σας θα υποβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Το πρόγραμμά σας θα αναβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Το πρόγραμμά σας θα υποβαθμιστεί σε %1$s στις %2$s.</string>
     <string name="planNamePlusMonthly">Plus Μηνιαίο</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestionar el pago o cancelar</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tu plan se revertirá a %1$s el %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tu plan se actualizará a %1$s el %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tu plan se revertirá a %1$s el %2$s.</string>
     <string name="planNamePlusMonthly">Plus mensual</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Makse haldamine või tühistamine</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Sinu pakett alandatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sinu plaan uuendatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sinu pakett alandatakse plaanile %1$s kuupäeval %2$s.</string>
     <string name="planNamePlusMonthly">Plus Monthly</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Hallitse maksua tai peruuta</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Sopimuksesi alenee tasolle %1$s alkaen %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sopimuksesi päivittyy sopimukseen %1$s %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Sopimuksesi alenee tasolle %1$s alkaen %2$s.</string>
     <string name="planNamePlusMonthly">Plus kuukausittain</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gérer le paiement ou annuler</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Le %2$s, vous passerez à un forfait inférieur : %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Le %2$s, vous passerez à un forfait supérieur : %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Le %2$s, vous passerez à un forfait inférieur : %1$s.</string>
     <string name="planNamePlusMonthly">Plus Mensuel</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Upravljanje plaćanjem ili otkazivanje</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvoj će se plan smanjiti na %1$s dana %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj će se plan nadograditi na %1$s dana %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj će se plan smanjiti na %1$s dana %2$s.</string>
     <string name="planNamePlusMonthly">mjesečni Plus</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Fizetés kezelése vagy lemondása</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">A csomagod %2$s dátummal erre vált vissza: %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">A csomagod %2$s dátummal erre frissül: %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">A csomagod %2$s dátummal erre vált vissza: %1$s.</string>
     <string name="planNamePlusMonthly">Plus – havi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestisci il pagamento o Annulla</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Il tuo piano passerà a %1$s il giorno %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Il tuo piano verrà aggiornato a %1$s il %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Il tuo piano passerà a %1$s il giorno %2$s.</string>
     <string name="planNamePlusMonthly">Plus Mensile</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Tvarkyti mokėjimą arba atšaukti</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">%2$s tavo planas pasikeis į žemesnio lygio %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s tavo planas atsinaujins į %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s tavo planas pasikeis į žemesnio lygio %1$s.</string>
     <string name="planNamePlusMonthly">Mėnesinis „Plus“</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Pārvaldīt maksājumu vai atcelt</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tavs plāns tiks pazemināts uz %1$s šādā datumā: %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tavs plāns tiks jaunināts uz %1$s šādā datumā: %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tavs plāns tiks pazemināts uz %1$s šādā datumā: %2$s.</string>
     <string name="planNamePlusMonthly">Plus ik mēnesi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Administrer betaling eller si opp</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Abonnementet ditt blir nedgradert til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Abonnementet ditt blir oppgradert til %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Abonnementet ditt blir nedgradert til %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus månedlig</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Betaling beheren of annuleren</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Je abonnement wordt op %2$s gedowngraded naar %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Je abonnement wordt op %2$s geüpgraded naar %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Je abonnement wordt op %2$s gedowngraded naar %1$s.</string>
     <string name="planNamePlusMonthly">Plus Maandelijks</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Zarządzaj płatnością lub anuluj</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">W dniu %2$s Twój plan zostanie obniżony do poziomu %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Twój plan zostanie zaktualizowany do %1$s w dniu %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">W dniu %2$s Twój plan zostanie obniżony do poziomu %1$s.</string>
     <string name="planNamePlusMonthly">Plus Miesięczny</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gerir pagamento ou Cancelar</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Será feito o downgrade do teu plano para %1$s a %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">O teu plano será atualizado para %1$s a %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Será feito o downgrade do teu plano para %1$s a %2$s.</string>
     <string name="planNamePlusMonthly">Plus Mensal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Gestionează plata sau anulează</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Planul tău va fi retrogradat la %1$s la data de %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planul tău va fi actualizat la %1$s la data de %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planul tău va fi retrogradat la %1$s la data de %2$s.</string>
     <string name="planNamePlusMonthly">Plus lunar</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Управление оплатой или Отмена</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">%2$s ваш план будет понижен до %1$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s ваш план будет повышен до %1$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">%2$s ваш план будет понижен до %1$s.</string>
     <string name="planNamePlusMonthly">Plus с оплатой раз в месяц</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Spravovať platbu alebo zrušiť</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Tvoj plán prejde na nižšiu úroveň %1$s dňa %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj plán prejde na vyššiu úroveň %1$s dňa %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Tvoj plán prejde na nižšiu úroveň %1$s dňa %2$s.</string>
     <string name="planNamePlusMonthly">Plus mesačne</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Upravljanje plačila ali preklic</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Vaša naročnina se bo znižala na %1$s dne %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Vaša naročnina bo nadgrajena na %1$s dne %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Vaša naročnina se bo znižala na %1$s dne %2$s.</string>
     <string name="planNamePlusMonthly">Plus – mesečno</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Hantera betalning eller avbryt</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Din plan kommer att nedgraderas till %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Din plan kommer att uppgraderas till %1$s den %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Din plan kommer att nedgraderas till %1$s den %2$s.</string>
     <string name="planNamePlusMonthly">Plus – månadsvis</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -189,6 +189,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Ödemeyi Yönetin veya İptal Edin</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Planınız %2$s tarihinde %1$s planına düşürülecek.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planın %2$s tarihinde %1$s planına yükseltilecek.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Planınız %2$s tarihinde %1$s planına düşürülecek.</string>
     <string name="planNamePlusMonthly">Plus Aylık</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -20,9 +20,6 @@
     <string name="pirStorageUnavailableDialogTitle">Temporary issue with Personal Information Removal</string>
     <string name="pirStorageUnavailableDialogMessage">Please restart the DuckDuckGo app and try again.</string>
     <string name="pirStorageUnavailableDialogButton">Got It</string>
-
-    <!-- Pending downgrade info panel - move to strings-subscriptions.xml once translations are requested -->
-    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="planTierNamePlus">Plus</string>
     <string name="planTierNamePro">Pro</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
@@ -188,6 +188,7 @@
     <string name="subscriptionSettingManagePaymentOrCancel">Manage Payment or Cancel</string>
 
     <!-- Pending plan changes -->
+    <string name="subscriptionPendingPlanChangeDowngradePanel" instruction="First placeholder is the Tier name (e.g. Plus, Pro), second is date in short format (month day)">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="subscriptionPendingPlanChangeUpgrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Your plan will upgrade to %1$s on %2$s.</string>
     <string name="subscriptionPendingPlanChangeDowngrade" instruction="First placeholder is the plan name (e.g. Plus Yearly), third is a date">Your plan will downgrade to %1$s on %2$s.</string>
     <string name="planNamePlusMonthly">Plus Monthly</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213983089199778?focus=true 

### Description
Translations request for downgrade info panel

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource-only changes (new localized copy and moving an English string) with no functional logic changes; risk is limited to missing/incorrect localization or build-time resource issues.
> 
> **Overview**
> Adds a new localized string `subscriptionPendingPlanChangeDowngradePanel` across many `strings-subscriptions.xml` locale files so the pending downgrade info panel can be translated.
> 
> Moves the English `subscriptionPendingPlanChangeDowngradePanel` out of `donottranslate.xml` into the main `values/strings-subscriptions.xml`, and fixes French typography for inactivity timeout strings (apostrophe → typographic apostrophe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb669a9fc1cf3730a529880a6554544a7611144b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->