### PR TITLE
Enables by default pro tier FF post-release

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -280,7 +280,7 @@ interface PrivacyProFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun tierMessagingEnabled(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun allowProTierPurchase(): Toggle
 
     /**


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213090399231415?focus=true 

### Description
After pro tier release, we can enabled it by default in code.

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips the default state of `allowProTierPurchase` to enabled, which can change purchase availability/UX for all users without requiring a remote config update. Risk is moderate because it affects subscription tier selection and monetization flows.
> 
> **Overview**
> Enables Pro tier purchasing by default by changing the `privacyPro` remote feature toggle `allowProTierPurchase` default value from `FALSE` to `TRUE` in `RealSubscriptions.kt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07126d598c0555abdf71946bfc762032d890602c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->