### PR TITLE
Copy translations for contextual fire

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Отмени</string>
     <string name="search">Търсене</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Чатът е изтрит</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Посетете Настройки, за да търсите и сърфирате с DuckDuckGo всеки път.</string>
     <string name="onboardingDefaultBrowserTitle">Направете DuckDuckGo Вашият браузър по подразбиране</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Zrušit</string>
     <string name="search">Vyhledávání</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat smazán</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Přejděte do Nastavení a vždy vyhledávejte a prohlížejte s DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Nastavte si DuckDuckGo jako výchozí</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Annullér</string>
     <string name="search">Søg</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat slettet</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Besøg Indstillinger for at søge og surfe med DuckDuckGo hver gang.</string>
     <string name="onboardingDefaultBrowserTitle">Gør DuckDuckGo til din standard</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Abbrechen</string>
     <string name="search">Suche</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat gelöscht</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Navigiere zu den Einstellungen, damit du in Zukunft immer mit DuckDuckGo suchen und browsen kannst.</string>
     <string name="onboardingDefaultBrowserTitle">DuckDuckGo als Standard-Browser einstellen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Ακύρωση</string>
     <string name="search">Αναζήτηση</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Η συνομιλία διαγράφηκε</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Επισκεφθείτε τις Ρυθμίσεις για να εκτελείτε κάθε φορά αναζήτηση και περιήγηση με το DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Κάντε το DuckDuckGo το δικό σας προεπιλεγμένο πρόγραμμα περιήγησης</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Cancelar</string>
     <string name="search">Buscar</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat eliminado</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Accede a Ajustes para realizar búsquedas y navegar con DuckDuckGo siempre.</string>
     <string name="onboardingDefaultBrowserTitle">Establece DuckDuckGo como tu navegador predeterminado</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Tühista</string>
     <string name="search">Otsing</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Vestlus kustutatud</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Avage sätted, et DuckDuckGo abil iga kord otsida ja sirvida.</string>
     <string name="onboardingDefaultBrowserTitle">Muuda DuckDuckGo oma vaikimisi brauseriks</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Peruuta</string>
     <string name="search">Hae</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Keskustelu poistettu</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Siirry asetuksiin hakeaksesi ja selaillaksesi aina DuckDuckGolla.</string>
     <string name="onboardingDefaultBrowserTitle">Tee DuckDuckGo:sta oletusarvo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Annuler</string>
     <string name="search">Rechercher</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Discussion supprimée</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Accédez systématiquement aux paramètres pour faire des recherches et naviguer avec DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Faites de DuckDuckGo votre appli par défaut</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Odustani</string>
     <string name="search">Pretraga</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Čavrljanje je izbrisano</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Posjetite Postavke kako biste svaki put pretraživali i pregledavali uz DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Postavi DuckDuckGo kao zadanu tražilicu</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Mégsem</string>
     <string name="search">Keresés</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Csevegés törölve</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">A Beállítások oldalon bármikor kereshetsz és böngészhetsz a DuckDuckGo segítségével.</string>
     <string name="onboardingDefaultBrowserTitle">Tedd a DuckDuckGót az alapértelmezett keresőoldaladdá</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Annulla</string>
     <string name="search">Ricerca</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat eliminata</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Visita la sezione Impostazioni per effettuare ricerche e navigare sempre con DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Imposta DuckDuckGo come predefinito</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Atšaukti</string>
     <string name="search">Paieška</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Pokalbis ištrintas</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Jei visada norite ieškoti ir naršyti naudojant „DuckDuckGo“, apsilankykite nustatymuose.</string>
     <string name="onboardingDefaultBrowserTitle">Nustatykite „DuckDuckGo“ savo numatytuoju puslapiu</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Atcelt</string>
     <string name="search">Meklēt</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Saruna izdzēsta</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Atver iestatījumu sadaļu, lai katru reizi meklētu un pārlūkotu ar DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Padarīt DuckDuckGo par noklusējumu</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Avbryt</string>
     <string name="search">Søk</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chatten er slettet</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Åpne innstillinger for å søke og surfe med DuckDuckGo hver gang.</string>
     <string name="onboardingDefaultBrowserTitle">Gjør DuckDuckGo til ditt standardvalg</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Annuleren</string>
     <string name="search">Zoeken</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat verwijderd</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Ga naar Instellingen om elke keer te zoeken en te browsen met DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Stel DuckDuckGo in als standaard</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Anuluj</string>
     <string name="search">Szukaj</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Usunięto czat</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Zmień ustawienia, aby zawsze wyszukiwać i przeglądać strony za pośrednictwem DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Ustaw DuckDuckGo jako domyślny</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Cancelar</string>
     <string name="search">Pesquisar</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat eliminado</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Visite as Definições para pesquisar e navegar sempre com o DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Faça do DuckDuckGo o seu predefinido</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Anulează</string>
     <string name="search">Căutare</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat șters</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Accesează „Setări” pentru a căuta și naviga cu DuckDuckGo de fiecare dată.</string>
     <string name="onboardingDefaultBrowserTitle">Fă DuckDuckGo aplicația ta implicită</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Отменить</string>
     <string name="search">Поиск</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Чат удален</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Чтобы сделать DuckDuckGo браузером по умолчанию, перейдите в «Настройки».</string>
     <string name="onboardingDefaultBrowserTitle">Сделайте DuckDuckGo браузером по умолчанию</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Zrušiť</string>
     <string name="search">Vyhľadávať</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat bol odstránený</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Na automatické vyhľadávanie a prehliadanie s DuckDuckGo navštívte Nastavenia.</string>
     <string name="onboardingDefaultBrowserTitle">Nastav DuckDuckGo ako svoju predvolenú aplikáciu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Preklic</string>
     <string name="search">Iskanje</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Klepet je izbrisan</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Vsakič obiščite Nastavitve za iskanje in brskanje z DuckDuckGo.</string>
     <string name="onboardingDefaultBrowserTitle">Nastavi aplikacijo DuckDuckGo kot privzeto</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Avbryt</string>
     <string name="search">Sökning</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chatt raderad</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Gå till Inställningar för att söka och bläddra med DuckDuckGo varje gång.</string>
     <string name="onboardingDefaultBrowserTitle">Ställ in DuckDuckGo som standard</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -27,6 +27,9 @@
     <string name="cancel">Vazgeç</string>
     <string name="search">Arama yap</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Sohbet silindi</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Her seferinde DuckDuckGo ile arama yapmak ve göz atmak için Ayarlar\'ı ziyaret edin.</string>
     <string name="onboardingDefaultBrowserTitle">DuckDuckGo\'yu varsayılan yap</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -105,7 +105,4 @@
     <string name="preOnboardingWelcomeDialogTitle">Hi there!</string>
     <string name="preOnboardingWelcomeDialogBody">Ready for a faster browser that keeps you protected?</string>
 
-    <!--Duck.ai contextual fire-->
-    <string name="duckAiChatDeletedSnackbar">Chat deleted</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="cancel">Cancel</string>
     <string name="search">Search</string>
 
+    <!--Duck.ai contextual fire-->
+    <string name="duckAiChatDeletedSnackbar">Chat deleted</string>
+
     <!-- Onboarding Activity -->
     <string name="onboardingDefaultBrowserDescription">Visit Settings to search and browse with DuckDuckGo every time.</string>
     <string name="onboardingDefaultBrowserTitle">Make DuckDuckGo your default</string>

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Автоматично изпращане на съдържанието на страницата до Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Прикачи съдържанието на страницата</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Изчистване на чата</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Изчистване на данни</string>
     <string name="duckChatBrowserMenuContentDescription">Още опции</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automaticky odesílat obsah stránky do Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Připojit obsah stránky</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Vymazat chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Vymazat data</string>
     <string name="duckChatBrowserMenuContentDescription">Další možnosti</string>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Send automatisk sideindhold til Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Vedhæft sideindhold</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Ryd chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Ryd data</string>
     <string name="duckChatBrowserMenuContentDescription">Flere muligheder</string>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Seiteninhalt automatisch an Duck.ai senden</string>
     <string name="duckAIContextualAttachPageContent">Seiteninhalt anhängen</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Chat löschen</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Daten löschen</string>
     <string name="duckChatBrowserMenuContentDescription">Weitere Optionen</string>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Αυτόματη αποστολή περιεχομένου σελίδας στο Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Επισύναψη περιεχομένου σελίδας</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Εκκαθάριση συνομιλίας</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Εκκαθάριση δεδομένων</string>
     <string name="duckChatBrowserMenuContentDescription">Περισσότερες επιλογές</string>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Envía automáticamente el contenido de la página a Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Adjuntar contenido de la página</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Borrar chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Borrar datos</string>
     <string name="duckChatBrowserMenuContentDescription">Más opciones</string>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Saada lehe sisu automaatselt Duck.ai-le</string>
     <string name="duckAIContextualAttachPageContent">Lisa lehe sisu</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Kustuta vestlus</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Kustuta andmed</string>
     <string name="duckChatBrowserMenuContentDescription">Veel valikuid</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Lähetä sivun sisältö automaattisesti Duck.ai:lle</string>
     <string name="duckAIContextualAttachPageContent">Liitä sivun sisältö</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Tyhjennä keskustelu</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Poista tiedot</string>
     <string name="duckChatBrowserMenuContentDescription">Lisää vaihtoehtoja</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Envoyer automatiquement le contenu de la page à Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Joindre le contenu de la page</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Effacer la discussion</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Effacer les données</string>
     <string name="duckChatBrowserMenuContentDescription">Plus d\'options</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automatski pošalji sadržaj stranice Duck.ai-ju</string>
     <string name="duckAIContextualAttachPageContent">Priloži sadržaj stranice</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Izbriši čavrljanje</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Obriši podatke</string>
     <string name="duckChatBrowserMenuContentDescription">Dodatne mogućnosti</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Az oldal tartalmának automatikus küldése a Duck.ai részére</string>
     <string name="duckAIContextualAttachPageContent">Oldal tartalmának csatolása</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Csevegés törlése</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Adatok törlése</string>
     <string name="duckChatBrowserMenuContentDescription">További lehetőségek</string>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Invia automaticamente il contenuto della pagina a Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Allega il contenuto della pagina</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Cancella chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Elimina dati</string>
     <string name="duckChatBrowserMenuContentDescription">Altre opzioni</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automatiškai siųsti puslapio turinį į „Duck.ai“</string>
     <string name="duckAIContextualAttachPageContent">Pridėkite puslapio turinį</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Išvalyti pokalbį</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Valyti duomenis</string>
     <string name="duckChatBrowserMenuContentDescription">Daugiau parinkčių</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automātiski nosūtīt lapas saturu uz Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Pievienot lapas saturu</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Notīrīt tērzēšanas sarunu</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Notīrīt datus</string>
     <string name="duckChatBrowserMenuContentDescription">Citas iespējas</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Send sideinnhold automatisk til Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Legg ved sideinnhold</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Fjern chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Slett data</string>
     <string name="duckChatBrowserMenuContentDescription">Flere alternativer</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Pagina-inhoud automatisch naar Duck.ai verzenden</string>
     <string name="duckAIContextualAttachPageContent">Pagina-inhoud bijvoegen</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Chat wissen</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Gegevens wissen</string>
     <string name="duckChatBrowserMenuContentDescription">Meer opties</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automatycznie wysyłaj zawartość strony do Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Dołącz zawartość strony</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Wyczyść czat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Wyczyść dane</string>
     <string name="duckChatBrowserMenuContentDescription">Więcej opcji</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Enviar automaticamente o conteúdo da página para o Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Anexar contexto da página</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Limpa a conversa</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Limpar dados</string>
     <string name="duckChatBrowserMenuContentDescription">Mais opções</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Trimite automat conținutul paginii către Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Atașează conținutul paginii</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Șterge chatul</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Ștergere date</string>
     <string name="duckChatBrowserMenuContentDescription">Mai multe opțiuni</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Автоматически отправлять содержимое страницы в Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Добавить содержимое страницы</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Стереть чат</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Сбросить данные</string>
     <string name="duckChatBrowserMenuContentDescription">Другие параметры</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automaticky odoslať obsah stránky do Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Pripoj obsah stránky</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Zmazať chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Vymazať údaje</string>
     <string name="duckChatBrowserMenuContentDescription">Ďalšie možnosti</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Vsebino strani samodejno pošljite Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Priloži vsebino strani</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Počisti klepet</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Počisti podatke</string>
     <string name="duckChatBrowserMenuContentDescription">Več možnosti</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Skicka sidinnehåll automatiskt till Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Bifoga sidans innehåll</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Rensa chatt</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Rensa data</string>
     <string name="duckChatBrowserMenuContentDescription">Fler alternativ</string>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -100,6 +100,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Sayfa içeriğini otomatik olarak Duck.ai\'a gönder</string>
     <string name="duckAIContextualAttachPageContent">Sayfa İçeriğini Ekle</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Sohbeti temizle</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Verileri Temizle</string>
     <string name="duckChatBrowserMenuContentDescription">Diğer seçenekler</string>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -28,7 +28,4 @@
     <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>
     <string name="duckAiModelPickerBasicModels" translatable="false">Basic Models</string>
     <string name="duckAiModelPickerPremiumModels" translatable="false">Advanced Models \u2014 DuckDuckGo subscription</string>
-
-    <!-- duck.ai contextual fire button -->
-    <string name="duckAIContextualFireButtonContentDescription">Clear chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -99,6 +99,9 @@
     <string name="duckAIContextualAutomaticContextMessage">Automatically send page content to Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Attach Page Content</string>
 
+    <!-- duck.ai contextual fire button -->
+    <string name="duckAIContextualFireButtonContentDescription">Clear chat</string>
+
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1214002222781858?focus=true

### Description
Translations

### Steps to test this PR

Repeat tests in https://github.com/duckduckgo/Android/pull/8149


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: resource-only changes that add/move localized strings, with no code or behavioral logic modifications.
> 
> **Overview**
> Adds localized UI strings for Duck.ai *contextual fire* actions across many locales.
> 
> Moves `duckAiChatDeletedSnackbar` and `duckAIContextualFireButtonContentDescription` out of `donottranslate.xml` into the appropriate translatable `strings.xml` / `strings-duckchat.xml` files, and populates translations so the “chat deleted” snackbar and “clear chat” content description can be localized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e8c44428d16581dfdaa4bc947d396f2f8d931a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->