### PR TITLE
Update content scope scripts to version 13.39.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -3273,7 +3273,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -4839,7 +4839,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
@@ -8059,7 +8058,8 @@
         });
         return ageRange || value;
       }
-    ]
+    ],
+    ["replaceWhitespace", (value, argument) => value.split(" ").join(argument ?? " ")]
   ]);
   function processSearchParams(searchParams, action, userData) {
     const updatedPairs = [...searchParams].map(([key, value]) => {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4808,7 +4808,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
@@ -8028,7 +8027,8 @@
         });
         return ageRange || value;
       }
-    ]
+    ],
+    ["replaceWhitespace", (value, argument) => value.split(" ").join(argument ?? " ")]
   ]);
   function processSearchParams(searchParams, action, userData) {
     const updatedPairs = [...searchParams].map(([key, value]) => {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4705,7 +4705,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,
@@ -12346,12 +12345,15 @@ ${iframeContent}
       this._notifyIfChanged(shouldLock);
     }
     /**
-     * Determine if UI should be locked based on scrollbar visibility.
-     * Lock if there's no visible vertical scrollbar on the page.
+     * Determine if UI should be locked based on scrollbar visibility or content type.
+     * Lock if the page is a direct image display or has no visible vertical scrollbar.
      * @returns {boolean}
      */
     _detectShouldLock() {
       try {
+        if (this.getFeatureSettingEnabled("lockImagePages", "enabled") && this._isImageDisplayPage()) {
+          return true;
+        }
         const html2 = document.documentElement;
         const body = document.body;
         if (html2 && this._hasExplicitlyVisibleScrollbar(html2)) {
@@ -12365,6 +12367,15 @@ ${iframeContent}
         this.log.warn("Failed to detect scroll state:", e);
         return false;
       }
+    }
+    /**
+     * Detect if the current page is a browser-rendered image display page.
+     * When navigating directly to an image URL, the browser renders a minimal page
+     * with the document's contentType set to an image MIME type (e.g. image/jpeg).
+     * @returns {boolean}
+     */
+    _isImageDisplayPage() {
+      return typeof document.contentType === "string" && document.contentType.startsWith("image/");
     }
     /**
      * Check if an element has a visible vertical scrollbar.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -3237,7 +3237,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -3237,7 +3237,6 @@
        *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
-       *   isDdgWebView?: boolean,
        *   featureSettings?: Record<string, unknown>,
        *   assets?: import('./content-feature.js').AssetConfig | undefined,
        *   site: import('./content-feature.js').Site,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.67.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.37.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.39.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.67.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.67.0.tgz",
-      "integrity": "sha512-mZMpDdn7IrgtJ3JFWbxU8krkZAS11PMqASmBqEpgWvEhbcL3leB2dzh1kA/KNyrmUv/iHrIVVLuZt5HlgyfsWQ==",
+      "version": "14.69.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.69.0.tgz",
+      "integrity": "sha512-0UqpTmcYOeBgQ0SXgbTiROgKofxXZktWsjU8RywBoQV7UUtVdKGOVK+Nn/LByDemTiZs/2N/XpzENcU5bh+OJg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#56754c6e0fd58a76a78f2241b6e811d08cfbee84",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#afb4f25c3c08e83336401bc8b0f5cb1c92446e22",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
-      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.27.tgz",
-      "integrity": "sha512-gKxrEupyAezMO5od1zsB0Tfhg+iAkV2itCr9Wk7MSm79sM4Uk2jewxYQZriDGBcdRxNhpnron7mez+sOKo5pkg==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.28.tgz",
+      "integrity": "sha512-z000DWdcayJ6TctJCb50BtJb89aeXw7WVUp5OREZZrkg56jEwLT18ySbSB28bJvEcNQ4D3JG5SLS/eSViGlRuA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.27"
+        "tldts-core": "^7.0.28"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.67.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.37.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.39.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1213987700668471/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled `content-scope-scripts` with behavior changes that affect in-page UI locking and template transforms, which could alter user-facing interactions on some sites. Dependency bumps in lockfiles are generally safe but can introduce subtle regressions in injected scripts.
> 
> **Overview**
> Updates the `@duckduckgo/content-scope-scripts` dependency to `13.39.0` (and refreshes the bundled Android build outputs in `node_modules`).
> 
> This brings in functional changes including a new optional template transform `replaceWhitespace` for user-data templating, and updated UI lock-state detection to optionally lock *direct image display pages* via a `lockImagePages` feature setting (in addition to scrollbar-based locking).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27538052bc2814136b30a4e55b2e7cb133cb9af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->