### PR TITLE
Fix: Maestro tests involving the fire dialog

### DIFF
--- a/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-10"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-11"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-12"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-13"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-14"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-1"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-2"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-3"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-4"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-5"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-7"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-8"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
@@ -14,8 +14,7 @@ tags:
       - pressKey: Enter
 
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn:
-          text: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertVisible:
           id: "ad-id-9"
       - tapOn:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -23,8 +23,8 @@ tags:
       - assertVisible:
             text: ".*browsing activity with the fire button.*"
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn: "Cancel"
+      - runFlow: ../shared/browser_screen/dismiss_fire_dialog.yaml
       - assertNotVisible: ".*browsing activity with the Fire Button.*"
       - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-      - tapOn: "Delete Tabs and Data"
+      - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
       - assertVisible: "You've got this!.*"

--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -56,7 +56,7 @@ tags:
                 id: "omnibarTextInput"
             - action: back
             - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
-            - tapOn: "Delete Tabs and Data"
+            - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
             - tapOn:
                 id: "omnibarTextInput"
             - pasteText

--- a/.maestro/shared/browser_screen/confirm_fire_dialog.yaml
+++ b/.maestro/shared/browser_screen/confirm_fire_dialog.yaml
@@ -1,0 +1,14 @@
+appId: com.duckduckgo.mobile.android
+---
+# Confirms clearing all data in the fire dialog.
+# Handles both the legacy dialog (Delete Tabs and Data) and the single-tab dialog (Delete All).
+- runFlow:
+    when:
+        visible: "Delete Tabs and Data"
+    commands:
+        - tapOn: "Delete Tabs and Data"
+- runFlow:
+    when:
+        visible: "Delete All"
+    commands:
+        - tapOn: "Delete All"

--- a/.maestro/shared/browser_screen/dismiss_fire_dialog.yaml
+++ b/.maestro/shared/browser_screen/dismiss_fire_dialog.yaml
@@ -1,0 +1,14 @@
+appId: com.duckduckgo.mobile.android
+---
+# Dismisses the fire dialog without clearing data.
+# Handles both the legacy dialog (Cancel button) and the single-tab dialog (no Cancel button).
+- runFlow:
+    when:
+      notVisible: "Cancel"
+    commands:
+      - pressKey: back
+- runFlow:
+    when:
+        visible: "Cancel"
+    commands:
+        - tapOn: "Cancel"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214050539043885?focus=true

### Description

Updates all tests that need to confirm the data clearing or cancel the fire dialog after the single tab fire dialog rollout.

### Steps to test this PR

- [ ] Verify all [E2E tests](https://github.com/duckduckgo/Android/actions/runs/24288604849) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Maestro E2E test flows, adding reusable helpers to dismiss/confirm the fire dialog across UI variants; no production app logic is modified.
> 
> **Overview**
> Updates Maestro E2E tests to handle both legacy and single-tab versions of the Fire dialog.
> 
> Replaces hardcoded `tapOn: Cancel` / `tapOn: Delete Tabs and Data` steps in multiple ad-click and privacy/onboarding flows with new shared helpers: `dismiss_fire_dialog.yaml` (cancel via *Cancel* or Android back) and `confirm_fire_dialog.yaml` (confirm via *Delete Tabs and Data* or *Delete All*).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76abd92060f8184c4a6e0cca956eca7fe1319ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->