### PR TITLE
Update PIR broker bundle - 2026-04-13

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/anywho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/anywho.com.json
@@ -1,7 +1,7 @@
 {
   "name": "AnyWho",
   "url": "anywho.com",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "parent": "spokeo.com",
   "addedDatetime": 1768780800000,
   "optOutUrl": "https://www.spokeo.com/optout",
@@ -12,8 +12,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "id": "a1b2c3d4-e5f6-4789-0123-456789abcdef",
-          "url": "https://www.anywho.com/people/${firstName}+${lastName}/${state|stateFull|downcase}/${city|downcase}?age_range=${age|ageRange}",
+          "id": "8b4204c1-f03d-4f6d-9496-661a42040f0b",
+          "url": "https://www.anywho.com/people/${firstName}+${lastName}/${state|stateFull|downcase|hyphenated}/${city|downcase|hyphenated}?age_range=${age|ageRange}",
           "ageRange": [
             "0-30",
             "31-60",
@@ -23,7 +23,7 @@
         },
         {
           "actionType": "expectation",
-          "id": "e5f6a7b8-c9d0-4123-4567-890123abcdef",
+          "id": "f20c61f2-f15d-4f6d-a370-5a95cd57daf6",
           "expectations": [
             {
               "type": "element",
@@ -33,7 +33,7 @@
         },
         {
           "actionType": "extract",
-          "id": "f6a7b8c9-d0e1-4234-5678-901234abcdef",
+          "id": "f47e9339-5796-40cf-ac64-3cf38d582f85",
           "selector": "#name-search-results > div.bg-white",
           "noResultsSelector": "//h1[contains(text(), \"Sorry, we couldn't find results\")]",
           "profile": {
@@ -48,12 +48,14 @@
               "selector": ".//h3[contains(text(), 'AKA')]/following-sibling::div[not(contains(@class, 'h-px'))]",
               "findElements": true
             },
-            "addressFull": {
-              "selector": ".//h3[contains(text(), 'Lives in')]/following-sibling::div[@class='text-body-md'][1]"
+            "addressCityState": {
+              "selector": ".//h3[contains(text(), 'Lives in')]/following-sibling::div[@class='text-body-md'][1]",
+              "separator": "/(?:(?:St|Ave|Blvd|Ln|Dr|Rd|Ct|Pl|Way|Pkwy|Hwy|Ter|Trl|Cir|Run)\\b|(?:Ste|Suite|Apt|Apartment|Unit|#|Bldg|Building)\\s*[^,]*)\\s*,\\s*|[•·|\\n]/"
             },
-            "addressFullList": {
+            "addressCityStateList": {
               "selector": ".//h3[contains(text(), 'Used to live in')]/following-sibling::div[@class='text-body-md']",
-              "findElements": true
+              "findElements": true,
+              "separator": "/(?:(?:St|Ave|Blvd|Ln|Dr|Rd|Ct|Pl|Way|Pkwy|Hwy|Ter|Trl|Cir|Run)\\b|(?:Ste|Suite|Apt|Apartment|Unit|#|Bldg|Building)\\s*[^,]*)\\s*,\\s*|[•·|\\n]/"
             },
             "relativesList": {
               "selector": ".//h3[contains(text(), 'May be related to')]/following-sibling::div[@class='text-body-md']/a",
@@ -62,7 +64,7 @@
             "profileUrl": {
               "selector": "a[href*='/people/']",
               "identifierType": "path",
-              "identifier": "https://www.anywho.com/people/${firstName}+${lastName}/${state|downcase}/${city|downcase}/${id}"
+              "identifier": "https://www.anywho.com/people/${firstName}+${lastName}/${state|downcase|hyphenated}/${city|downcase|hyphenated}/${id}"
             }
           }
         }

--- a/pir/pir-impl/src/main/assets/brokers/courtrec.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/courtrec.com.json
@@ -1,0 +1,150 @@
+{
+  "name": "CourtRec",
+  "url": "courtrec.com",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.courtrec.com/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "228c9575-c719-4586-94de-259ee950bab2",
+          "url": "https://www.courtrec.com/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "175fc808-0308-457d-875b-69118ed7e60e"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "db22d4ff-e40f-49ba-bfb8-a1b8ff5ab701"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "5a229e1d-e84d-4005-88a4-d88dca619018"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "4e8c5bda-3d7f-4164-ac9f-318036ee0fc9"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "f1a05523-08e8-4094-a4d6-c30f972ae7cb"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "838f280a-1a12-4bfc-afea-3243171a566c"
+            }
+          ],
+          "id": "2bbf5462-4659-4560-8d26-24401966e107"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "e251da34-d73e-4255-a58d-c3d8640800c9"
+        },
+        {
+          "actionType": "extract",
+          "id": "b2daa7f9-b809-4d21-b49b-bca0b4dc6253",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/peoplewhiz.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplewhiz.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleWhiz.com",
   "url": "peoplewhiz.com",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "addedDatetime": 1676160000000,
   "optOutUrl": "https://www.peoplewhiz.com/remove-my-info",
   "steps": [
@@ -99,6 +99,16 @@
           "id": "d04e9122-30e1-49fa-b684-2398b4f96213"
         },
         {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(concat(' ', normalize-space(@class), ' '), ' altcha ')]//span[@role='status' and normalize-space(.)='Verified']"
+            }
+          ],
+          "id": "538eadc4-5fdb-44e2-8cf4-d7a65bdea0d7"
+        },
+        {
           "actionType": "click",
           "id": "0d61b830-c740-4d55-a32e-dcc370ff0cdc",
           "elements": [
@@ -144,5 +154,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": 1763741688379
+  "removedAt": null
 }

--- a/pir/pir-impl/src/main/assets/brokers/peoplewhizr.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplewhizr.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleWhizr.com",
   "url": "peoplewhizr.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplewhiz.com",
   "addedDatetime": 1709445600000,
   "optOutUrl": "https://peoplewhizr.com/optout",
@@ -54,5 +54,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": 1763742029894
+  "removedAt": null
 }

--- a/pir/pir-impl/src/main/assets/brokers/propertyrec.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrec.com.json
@@ -1,0 +1,131 @@
+{
+  "name": "PropertyRec",
+  "url": "propertyrec.com",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.propertyrec.com/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "_comment": "All other child sites go to the homepage first and click the opt-out link, but this one pops the page up in a new window, so we'll go to the opt-out page directly instead",
+          "id": "3591978e-66c7-4bc8-864c-4a0c4741d182",
+          "url": "https://dashboard.propertyrec.com/opt-out/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "3e44df56-fc5d-49d3-a408-0bc059c5d2c8"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "790f6a0e-2236-4502-8627-726c214094bd"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "5d160b1d-d825-4b7a-aaa2-d43972edb7ca"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "074b7f8d-0438-44cf-b3d6-3d03b2cb4f71"
+            }
+          ],
+          "id": "0ffcb4fa-c9c7-418d-822d-8c70d6f811f7"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "56ac8192-ec96-4129-8f69-0ed50475d771"
+        },
+        {
+          "actionType": "extract",
+          "id": "7cdeb58f-7b1c-494e-b367-4eb17d45aa76",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/propertyrecord.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrecord.com.json
@@ -1,0 +1,282 @@
+{
+  "name": "PropertyRecord",
+  "url": "propertyrecord.com",
+  "version": "0.4.0",
+  "addedDatetime": 1775736000000,
+  "optOutUrl": "https://dashboard.propertyrecord.com/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "4e3682bd-cc48-4ebe-9172-0ea3b89fe503",
+          "url": "https://www.propertyrecord.com/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "65e32379-fb7b-42d5-9817-00ba4075c36a"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "7562499b-cff9-4fb2-a87e-92432a49f827"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "bd6730a0-3381-43b4-8317-1e27f9df05d6"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "8fde207e-9e1e-476e-9e6d-184a72d279d4"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "d0030ece-5888-40ae-8b93-3f9f157da3cd"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "433039ee-c3e7-44c4-9056-e7ad09abe618"
+            }
+          ],
+          "id": "9cbacc8a-2afa-46bb-b72a-d39f46ec9046"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "441dce5c-d29f-4f01-847e-405795aae7d1"
+        },
+        {
+          "actionType": "extract",
+          "id": "8b02aa75-9acb-4f22-9ed5-efda7fd0b2fa",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "formOptOut",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "9e7126b9-7101-4953-b132-2e5c9668275b",
+          "url": "https://www.propertyrecord.com/"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "ce2f0fa7-f9c1-4df3-9e6a-102d27353ea8"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "54ca8a38-6900-408d-98ce-151d929ca948"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "37b5dae9-35dc-464a-a044-f2e0332efcbc"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "ee4a70fa-f0da-4f6b-a5d0-db42a0bca5a0"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "672b570b-75d7-42f5-9abb-e767b3901b1e"
+            }
+          ],
+          "id": "8d2d1ab8-54d9-434d-92f1-27175a57b93b"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "848b3be4-8d48-440e-8ce0-b640281d8872"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": ".//button[contains(normalize-space(.), 'Remove My Info')]",
+              "parent": {
+                "profileMatch": {
+                  "selector": "//ul[@id='people-search-results']/li",
+                  "profile": {
+                    "name": {
+                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+                    },
+                    "addressCityState": {
+                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+                    },
+                    "age": {
+                      "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+                    },
+                    "addressCityStateList": {
+                      "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+                      "findElements": true
+                    },
+                    "relativesList": {
+                      "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+                      "findElements": true
+                    },
+                    "profileUrl": {
+                      "identifierType": "hash"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "id": "f47133ae-dc60-42ea-a1c7-be42d843ec6e"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "text",
+              "selector": "body",
+              "expect": "Success: Information Removed"
+            }
+          ],
+          "id": "eb466716-5675-48c0-adc8-9823099c1c61"
+        }
+      ]
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/propertyrecs.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/propertyrecs.com.json
@@ -1,0 +1,150 @@
+{
+  "name": "PropertyRecs",
+  "url": "propertyrecs.com",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.propertyrecs.com/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "7ae4f835-bf67-468e-bc85-98723d0ff766",
+          "url": "https://www.propertyrecs.com/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "23414895-7813-4fab-a80f-8a8ba36a5185"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "59002bbe-7c2e-4cdc-934f-df2cff270a89"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "1ddc81f1-7048-4e1b-b601-8a7b89f1e19d"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "cff3b925-7d91-4950-80a3-b3ad0cdc2c10"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "cc9429c8-881e-43f3-8a1b-db214144aa09"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "65289830-c4dd-4448-91c5-5231edafc9a0"
+            }
+          ],
+          "id": "14bd6a6b-48ce-43e6-9558-b9d89962f0d1"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "a14018e9-c24e-44db-bcf5-fdc01c4eeaf2"
+        },
+        {
+          "actionType": "extract",
+          "id": "b84a3b27-c9ce-4707-b011-8b47453e18b8",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/publicrecords.info.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicrecords.info.json
@@ -1,0 +1,150 @@
+{
+  "name": "PublicRecordsInfo",
+  "url": "publicrecords.info",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.publicrecords.info/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "19677c91-451c-49c2-b1fa-67ab45717b47",
+          "url": "https://www.publicrecords.info/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "6915ac9f-f899-4718-a9d2-943de410cf45"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "171052b7-e18d-4db5-90db-11aed7ce776c"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "cebf9b17-b872-4f50-923e-683447603cce"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "62e6a0f9-cb99-4c7e-b287-2738b1ab2452"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "7ae485fd-ed88-482b-85d9-ddb2606143f6"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "43799cbb-c601-4611-adbd-788a8c0729aa"
+            }
+          ],
+          "id": "c634d7f5-68c7-4c0e-b5ae-1a4334424f84"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "f86e0821-03c4-4768-85d7-73f1c60ae7cc"
+        },
+        {
+          "actionType": "extract",
+          "id": "d13d6e63-a922-4e54-9291-aeadcf623f0b",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/publicrecords.us.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicrecords.us.json
@@ -1,0 +1,150 @@
+{
+  "name": "PublicRecordsUs",
+  "url": "publicrecords.us",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.publicrecords.us/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "695fb2f0-b2e4-4127-ab75-252a4b8430c0",
+          "url": "https://www.publicrecords.us/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "7c5df98e-3636-470d-b397-c1c7f52fe788"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "41fea052-1cfe-4cd0-ae37-fb90fef82949"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "61914e4e-4587-46e7-8682-73c82642af21"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "9d03c424-e97a-4ee6-9b17-114afe7dc41a"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "492b18f5-23a0-45ae-b215-75b03dbc9a2e"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "9eb789a0-c09b-418b-b5cc-624e6617f98a"
+            }
+          ],
+          "id": "f44c622a-00e8-4be4-88c8-ee8d5ab2b641"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "b9153480-1eae-42ea-8b42-172d68fb3d80"
+        },
+        {
+          "actionType": "extract",
+          "id": "30cdf1b8-399b-467a-a021-2014100e574f",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}

--- a/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
@@ -1,7 +1,7 @@
 {
   "name": "SpyFly",
   "url": "spyfly.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "addedDatetime": 1775214750818,
   "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "scan-navigate-to-privacy-page"
+          "id": "91ea665d-89f1-4f38-942e-d27ea2438ec2"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": ".main"
             }
           ],
-          "id": "scan-expect-page-loaded"
+          "id": "0527398b-b22a-4d51-b6d6-fa5c46048c90"
         },
         {
           "actionType": "fillForm",
@@ -47,15 +47,15 @@
               "selector": "#states"
             },
             {
-              "type": "$generated_zip_code$",
-              "selector": "#zip"
-            },
-            {
               "type": "age",
               "selector": "#age"
+            },
+            {
+              "type": "$generated_zip_code$",
+              "selector": "#zip"
             }
           ],
-          "id": "scan-fill-user-profile"
+          "id": "2a124512-7c05-4395-bfde-92e5b6b2c8e3"
         },
         {
           "actionType": "expectation",
@@ -67,7 +67,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "scan-expect-turnstile-solved"
+          "id": "c83793ff-9b93-4924-ad9c-008e01356bea"
         },
         {
           "actionType": "click",
@@ -77,7 +77,7 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "scan-click-submit"
+          "id": "4824a82a-8009-4c02-82bc-75dc26e5f703"
         },
         {
           "_comment": "Last supported action. If we reach here, Cloudflare did not block us. The scan will fail after this because generateEmail is not yet implemented.",
@@ -88,7 +88,7 @@
               "selector": "#email-address"
             }
           ],
-          "id": "scan-expect-email-page-loaded"
+          "id": "619924fc-4ad6-47aa-a5e6-44b2c8013273"
         },
         {
           "_comment": "Terminal action. We are on the email page, not results. noResultsSelector matches #email-address so extract returns empty results cleanly.",
@@ -100,7 +100,18 @@
               "selector": "h2"
             }
           },
-          "id": "scan-extract-terminal"
+          "id": "bab84c87-785a-427d-b38b-add9dba0aa3d"
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "formOptOut",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "url": "https://www.spyfly.com/help-center/privacy-requests",
+          "id": "0cb6e2ed-dff5-4dee-b9df-0ca19c9fc6ad"
         }
       ]
     }

--- a/pir/pir-impl/src/main/assets/brokers/vehiclehistory.us.json
+++ b/pir/pir-impl/src/main/assets/brokers/vehiclehistory.us.json
@@ -1,0 +1,150 @@
+{
+  "name": "VehicleHistory",
+  "url": "vehiclehistory.us",
+  "version": "0.3.0",
+  "parent": "propertyrecord.com",
+  "addedDatetime": 1775829600000,
+  "optOutUrl": "https://dashboard.vehiclehistory.us/opt-out",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "id": "b5e5aedd-72ff-497d-baa9-3fd3bb4715e1",
+          "url": "https://www.vehiclehistory.us/"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "44e75eae-a288-472b-b392-f664a3e44e5b"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//a[@title='Remove My Info']"
+            }
+          ],
+          "id": "24f92a0c-cb34-432c-9d84-ec6069f83406"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h1[contains(text(), 'Remove My Information')]"
+            }
+          ],
+          "id": "44fe39d2-88c9-4119-b915-172d752d1e2a"
+        },
+        {
+          "actionType": "fillForm",
+          "selector": "form#backgroundCheckForm",
+          "dataSource": "userProfile",
+          "elements": [
+            {
+              "type": "fullName",
+              "selector": ".//input[@name='name']"
+            },
+            {
+              "type": "cityState",
+              "selector": ".//input[@name='cityState']"
+            }
+          ],
+          "id": "85072b72-6a48-4635-a29b-158b85040051"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "button[type='submit']"
+            }
+          ],
+          "id": "227207ce-699d-46ee-8693-0f42015c602c"
+        },
+        {
+          "actionType": "condition",
+          "_comment": "Occasionally the site pops ups a spelling correction, and we need to press the 'Use Original' button",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#spellcheck-original"
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "#spellcheck-original"
+                }
+              ],
+              "id": "cff4145b-0bc6-4c12-b083-5edde166423d"
+            }
+          ],
+          "id": "e51690b2-c18a-4ec4-bb1b-a421c32ad7e5"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[contains(text(), 'Search Results')]"
+            }
+          ],
+          "id": "b7261daf-b111-4c09-aab9-0ddf142f9a7a"
+        },
+        {
+          "actionType": "extract",
+          "id": "e6a406a6-b813-43f2-9013-11069485a757",
+          "selector": "//ul[@id='people-search-results']/li",
+          "noResultsSelector": "//h3[contains(text(), 'No results found')]",
+          "profile": {
+            "name": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!text-[#222]')]"
+            },
+            "addressCityState": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(@class,'!leading-tight')]"
+            },
+            "age": {
+              "selector": ".//div[contains(@class,'grid')]/div[contains(@class,'flex-col')][1]/div[contains(.,'Years Old') or contains(.,'Deceased')]"
+            },
+            "addressCityStateList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Locations Include']/following-sibling::div",
+              "findElements": true
+            },
+            "relativesList": {
+              "selector": ".//div[contains(@class,'text-xs') and normalize-space(.)='Possible Relatives']/following-sibling::div",
+              "findElements": true
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1214022749574036/f 

 ----- 
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Added (7):**
- courtrec.com.json
- propertyrec.com.json
- propertyrecord.com.json
- propertyrecs.com.json
- publicrecords.info.json
- publicrecords.us.json
- vehiclehistory.us.json
**Updated (4):**
- anywho.com.json (0.1.0 → 0.4.0)
- peoplewhiz.com.json (0.8.0 → 0.9.0)
- peoplewhizr.com.json (0.6.0 → 0.7.0)
- spyfly.com.json (0.3.0 → 0.4.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify and add broker automation JSONs that drive scan/opt-out flows; incorrect selectors/URLs can break broker processing at runtime. No app code changes, but impact is user-facing within PIR broker coverage and success rates.
> 
> **Overview**
> Updates the bundled PIR broker definitions by adding **seven new `propertyrecord.com`-family brokers** (including `propertyrecord.com` itself) with scan flows and either `formOptOut` (for `propertyrecord.com`) or `parentSiteOptOut` (for child sites).
> 
> Refreshes existing broker configs: `anywho.com` now uses hyphenated city/state URL templating and extracts `addressCityState` (with separators) instead of full addresses, `peoplewhiz.com` adds a post-captcha *Verified* expectation and is re-enabled (`removedAt: null`), `peoplewhizr.com` is re-enabled, and `spyfly.com` bumps version/IDs and adds an explicit opt-out step skeleton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29180850ebc3b10657e9451a450f97c375164ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->