### PR TITLE
Fix: Remove the instrumentation leak from the production build

### DIFF
--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation AndroidX.webkit
 
     testImplementation project(':common-test')
-    implementation project(':data-store-test')
+    testImplementation project(':data-store-test')
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing
     testImplementation AndroidX.test.ext.junit

--- a/common/common-utils/src/main/AndroidManifest.xml
+++ b/common/common-utils/src/main/AndroidManifest.xml
@@ -17,11 +17,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <instrumentation
-        android:name="androidx.test.runner.AndroidJUnitRunner"
-        android:targetPackage="com.duckduckgo.common.utils"
-        android:label="Test for common"
-        />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1213991701535555?focus=true

### Description

This PR fixes rogue instrumentation runners from the production APK, which was leaked due to misconfiguration.

### Steps to test this PR

_Verify instrumentation is gone from the build_
- [ ] Install a release build with `./gradlew installInternalRelease`
- [ ] Run `adb shell pm list instrumentation`
- [ ] Verify there is no instrumentation mentioned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Android packaging/build configuration by removing an instrumentation runner from `common-utils` and correcting a test dependency scope, which could affect test execution and what ends up in the shipped APK.
> 
> **Overview**
> Removes the `AndroidJUnitRunner` `<instrumentation>` entry from `common-utils`’s `AndroidManifest.xml` to ensure no instrumentation is packaged into production APKs.
> 
> Adjusts `anrs-impl`’s Gradle dependencies so `:data-store-test` is `testImplementation` (not `implementation`), preventing test-only code from being pulled into runtime builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c28ad4241bf85cdc72e19d2a65669c519c48a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->