### PR TITLE
Check legacy when canUseEncryption in multiprocess

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -548,8 +548,8 @@ class RealSecureStorageKeyStore(
     override suspend fun canUseEncryption(): Boolean = withContext(dispatcherProvider.io()) {
         val harmonyFlags = harmonyFlags()
         when {
-            harmonyFlags.multiProcess -> getHarmonyEncryptedPreferences() != null
-            harmonyFlags.useHarmony && !harmonyFlags.multiProcess -> getEncryptedPreferences() != null && getHarmonyEncryptedPreferences() != null
+            harmonyFlags.multiProcess -> getEncryptedPreferences() != null && getHarmonyEncryptedPreferences() != null
+            harmonyFlags.useHarmony -> getEncryptedPreferences() != null && getHarmonyEncryptedPreferences() != null
             else -> getEncryptedPreferences() != null
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1214039006242283?focus=true

### Description
Since multi-process still writes to legacy for rollback purposes, also check it exists in `canUseEncryption`

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gating logic for secure storage encryption availability, which can alter whether autofill considers the keystore usable and may affect key access in multi-process setups.
> 
> **Overview**
> Tightens `RealSecureStorageKeyStore.canUseEncryption()` so that when *multi-process* or `useHarmony` is active it now requires **both** legacy encrypted preferences and Harmony preferences to be available (instead of allowing multi-process to pass with only Harmony).
> 
> This aligns the encryption-availability check with the dual-store expectations during multi-process/Harmony operation, reducing the chance of proceeding with encryption when one backing store is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea939cb2affeff5f7e9fc6f5bd684932d2662f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->