### PR TITLE
create subfeature to enable gradual rollouts

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2159,7 +2159,7 @@ class BrowserTabViewModel @Inject constructor(
 
         // Once a page load completes, ignore subsequent progress events (iframes, subresources)
         // until a new navigation starts (pageStarted/onPageContentStart resets hasCompletedPageLoad)
-        if (progressBarUpgradeFeature.self().isEnabled() && hasCompletedPageLoad) return
+        if (progressBarUpgradeFeature.behaviourUpdate().isEnabled() && hasCompletedPageLoad) return
 
         if (!currentBrowserViewState().maliciousSiteBlocked) {
             navigationStateChanged(webViewNavigationState)
@@ -2169,7 +2169,7 @@ class BrowserTabViewModel @Inject constructor(
         val progress = currentLoadingViewState()
         if (progress.progress == newProgress) return
 
-        val reportedProgress = if (progressBarUpgradeFeature.self().isEnabled()) {
+        val reportedProgress = if (progressBarUpgradeFeature.behaviourUpdate().isEnabled()) {
             newProgress
         } else {
             if (newProgress < FIXED_PROGRESS || isProcessingTrackingLink) FIXED_PROGRESS else newProgress
@@ -2177,7 +2177,7 @@ class BrowserTabViewModel @Inject constructor(
 
         // Track the first time we escape from max progress threshold for Wide Events
         val currentUrl = webViewNavigationState.currentUrl
-        val progressThreshold = if (progressBarUpgradeFeature.self().isEnabled()) UPGRADED_PROGRESS_THRESHOLD else FIXED_PROGRESS
+        val progressThreshold = if (progressBarUpgradeFeature.behaviourUpdate().isEnabled()) UPGRADED_PROGRESS_THRESHOLD else FIXED_PROGRESS
         if (!hasExitedFixedProgress && currentUrl != null && newProgress > progressThreshold) {
             hasExitedFixedProgress = true
             pageLoadWideEvent.onProgressChanged(tabId, currentUrl)
@@ -2274,7 +2274,7 @@ class BrowserTabViewModel @Inject constructor(
         // Reset progress so stale progress=100 from the previous page doesn't
         // trigger tracker animations before the new page's progress events arrive
         val progress = currentLoadingViewState()
-        if (progressBarUpgradeFeature.self().isEnabled() && progress.progress == 100) {
+        if (progressBarUpgradeFeature.behaviourUpdate().isEnabled() && progress.progress == 100) {
             loadingViewState.value = progress.copy(progress = 0)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -116,7 +116,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val isSplitOmnibarEnabled = settingsDataStore.omnibarType == OmnibarType.SPLIT
-    private val isProgressBarUpgradeEnabled = progressBarUpgradeFeature.self().isEnabled()
+    private val isProgressBarUpgradeEnabled = progressBarUpgradeFeature.behaviourUpdate().isEnabled()
     private var isSetFavouriteEasterEggLogoFeatureEnabled: Boolean = false
 
     private val _viewState = MutableStateFlow(

--- a/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarUpgradeFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/progressbar/ProgressBarUpgradeFeature.kt
@@ -28,4 +28,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 interface ProgressBarUpgradeFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun behaviourUpdate(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1655,7 +1655,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenBrowsingAndViewModelGetsProgressUpdateLowerThan50ThenViewStateIsUpdatedTo50() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = false))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = false))
         setBrowserShowing(true)
 
         testee.progressChanged(15, WebViewNavigationState(mockStack, 15))
@@ -1675,7 +1675,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressReaches100ThenSubsequentProgressEventsAreIgnored() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = true))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
         setBrowserShowing(true)
         testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
         assertEquals(true, loadingViewState().isLoading)
@@ -1691,7 +1691,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPageStartedAfterCompletionThenProgressEventsFlowAgain() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = true))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
         setBrowserShowing(true)
         testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
         testee.progressChanged(100, WebViewNavigationState(mockStack, 100))
@@ -1711,7 +1711,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressBarUpgradeEnabledThenRawProgressPassedThrough() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = true))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = true))
         setBrowserShowing(true)
 
         testee.progressChanged(15, WebViewNavigationState(mockStack, 15))
@@ -1721,7 +1721,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressBarUpgradeDisabledThenProgressFlooredAtFixedProgress() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = false))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = false))
         setBrowserShowing(true)
 
         testee.progressChanged(15, WebViewNavigationState(mockStack, 15))
@@ -1775,7 +1775,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenProgressChangesAndIsProcessingTrackingLinkThenVisualProgressEqualsFixedProgress() {
-        fakeProgressBarUpgradeFeature.self().setRawStoredState(State(enable = false))
+        fakeProgressBarUpgradeFeature.behaviourUpdate().setRawStoredState(State(enable = false))
         setBrowserShowing(true)
         testee.startProcessingTrackingLink()
         testee.progressChanged(100, WebViewNavigationState(mockStack, 100))


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1213877617250611?focus=true

### Description
No behaviour change, just use a sub-feature as it's the only way to do gradual rollouts. see: https://github.com/duckduckgo/privacy-configuration/blob/main/docs/incremental-rollout-implementation-guide.md 
and: https://github.com/duckduckgo/privacy-configuration/pull/4949

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a toggle wiring change that routes existing progress-bar logic through a new sub-feature flag, with no functional changes when the toggle configuration matches the old setup.
> 
> **Overview**
> Switches the progress-bar upgrade gating from the main `progressBarUpgrade` toggle to a new sub-toggle (`behaviourUpdate`) so the feature can be rolled out incrementally.
> 
> Updates browser loading/progress handling and omnibar UI state to consult `behaviourUpdate`, and adjusts unit tests accordingly; the remote feature interface now exposes the new sub-toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f559793befc11aafe5720abef5e6836f2072e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->