### PR TITLE
Exclude selected tab from return hatch query to prevent stale data

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -238,15 +238,19 @@ abstract class TabsDao {
 
     @Query(
         "select * from tabs where deletable is 0 and lastAccessTime is not null" +
-            " and url is not null and title is not null order by lastAccessTime desc limit 1",
+            " and url is not null and title is not null" +
+            " and tabId not in (select tabId from tab_selection where tabId is not null)" +
+            " order by lastAccessTime desc limit 1",
     )
-    abstract fun lastAccessedTab(): TabEntity?
+    abstract fun lastAccessedNonSelectedTab(): TabEntity?
 
     @Query(
         "select * from tabs where deletable is 0 and lastAccessTime is not null" +
-            " and url is not null and title is not null order by lastAccessTime desc limit 1",
+            " and url is not null and title is not null" +
+            " and tabId not in (select tabId from tab_selection where tabId is not null)" +
+            " order by lastAccessTime desc limit 1",
     )
-    abstract fun flowLastAccessedTab(): Flow<TabEntity?>
+    abstract fun flowLastAccessedNonSelectedTab(): Flow<TabEntity?>
 
     @Query("update tabs set lastAccessTime=:lastAccessTime where tabId=:tabId")
     abstract fun updateTabLastAccess(

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -447,10 +447,10 @@ class TabDataRepository @Inject constructor(
     override suspend fun getSelectedTab(): TabEntity? =
         withContext(dispatchers.io()) { tabsDao.selectedTab() }
 
-    override suspend fun getLastAccessedTab(): TabEntity? =
-        withContext(dispatchers.io()) { tabsDao.lastAccessedTab() }
+    override suspend fun getLastAccessedNonSelectedTab(): TabEntity? =
+        withContext(dispatchers.io()) { tabsDao.lastAccessedNonSelectedTab() }
 
-    override val flowLastAccessedTab: Flow<TabEntity?> = tabsDao.flowLastAccessedTab()
+    override val flowLastAccessedNonSelectedTab: Flow<TabEntity?> = tabsDao.flowLastAccessedNonSelectedTab()
         .distinctUntilChanged()
 
     override suspend fun select(tabId: String) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -899,11 +899,11 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             return selectedTab
         }
 
-        override suspend fun getLastAccessedTab(): TabEntity? {
+        override suspend fun getLastAccessedNonSelectedTab(): TabEntity? {
             TODO("Not yet implemented")
         }
 
-        override val flowLastAccessedTab: Flow<TabEntity?>
+        override val flowLastAccessedNonSelectedTab: Flow<TabEntity?>
             get() = TODO("Not yet implemented")
 
         override fun updateTabPreviewImage(

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -105,9 +105,9 @@ interface TabRepository {
 
     suspend fun getSelectedTab(): TabEntity?
 
-    suspend fun getLastAccessedTab(): TabEntity?
+    suspend fun getLastAccessedNonSelectedTab(): TabEntity?
 
-    val flowLastAccessedTab: Flow<TabEntity?>
+    val flowLastAccessedNonSelectedTab: Flow<TabEntity?>
 
     suspend fun select(tabId: String)
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -53,7 +53,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
         val isSerp: Boolean = false,
     )
 
-    val viewState = tabRepository.flowLastAccessedTab
+    val viewState = tabRepository.flowLastAccessedNonSelectedTab
         .map { lastTab ->
             if (lastTab != null) {
                 val url = lastTab.url.orEmpty()

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -52,7 +52,7 @@ class NewTabReturnHatchViewModelTest {
 
     @Before
     fun setup() {
-        whenever(mockTabRepository.flowLastAccessedTab).thenReturn(lastAccessedTabFlow)
+        whenever(mockTabRepository.flowLastAccessedNonSelectedTab).thenReturn(lastAccessedTabFlow)
 
         testee = NewTabReturnHatchViewModel(
             tabRepository = mockTabRepository,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213988415500467?focus=true

### Description

The return hatch query (flowLastAccessedTab) could return the currently selected tab, displaying the site that was loading even after the user navigated back to the NTP. Concurrent DB writes from tracker events could overwrite the null URL written by navigateHome(), leaving the tab with stale data permanently.

**Root cause**                                                          
`onSiteChanged()` is called frequently during page load (every tracker event triggers it), each call asynchronously writing the site URL to the tab database. When the user presses back, navigateHome() clears the URL asynchronously, but stale writes from tracker events can land after the null write, briefly restoring the URL in the database. The return hatch observes these changes via a Room Flow and renders the stale data.

**Fix**
Excluding the selected tab from the query eliminates the race entirely regardless of DB write ordering, the current tab's data is never shown in the hatch.

Also renamed and updated the query to flowLastAccessedNonSelectedTab, so it better reflects what the query is doing and avoids confusion.

### Steps to test this Bug
1. Open a tab and navigate to a site (e.g., wikipedia.org), let it fully load
2. Open a new tab
3. Navigate to a tracker-heavy site (e.g., nba.com)
4. Press back quickly while the page is still loading
5. Observe the return hatch on the new tab page. 
6. If done a the right timing the escape hatch will incorrectly show the NBA logo instead of wikipedia.

This PR should fix that


<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c2347449950f8685198d4faf976087083bc79126. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to a Room query and associated API rename to prevent the return hatch from observing stale data; main risk is unintended behavior changes in which tab is considered "last accessed".
> 
> **Overview**
> Prevents the new-tab "return hatch" from ever showing the *currently selected tab* by updating the "last accessed" tab queries to exclude `tabId`s present in `tab_selection`, eliminating a race where late DB writes could restore stale URL/title data.
> 
> Renames the affected DAO/repository APIs from `lastAccessedTab`/`flowLastAccessedTab` to `lastAccessedNonSelectedTab`/`flowLastAccessedNonSelectedTab` and updates call sites and tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755658344e6afa5d58a6b4c0d9495be07da7fc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->