### PR TITLE
Fix: Fireproofing for single tab burning

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DeleteBrowsingData
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.fire.AppCacheClearer
+import com.duckduckgo.app.fire.SiteDataCleaner
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
@@ -38,6 +39,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.sync.api.DeviceSyncState
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -50,8 +52,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class ClearPersonalDataActionTest {
-
-    private lateinit var testee: ClearPersonalDataAction
 
     private val mockDataManager: WebDataManager = mock()
     private val mockClearingUnsentForgetAllPixelStore: UnsentForgetAllPixelStore = mock()
@@ -72,31 +72,38 @@ class ClearPersonalDataActionTest {
 
     private val fireproofWebsites: LiveData<List<FireproofWebsiteEntity>> = MutableLiveData()
 
+    private lateinit var testee: ClearPersonalDataAction
+
     @Before
     fun setup() {
         whenever(mockDuckAiHostProvider.getHost()).thenReturn("duck.ai")
-        testee = ClearPersonalDataAction(
-            context = InstrumentationRegistry.getInstrumentation().targetContext,
-            dataManager = mockDataManager,
-            clearingStore = mockClearingUnsentForgetAllPixelStore,
-            tabRepository = mockTabRepository,
-            settingsDataStore = mockSettingsDataStore,
-            cookieManager = mockCookieManager,
-            appCacheClearer = mockAppCacheClearer,
-            thirdPartyCookieManager = mockThirdPartyCookieManager,
-            fireproofWebsiteRepository = mockFireproofWebsiteRepository,
-            deviceSyncState = mockDeviceSyncState,
-            savedSitesRepository = mockSavedSitesRepository,
-            sitePermissionsManager = mockSitePermissionsManager,
-            navigationHistory = mockNavigationHistory,
-            webTrackersBlockedRepository = mockWebTrackersBlockedRepository,
-            tabVisitedSitesRepository = mockTabVisitedSitesRepository,
-            webViewCapabilityChecker = mockWebViewCapabilityChecker,
-            duckAiHostProvider = mockDuckAiHostProvider,
-        )
+        testee = createTestee()
         whenever(mockFireproofWebsiteRepository.getFireproofWebsites()).thenReturn(fireproofWebsites)
         whenever(mockDeviceSyncState.isUserSignedInOnDevice()).thenReturn(true)
     }
+
+    private fun createTestee(
+        siteDataCleaner: SiteDataCleaner = SiteDataCleaner { _, _ -> },
+    ) = ClearPersonalDataAction(
+        context = InstrumentationRegistry.getInstrumentation().targetContext,
+        dataManager = mockDataManager,
+        clearingStore = mockClearingUnsentForgetAllPixelStore,
+        tabRepository = mockTabRepository,
+        settingsDataStore = mockSettingsDataStore,
+        cookieManager = mockCookieManager,
+        appCacheClearer = mockAppCacheClearer,
+        thirdPartyCookieManager = mockThirdPartyCookieManager,
+        fireproofWebsiteRepository = mockFireproofWebsiteRepository,
+        deviceSyncState = mockDeviceSyncState,
+        savedSitesRepository = mockSavedSitesRepository,
+        sitePermissionsManager = mockSitePermissionsManager,
+        navigationHistory = mockNavigationHistory,
+        webTrackersBlockedRepository = mockWebTrackersBlockedRepository,
+        tabVisitedSitesRepository = mockTabVisitedSitesRepository,
+        webViewCapabilityChecker = mockWebViewCapabilityChecker,
+        duckAiHostProvider = mockDuckAiHostProvider,
+        siteDataCleaner = siteDataCleaner,
+    )
 
     @Test
     fun whenClearCalledWithPixelIncrementSetToTrueThenPixelCountIncremented() = runTest {
@@ -366,6 +373,21 @@ class ClearPersonalDataActionTest {
         )
         val result = testee.clearDataForSpecificDomains(domains = setOf("fireproof.com", "another-fireproof.com", "duckduckgo.com", "duck.ai"))
         assertTrue(result is ClearDataResult.Success)
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledWithMixedDomainsThenOnlyNonFireproofDomainsAreCleared() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
+            listOf(FireproofWebsiteEntity("fireproof.com")),
+        )
+        val clearedDomains = mutableListOf<String>()
+        val testeeWithCapture = createTestee(
+            siteDataCleaner = { _, domain -> clearedDomains.add(domain) },
+        )
+        val result = testeeWithCapture.clearDataForSpecificDomains(domains = setOf("fireproof.com", "clearable.com"))
+        assertTrue(result is ClearDataResult.Success)
+        assertEquals(listOf("clearable.com"), clearedDomains)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -391,6 +391,30 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
+    fun whenClearDataForSpecificDomainsCalledWithMixedDuckDuckGoDomainsThenOnlyNonDdgDomainsAreCleared() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
+        val clearedDomains = mutableListOf<String>()
+        val testeeWithCapture = createTestee(
+            siteDataCleaner = { _, domain -> clearedDomains.add(domain) },
+        )
+        val result = testeeWithCapture.clearDataForSpecificDomains(domains = setOf("duckduckgo.com", "duck.ai", "clearable.com"))
+        assertTrue(result is ClearDataResult.Success)
+        assertEquals(listOf("clearable.com"), clearedDomains)
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledAndCleanerThrowsThenReturnsError() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
+        val testeeWithError = createTestee(
+            siteDataCleaner = { _, _ -> throw RuntimeException("WebView error") },
+        )
+        val result = testeeWithError.clearDataForSpecificDomains(domains = setOf("example.com"))
+        assertTrue(result is ClearDataResult.Error)
+    }
+
+    @Test
     fun whenClearDataForSpecificDomainsCalledAndFeatureNotSupportedThenFireproofWebsitesNotQueried() = runTest {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(false)
         testee.clearDataForSpecificDomains(domains = setOf("example.com"))

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -349,10 +349,20 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
+    fun whenClearDataForSpecificDomainsCalledWithSubdomainFireproofDomainThenEtldPlusOneMatchFiltersThem() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
+            listOf(FireproofWebsiteEntity("www.facebook.com")),
+        )
+        val result = testee.clearDataForSpecificDomains(domains = setOf("facebook.com"))
+        assertTrue(result is ClearDataResult.Success)
+    }
+
+    @Test
     fun whenClearDataForSpecificDomainsCalledWithFireproofAndDuckDuckGoDomainsOnlyThenReturnsSuccess() = runTest {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
-            listOf(FireproofWebsiteEntity("fireproof.com"), FireproofWebsiteEntity("another-fireproof.com")),
+            listOf(FireproofWebsiteEntity("www.fireproof.com"), FireproofWebsiteEntity("login.another-fireproof.com")),
         )
         val result = testee.clearDataForSpecificDomains(domains = setOf("fireproof.com", "another-fireproof.com", "duckduckgo.com", "duck.ai"))
         assertTrue(result is ClearDataResult.Success)

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -332,6 +332,40 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
+    fun whenClearDataForSpecificDomainsCalledThenFireproofWebsitesAreQueried() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        testee.clearDataForSpecificDomains(domains = setOf("example.com"))
+        verify(mockFireproofWebsiteRepository).fireproofWebsitesSync()
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledWithFireproofDomainsOnlyThenReturnsSuccess() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
+            listOf(FireproofWebsiteEntity("fireproof.com")),
+        )
+        val result = testee.clearDataForSpecificDomains(domains = setOf("fireproof.com"))
+        assertTrue(result is ClearDataResult.Success)
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledWithFireproofAndDuckDuckGoDomainsOnlyThenReturnsSuccess() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
+            listOf(FireproofWebsiteEntity("fireproof.com"), FireproofWebsiteEntity("another-fireproof.com")),
+        )
+        val result = testee.clearDataForSpecificDomains(domains = setOf("fireproof.com", "another-fireproof.com", "duckduckgo.com", "duck.ai"))
+        assertTrue(result is ClearDataResult.Success)
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledAndFeatureNotSupportedThenFireproofWebsitesNotQueried() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(false)
+        testee.clearDataForSpecificDomains(domains = setOf("example.com"))
+        verify(mockFireproofWebsiteRepository, never()).fireproofWebsitesSync()
+    }
+
+    @Test
     fun whenSetAppUsedSinceLastClearFlagCalledWithTrueThenFlagSetToTrue() = runTest {
         testee.setAppUsedSinceLastClearFlag(true)
         verify(mockSettingsDataStore).appUsedSinceLastClear = true

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.fire.AppCacheClearer
 import com.duckduckgo.app.fire.BackgroundTimeKeeper
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
 import com.duckduckgo.app.fire.DataClearerTimeKeeper
+import com.duckduckgo.app.fire.SiteDataCleaner
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.model.AppCacheExclusionPlugin
@@ -91,6 +92,7 @@ object PrivacyModule {
         tabVisitedSitesRepository: TabVisitedSitesRepository,
         webViewCapabilityChecker: WebViewCapabilityChecker,
         duckAiHostProvider: DuckAiHostProvider,
+        siteDataCleaner: SiteDataCleaner,
     ): ClearDataAction {
         return ClearPersonalDataAction(
             context,
@@ -111,6 +113,7 @@ object PrivacyModule {
             tabVisitedSitesRepository,
             webViewCapabilityChecker,
             duckAiHostProvider,
+            siteDataCleaner,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import android.annotation.SuppressLint
+import android.webkit.WebStorage
+import androidx.webkit.WebStorageCompat
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+fun interface SiteDataCleaner {
+    suspend fun deleteSiteData(webStorage: WebStorage, domain: String)
+}
+
+@ContributesBinding(AppScope::class)
+@SuppressLint("RequiresFeature")
+class RealSiteDataCleaner @Inject constructor() : SiteDataCleaner {
+    override suspend fun deleteSiteData(webStorage: WebStorage, domain: String) {
+        suspendCancellableCoroutine { continuation ->
+            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
+                continuation.resume(Unit)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.WebStorage
 import android.webkit.WebView
+import androidx.annotation.VisibleForTesting
 import androidx.webkit.WebStorageCompat
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
@@ -137,6 +138,15 @@ class ClearPersonalDataAction(
     private val tabVisitedSitesRepository: TabVisitedSitesRepository,
     private val webViewCapabilityChecker: WebViewCapabilityChecker,
     duckAiHostProvider: DuckAiHostProvider,
+    @VisibleForTesting
+    internal val deleteSiteData: suspend (WebStorage, String) -> Unit = { webStorage, domain ->
+        @SuppressLint("RequiresFeature")
+        suspendCancellableCoroutine { continuation ->
+            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
+                continuation.resume(Unit)
+            }
+        }
+    },
 ) : ClearDataAction {
 
     override fun killAndRestartProcess(notifyDataCleared: Boolean, enableTransitionAnimation: Boolean, deletedTabCount: Int) {
@@ -228,7 +238,6 @@ class ClearPersonalDataAction(
         }
     }
 
-    @SuppressLint("RequiresFeature")
     override suspend fun clearDataForSpecificDomains(
         domains: Set<String>,
     ): ClearDataResult {
@@ -239,7 +248,9 @@ class ClearPersonalDataAction(
 
         return try {
             val fireproofDomains = withContext(dispatchers.io()) {
-                fireproofWebsiteRepository.fireproofWebsitesSync().mapNotNull { it.domain.toTldPlusOne() }
+                fireproofWebsiteRepository.fireproofWebsitesSync()
+                    .mapNotNull { it.domain.toTldPlusOne() }
+                    .toSet()
             }
 
             withContext(dispatchers.main()) {
@@ -247,11 +258,7 @@ class ClearPersonalDataAction(
                 domains
                     .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
                     .forEach { domain ->
-                        suspendCancellableCoroutine { continuation ->
-                            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
-                                continuation.resume(Unit)
-                            }
-                        }
+                        deleteSiteData(webStorage, domain)
                     }
                 logcat(INFO) { "Cleared site data for ${domains.size} domains" }
             }

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.history.api.NavigationHistory
@@ -238,7 +239,7 @@ class ClearPersonalDataAction(
 
         return try {
             val fireproofDomains = withContext(dispatchers.io()) {
-                fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
+                fireproofWebsiteRepository.fireproofWebsitesSync().mapNotNull { it.domain.toTldPlusOne() }
             }
 
             withContext(dispatchers.main()) {

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -16,18 +16,16 @@
 
 package com.duckduckgo.app.global.view
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.WebStorage
 import android.webkit.WebView
-import androidx.annotation.VisibleForTesting
-import androidx.webkit.WebStorageCompat
 import com.duckduckgo.app.browser.WebDataManager
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DeleteBrowsingData
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.fire.AppCacheClearer
 import com.duckduckgo.app.fire.FireActivity
+import com.duckduckgo.app.fire.SiteDataCleaner
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
@@ -43,13 +41,11 @@ import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.sync.api.DeviceSyncState
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.resume
 
 sealed class ClearDataResult {
     data object Success : ClearDataResult()
@@ -138,15 +134,7 @@ class ClearPersonalDataAction(
     private val tabVisitedSitesRepository: TabVisitedSitesRepository,
     private val webViewCapabilityChecker: WebViewCapabilityChecker,
     duckAiHostProvider: DuckAiHostProvider,
-    @VisibleForTesting
-    internal val deleteSiteData: suspend (WebStorage, String) -> Unit = { webStorage, domain ->
-        @SuppressLint("RequiresFeature")
-        suspendCancellableCoroutine { continuation ->
-            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
-                continuation.resume(Unit)
-            }
-        }
-    },
+    private val siteDataCleaner: SiteDataCleaner,
 ) : ClearDataAction {
 
     override fun killAndRestartProcess(notifyDataCleared: Boolean, enableTransitionAnimation: Boolean, deletedTabCount: Int) {
@@ -258,7 +246,7 @@ class ClearPersonalDataAction(
                 domains
                     .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
                     .forEach { domain ->
-                        deleteSiteData(webStorage, domain)
+                        siteDataCleaner.deleteSiteData(webStorage, domain)
                     }
                 logcat(INFO) { "Cleared site data for ${domains.size} domains" }
             }

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -237,10 +237,14 @@ class ClearPersonalDataAction(
         }
 
         return try {
+            val fireproofDomains = withContext(dispatchers.io()) {
+                fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
+            }
+
             withContext(dispatchers.main()) {
                 val webStorage = createWebStorage()
                 domains
-                    .filter { !duckDuckGoDomains.contains(it) }
+                    .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
                     .forEach { domain ->
                         suspendCancellableCoroutine { continuation ->
                             WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -320,6 +320,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
+    @Toggle.InternalAlwaysEnabled
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun singleTabFireDialog(): Toggle
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214044754400239?focus=true

### Description

This PR fixes the fireproofing for single tab burning.

### Steps to test this PR

- [x] Enable `singeTabFireDialog`
- [x] Log in to some website
- [x] Fireproof it
- [x] Use the fire dialog to delete this single tab
- [x] Navigate to the same domain where you logged in
- [x] Verify the user is logged in


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes single-tab/site-specific data deletion to exclude fireproofed domains and refactors WebView storage deletion behind an injectable cleaner, which could impact what data gets cleared or retained.
> 
> **Overview**
> Fixes single-tab “burn” data clearing to **not delete site data for fireproofed domains** (matching by eTLD+1) in `ClearPersonalDataAction.clearDataForSpecificDomains`, while continuing to always exclude DuckDuckGo/Duck AI domains.
> 
> Introduces an injectable `SiteDataCleaner` (with `RealSiteDataCleaner` using `WebStorageCompat.deleteBrowsingDataForSite`) and wires it through DI, enabling tests to capture/force failures; expands instrumentation tests to cover fireproof filtering, DDG filtering, capability gating, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd592ab28a345697cf86d8c6cc4093a1d40f3089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->