### PR TITLE
Add translation for the "New tab toggle position" in the settings

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -17,10 +17,6 @@
 <resources>
     <string name="duckAiNativeInputFieldTitle">Native Input Field</string>
     <string name="duckAiNativeInputFieldMessage">Use the native input field for Duck.ai</string>
-    <string name="duckAiDefaultTogglePositionTitle">New tab toggle position</string>
-    <string name="duckAiDefaultTogglePositionSearch">Search</string>
-    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
-    <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
     <string name="input_screen_user_pref_without_ai_updated">Search only</string>
     <string name="input_screen_user_pref_with_ai_updated">Toggle between\nSearch and Duck.ai</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -47,6 +47,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai Shortcuts</string>
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New tab toggle position</string>
+    <string name="duckAiDefaultTogglePositionSearch">Search</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Voice Search</string>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213800808542018?focus=true 

### Description

Add translation for the "New tab toggle position" setting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: resource-only changes that just relocate/add string entries and translator instructions, with no functional logic changes.
> 
> **Overview**
> Enables translation for the **“New tab toggle position”** setting by moving its title/options strings (`duckAiDefaultTogglePosition*`) from `donottranslate.xml` into `strings-duckchat.xml`.
> 
> Adds a Smartling `instruction` on `duckAiDefaultTogglePositionTitle` to clarify that *“Toggle”* refers to the Search/Duck.ai tab switcher UI component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b910f44e12a7ca96fe695655e5f8235f31ff27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->