### PR TITLE
Enable harmony by default

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -178,7 +178,7 @@ interface AutofillFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun prioritizeDomainMatchesOnSearch(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun useHarmony(): Toggle
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1214039006242286?focus=true

### Description
Enable harmony by default without waiting for RC to be downloaded, to prevent race conditions when enabling the service

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips the default for `useHarmony` to on, changing the default encrypted key storage/migration behavior for users without remote-config overrides; this can affect credential/key persistence and rollback paths if issues arise.
> 
> **Overview**
> Enables Harmony-backed autofill storage by default by changing the `AutofillFeature.useHarmony` toggle’s default value from `FALSE` to `TRUE`.
> 
> This makes Harmony the default path for secure storage/migration logic in callers that rely on this flag when no remote-config value is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec753d237a572d79e6682fa0499b7e69018cab3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->