### PR TITLE
duckAI <> Subscription kill switch cleanup

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -232,9 +232,6 @@ interface SubscriptionsFeature {
     fun duckAISubscriptionMessaging(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun refreshSubscriptionPlanFeatures(): Toggle
-
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun supportsAlternateStripePaymentFlow(): Toggle
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -223,8 +223,9 @@ interface SubscriptionsFeature {
     fun authApiV2JwksCache(): Toggle
 
     /**
-     * As part of Duck.ai we are adding new supported JS messages.
-     * This is enabled by default, but can be disabled if necessary.
+     * Controls Duck.ai <> subscription JS messaging.
+     * Enabled by default.
+     * When Disabled, no subscription messaging supported.
      * FF only controls native messaging (enabled/disabled).
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -202,13 +202,9 @@ interface SubscriptionsFeature {
     /**
      * Enables/Disables duckAi for subscribers (advanced models)
      * This flag is used to hide the feature in the native client and FE.
-    /**
-     * Android supports v2 token, but still relies on old v1 subscription messaging.
-     * We are introducing new JS messaging. Use this flag as kill-switch if necessary.
-     * It doesn't control which version of messaging FE uses.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun enableNewSubscriptionMessages(): Toggle
+    fun duckAiPlus(): Toggle
 
     /**
      * When enabled, we signal FE if v2 is available, enabling v2 messaging

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -211,6 +211,7 @@ interface SubscriptionsFeature {
      * When disabled, FE works with old messaging (v1)
      * This flag will be used to select FE subscription messaging mode.
      * The value is added into GetFeatureConfig to allow FE to select the mode.
+     * Note: best to remove together with v1 clean up.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun enableSubscriptionFlowsV2(): Toggle

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -202,11 +202,6 @@ interface SubscriptionsFeature {
     /**
      * Enables/Disables duckAi for subscribers (advanced models)
      * This flag is used to hide the feature in the native client and FE.
-     * It will be used for the feature rollout and kill-switch if necessary.
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun duckAiPlus(): Toggle
-
     /**
      * Android supports v2 token, but still relies on old v1 subscription messaging.
      * We are introducing new JS messaging. Use this flag as kill-switch if necessary.

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -69,18 +69,6 @@ class SubscriptionFeaturesFetcher @Inject constructor(
             ?.flatMap { it.subscriptionOfferDetails ?: emptyList() }
             ?.map { it.basePlanId }
             ?.distinct()
-            ?.let { basePlanIds ->
-                logcat {
-                    "fetchSubscriptionFeatures: found base plan ids: $basePlanIds"
-                }
-                if (subscriptionsFeature.refreshSubscriptionPlanFeatures().isEnabled()) {
-                    basePlanIds
-                } else {
-                    basePlanIds.filter {
-                        authRepository.getFeatures(it).isEmpty()
-                    }
-                }
-            }
             ?.forEach { basePlanId ->
                 runCatching {
                     if (subscriptionsFeature.tierMessagingEnabled().isEnabled()) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -408,8 +408,6 @@ class SubscriptionMessagingInterface @Inject constructor(
         ) {
             val jsMessageId = jsMessage.id ?: return
 
-            if (subscriptionsFeature.enableNewSubscriptionMessages().isEnabled().not()) return
-
             val authV2Enabled = subscriptionsFeature.enableSubscriptionFlowsV2().isEnabled()
             val duckAiSubscriberModelsEnabled = subscriptionsFeature.duckAiPlus().isEnabled()
             val supportsAlternateStripePaymentFlow = subscriptionsFeature.supportsAlternateStripePaymentFlow().isEnabled()

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
@@ -127,41 +127,6 @@ class SubscriptionFeaturesFetcherTest {
     }
 
     @Test
-    fun `when features already stored and refresh features FF Disabled then does not fetch again`() = runTest {
-        givenRefreshSubscriptionPlanFeaturesEnabled(false)
-        givenTierMessagingEnabled(false)
-        val productDetails = mockProductDetails()
-        whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
-        whenever(authRepository.getFeatures(any())).thenReturn(setOf(NETP, ITR))
-
-        processLifecycleOwner.currentState = CREATED
-
-        verify(playBillingManager).productsFlow
-        verify(authRepository).getFeatures(MONTHLY_PLAN_US)
-        verify(authRepository).getFeatures(YEARLY_PLAN_US)
-        verify(authRepository, never()).setFeatures(any(), any())
-        verifyNoInteractions(subscriptionsCachedService)
-    }
-
-    @Test
-    fun `when features already stored and refresh features FF enabled then does fetch again`() = runTest {
-        givenRefreshSubscriptionPlanFeaturesEnabled(true)
-        givenTierMessagingEnabled(false)
-        val productDetails = mockProductDetails()
-        whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
-        whenever(authRepository.getFeatures(any())).thenReturn(setOf(NETP, ITR))
-        whenever(subscriptionsCachedService.features(any())).thenReturn(FeaturesResponse(listOf(NETP, ITR, DUCK_AI)))
-
-        processLifecycleOwner.currentState = CREATED
-
-        verify(playBillingManager).productsFlow
-        verify(subscriptionsCachedService).features(MONTHLY_PLAN_US)
-        verify(subscriptionsCachedService).features(YEARLY_PLAN_US)
-        verify(authRepository).setFeatures(MONTHLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
-        verify(authRepository).setFeatures(YEARLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
-    }
-
-    @Test
     fun `when tierMessagingEnabled ON and V2 features empty then does not store anything`() = runTest {
         givenTierMessagingEnabled(true)
         val productDetails = mockProductDetails()
@@ -176,11 +141,6 @@ class SubscriptionFeaturesFetcherTest {
         verify(subscriptionsCachedService).featuresV2(MONTHLY_PLAN_US)
         verify(subscriptionsCachedService).featuresV2(YEARLY_PLAN_US)
         verify(authRepository, never()).setFeaturesV2(any(), any())
-    }
-
-    @SuppressLint("DenyListedApi")
-    private fun givenRefreshSubscriptionPlanFeaturesEnabled(value: Boolean) {
-        subscriptionsFeature.refreshSubscriptionPlanFeatures().setRawStoredState(State(value))
     }
 
     @SuppressLint("DenyListedApi")

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
@@ -862,7 +862,6 @@ class SubscriptionMessagingInterfaceTest {
     @Test
     fun `when process and get feature config and messaging enabled then return response with feature flags`() = runTest {
         givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = true)
         givenAuthV2(enabled = true)
         givenDuckAiPlus(enabled = true)
         givenStripeSupported(enabled = true)
@@ -895,7 +894,6 @@ class SubscriptionMessagingInterfaceTest {
     @Test
     fun `when process and get feature config and messaging enabled but auth v2 disabled then return response with auth v2 false`() = runTest {
         givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = true)
         givenAuthV2(enabled = false)
         givenDuckAiPlus(enabled = true)
         givenStripeSupported(enabled = true)
@@ -930,7 +928,6 @@ class SubscriptionMessagingInterfaceTest {
     @Test
     fun `when process and get feature config and messaging enabled but duck ai plus disabled then return response with duck ai false`() = runTest {
         givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = true)
         givenAuthV2(enabled = true)
         givenDuckAiPlus(enabled = false)
         givenStripeSupported(enabled = true)
@@ -965,7 +962,6 @@ class SubscriptionMessagingInterfaceTest {
     @Test
     fun `when process and get feature config and tier options enabled then return response with tier options true`() = runTest {
         givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = true)
         givenAuthV2(enabled = true)
         givenDuckAiPlus(enabled = true)
         givenStripeSupported(enabled = true)
@@ -998,23 +994,8 @@ class SubscriptionMessagingInterfaceTest {
     }
 
     @Test
-    fun `when process and get feature config and messaging disabled then do nothing`() = runTest {
-        givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = false)
-
-        val message = """
-            {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","id":"myId","params":{}}
-        """.trimIndent()
-
-        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
-
-        verifyNoInteractions(jsMessageHelper)
-    }
-
-    @Test
     fun `when process and get feature config if no id do nothing`() = runTest {
         givenInterfaceIsRegistered()
-        givenSubscriptionMessaging(enabled = true)
 
         val message = """
             {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","params":{}}
@@ -1062,12 +1043,6 @@ class SubscriptionMessagingInterfaceTest {
 
     private suspend fun givenAccessTokenIsFailure() {
         whenever(subscriptionsManager.getAccessToken()).thenReturn(AccessTokenResult.Failure(message = "something happened"))
-    }
-
-    private fun givenSubscriptionMessaging(enabled: Boolean) {
-        val subscriptionMessagingToggle = mock<com.duckduckgo.feature.toggles.api.Toggle>()
-        whenever(subscriptionMessagingToggle.isEnabled()).thenReturn(enabled)
-        whenever(subscriptionsFeature.enableNewSubscriptionMessages()).thenReturn(subscriptionMessagingToggle)
     }
 
     private fun givenAuthV2(enabled: Boolean) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213994643611535?focus=true 

### Description
Removes 2 kill switches that have been enabled by default since release and stable.
- `refreshSubscriptionPlanFeatures`: stable, service support caching.
- `enableNewSubscriptionMessages`: stable, enables `getFeatureConfig` message, which includes values that are also gated by FF.
- `duckAiPlus` default value to True instead of Internal.

### Steps to test this PR
QA-optional: both flags have been enabled by default since released.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime feature-flag behavior by removing two kill-switches and making `getFeatureConfig` always respond, which could affect subscription web messaging and feature-fetch frequency.
> 
> **Overview**
> Removes the deprecated `refreshSubscriptionPlanFeatures` and `enableNewSubscriptionMessages` toggles and their associated branching, simplifying subscription feature fetching and `getFeatureConfig` JS messaging behavior.
> 
> Updates `duckAiPlus` to default to **enabled** and makes subscription plan features always fetched/stored per base plan (instead of optionally skipping when cached). Tests were updated by deleting coverage for the removed flags and adjusting `getFeatureConfig` expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3315568d8f883c24af09eeb3bd069df4bfb401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->