### PR TITLE
Update content scope scripts to version 14.0.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -380,6 +380,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -503,6 +506,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -535,10 +541,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1886,6 +1886,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -2009,6 +2012,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -2041,10 +2047,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1886,6 +1886,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -2009,6 +2012,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -2041,10 +2047,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -852,6 +852,7 @@
     importKey: () => importKey,
     objectDefineProperty: () => objectDefineProperty,
     objectEntries: () => objectEntries,
+    objectFromEntries: () => objectFromEntries,
     objectKeys: () => objectKeys,
     randomUUID: () => randomUUID,
     removeEventListener: () => removeEventListener,
@@ -867,6 +868,7 @@
   var toString = Object.prototype.toString;
   var objectKeys = Object.keys;
   var objectEntries = Object.entries;
+  var objectFromEntries = Object.fromEntries;
   var objectDefineProperty = Object.defineProperty;
   var URL2 = globalThis.URL;
   var Proxy2 = globalThis.Proxy;
@@ -1235,6 +1237,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -1358,6 +1363,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -1390,10 +1398,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -362,6 +362,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -485,6 +488,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -517,10 +523,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -362,6 +362,9 @@
       return false;
     }
     const domainParts = topLevelHostname.split(".");
+    if (domainParts.length === 1) {
+      return featureList.some((entry) => entry.domain === topLevelHostname);
+    }
     while (domainParts.length > 1 && !unprotectedDomain) {
       const partialDomain = domainParts.join(".");
       unprotectedDomain = featureList.filter((domain) => domain.domain === partialDomain).length > 0;
@@ -485,6 +488,9 @@
           return false;
         }
       }
+      if (isSelfGatingFeature(featureName)) {
+        return isStateEnabled(feature.state, platform);
+      }
       return isStateEnabled(feature.state, platform) && !isUnprotectedDomain(topLevelHostname, feature.exceptions);
     }).concat(platformSpecificFeaturesNotInRemoteConfig);
     return enabledFeatures;
@@ -517,10 +523,19 @@
     "webDetection",
     "webEvents",
     "pageObserver",
-    "hover"
+    "hover",
+    "trackerProtection"
+    // only enabled on apple platforms
   ];
+  var selfGatingFeatures = ["trackerProtection"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(
+      /** @type {import('./features.js').FeatureName} */
+      featureName
+    );
+  }
+  function isSelfGatingFeature(featureName) {
+    return selfGatingFeatures.includes(
       /** @type {import('./features.js').FeatureName} */
       featureName
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.67.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.41.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.0.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.69.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.69.0.tgz",
-      "integrity": "sha512-0UqpTmcYOeBgQ0SXgbTiROgKofxXZktWsjU8RywBoQV7UUtVdKGOVK+Nn/LByDemTiZs/2N/XpzENcU5bh+OJg==",
+      "version": "14.70.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.70.0.tgz",
+      "integrity": "sha512-2KhHxyI39IGtHVTV4YAjZBHF2+tJcYKA5c/PSYpoyRufl+jUYfKfI5FC3l0Z9SAEg3JlEtAAUARLhVpTYuGZRQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#454f3131bbbdc19a4bf5bc1c2aabf1725cc9f5fc",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5c616fb4064c32fb1e5f7de96916ca9b89646f75",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -349,6 +349,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
@@ -516,12 +526,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.67.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#13.41.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.0.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214025343862710?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [ ] Privacy tests do not need to run