### PR TITLE
Added new subscription_promo_shown pixel param

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -83,35 +83,35 @@
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened"]
+        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
     "m_subscription_paywall_not_seen_d3_u": {
         "description": "Fired once (unique) on day 4 if the user has not yet opened the Privacy Pro paywall since install.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened"]
+        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
     "m_subscription_paywall_not_seen_d7_u": {
         "description": "Fired once (unique) on day 8 if the user has not yet opened the Privacy Pro paywall since install.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened"]
+        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
     "m_subscription_paywall_not_seen_d14_u": {
         "description": "Fired once (unique) on day 15 if the user has not yet opened the Privacy Pro paywall since install.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened"]
+        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
     "m_subscription_paywall_not_seen_d30_u": {
         "description": "Fired once (unique) on day 31 if the user has not yet opened the Privacy Pro paywall since install.",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened"]
+        "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
     "m_privacy-pro_app_subscription_active_d": {
         "description": "Fired once daily on app start for an active subscription",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -111,5 +111,10 @@
         "key": "privacy_dashboard_opened",
         "type": "boolean",
         "description": "Whether the user has ever opened the Privacy Dashboard"
+    },
+    "subscriptionPromoShown": {
+        "key": "subscription_promo_shown",
+        "type": "boolean",
+        "description": "Whether the subscription promo CTA has been shown to the user"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/PaywallMetricsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/PaywallMetricsManager.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.impl.pixels
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.dashboard.api.PrivacyDashboardOpenedPlugin
+import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.impl.store.PaywallMetricsDataStore
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -34,15 +35,25 @@ import javax.inject.Inject
     AppScope::class,
     boundType = PrivacyDashboardOpenedPlugin::class,
 )
+@ContributesMultibinding(
+    AppScope::class,
+    boundType = SubscriptionPromoCtaShownPlugin::class,
+)
 class PaywallMetricsManager @Inject constructor(
     private val paywallMetricsStore: PaywallMetricsDataStore,
-) : PrivacyDashboardOpenedPlugin {
+) : PrivacyDashboardOpenedPlugin, SubscriptionPromoCtaShownPlugin {
     val paywallEverSeen: Boolean get() = paywallMetricsStore.paywallEverSeen
 
     val privacyDashboardEverOpened: Boolean get() = paywallMetricsStore.privacyDashboardEverOpened
 
+    val subscriptionPromoShown: Boolean get() = paywallMetricsStore.subscriptionPromoShown
+
     override suspend fun onPrivacyDashboardOpened() {
         paywallMetricsStore.privacyDashboardEverOpened = true
+    }
+
+    override suspend fun onSubscriptionPromoCtaShown() {
+        paywallMetricsStore.subscriptionPromoShown = true
     }
 
     fun recordFirstPaywallSeen(): String? {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/PaywallNotSeenWorker.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/PaywallNotSeenWorker.kt
@@ -73,7 +73,8 @@ class PaywallNotSeenWorker(
 
         val returningUser = appBuildConfig.isAppReinstall()
         val privacyDashboardEverOpened = paywallMetricsManager.privacyDashboardEverOpened
-        pixelSender.reportPaywallNotSeen(dayBucket, returningUser, privacyDashboardEverOpened)
+        val subscriptionPromoShown = paywallMetricsManager.subscriptionPromoShown
+        pixelSender.reportPaywallNotSeen(dayBucket, returningUser, privacyDashboardEverOpened, subscriptionPromoShown)
         paywallMetricsManager.markNotSeenDayFired(dayBucket)
         return Result.success()
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -335,6 +335,7 @@ object SubscriptionPixelParameter {
     const val DAYS_SINCE_INSTALL = "days_since_install"
     const val RETURNING_USER = "returning_user"
     const val PRIVACY_DASHBOARD_EVER_OPENED = "privacy_dashboard_opened"
+    const val SUBSCRIPTION_PROMO_SHOWN = "subscription_promo_shown"
 }
 
 internal val PixelType.pixelNameSuffix: String

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -133,7 +133,7 @@ interface SubscriptionPixelSender {
     fun reportFreeTrialStart()
     fun reportFreeTrialVpnActivation(activationDay: String, platform: String)
     fun reportFreeTrialDuckAiPaidUsed(activationDay: String, platform: String)
-    fun reportPaywallNotSeen(dayBucket: String, returningUser: Boolean, privacyDashboardEverOpened: Boolean)
+    fun reportPaywallNotSeen(dayBucket: String, returningUser: Boolean, privacyDashboardEverOpened: Boolean, subscriptionPromoShown: Boolean)
 }
 
 @ContributesBinding(AppScope::class)
@@ -326,7 +326,12 @@ class SubscriptionPixelSenderImpl @Inject constructor(
         fire(FREE_TRIAL_DUCK_AI_PAID_USED, mapOf(ACTIVATION_DAY to activationDay, ACTIVATION_PLATFORM to platform))
     }
 
-    override fun reportPaywallNotSeen(dayBucket: String, returningUser: Boolean, privacyDashboardEverOpened: Boolean) {
+    override fun reportPaywallNotSeen(
+        dayBucket: String,
+        returningUser: Boolean,
+        privacyDashboardEverOpened: Boolean,
+        subscriptionPromoShown: Boolean,
+    ) {
         val pixel = when (dayBucket) {
             "d0" -> PAYWALL_NOT_SEEN_D0
             "d3" -> PAYWALL_NOT_SEEN_D3
@@ -340,6 +345,7 @@ class SubscriptionPixelSenderImpl @Inject constructor(
             mapOf(
                 SubscriptionPixelParameter.RETURNING_USER to returningUser.toString(),
                 SubscriptionPixelParameter.PRIVACY_DASHBOARD_EVER_OPENED to privacyDashboardEverOpened.toString(),
+                SubscriptionPixelParameter.SUBSCRIPTION_PROMO_SHOWN to subscriptionPromoShown.toString(),
             ),
         )
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/PaywallMetricsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/PaywallMetricsDataStore.kt
@@ -41,6 +41,10 @@ class PaywallMetricsDataStore @Inject constructor(
         get() = preferences.getBoolean(KEY_PRIVACY_DASHBOARD_EVER_OPENED, false)
         set(value) { preferences.edit { putBoolean(KEY_PRIVACY_DASHBOARD_EVER_OPENED, value) } }
 
+    var subscriptionPromoShown: Boolean
+        get() = preferences.getBoolean(KEY_SUBSCRIPTION_PROMO_SHOWN, false)
+        set(value) { preferences.edit { putBoolean(KEY_SUBSCRIPTION_PROMO_SHOWN, value) } }
+
     val firstInstallTimestamp: Long by lazy {
         context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime
     }
@@ -59,5 +63,6 @@ class PaywallMetricsDataStore @Inject constructor(
         const val KEY_PAYWALL_EVER_SEEN = "KEY_PAYWALL_EVER_SEEN"
         const val KEY_NOT_SEEN_FIRED_DAYS = "KEY_NOT_SEEN_FIRED_DAYS"
         const val KEY_PRIVACY_DASHBOARD_EVER_OPENED = "KEY_PRIVACY_DASHBOARD_EVER_OPENED"
+        const val KEY_SUBSCRIPTION_PROMO_SHOWN = "KEY_SUBSCRIPTION_PROMO_SHOWN"
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/PaywallNotSeenWorkerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/PaywallNotSeenWorkerTest.kt
@@ -83,7 +83,7 @@ class PaywallNotSeenWorkerTest {
         val result = buildWorker("d0").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any())
+        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any(), any())
     }
 
     @Test
@@ -99,7 +99,7 @@ class PaywallNotSeenWorkerTest {
         val result = buildWorker("d0").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any())
+        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any(), any())
     }
 
     @Test
@@ -110,7 +110,7 @@ class PaywallNotSeenWorkerTest {
         val result = buildWorker("d0").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any())
+        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any(), any())
     }
 
     @Test
@@ -122,7 +122,7 @@ class PaywallNotSeenWorkerTest {
         val result = buildWorker("d0").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any())
+        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any(), any())
     }
 
     @Test
@@ -135,7 +135,7 @@ class PaywallNotSeenWorkerTest {
         val result = buildWorker("d3").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any())
+        verify(pixelSender, never()).reportPaywallNotSeen(any(), any(), any(), any())
     }
 
     @Test
@@ -146,11 +146,12 @@ class PaywallNotSeenWorkerTest {
         whenever(paywallMetricsManager.isNotSeenDayFired("d7")).thenReturn(false)
         whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
         whenever(paywallMetricsManager.privacyDashboardEverOpened).thenReturn(false)
+        whenever(paywallMetricsManager.subscriptionPromoShown).thenReturn(false)
 
         val result = buildWorker("d7").doWork()
 
         assertEquals(Result.success(), result)
-        verify(pixelSender).reportPaywallNotSeen("d7", false, false)
+        verify(pixelSender).reportPaywallNotSeen("d7", false, false, false)
         verify(paywallMetricsManager).markNotSeenDayFired("d7")
     }
 
@@ -162,10 +163,11 @@ class PaywallNotSeenWorkerTest {
         whenever(paywallMetricsManager.isNotSeenDayFired("d0")).thenReturn(false)
         whenever(appBuildConfig.isAppReinstall()).thenReturn(true)
         whenever(paywallMetricsManager.privacyDashboardEverOpened).thenReturn(false)
+        whenever(paywallMetricsManager.subscriptionPromoShown).thenReturn(false)
 
         buildWorker("d0").doWork()
 
-        verify(pixelSender).reportPaywallNotSeen("d0", true, false)
+        verify(pixelSender).reportPaywallNotSeen("d0", true, false, false)
     }
 
     @Test
@@ -176,10 +178,11 @@ class PaywallNotSeenWorkerTest {
         whenever(paywallMetricsManager.isNotSeenDayFired("d0")).thenReturn(false)
         whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
         whenever(paywallMetricsManager.privacyDashboardEverOpened).thenReturn(false)
+        whenever(paywallMetricsManager.subscriptionPromoShown).thenReturn(false)
 
         buildWorker("d0").doWork()
 
-        verify(pixelSender).reportPaywallNotSeen("d0", false, false)
+        verify(pixelSender).reportPaywallNotSeen("d0", false, false, false)
     }
 
     @Test
@@ -190,9 +193,25 @@ class PaywallNotSeenWorkerTest {
         whenever(paywallMetricsManager.isNotSeenDayFired("d0")).thenReturn(false)
         whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
         whenever(paywallMetricsManager.privacyDashboardEverOpened).thenReturn(true)
+        whenever(paywallMetricsManager.subscriptionPromoShown).thenReturn(false)
 
         buildWorker("d0").doWork()
 
-        verify(pixelSender).reportPaywallNotSeen("d0", false, true)
+        verify(pixelSender).reportPaywallNotSeen("d0", false, true, false)
+    }
+
+    @Test
+    fun `when subscription promo was shown then subscription_promo_shown is true`() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(true)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(paywallMetricsManager.paywallEverSeen).thenReturn(false)
+        whenever(paywallMetricsManager.isNotSeenDayFired("d0")).thenReturn(false)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(paywallMetricsManager.privacyDashboardEverOpened).thenReturn(false)
+        whenever(paywallMetricsManager.subscriptionPromoShown).thenReturn(true)
+
+        buildWorker("d0").doWork()
+
+        verify(pixelSender).reportPaywallNotSeen("d0", false, false, true)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213984531261843?focus=true

### Description
Added new pixel param name `subscription_promo_shown` to `m_subscription_paywall_not_seen_dX` pixel

### Steps to test this PR
_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729
- [x] In line 129 of _PaywallNotSeenWorker.kt_, change the setInitialDelay to for example `.setInitialDelay(mapOf("d0" to 30L, "d3" to 40L, "d7" to 50L, "d14" to 60L, "d30" to 70L)[dayBucket] ?: 30L, TimeUnit.SECONDS)` so pixels are fired at 30 seconds, 40 seconds, etc.. instead waiting for days.

_Paywall Not Seen Pixels fired_
- [x] Uninstall any previous versions of staging app and do a fresh install
- [x] Verify in logcat that pixels are fired after the scheduled time of each work:
            1. `Pixel sent: 1 m_subscription_paywall_not_seen_d0_u with params: {appVersion=5.274.2, returning_user=true, privacy_dashboard_opened=false, subscription_promo_shown=false} {}`
            2. `Pixel sent: 2 m_subscription_paywall_not_seen_d3_u with params: {appVersion=5.274.2, returning_user=true, privacy_dashboard_opened=false, subscription_promo_shown=false} {}`
            3. `Pixel sent: 3 m_subscription_paywall_not_seen_d7_u with params: {appVersion=5.274.2, returning_user=true, privacy_dashboard_opened=false, subscription_promo_shown=false} {}`
            4. `Pixel sent: 4 m_subscription_paywall_not_seen_d14_u with params: {appVersion=5.274.2, returning_user=true, privacy_dashboard_opened=false, subscription_promo_shown=false} {}`
            5. `Pixel sent: 5 m_subscription_paywall_not_seen_d30_u with params: {appVersion=5.274.2, returning_user=true, privacy_dashboard_opened=false, subscription_promo_shown=false} {}`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics/pixel plumbing and a new persisted boolean flag, with no impact to subscription eligibility or purchase flows.
> 
> **Overview**
> Adds a new boolean pixel parameter, `subscription_promo_shown`, to the `m_subscription_paywall_not_seen_*` pixels and registers it in the shared pixel params dictionary.
> 
> Plumbs the new value end-to-end by persisting a `subscriptionPromoShown` flag in `PaywallMetricsDataStore`, exposing/updating it via `PaywallMetricsManager` (now also a `SubscriptionPromoCtaShownPlugin`), and including it when `PaywallNotSeenWorker` fires `reportPaywallNotSeen`; updates the sender interface/implementation and worker tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa5feb31a4d8855f6e74186ea0fcd3c0ff1ddf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->