### PR TITLE
Removes featuresApi FF from subscriptions

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -196,10 +196,6 @@ interface SubscriptionsFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun authApiV2(): Toggle
 
-    // Kill switch
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun featuresApi(): Toggle
-
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun privacyProFreeTrial(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.subscriptions.impl
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ADVANCED_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BASIC_SUBSCRIPTION
@@ -31,7 +30,6 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
@@ -45,24 +43,17 @@ class SubscriptionFeaturesFetcher @Inject constructor(
     private val subscriptionsCachedService: SubscriptionsCachedService,
     private val authRepository: AuthRepository,
     private val subscriptionsFeature: SubscriptionsFeature,
-    private val dispatcherProvider: DispatcherProvider,
 ) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         appCoroutineScope.launch {
             try {
-                if (isFeaturesApiEnabled()) {
-                    fetchSubscriptionFeatures()
-                }
+                fetchSubscriptionFeatures()
             } catch (e: Exception) {
                 logcat { "Failed to fetch subscription features" }
             }
         }
-    }
-
-    private suspend fun isFeaturesApiEnabled(): Boolean = withContext(dispatcherProvider.io()) {
-        subscriptionsFeature.featuresApi().isEnabled()
     }
 
     private suspend fun fetchSubscriptionFeatures() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -37,14 +37,9 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.impl.RealSubscriptionsManager.RecoverSubscriptionResult
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ADVANCED_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BASIC_SUBSCRIPTION
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_ITR
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_NETP
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_PIR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LIST_OF_PRO_PLANS
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.NETP
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ROW_ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.auth2.AccessTokenClaims
@@ -1102,21 +1097,9 @@ class RealSubscriptionsManager @Inject constructor(
         logcat {
             "Subs: getEntitlementsForPlan fallback to legacy features for planId: $planId"
         }
-        return getLegacyFeatures(planId).map { feature ->
+        return authRepository.getFeatures(planId).map { feature ->
             Entitlement(name = "plus", product = feature) // Temporary name placeholder until we have support multiple tiers
         }.toSet()
-    }
-
-    private suspend fun getLegacyFeatures(planId: String): Set<String> {
-        return if (subscriptionsFeature.get().featuresApi().isEnabled()) {
-            authRepository.getFeatures(planId)
-        } else {
-            when (planId) {
-                MONTHLY_PLAN_US, YEARLY_PLAN_US -> setOf(LEGACY_FE_NETP, LEGACY_FE_PIR, LEGACY_FE_ITR)
-                MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW -> setOf(NETP, ROW_ITR)
-                else -> throw IllegalStateException()
-            }
-        }
     }
 
     override suspend fun purchase(

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
@@ -55,7 +55,6 @@ class SubscriptionFeaturesFetcherTest {
         subscriptionsCachedService = subscriptionsCachedService,
         authRepository = authRepository,
         subscriptionsFeature = subscriptionsFeature,
-        dispatcherProvider = coroutineRule.testDispatcherProvider,
     )
 
     @Before
@@ -64,19 +63,7 @@ class SubscriptionFeaturesFetcherTest {
     }
 
     @Test
-    fun `when FF disabled then does not do anything`() = runTest {
-        givenIsFeaturesApiEnabled(false)
-
-        processLifecycleOwner.currentState = CREATED
-
-        verifyNoInteractions(playBillingManager)
-        verifyNoInteractions(authRepository)
-        verifyNoInteractions(subscriptionsCachedService)
-    }
-
-    @Test
     fun `when products loaded and tierMessagingEnabled OFF then fetches V1 features and stores`() = runTest {
-        givenIsFeaturesApiEnabled(true)
         givenTierMessagingEnabled(false)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
@@ -94,7 +81,6 @@ class SubscriptionFeaturesFetcherTest {
 
     @Test
     fun `when products loaded and tierMessagingEnabled ON then fetches V2 features and stores entitlements`() = runTest {
-        givenIsFeaturesApiEnabled(true)
         givenTierMessagingEnabled(true)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
@@ -131,7 +117,6 @@ class SubscriptionFeaturesFetcherTest {
 
     @Test
     fun `when there are no products then does not store anything`() = runTest {
-        givenIsFeaturesApiEnabled(true)
         whenever(playBillingManager.productsFlow).thenReturn(flowOf())
 
         processLifecycleOwner.currentState = CREATED
@@ -144,7 +129,6 @@ class SubscriptionFeaturesFetcherTest {
     @Test
     fun `when features already stored and refresh features FF Disabled then does not fetch again`() = runTest {
         givenRefreshSubscriptionPlanFeaturesEnabled(false)
-        givenIsFeaturesApiEnabled(true)
         givenTierMessagingEnabled(false)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
@@ -162,7 +146,6 @@ class SubscriptionFeaturesFetcherTest {
     @Test
     fun `when features already stored and refresh features FF enabled then does fetch again`() = runTest {
         givenRefreshSubscriptionPlanFeaturesEnabled(true)
-        givenIsFeaturesApiEnabled(true)
         givenTierMessagingEnabled(false)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
@@ -180,7 +163,6 @@ class SubscriptionFeaturesFetcherTest {
 
     @Test
     fun `when tierMessagingEnabled ON and V2 features empty then does not store anything`() = runTest {
-        givenIsFeaturesApiEnabled(true)
         givenTierMessagingEnabled(true)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
@@ -194,11 +176,6 @@ class SubscriptionFeaturesFetcherTest {
         verify(subscriptionsCachedService).featuresV2(MONTHLY_PLAN_US)
         verify(subscriptionsCachedService).featuresV2(YEARLY_PLAN_US)
         verify(authRepository, never()).setFeaturesV2(any(), any())
-    }
-
-    @SuppressLint("DenyListedApi")
-    private fun givenIsFeaturesApiEnabled(value: Boolean) {
-        subscriptionsFeature.featuresApi().setRawStoredState(State(value))
     }
 
     @SuppressLint("DenyListedApi")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213991250822384?focus=true 

### Description
Removes featuresApi killSwitch

### Steps to test this PR
QA-optional: FF is enabled by default so no expected change.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a feature-flag gate so subscription feature fetching and entitlement fallback always use the backend/API path; risk is low but could increase network calls or expose issues if the API is unavailable.
> 
> **Overview**
> Removes the `featuresApi` remote feature flag and all conditional logic that depended on it.
> 
> `SubscriptionFeaturesFetcher` now always runs on app start (no FF gate) and drops the extra dispatcher dependency. `SubscriptionsManager` also removes the legacy hardcoded feature fallback, always deriving legacy entitlements via `authRepository.getFeatures(planId)`, and tests are updated by deleting the FF-disabled coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa0c459d418d240545a2e5cb683bb39aef4b66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->