### PR TITLE
Fix return hatch favicon showing incorrect site after navigating back to NTP

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManagerTest.kt
@@ -35,6 +35,8 @@ import com.duckduckgo.common.utils.faviconLocation
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -43,6 +45,7 @@ import org.junit.Test
 import org.mockito.kotlin.*
 import java.io.File
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class DuckDuckGoFaviconManagerTest {
 
     @get:Rule
@@ -217,6 +220,41 @@ class DuckDuckGoFaviconManagerTest {
         testee.loadToViewFromLocalWithPlaceholder(tabId = null, url = url, view = view)
 
         verify(mockFaviconDownloader).getFaviconFromDisk(mockFile)
+    }
+
+    @Test
+    @UiThreadTest
+    fun whenLoadToViewFromLocalWithCancellableRetryCalledThenFaviconLoadedFromDisk() = runTest {
+        givenFaviconExistsInDirectory(FAVICON_PERSISTED_DIR)
+        whenever(mockFaviconDownloader.getFaviconFromDisk(mockFile)).thenReturn(asBitmap())
+        val url = "https://example.com"
+        val view = ImageView(context)
+
+        testee.loadToViewFromLocalWithRetry(tabId = null, url = url, view = view)
+
+        verify(mockFaviconDownloader).getFaviconFromDisk(mockFile)
+    }
+
+    @Test
+    @UiThreadTest
+    fun whenLoadToViewFromLocalWithCancellableRetryCancelledThenRetriesStop() = runTest {
+        val url = "https://example.com"
+        val view = ImageView(context)
+
+        val job = launch {
+            testee.loadToViewFromLocalWithRetry(tabId = null, url = url, view = view)
+        }
+
+        // Let initial load + first retry complete
+        advanceTimeBy(2100)
+        job.cancel()
+
+        // Advance past all remaining retry delays
+        advanceTimeBy(10000)
+
+        // Each loadFromDisk call with tabId=null makes 1 call to faviconFile(PERSISTED_DIR, ...)
+        // Initial + 1 completed retry = 2 calls. Without cancellation would be 4 (1 initial + 3 retries).
+        verify(mockFaviconPersister, atMost(2)).faviconFile(eq(FAVICON_PERSISTED_DIR), any(), any())
     }
 
     private fun asBitmap(): Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.RGB_565)

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
@@ -194,6 +194,21 @@ class DuckDuckGoFaviconManager constructor(
         }
     }
 
+    override suspend fun loadToViewFromLocalWithRetry(tabId: String?, url: String, view: ImageView, placeholder: String?) {
+        var bitmap = loadFromDisk(tabId, url)
+        view.loadFavicon(bitmap, url, placeholder)
+
+        repeat(FAVICON_LOAD_RETRIES) {
+            if (bitmap == null) {
+                delay(FAVICON_LOAD_RETRY_DELAY)
+                bitmap = loadFromDisk(tabId, url)
+                if (bitmap != null) {
+                    view.loadFavicon(bitmap, url, placeholder)
+                }
+            }
+        }
+    }
+
     override suspend fun persistCachedFavicon(
         tabId: String,
         url: String,

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -238,19 +238,15 @@ abstract class TabsDao {
 
     @Query(
         "select * from tabs where deletable is 0 and lastAccessTime is not null" +
-            " and url is not null and title is not null" +
-            " and tabId not in (select tabId from tab_selection where tabId is not null)" +
-            " order by lastAccessTime desc limit 1",
+            " and url is not null and title is not null order by lastAccessTime desc limit 1",
     )
-    abstract fun lastAccessedNonSelectedTab(): TabEntity?
+    abstract fun lastAccessedTab(): TabEntity?
 
     @Query(
         "select * from tabs where deletable is 0 and lastAccessTime is not null" +
-            " and url is not null and title is not null" +
-            " and tabId not in (select tabId from tab_selection where tabId is not null)" +
-            " order by lastAccessTime desc limit 1",
+            " and url is not null and title is not null order by lastAccessTime desc limit 1",
     )
-    abstract fun flowLastAccessedNonSelectedTab(): Flow<TabEntity?>
+    abstract fun flowLastAccessedTab(): Flow<TabEntity?>
 
     @Query("update tabs set lastAccessTime=:lastAccessTime where tabId=:tabId")
     abstract fun updateTabLastAccess(

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -447,10 +447,10 @@ class TabDataRepository @Inject constructor(
     override suspend fun getSelectedTab(): TabEntity? =
         withContext(dispatchers.io()) { tabsDao.selectedTab() }
 
-    override suspend fun getLastAccessedNonSelectedTab(): TabEntity? =
-        withContext(dispatchers.io()) { tabsDao.lastAccessedNonSelectedTab() }
+    override suspend fun getLastAccessedTab(): TabEntity? =
+        withContext(dispatchers.io()) { tabsDao.lastAccessedTab() }
 
-    override val flowLastAccessedNonSelectedTab: Flow<TabEntity?> = tabsDao.flowLastAccessedNonSelectedTab()
+    override val flowLastAccessedTab: Flow<TabEntity?> = tabsDao.flowLastAccessedTab()
         .distinctUntilChanged()
 
     override suspend fun select(tabId: String) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -899,11 +899,11 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             return selectedTab
         }
 
-        override suspend fun getLastAccessedNonSelectedTab(): TabEntity? {
+        override suspend fun getLastAccessedTab(): TabEntity? {
             TODO("Not yet implemented")
         }
 
-        override val flowLastAccessedNonSelectedTab: Flow<TabEntity?>
+        override val flowLastAccessedTab: Flow<TabEntity?>
             get() = TODO("Not yet implemented")
 
         override fun updateTabPreviewImage(

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/favicon/FaviconManager.kt
@@ -47,7 +47,24 @@ interface FaviconManager {
         placeholder: String? = null,
     )
 
+    @Deprecated("Use loadToViewFromLocalWithRetry instead, which supports cancellation of pending retries")
     suspend fun loadToViewFromLocalWithPlaceholder(
+        tabId: String? = null,
+        url: String,
+        view: ImageView,
+        placeholder: String? = null,
+    )
+
+    /**
+     * Loads a favicon from local disk into the given [ImageView], retrying up to 3 times with a delay if the
+     * favicon is not yet cached. Cancelling the coroutine cancels pending retries immediately.
+     *
+     * @param tabId the tab ID to look up the favicon for, or null to skip the temp directory lookup
+     * @param url the URL whose domain is used to locate the cached favicon
+     * @param view the [ImageView] to load the favicon into
+     * @param placeholder optional text used to generate a placeholder drawable if the favicon is not found
+     */
+    suspend fun loadToViewFromLocalWithRetry(
         tabId: String? = null,
         url: String,
         view: ImageView,

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -105,9 +105,9 @@ interface TabRepository {
 
     suspend fun getSelectedTab(): TabEntity?
 
-    suspend fun getLastAccessedNonSelectedTab(): TabEntity?
+    suspend fun getLastAccessedTab(): TabEntity?
 
-    val flowLastAccessedNonSelectedTab: Flow<TabEntity?>
+    val flowLastAccessedTab: Flow<TabEntity?>
 
     suspend fun select(tabId: String)
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -63,6 +63,7 @@ class NewTabReturnHatchView @JvmOverloads constructor(
     private val binding: ViewNewTabHatchBinding by viewBinding()
 
     private val conflatedJob = ConflatedJob()
+    private val faviconJob = ConflatedJob()
 
     private var hatchHatchListener: HatchListener? = null
 
@@ -86,12 +87,14 @@ class NewTabReturnHatchView @JvmOverloads constructor(
 
         findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         conflatedJob.cancel()
+        faviconJob.cancel()
     }
 
     val tabId: String
         get() = viewModel.viewState.value.tabId
 
     fun render(state: NewTabReturnHatchViewModel.ViewState) {
+        faviconJob.cancel()
         if (state.shouldShow) {
             binding.returnHatchSiteTitle.text = state.titleOrPlaceholder()
             if (state.isDuckChat) {
@@ -99,8 +102,8 @@ class NewTabReturnHatchView @JvmOverloads constructor(
                 binding.returnHatchFavicon.setImageResource(CommonR.drawable.ic_duckai)
             } else {
                 binding.returnHatchSiteURL.text = state.url.extractDomain()
-                viewModel.viewModelScope.launch {
-                    faviconManager.loadToViewFromLocalWithPlaceholder(state.tabId, state.url, binding.returnHatchFavicon)
+                faviconJob += viewModel.viewModelScope.launch {
+                    faviconManager.loadToViewFromLocalWithRetry(state.tabId, state.url, binding.returnHatchFavicon)
                 }
             }
             binding.returnHatchRoot.show()

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -53,7 +53,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
         val isSerp: Boolean = false,
     )
 
-    val viewState = tabRepository.flowLastAccessedNonSelectedTab
+    val viewState = tabRepository.flowLastAccessedTab
         .map { lastTab ->
             if (lastTab != null) {
                 val url = lastTab.url.orEmpty()

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -52,7 +52,7 @@ class NewTabReturnHatchViewModelTest {
 
     @Before
     fun setup() {
-        whenever(mockTabRepository.flowLastAccessedNonSelectedTab).thenReturn(lastAccessedTabFlow)
+        whenever(mockTabRepository.flowLastAccessedTab).thenReturn(lastAccessedTabFlow)
 
         testee = NewTabReturnHatchViewModel(
             tabRepository = mockTabRepository,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213988415500467?focus=true

### Description

This PR has 2 commits. I recommend reviewing them separately.

Commit #1: revert the fix made in https://github.com/duckduckgo/Android/pull/8224. It introduced an undesirable side effect when tapping the hatch to navigate away. The older tab flashes quickly before navigation
Commit #2: Fixing the actual root cause for the Hatch logo incorrectly loading the wrong image after quick back navigation.

### Details on the fix (In commit #2):

The return hatch's favicon load uses a retry mechanism that launches fire-and-forget coroutines on the view's lifecycleScope. When the hatch re-renders with a different tab's data, the stale retries keep running and overwrite the ImageView with the old favicon. 
Even if we cancel the favicon coroutine, it does not cancel the retries if they are launched as separate coroutines. So the existing load method cannot be used. 
1. Added a method to the FavIconManager that does the same thing with the retry but they are canceleable 
2. Canceled the favicon load when new loads are triggered or when the coroutine is detached. 

### Steps to test this PR
- Open a tab and navigate to a site (e.g., wikipedia.org), let it fully load
- Open a new tab
- Navigate to a tracker-heavy site ideally new site where the fav icon is not cached yet (I had good success with nba.com)
- Press back quickly while the page is still loading
- Observe the return hatch on the new tab page.
- If done a the right timing the escape hatch will incorrectly show the NBA logo instead of wikipedia.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes favicon loading to a new cancellable retry path and alters the "last accessed tab" query to include selected tabs, which can affect NTP return-hatch behavior and any callers relying on the previous non-selected semantics.
> 
> **Overview**
> Fixes the New Tab Page return hatch showing a stale/incorrect favicon by introducing `FaviconManager.loadToViewFromLocalWithRetry`, where all retries run in the calling coroutine and are cancelled when the job is cancelled (the old `loadToViewFromLocalWithPlaceholder` is now deprecated).
> 
> Updates `NewTabReturnHatchView` to cancel any in-flight favicon load on re-render/detach and to use the new retry API. Separately, renames and changes tab-access APIs from *last accessed non-selected tab* to `lastAccessedTab`/`flowLastAccessedTab` (and updates tests) by removing the exclusion of currently selected tabs in the Room query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b529e835bcb5b4bee8871c11a98ab1dc173e7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->