### PR TITLE
DuckAi/Voice chat: Fix entry point for bottom bar

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -473,10 +473,6 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 binding.viewPager.setCurrentItem(1, animate)
                 viewModel.onChatSelected()
                 viewModel.onChatInputTextChanged(inputModeWidget.text)
-                if (!useTopBar) {
-                    inputScreenButtons.setSendButtonVisible(true)
-                    inputModeWidget.setInputScreenButtonsVisible(true)
-                }
             }
             onSubmitMessageAvailable = { isAvailable ->
                 viewModel.onSubmitMessageAvailableChange(isAvailable)
@@ -489,11 +485,6 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             }
             onChatTextChanged = { text ->
                 viewModel.onChatInputTextChanged(text)
-                if (!useTopBar) {
-                    val isOnChatTab = inputModeWidget.isChatTabSelected() || !viewModel.visibilityState.value.searchMode
-                    inputScreenButtons.setSendButtonVisible(isOnChatTab)
-                    inputModeWidget.setInputScreenButtonsVisible(isOnChatTab)
-                }
             }
             onInputFieldClicked = {
                 viewModel.onInputFieldTouched()
@@ -620,8 +611,8 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 } else {
                     val inputText = inputModeWidget.text
                     if (inputText.isEmpty()) {
-                        inputModeWidget.setVoiceButtonVisible(it.voiceSearchButtonVisible || it.voiceChatButtonVisible)
-                        inputScreenButtons.setVoiceChatVisible(false)
+                        inputModeWidget.setVoiceButtonVisible(it.voiceSearchButtonVisible)
+                        inputScreenButtons.setVoiceChatVisible(it.voiceChatButtonVisible)
                         inputScreenButtons.setVoiceSearchVisible(false)
                     } else {
                         inputScreenButtons.setVoiceChatVisible(it.voiceChatButtonVisible)
@@ -804,8 +795,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             inputScreenButtons.setSendButtonVisible(state.submitButtonVisible)
         } else {
             val isOnChatTab = inputModeWidget.isChatTabSelected() || !state.searchMode
-            inputScreenButtons.setSendButtonVisible(isOnChatTab)
-            inputModeWidget.setInputScreenButtonsVisible(isOnChatTab)
+            inputScreenButtons.setSendButtonVisible(isOnChatTab && state.submitButtonVisible)
         }
         inputModeWidget.setMainButtonsVisible(state.mainButtonsVisible)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -70,8 +70,7 @@ class InputScreenButtons @JvmOverloads constructor(
             // when used in top bar we want to transform the buttons to floating
             transformButtonsToFloating()
         } else {
-            // when in bottom bar mode, the voice icon is shown in the input field
-            binding.actionVoiceChat.gone()
+            // when in bottom bar mode, the voice search icon is shown in the input field
             binding.actionVoiceSearch.gone()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/492600419927320/task/1213980797394368?focus=true 

### Description
This PR switches to use the InputScreenButtons instead of InputModeWidget for the voice chat entry.
I also removed some updates to `setSendButtonVisible` which controls the send icon and have it updated via `updateButtonVisibility` only.

### Steps to test this PR

_Preconditions_
- [ ] Ensure that Setting for `Duck.ai` is ENABLED and `Search & Duck.ai` is ENABLED.
- [ ] FF: Ensure that `nativeInputField` is `DISABLED`.
- [ ] Set Appreance to use Bottom Bar

_Voice search and DuckAi voice chat entry enabled - Top and Bottom bar_
- [ ] FF: Enable `duckAiVoiceEntryPoint`
- [ ] Enable Private Voice Search (Settings > Enable Private Voice Search)
- [ ] Open new tab and click on address bar 
- [ ] Verify Microphone icon is shown and clicking on it opens voice search
- [ ] Click on Duck.ai
- [ ] Verify that Updated icon is shown and clicking on it opens voice chat 

_Voice search disabled and DuckAi voice chat entry enabled_
- [ ] FF: Enable `duckAiVoiceEntryPoint`
- [ ] Disable Private Voice Search (Settings > Enable Private Voice Search)
- [ ] Open new tab and click on address bar 
- [ ] Verify no microphone icon shown
- [ ] Click on Duck.ai
- [ ] Verify that Updated icon is shown and clicking on it opens voice chat

_Voice search enabled and DuckAi voice chat entry disabled_
- [ ] FF: Disable `duckAiVoiceEntryPoint`
- [ ] Enable Private Voice Search (Settings > Enable Private Voice Search)
- [ ] Open new tab and click on address bar 
- [ ] Verify Microphone icon is shown and clicking on it opens voice search
- [ ] Click on Duck.ai
- [ ] Verify Microphone icon is shown and clicking on it opens voice search

_Voice search and DuckAi voice chat entry disabled_
- [ ] FF: Disable `duckAiVoiceEntryPoint`
- [ ] Disable Private Voice Search (Settings > Enable Private Voice Search)
- [ ] Open new tab and click on address bar 
- [ ] Verify Microphone icon is NOT shown
- [ ] Click on Duck.ai
- [ ] Verify Microphone icon  or Updated icon is NOT shown

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="388" height="505" alt="before-bottombar" src="https://github.com/user-attachments/assets/73c23112-79f4-4777-b805-8643cc7966d2" /> | <img width="347" height="455" alt="after-bottombar" src="https://github.com/user-attachments/assets/6434b49b-8b69-4223-a267-1987f4d2f296" /> |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bottom-bar voice button routing and visibility logic for voice search/voice chat, which could regress when/where mic icons appear or which launcher opens. Scope is limited to input-screen UI behavior.
> 
> **Overview**
> Fixes the *bottom bar* voice entry behavior by routing voice chat visibility through `InputScreenButtons` while keeping the in-field mic icon reserved for voice search.
> 
> Simplifies UI state updates by removing ad-hoc `setSendButtonVisible`/`setInputScreenButtonsVisible` toggles during tab/text changes and instead gating the send button in bottom-bar mode via `updateButtonVisibility` (only shown on chat tab *and* when `submitButtonVisible` is true).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3629ad7730888dd49c28046a45ad30c326953d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->