### PR TITLE
PIR: Add new email flexibility action models

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirMessagingInterface.kt
@@ -215,6 +215,20 @@ class FakePirMessagingInterface(moshi: Moshi) : JsMessaging {
                     }
                 }
             """.trimIndent()
+
+            is BrokerAction.GenerateEmail -> """
+                {
+                    "actionID": "${action.id}",
+                    "actionType": "generateEmail"
+                }
+            """.trimIndent()
+
+            is BrokerAction.GetEmailData -> """
+                {
+                    "actionID": "${action.id}",
+                    "actionType": "getEmailData"
+                }
+            """.trimIndent()
         }
 
         return JSONObject(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
@@ -151,7 +151,9 @@ class PirModule {
                     .withSubtype(BrokerAction.GetCaptchaInfo::class.java, "getCaptchaInfo")
                     .withSubtype(BrokerAction.SolveCaptcha::class.java, "solveCaptcha")
                     .withSubtype(BrokerAction.EmailConfirmation::class.java, "emailConfirmation")
-                    .withSubtype(BrokerAction.Condition::class.java, "condition"),
+                    .withSubtype(BrokerAction.Condition::class.java, "condition")
+                    .withSubtype(BrokerAction.GenerateEmail::class.java, "generateEmail")
+                    .withSubtype(BrokerAction.GetEmailData::class.java, "getEmailData"),
             ).add(
                 PolymorphicJsonAdapterFactory.of(BrokerStepActions::class.java, "stepType")
                     .withSubtype(ScanStepActions::class.java, "scan")

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -115,6 +115,16 @@ sealed class BrokerAction(
         val expectations: List<ExpectationSelector>,
         val actions: List<BrokerAction>,
     ) : BrokerAction(id)
+
+    data class GenerateEmail(
+        override val id: String,
+    ) : BrokerAction(id)
+
+    data class GetEmailData(
+        override val id: String,
+        val pollingTime: Int,
+        val extract: List<String>,
+    ) : BrokerAction(id)
 }
 
 data class ExtractProfileSelectors(
@@ -182,5 +192,7 @@ fun BrokerAction.asActionType(): String {
         is SolveCaptcha -> "solveCaptcha"
         is EmailConfirmation -> "emailConfirmation"
         is Condition -> "condition"
+        is BrokerAction.GenerateEmail -> "generateEmail"
+        is BrokerAction.GetEmailData -> "getEmailData"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -122,7 +122,7 @@ sealed class BrokerAction(
 
     data class GetEmailData(
         override val id: String,
-        val pollingTime: Int,
+        val pollingTime: String,
         val extract: List<String>,
     ) : BrokerAction(id)
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213886961787937?focus=true

### Description
Adds new models for two new broker actions needed to support email flexibility.

### Steps to test this PR
No QA needed, will be testable on later branches

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new `BrokerAction` subtypes and Moshi wiring with minor test fake updates; no core opt-out/scan logic changes.
> 
> **Overview**
> Adds two new PIR broker action models, `BrokerAction.GenerateEmail` and `BrokerAction.GetEmailData` (including `pollingTime` and `extract` fields), and updates `asActionType()` to emit the new action type strings.
> 
> Updates PIR’s Moshi polymorphic adapter configuration in `PirModule` to deserialize these new `actionType` values, and extends `FakePirMessagingInterface` to return success responses for them in integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb4a04b1c6c29debde2fb867f373af853deb6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->