### PR TITLE
Simplify DRM popup copy and add span-safe format utility

### DIFF
--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/SpannableExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/SpannableExtensions.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.common.utils.extensions
 import android.graphics.Typeface
 import android.text.Spannable
 import android.text.SpannableStringBuilder
+import android.text.SpannedString
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
 
@@ -45,4 +46,22 @@ fun String.applyUnderscoreSpanTo(textToStyle: List<String>): SpannableStringBuil
         spannable.setSpan(UnderlineSpan(), index, index + it.length, Spannable.SPAN_EXCLUSIVE_INCLUSIVE)
     }
     return spannable
+}
+
+/**
+ * Replaces placeholders in the format of "%1\$s", "%2\$s", etc. with the provided arguments and returns a [SpannedString].
+ *
+ * @param args The arguments to replace the placeholders with.
+ * @return A [SpannedString] with the placeholders replaced by the provided arguments.
+ */
+fun CharSequence.formatWithSpans(vararg args: String): SpannedString {
+    val builder = SpannableStringBuilder(this)
+    args.forEachIndexed { index, replacement ->
+        val placeholder = "%${index + 1}\$s"
+        val start = builder.indexOf(placeholder)
+        if (start >= 0) {
+            builder.replace(start, start + placeholder.length, replacement)
+        }
+    }
+    return SpannedString(builder)
 }

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/SpannableExtensionsTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/SpannableExtensionsTest.kt
@@ -1,0 +1,78 @@
+package com.duckduckgo.common.utils.extensions
+
+import android.text.Annotation
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SpannableExtensionsTest {
+
+    @Test
+    fun whenSinglePlaceholderThenReplacedCorrectly() {
+        val input = "Hello %1\$s world"
+        val result = input.formatWithSpans("DuckDuckGo")
+        assertEquals("Hello DuckDuckGo world", result.toString())
+    }
+
+    @Test
+    fun whenMultiplePlaceholdersThenAllReplacedCorrectly() {
+        val input = "%1\$s wants to access %2\$s"
+        val result = input.formatWithSpans("example.com", "DRM")
+        assertEquals("example.com wants to access DRM", result.toString())
+    }
+
+    @Test
+    fun whenNoPlaceholdersThenTextUnchanged() {
+        val input = "No placeholders here"
+        val result = input.formatWithSpans("unused")
+        assertEquals("No placeholders here", result.toString())
+    }
+
+    @Test
+    fun whenAnnotationSpanPresentThenPreservedAfterReplacement() {
+        val builder = SpannableStringBuilder("Visit %1\$s for details. ")
+        val learnMore = "Learn More"
+        builder.append(learnMore)
+        builder.setSpan(
+            Annotation("type", "learn_more_link"),
+            builder.length - learnMore.length,
+            builder.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
+
+        val result = builder.formatWithSpans("example.com")
+
+        assertEquals("Visit example.com for details. Learn More", result.toString())
+        val annotations = result.getSpans(0, result.length, Annotation::class.java)
+        assertEquals(1, annotations.size)
+        assertEquals("learn_more_link", annotations[0].value)
+        assertTrue(result.getSpanStart(annotations[0]) > 0)
+    }
+
+    @Test
+    fun whenPlaceholderAfterAnnotationThenBothPreserved() {
+        val builder = SpannableStringBuilder("")
+        val linkText = "Learn More"
+        builder.append(linkText)
+        builder.setSpan(
+            Annotation("type", "link"),
+            0,
+            linkText.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+        )
+        builder.append(" about %1\$s")
+
+        val result = builder.formatWithSpans("DRM")
+
+        assertEquals("Learn More about DRM", result.toString())
+        val annotations = result.getSpans(0, result.length, Annotation::class.java)
+        assertEquals(1, annotations.size)
+        assertEquals(0, result.getSpanStart(annotations[0]))
+        assertEquals(linkText.length, result.getSpanEnd(annotations[0]))
+    }
+}

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.ui.view.button.ButtonType.GHOST
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.formatWithSpans
 import com.duckduckgo.common.utils.extensions.websiteFromGeoLocationsApiOrigin
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.di.scopes.FragmentScope
@@ -265,12 +266,12 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         TextAlertDialogBuilder(activity)
             .setTitle(
                 String.format(
-                    activity.getString(R.string.drmSiteDialogTitle),
+                    activity.getString(R.string.drmSitePermissionDialogTitle),
                     title,
                 ),
             )
             .setClickableMessage(
-                activity.getText(R.string.drmSiteDialogSubtitle),
+                activity.getText(R.string.drmSitePermissionDialogSubtitle).formatWithSpans(title),
                 DRM_LEARN_MORE_ANNOTATION,
             ) {
                 denyPermissions()

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -274,7 +274,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 activity.getText(R.string.drmSitePermissionDialogSubtitle).formatWithSpans(title),
                 DRM_LEARN_MORE_ANNOTATION,
             ) {
-                denyPermissions()
                 activity.startActivity(Intent(Intent.ACTION_VIEW, DRM_LEARN_MORE_URL))
             }
             .setPositiveButton(R.string.sitePermissionsDialogAllowButton, GHOST)

--- a/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
@@ -34,7 +34,7 @@
                 app:typography="h2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/drmSiteDialogTitle"/>
+                android:text="@string/drmSitePermissionDialogTitle"/>
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/sitePermissionDialogSubtitle"
@@ -42,7 +42,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/keyline_2"
-                android:text="@string/drmSiteDialogSubtitle"/>
+                android:text="@string/drmSitePermissionDialogSubtitle"/>
 
         <LinearLayout
                 android:layout_width="match_parent"

--- a/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-bg/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ иска да отвори софтуера за DRM</string>
-    <string name="drmSiteDialogSubtitle">Софтуерът за управление на цифровите права (DRM) е необходим за възпроизвеждане на защитено мултимедийно съдържание, но освен това осигурява достъп до идентификаторите на устройствата. Дайте разрешение за използване на тези данни само на сайтове, на които имате доверие. Можете да управлявате разрешенията по всяко време в Настройки. <annotation type="drm_learn_more_link">Научете повече</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ иска да отвори софтуера за управление на цифровите права (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Ако изберете „Отказвам“, има вероятност видеоклиповете на сайта да не могат да бъдат възпроизвеждани, но %1$s няма да има достъп до идентификатори на устройства, предоставени от софтуера за DRM. Можете да управлявате разрешенията по всяко време в Настройки. <annotation type="drm_learn_more_link">Научете повече</annotation></string>
     <string name="drmSiteDialogAllowAlways">Винаги</string>
     <string name="drmSiteDialogAllowOnce">Само за тази сесия</string>
     <string name="drmSiteDialogDenyAlways">Винаги да се отказва</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-cs/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">%1$s chce spustit tvůj DRM software</string>
-    <string name="drmSiteDialogSubtitle">Software DRM (tedy software pro správu digitálních oprávnění) je nutný k přehrávání chráněného mediálního obsahu, poskytuje ale taky přístup k identifikátorům zařízení. Povolení je vhodné udělit jen stránkám, kterým důvěřuješ. Oprávnění můžeš kdykoli spravovat v Nastaveních. <annotation type="drm_learn_more_link">Další informace</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ chce otevřít tvůj software pro správu digitálních práv (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Pokud vybereš možnost „Odmítnout“, může se stát, že nepůjdou přehrát videa na stránce, ale %1$s nebude mít přístup k identifikátorům zařízení poskytovaným softwarem DRM. Oprávnění můžeš kdykoli spravovat v Nastaveních. <annotation type="drm_learn_more_link">Další informace</annotation></string>
     <string name="drmSiteDialogAllowAlways">Vždy</string>
     <string name="drmSiteDialogAllowOnce">Pouze pro tuto relaci</string>
     <string name="drmSiteDialogDenyAlways">Vždy odmítnout</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-da/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" ønsker at åbne din DRM-software</string>
-    <string name="drmSiteDialogSubtitle">Digital Rights Management-software er nødvendig for at afspille beskyttet medieindhold, men giver også adgang til enhedsidentifikatorer. Giv kun tilladelse til sider, du stoler på, til at bruge disse data. Du kan til enhver tid administrere tilladelser i Indstillinger. <annotation type="drm_learn_more_link">Få mere at vide</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" vil åbne din Digital Rights Management (DRM)-software</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Hvis du vælger \"Afvis\", kan videoer på webstedet muligvis ikke afspilles, men %1$s vil ikke have adgang til enhedens identifikatorer leveret af DRM-software. Du kan til enhver tid administrere tilladelser i Indstillinger. <annotation type="drm_learn_more_link">Læs mere</annotation></string>
     <string name="drmSiteDialogAllowAlways">Altid</string>
     <string name="drmSiteDialogAllowOnce">Kun for denne session</string>
     <string name="drmSiteDialogDenyAlways">Afvis altid</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-de/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ möchte deine DRM-Software öffnen</string>
-    <string name="drmSiteDialogSubtitle">Zum Abspielen geschützter Medieninhalte ist eine Digital Rights Management-Software erforderlich, die aber auch Zugriff auf Gerätekennungen ermöglicht. Erlaube nur Websites, denen du vertraust, den Zugriff auf diese Daten. Du kannst die Berechtigungen jederzeit in den Einstellungen verwalten. <annotation type="drm_learn_more_link">Mehr erfahren</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ möchte deine DRM-Software (Digital Rights Management) öffnen</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Wenn du „Ablehnen“ wählst, können Videos auf der Website möglicherweise nicht mehr abgespielt werden, aber %1$s hat dann keinen Zugriff auf die von der DRM-Software bereitgestellten Gerätekennungen. Du kannst die Berechtigungen jederzeit in den Einstellungen verwalten. <annotation type="drm_learn_more_link">Mehr erfahren</annotation></string>
     <string name="drmSiteDialogAllowAlways">Immer</string>
     <string name="drmSiteDialogAllowOnce">Nur für diese Sitzung</string>
     <string name="drmSiteDialogDenyAlways">Immer ablehnen</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-el/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">Η εφαρμογή «%1$s» θέλει να ανοίξει το λογισμικό σας DRM</string>
-    <string name="drmSiteDialogSubtitle">Το λογισμικό Διαχείριση ψηφιακών δικαιωμάτων απαιτείται για αναπαραγωγή προστατευμένου περιεχομένου πολυμέσων, ωστόσο παρέχει επίσης πρόσβαση σε αναγνωριστικά συσκευών. Χορηγήστε άδεια μόνο σε ιστότοπους που εμπιστεύεστε για αυτά τα δεδομένα. Μπορείτε να διαχειριστείτε τα δικαιώματα οποιαδήποτε στιγμή από τις Ρυθμίσεις. <annotation type="drm_learn_more_link">Μάθετε περισσότερα</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">Ο ιστότοπος «%1$s» επιθυμεί να ανοίξει το λογισμικό διαχείρισης ψηφιακών δικαιωμάτων (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Αν επιλέξετε «Απόρριψη», η αναπαραγωγή των βίντεο στον ιστότοπο ενδέχεται να μην είναι δυνατή, ωστόσο ο ιστότοπος %1$s δεν θα έχει πρόσβαση στα αναγνωριστικά συσκευών που παρέχονται από το λογισμικό DRM. Μπορείτε να διαχειριστείτε τα δικαιώματα οποιαδήποτε στιγμή από τις Ρυθμίσεις. <annotation type="drm_learn_more_link">Μάθετε περισσότερα</annotation></string>
     <string name="drmSiteDialogAllowAlways">Πάντα</string>
     <string name="drmSiteDialogAllowOnce">Μόνο γι\' αυτή τη σύνδεση</string>
     <string name="drmSiteDialogDenyAlways">Άρνηση για πάντα</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-es/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">«%1$s» quiere abrir tu software DRM</string>
-    <string name="drmSiteDialogSubtitle">El software de gestión de derechos digitales(DRM, por sus siglas en inglés) es necesario para reproducir contenido multimedia protegido, pero también proporciona acceso a identificadores de dispositivos. Concede permiso solo a los sitios a los que confíes estos datos. Puedes gestionar los permisos en cualquier momento en Ajustes. <annotation type="drm_learn_more_link">Más información</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">«%1$s» quiere abrir tu software de Gestión de Derechos Digitales (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Si seleccionas «Denegar», los vídeos en el sitio pueden volverse irreproducibles, pero %1$s no tendrá acceso a los identificadores de dispositivo proporcionados por el software DRM. Puedes gestionar los permisos en cualquier momento en Ajustes. <annotation type="drm_learn_more_link">Más información</annotation></string>
     <string name="drmSiteDialogAllowAlways">Siempre</string>
     <string name="drmSiteDialogAllowOnce">Solo para esta sesión</string>
     <string name="drmSiteDialogDenyAlways">Rechazar siempre</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-et/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ soovib avada teie DRM-tarkvara</string>
-    <string name="drmSiteDialogSubtitle">Digitaalsete õiguste haldamise tarkvara on vajalik kaitstud meediasisu esitamiseks, kuid see võimaldab ka juurdepääsu seadme identifikaatoritele. Anna luba ainult saitidele, mida sa usaldad. Saad õigusi igal ajal seadetes hallata. <annotation type="drm_learn_more_link">Lisateave</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ soovib avada sinu digitaalõiguste halduse (DRM) tarkvara</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Kui valid „Keeldu“, võivad saidil videod muutuda mängitamatuks, kuid %1$s -l puudub juurdepääs DRM-tarkvara pakutavatele seadme identifikaatoritele. Saad õigusi igal ajal seadetes hallata. <annotation type="drm_learn_more_link">Lisateave</annotation></string>
     <string name="drmSiteDialogAllowAlways">Alati</string>
     <string name="drmSiteDialogAllowOnce">Ainult selle seansi jaoks</string>
     <string name="drmSiteDialogDenyAlways">Keela alati</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fi/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" haluaa avata DRM-ohjelmistosi</string>
-    <string name="drmSiteDialogSubtitle">Suojatun mediasisällön toistaminen vaatii Digital Rights Management -ohjelmiston, mutta se antaa lisäksi laitteen tunnisteiden käyttöluvan. Myönnä lupa vain sivustoille, joihin luotat näiden tietojen suhteen. Voit hallita lupia milloin vain asetuksissa. <annotation type="drm_learn_more_link">Lue lisää</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" haluaa avata DRM-ohjelmiston (Digital Rights Management).</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Jos valitset \"Estä\", sivustolla olevia videoita ei ehkä voida toistaa, mutta %1$s ei voi käyttää DRM-ohjelmiston tarjoamia laitetunnisteita. Voit hallita lupia milloin vain asetuksissa. <annotation type="drm_learn_more_link">Lue lisää</annotation></string>
     <string name="drmSiteDialogAllowAlways">Aina</string>
     <string name="drmSiteDialogAllowOnce">Vain tässä istunnossa</string>
     <string name="drmSiteDialogDenyAlways">Kiellä aina</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-fr/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">« %1$s » souhaite ouvrir votre logiciel DRM</string>
-    <string name="drmSiteDialogSubtitle">Le logiciel de gestion des droits numériques est nécessaire pour lire du contenu multimédia protégé, mais il permet également d\'accéder aux identifiants des appareils. N\'accordez l\'autorisation d\'accès à ces données qu\'aux sites auxquels vous faites confiance. Vous pouvez gérer les autorisations à tout moment dans Paramètres. <annotation type="drm_learn_more_link">En savoir plus</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">« %1$s » souhaite ouvrir votre logiciel de gestion des droits numériques (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Si vous choisissez « Refuser », les vidéos sur le site pourraient ne pas être lues, mais %1$s n’aura pas accès aux identifiants d’appareil fournis par le logiciel DRM. Vous pouvez gérer les autorisations à tout moment dans Paramètres. <annotation type="drm_learn_more_link">En savoir plus</annotation></string>
     <string name="drmSiteDialogAllowAlways">Toujours</string>
     <string name="drmSiteDialogAllowOnce">Seulement pour cette session</string>
     <string name="drmSiteDialogDenyAlways">Toujours refuser</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hr/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" želi otvoriti tvoj DRM softver</string>
-    <string name="drmSiteDialogSubtitle">Softver za upravljanje digitalnim pravima potreban je za reprodukciju zaštićenog medijskog sadržaja, ali i za pristup identifikatorima uređaja. Pruži dopuštenje samo web lokacijama kojima vjeruješ u vezi s rukovanjem ovim podacima. Dopuštenjima možeš upravljati u svakom trenutku u Postavkama. <annotation type="drm_learn_more_link">Saznaj više</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" želi otvoriti tvoj softver za upravljanje digitalnim pravima (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Ako odabereš \"Zabrani\", videozapise na web-mjestu možda neće biti moguće reproducirati, ali %1$s neće imati pristup identifikatorima uređaja koje pruža DRM softver. Dopuštenjima možeš upravljati u svakom trenutku u Postavkama. <annotation type="drm_learn_more_link">Saznaj više</annotation></string>
     <string name="drmSiteDialogAllowAlways">Uvijek</string>
     <string name="drmSiteDialogAllowOnce">Samo za ovu sesiju</string>
     <string name="drmSiteDialogDenyAlways">Uvijek odbij</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-hu/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">A(z) „%1$s” meg akarja nyitni a DRM-szoftveredet</string>
-    <string name="drmSiteDialogSubtitle">A digitális jogosultságokat kezelő szoftver a védett médiatartalmak lejátszásához szükséges, de az eszközazonosítókhoz is hozzáférést biztosít. Csak olyan webhelyeknek adj engedélyt ezekhez az adatokhoz, amelyekben megbízol. Az engedélyek bármikor kezelhetők a Beállításokban. <annotation type="drm_learn_more_link">További tudnivalók</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">A(z) „%1$s” meg szeretné nyitni a digitális jogkezelő (DRM-) szoftveredet</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Ha az „Elutasítás” lehetőséget választod, előfordulhat, hogy a webhelyen lévő videók nem lesznek lejátszhatók, de a(z) %1$s nem fog hozzáférni a DRM-szoftver által biztosított eszközazonosítókhoz. Az engedélyeket bármikor kezelheted a Beállításokban. <annotation type="drm_learn_more_link">További információk</annotation></string>
     <string name="drmSiteDialogAllowAlways">Mindig</string>
     <string name="drmSiteDialogAllowOnce">Csak erre a munkamenetre</string>
     <string name="drmSiteDialogDenyAlways">Mindig megtagad</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-it/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" vuole aprire il tuo software DRM</string>
-    <string name="drmSiteDialogSubtitle">Il software di gestione dei diritti digitali è necessario per riprodurre contenuti multimediali protetti, ma consente anche di accedere agli identificatori dei dispositivi. Concedi l\'autorizzazione per questi dati solo ai siti di cui ti fidi. Puoi gestire le autorizzazioni in qualsiasi momento in Impostazioni. <annotation type="drm_learn_more_link">Maggiori informazioni</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" vuole aprire il software Digital Rights Management (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Se selezioni \"Nega\", i video sul sito potrebbero diventare non riproducibili, ma %1$s non avrà accesso agli identificatori del dispositivo forniti dal software DRM. Puoi gestire le autorizzazioni in qualsiasi momento in Impostazioni. <annotation type="drm_learn_more_link">Scopri di più</annotation></string>
     <string name="drmSiteDialogAllowAlways">Sempre</string>
     <string name="drmSiteDialogAllowOnce">Solo per questa sessione</string>
     <string name="drmSiteDialogDenyAlways">Nega sempre</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lt/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ nori atidaryti jūsų DRM programinę įrangą</string>
-    <string name="drmSiteDialogSubtitle">Skaitmeninių teisių valdymo programinė įranga reikalinga norint atkurti apsaugotą medijos turinį, bet taip pat suteikia prieigą prie įrenginio identifikatorių. Suteikite leidimą tik toms svetainėms, kurioms patikite šiuos duomenis. Leidimus bet kada galite tvarkyti nustatymuose. <annotation type="drm_learn_more_link">Sužinokite daugiau</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ nori atidaryti tavo skaitmeninių teisių valdymo (angl. „Digital Rights Management“, DRM) programinę įrangą</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Jei pasirinksi „Drausti“, vaizdo įrašai interneto svetainėje gali nebeveikti, tačiau „%1$s“ neturės prieigos prie įrenginio identifikatorių, kuriuos teikia DRM programinė įranga. Leidimus bet kada gali valdyti nuostatose. <annotation type="drm_learn_more_link">Sužinok daugiau</annotation></string>
     <string name="drmSiteDialogAllowAlways">Visada</string>
     <string name="drmSiteDialogAllowOnce">Tik šiam seansui</string>
     <string name="drmSiteDialogDenyAlways">Visada atsisakyti</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-lv/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" grib atvērt tavu DRM programmatūru</string>
-    <string name="drmSiteDialogSubtitle">Lai atskaņotu aizsargātu multivides saturu, ir nepieciešama digitālo tiesību pārvaldības programmatūra, kas nodrošina arī piekļuvi ierīces identifikatoriem. Piešķir atļauju tikai tām vietnēm, kurām uztici šos datus. Atļaujas jebkurā laikā vari pārvaldīt iestatījumos. <annotation type="drm_learn_more_link">Uzzināt vairāk</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">“%1$s” vēlas atvērt jūsu digitālā satura tiesību pārvaldības (DRM) programmatūru.</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Ja izvēlies “Aizliegt”, vietnē esošos videoklipus, iespējams, nevarēs atskaņot, taču %1$s nebūs piekļuves DRM programmatūras nodrošinātajiem ierīču identifikatoriem. Atļaujas jebkurā laikā vari pārvaldīt iestatījumos. <annotation type="drm_learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="drmSiteDialogAllowAlways">Vienmēr</string>
     <string name="drmSiteDialogAllowOnce">Tikai šai sesijai</string>
     <string name="drmSiteDialogDenyAlways">Vienmēr aizliegt</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nb/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">«%1$s» ønsker å åpne DRM-programvaren din</string>
-    <string name="drmSiteDialogSubtitle">Programvare for digital rettighetsadministrasjon er nødvendig for å spille av beskyttet medieinnhold, men gir også tilgang til enhetsidentifikatorer. Gi bare tillatelse til nettsteder du stoler på med disse dataene. Du kan administrere tillatelser når som helst i Innstillinger. <annotation type="drm_learn_more_link">Les mer</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">«%1$s» ønsker å åpne programvaren din for digital rettighetsadministrasjon (DRA)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Hvis du velger «Avvis», kan det hende at videoer på nettstedet ikke kan spilles av, men %1$s får ikke tilgang til enhetsidentifikatorer oppgitt av DRA-programvaren. Du kan administrere tillatelser når som helst i Innstillinger. <annotation type="drm_learn_more_link">Les mer</annotation></string>
     <string name="drmSiteDialogAllowAlways">Alltid</string>
     <string name="drmSiteDialogAllowOnce">Kun for denne økten</string>
     <string name="drmSiteDialogDenyAlways">Aldri tillat</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-nl/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\'%1$s\' wil je DRM-software openen</string>
-    <string name="drmSiteDialogSubtitle">Digital Rights Management-software is nodig om beveiligde mediacontent af te spelen, maar biedt ook toegang tot apparaatherkenners. Geef alleen toestemming aan sites die je vertrouwt met deze gegevens. Je kunt de machtigingen op elk moment beheren in de instellingen. <annotation type="drm_learn_more_link">Meer informatie</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\'%1$s\' wil je DRM-software (Digital Rights Management) openen.</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Als je op \'Weigeren\' kiest, kunnen video\'s op de site mogelijk niet worden afgespeeld, maar %1$s heeft geen toegang tot apparaat-ID\'s die door DRM-software worden verstrekt. Je kunt de machtigingen op elk moment beheren in de instellingen. <annotation type="drm_learn_more_link">Meer informatie</annotation></string>
     <string name="drmSiteDialogAllowAlways">Altijd</string>
     <string name="drmSiteDialogAllowOnce">Alleen voor deze sessie</string>
     <string name="drmSiteDialogDenyAlways">Altijd weigeren</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pl/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s” chce uzyskać dostęp do oprogramowania DRM</string>
-    <string name="drmSiteDialogSubtitle">Oprogramowanie Digital Rights Management jest wymagane do odtwarzania chronionych treści multimedialnych, ale zapewnia również dostęp do identyfikatorów urządzeń. Udzielaj zgody na dostęp do tych danych tylko witrynom, którym ufasz. W każdej chwili możesz zarządzać uprawnieniami w ustawieniach. <annotation type="drm_learn_more_link">Dowiedz się więcej</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" chce otworzyć twoje oprogramowanie do zarządzania prawami cyfrowymi (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Jeśli wybierzesz „Odmów”, filmy na stronie mogą stać się niedostępne, ale %1$s nie będzie miał dostępu do identyfikatorów urządzeń dostarczanych przez oprogramowanie DRM. W każdej chwili możesz zarządzać uprawnieniami w ustawieniach. <annotation type="drm_learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="drmSiteDialogAllowAlways">Zawsze</string>
     <string name="drmSiteDialogAllowOnce">Tylko dla tej sesji</string>
     <string name="drmSiteDialogDenyAlways">Zawsze odmawiaj</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-pt/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" quer abrir o teu software DRM</string>
-    <string name="drmSiteDialogSubtitle">O software de gestão de direitos digitais é necessário para reproduzir conteúdo multimédia protegido, mas também fornece acesso a identificadores do dispositivo. Concede permissão apenas a sites de confiança. Podes gerir as permissões em qualquer altura nas Definições. <annotation type="drm_learn_more_link">Sabe mais</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" pretende abrir o teu software de Gestão de Direitos Digitais (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Se escolheres \"Recusar\", os vídeos no site podem tornar-se inutilizáveis, mas %1$s não terá acesso aos identificadores de dispositivo fornecidos pelo software de DRM. Podes gerir as permissões em qualquer altura nas Definições. <annotation type="drm_learn_more_link">Sabe mais</annotation></string>
     <string name="drmSiteDialogAllowAlways">Sempre</string>
     <string name="drmSiteDialogAllowOnce">Apenas para esta sessão</string>
     <string name="drmSiteDialogDenyAlways">Negar sempre</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ro/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s” dorește să-ți deschidă software-ul DRM</string>
-    <string name="drmSiteDialogSubtitle">Software-ul DRM este necesar pentru a reda conținut media protejat, dar oferă, de asemenea, acces la identificatorii dispozitivelor. Acordă permisiunea de a utiliza aceste date numai site-urilor în care ai încredere. Poți gestiona oricând permisiunile din Setări. <annotation type="drm_learn_more_link">Află mai multe</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s” dorește să deschidă software-ul tău de management al drepturilor digitale (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Dacă alegi „Refuză”, videoclipurile de pe site ar putea deveni de neredat, dar %1$s nu va avea acces la identificatorii de dispozitiv oferiți de software-ul DRM. Poți gestiona oricând permisiunile din Setări. <annotation type="drm_learn_more_link">Află mai multe</annotation></string>
     <string name="drmSiteDialogAllowAlways">Întotdeauna</string>
     <string name="drmSiteDialogAllowOnce">Numai pentru această sesiune</string>
     <string name="drmSiteDialogDenyAlways">Respinge întotdeauna</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-ru/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">Сайт «%1$s» хочет открывать ваши программы DRM (защиты авторских прав)</string>
-    <string name="drmSiteDialogSubtitle">Программы защиты авторских прав (DRM) необходимы для воспроизведения защищенного медиаконтента, однако они также открывают доступ к идентификатором устройства. Предоставляйте доступ только тем сайтам, которым вы доверяете. Права доступа можно изменить в «Настройках». <annotation type="drm_learn_more_link">Подробнее...</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">Сайт «%1$s» хочет открывать ваши программы защиты авторских прав (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">В случае отказа вы, возможно, не сможете проигрывать видео на сайте, но «%1$s» не получит доступа к идентификаторам устройств, которые предоставляет DRM. Права доступа можно изменить в «Настройках». <annotation type="drm_learn_more_link">Подробнее...</annotation></string>
     <string name="drmSiteDialogAllowAlways">Всегда</string>
     <string name="drmSiteDialogAllowOnce">Только для этой сессии</string>
     <string name="drmSiteDialogDenyAlways">Всегда отказывать</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sk/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ chce otvoriť tvoj softvér DRM</string>
-    <string name="drmSiteDialogSubtitle">Softvér Digital Rights Management je potrebný na prehrávanie chráneného mediálneho obsahu, no poskytuje aj prístup k identifikátorom zariadenia. Povolenie pre tieto údaje povoľte iba stránkam, ktorým dôverujete. Povolenia môžete kedykoľvek spravovať v Nastaveniach. <annotation type="drm_learn_more_link">Zistiť viac</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">„%1$s“ chce otvoriť tvoj softvér na správu digitálnych práv (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Ak vyberieš možnosť „Zakázať“, videá na stránke sa nemusia dať prehrať, ale %1$s nebude mať prístup k identifikátorom zariadení poskytovaným softvérom DRM. Povolenia môžeš kedykoľvek spravovať v Nastaveniach. <annotation type="drm_learn_more_link">Zistiť viac</annotation></string>
     <string name="drmSiteDialogAllowAlways">Vždy</string>
     <string name="drmSiteDialogAllowOnce">Iba pre túto reláciu</string>
     <string name="drmSiteDialogDenyAlways">Vždy odmietnuť</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sl/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">»%1$s« želi odpreti vašo programsko opremo DRM.</string>
-    <string name="drmSiteDialogSubtitle">Programska oprema za upravljanje digitalnih pravic je potrebna za predvajanje zaščitene medijske vsebine, omogoča pa tudi dostop do identifikatorjev naprave. Dovoljenje za uporabo teh podatkov podelite le spletnim mestom, ki jim zaupate te podatke. Dovoljenja lahko kadar koli upravljate v nastavitvah. <annotation type="drm_learn_more_link">Več o tem</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">»%1$s« želi odpreti vašo programsko opremo za upravljanje digitalnih pravic (DRM)</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Če izberete »Zavrni«, videoposnetkov na spletnem mestu morda ne bo mogoče predvajati, vendar spletno mesto %1$s ne bo imelo dostopa do identifikatorjev naprav, ki jih zagotavlja programska oprema DRM. Dovoljenja lahko kadar koli upravljate v nastavitvah. <annotation type="drm_learn_more_link">Več o tem</annotation></string>
     <string name="drmSiteDialogAllowAlways">Vedno</string>
     <string name="drmSiteDialogAllowOnce">Samo za to sejo</string>
     <string name="drmSiteDialogDenyAlways">Vedno zavrni</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-sv/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">”%1$s” vill öppna din DRM-programvara</string>
-    <string name="drmSiteDialogSubtitle">DRM-programvara (Digital Rights Management) krävs för att spela upp skyddat medieinnehåll, men ger också tillgång till enhetsidentifierare. Ge endast behörighet att hantera dessa uppgifter till webbplatser du litar på.Du kan hantera behörigheter när som helst i Inställningar. <annotation type="drm_learn_more_link">Läs mer</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">”%1$s” vill öppna din DRM (Digital Rights Management)-programvara</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">Om du väljer ”Avböj” kan videor på webbplatsen bli ospelbara, men %1$s kommer inte att ha åtkomst till enhetsidentifierare som tillhandahålls av DRM-programvara. Du kan hantera behörigheter när som helst i Inställningar. <annotation type="drm_learn_more_link">Läs mer</annotation></string>
     <string name="drmSiteDialogAllowAlways">Alltid</string>
     <string name="drmSiteDialogAllowOnce">Endast för denna session</string>
     <string name="drmSiteDialogDenyAlways">Neka alltid</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values-tr/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" DRM yazılımınızı açmak istiyor</string>
-    <string name="drmSiteDialogSubtitle">Dijital Haklar Yönetimi yazılımı, korumalı medya içeriğini yürütmek için gereklidir, ancak aynı zamanda cihaz tanımlayıcılara erişim sağlar. Bu veriler için yalnızca güvendiğiniz sitelere izin verin. İzinleri istediğiniz zaman Ayarlar\'dan yönetebilirsiniz. <annotation type="drm_learn_more_link">Daha Fazla Bilgi</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" Dijital Haklar Yönetimi (DRM) yazılımını açmak istiyor.</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">\"Reddet\" seçeneğini seçerseniz sitedeki videolar oynatılamaz duruma gelebilir ancak %1$s, DRM yazılımı tarafından sağlanan cihaz tanımlayıcılarına erişemez. İzinleri istediğiniz zaman Ayarlar\'dan yönetebilirsiniz. <annotation type="drm_learn_more_link">Daha Fazla Bilgi</annotation></string>
     <string name="drmSiteDialogAllowAlways">Her zaman</string>
     <string name="drmSiteDialogAllowOnce">Yalnızca Bu Oturum için</string>
     <string name="drmSiteDialogDenyAlways">Her Zaman Reddet</string>

--- a/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/values/strings-site-permissions.xml
@@ -18,8 +18,8 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <!-- DRM Permission -->
-    <string name="drmSiteDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" wants to open your DRM software</string>
-    <string name="drmSiteDialogSubtitle">Digital Rights Management software is required to play protected media content, but also provides access to device identifiers. Only grant permission to sites you trust with this data. You can manage permissions at any time in Settings. <annotation type="drm_learn_more_link">Learn More</annotation></string>
+    <string name="drmSitePermissionDialogTitle" instruction="Placeholder is the name of a website">\"%1$s\" wants to open your Digital Rights Management (DRM) software</string>
+    <string name="drmSitePermissionDialogSubtitle" instruction="Placeholder is the name of a website">If you pick \"Deny\" videos on the site may become unplayable, but %1$s will not have access to device identifiers provided by DRM software. You can manage permissions at any time in Settings. <annotation type="drm_learn_more_link">Learn More</annotation></string>
     <string name="drmSiteDialogAllowAlways">Always</string>
     <string name="drmSiteDialogAllowOnce">Only for This Session</string>
     <string name="drmSiteDialogDenyAlways">Deny Always</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1212714203057293?focus=true 

### Description

Updated the DRM permission dialog copy to be clearer and less confusing. The previous wording was suspected of causing breakage reports. New copy has been reviewed by Copywriting.

Also added a reusable `CharSequence.formatWithSpans()` extension in `SpannableExtensions.kt` that replaces positional placeholders (`%1$s`) while preserving annotation spans — needed because the subtitle now includes both a domain placeholder and a clickable "Learn More" link.

### Steps to test this PR

_DRM dialog copy_
- [x] Install the app and clear any existing DRM site permissions in Settings → Site Permissions
- [x] Navigate to `https://bitmovin.com/demos/drm`
- [x] Verify the dialog title reads: `"bitmovin.com" wants to open your Digital Rights Management (DRM) software`
- [x] Verify the dialog subtitle reads: `If you pick "Deny" videos on the site may become unplayable, but bitmovin.com will not have access to device identifiers provided by DRM software. You can manage permissions at any time in Settings. Learn More`
- [x] Verify "Learn More" is clickable and opens the DRM help page
- [x] Tap Allow / Deny and verify permissions work as before

### UI changes
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/dfabf293-9a78-4f2d-9bcd-9b4d3d308eb0" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing DRM permission dialog strings and formatting logic; mistakes could break placeholder replacement or the clickable "Learn More" span in a permissions-critical flow.
> 
> **Overview**
> Updates the DRM site-permission dialog title/subtitle copy across locales (and layout references) to clarify the deny consequence, renaming the string resources to `drmSitePermissionDialogTitle`/`drmSitePermissionDialogSubtitle`.
> 
> Adds `CharSequence.formatWithSpans` to replace positional placeholders (e.g., `%1$s`) while preserving spans, with new instrumentation tests to verify placeholder replacement and `Annotation` span retention; the DRM dialog now uses this utility to inject the site title into the clickable subtitle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82238554a137c0a29f1f441d31be8c58ecb34ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->