### PR TITLE
removes launch ROW FF

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -196,9 +196,6 @@ interface PrivacyProFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun authApiV2(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun isLaunchedROW(): Toggle
-
     // Kill switch
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun featuresApi(): Toggle

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -1038,10 +1038,7 @@ class RealSubscriptionsManager @Inject constructor(
 
     private suspend fun activePlanIds(): List<String> =
         buildList {
-            addAll(listOf(YEARLY_PLAN_US, MONTHLY_PLAN_US))
-            if (isLaunchedRow()) {
-                addAll(listOf(YEARLY_PLAN_ROW, MONTHLY_PLAN_ROW))
-            }
+            addAll(listOf(YEARLY_PLAN_US, MONTHLY_PLAN_US, YEARLY_PLAN_ROW, MONTHLY_PLAN_ROW))
             if (privacyProFeature.get().allowProTierPurchase().isEnabled()) {
                 addAll(LIST_OF_PRO_PLANS)
             }
@@ -1368,10 +1365,6 @@ class RealSubscriptionsManager @Inject constructor(
             }
             throw e
         }
-    }
-
-    private suspend fun isLaunchedRow(): Boolean = withContext(dispatcherProvider.io()) {
-        privacyProFeature.get().isLaunchedROW().isEnabled()
     }
 
     private fun parseError(e: HttpException): ResponseError? {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1419,7 +1419,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
         authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
-        givenIsLaunchedRow(true)
 
         val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
 
@@ -1430,16 +1429,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             assertEquals("1$", find { it.planId == YEARLY_PLAN_ROW }?.pricingPhases?.first()?.formattedPrice)
             assertEquals(setOf(NETP), first().features)
         }
-    }
-
-    @Test
-    fun whenGetSubscriptionAndRowPlansAvailableAndFeatureDisabledThenReturnEmptyList() = runTest {
-        authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
-        authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
-        givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
-        givenIsLaunchedRow(false)
-
-        assertEquals(emptyList<SubscriptionOfferDetails>(), subscriptionsManager.getSubscriptionOffer())
     }
 
     @Test
@@ -2391,11 +2380,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             experimentName = experimentName,
             origin = null,
         )
-    }
-
-    @SuppressLint("DenyListedApi")
-    private fun givenIsLaunchedRow(value: Boolean) {
-        privacyProFeature.isLaunchedROW().setRawStoredState(State(remoteEnableState = value))
     }
 
     @SuppressLint("DenyListedApi")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213990975007400?focus=true 

### Description
Removes launch ROW FF

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which subscription base plans are considered eligible, which could surface ROW offers in environments that previously relied on the flag for rollout control.
> 
> **Overview**
> Removes the `privacyPro.isLaunchedROW` remote toggle and all related gating logic.
> 
> `SubscriptionsManager.activePlanIds()` now always includes ROW base plan IDs (alongside US plans), and the related unit tests are updated by deleting the flag setup/helper and the “flag disabled returns empty” test case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dbb3af95adac1826e62baddbf31eecd3cfa102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->