### PR TITLE
Fix imports for Subscription Cta

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -153,7 +153,7 @@ class CtaViewModel @Inject constructor(
             if (cta is BrokenSitePromptDialogCta) {
                 brokenSitePrompt.ctaShown()
             }
-            if (cta is DaxBubbleCta.DaxPrivacyProCta || cta is SubscriptionPromoModalCta) {
+            if (cta is DaxBubbleCta.DaxSubscriptionCta || cta is SubscriptionPromoModalCta) {
                 subscriptionPromoCtaShownPlugins.getPlugins().forEach { it.onSubscriptionPromoCtaShown() }
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1009,8 +1009,8 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenDaxPrivacyProCtaIsShownThenSubscriptionPromoPluginsAreCalled() = runTest {
-        testee.onCtaShown(DaxBubbleCta.DaxPrivacyProCta(mockOnboardingStore, mockAppInstallStore, isFreeTrialCopy = false))
+    fun whenDaxSubscriptionCtaIsShownThenSubscriptionPromoPluginsAreCalled() = runTest {
+        testee.onCtaShown(DaxBubbleCta.DaxSubscriptionCta(mockOnboardingStore, mockAppInstallStore, isFreeTrialCopy = false))
         verify(mockSubscriptionPromoCtaShownPlugin).onSubscriptionPromoCtaShown()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213995541249192?focus=true

### Description
Update Subscription CTA classes name

### Steps to test this PR
- [ ] CI tests pass
- [ ] Subscription CTA smoke test (Optional)

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-level change: updates the `onCtaShown` type check and its unit test to use `DaxSubscriptionCta` instead of `DaxPrivacyProCta`, with no behavior changes beyond which class name triggers the callback.
> 
> **Overview**
> Updates the subscription promo tracking hook so `subscriptionPromoCtaShownPlugins` is invoked when a `DaxBubbleCta.DaxSubscriptionCta` is shown (replacing the old `DaxBubbleCta.DaxPrivacyProCta` type check).
> 
> Adjusts `CtaViewModelTest` to assert the plugin callback is fired for `DaxSubscriptionCta` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63402aa567da45b518e428592be5a066c86f022d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->