### PR TITLE
Added new pro tier products to pixel definition

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
@@ -24,14 +24,18 @@
                 "key": "feature.data.ext.free_trial_plan",
                 "description": "The base plan ID of the free trial product activated",
                 "enum": [
-                    "ddg-privacy-pro-monthly-renews-us",
-                    "ddg-privacy-pro-monthly-renews-row",
-                    "ddg-privacy-pro-yearly-renews-us",
-                    "ddg-privacy-pro-yearly-renews-row",
-                    "ddg-privacy-pro-sandbox-monthly-renews-us",
-                    "ddg-privacy-pro-sandbox-monthly-renews-row",
-                    "ddg-privacy-pro-sandbox-yearly-renews-us",
-                    "ddg-privacy-pro-sandbox-yearly-renews-row"
+                  "ddg-privacy-pro-monthly-renews-us",
+                  "ddg-privacy-pro-monthly-renews-row",
+                  "ddg-privacy-pro-yearly-renews-us",
+                  "ddg-privacy-pro-yearly-renews-row",
+                  "ddg-privacy-pro-sandbox-monthly-renews-us",
+                  "ddg-privacy-pro-sandbox-monthly-renews-row",
+                  "ddg-privacy-pro-sandbox-yearly-renews-us",
+                  "ddg-privacy-pro-sandbox-yearly-renews-row",
+                  "ddg-subscription-pro-yearly-renews-us",
+                  "ddg-subscription-pro-monthly-renews-us",
+                  "ddg-subscription-pro-yearly-renews-row",
+                  "ddg-subscription-pro-monthly-renews-row"
                 ]
             },
             {

--- a/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
+++ b/PixelDefinitions/pixels/definitions/wide_free_trial_conversion.json5
@@ -24,18 +24,18 @@
                 "key": "feature.data.ext.free_trial_plan",
                 "description": "The base plan ID of the free trial product activated",
                 "enum": [
-                  "ddg-privacy-pro-monthly-renews-us",
-                  "ddg-privacy-pro-monthly-renews-row",
-                  "ddg-privacy-pro-yearly-renews-us",
-                  "ddg-privacy-pro-yearly-renews-row",
-                  "ddg-privacy-pro-sandbox-monthly-renews-us",
-                  "ddg-privacy-pro-sandbox-monthly-renews-row",
-                  "ddg-privacy-pro-sandbox-yearly-renews-us",
-                  "ddg-privacy-pro-sandbox-yearly-renews-row",
-                  "ddg-subscription-pro-yearly-renews-us",
-                  "ddg-subscription-pro-monthly-renews-us",
-                  "ddg-subscription-pro-yearly-renews-row",
-                  "ddg-subscription-pro-monthly-renews-row"
+                    "ddg-privacy-pro-monthly-renews-us",
+                    "ddg-privacy-pro-monthly-renews-row",
+                    "ddg-privacy-pro-yearly-renews-us",
+                    "ddg-privacy-pro-yearly-renews-row",
+                    "ddg-privacy-pro-sandbox-monthly-renews-us",
+                    "ddg-privacy-pro-sandbox-monthly-renews-row",
+                    "ddg-privacy-pro-sandbox-yearly-renews-us",
+                    "ddg-privacy-pro-sandbox-yearly-renews-row",
+                    "ddg-subscription-pro-yearly-renews-us",
+                    "ddg-subscription-pro-monthly-renews-us",
+                    "ddg-subscription-pro-yearly-renews-row",
+                    "ddg-subscription-pro-monthly-renews-row"
                 ]
             },
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213864343373008?focus=true

### Description
Add new pro plans to pixel definition values

### Steps to test this PR
- [ ] N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands an enum in a pixel definition to accept additional plan IDs, with no runtime logic or data handling changes.
> 
> **Overview**
> Updates the `wide_free-trial-conversion` pixel definition to recognize new Pro-tier subscription products by adding four `ddg-subscription-pro-*` plan IDs to the allowed `feature.data.ext.free_trial_plan` enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f4a5387c7b5fee567cb31c2eee77d4c8d53ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->