### PR TITLE
Add translation for the "New tab toggle position" in the settings

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Преки пътища за Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Изберете кои преки пътища на Duck.ai да се показват</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Позиция на превключвателя за нов раздел</string>
+    <string name="duckAiDefaultTogglePositionSearch">Търсене</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Последно използвано</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Гласово търсене</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Zkratky Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Vyber, které zkratky Duck.ai se mají zobrazit</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Umístění přepínače na nové kartě</string>
+    <string name="duckAiDefaultTogglePositionSearch">Vyhledávání</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Naposledy použité</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Hlasové vyhledávání</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-genveje</string>
     <string name="duck_ai_shortcut_settings_description">Vælg hvilke Duck.ai-genveje der skal vises</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Ny position for faneskift</string>
+    <string name="duckAiDefaultTogglePositionSearch">Søg</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Sidst brugt</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Stemmesøgning</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-Shortcuts</string>
     <string name="duck_ai_shortcut_settings_description">Wähle aus, welche Duck.ai-Shortcuts angezeigt werden sollen</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Neuer Tab Schalterposition</string>
+    <string name="duckAiDefaultTogglePositionSearch">Suche</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Zuletzt verwendet</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Sprachsuche</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Συντομεύσεις Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Επιλέξτε ποιες συντομεύσεις του Duck.ai θα εμφανίζονται</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Θέση εναλλαγής νέας καρτέλας</string>
+    <string name="duckAiDefaultTogglePositionSearch">Αναζήτηση</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Τελευταία χρήση</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Φωνητική αναζήτηση</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Atajos de Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Elige qué atajos de Duck.ai quieres mostrar</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Nueva pestaña Alternar posición</string>
+    <string name="duckAiDefaultTogglePositionSearch">Buscar</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Último uso</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Búsqueda por voz</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai otseteed</string>
     <string name="duck_ai_shortcut_settings_description">Vali, milliseid Duck.ai otseteid kuvada</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Uue vahekaardi lüliti asend</string>
+    <string name="duckAiDefaultTogglePositionSearch">Otsing</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Viimati kasutatud</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Häälotsing</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-pikakuvakkeet</string>
     <string name="duck_ai_shortcut_settings_description">Valitse, mitkä Duck.ai-pikakuvakkeet näytetään</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Uuden välilehden vaihtopainikkeen sijainti</string>
+    <string name="duckAiDefaultTogglePositionSearch">Hae</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Viimeksi käytetty</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Äänihaku</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Raccourcis Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Choisissez les raccourcis Duck.ai à afficher</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Position de bascule du nouvel onglet</string>
+    <string name="duckAiDefaultTogglePositionSearch">Rechercher</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Dernière utilisation</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Recherche vocale</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai prečaci</string>
     <string name="duck_ai_shortcut_settings_description">Odaberi koje Duck.ai prečace želiš prikazati</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Prebacivanje položaja nove kartice</string>
+    <string name="duckAiDefaultTogglePositionSearch">Pretraga</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Posljednje korišteno</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Glasovno pretraživanje</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-gyorsparancsok</string>
     <string name="duck_ai_shortcut_settings_description">Válaszd ki a megjelenítendő Duck.ai-gyorsparancsokat</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Új lap kapcsolójának pozíciója</string>
+    <string name="duckAiDefaultTogglePositionSearch">Keresés</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Utoljára használt</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Beszédhangalapú keresés</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Scorciatoie Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Scegli quali scorciatoie di Duck.ai visualizzare</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Posizione del toggle Nuova scheda</string>
+    <string name="duckAiDefaultTogglePositionSearch">Ricerca</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Ultimo utilizzo</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Ricerca vocale</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">„Duck.ai“ spartieji klavišai</string>
     <string name="duck_ai_shortcut_settings_description">Pasirinkite, kuriuos „Duck.ai“ sparčiuosius klavišus rodyti</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Naujos kortelės perjungimo vieta</string>
+    <string name="duckAiDefaultTogglePositionSearch">Paieška</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Paskutinį kartą naudota</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Paieška balsu</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai īsceļi</string>
     <string name="duck_ai_shortcut_settings_description">Izvēlies, kurus Duck.ai īsceļus parādīt</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Jauna cilnes slēdža pozīcija</string>
+    <string name="duckAiDefaultTogglePositionSearch">Meklēt</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Pēdējo reizi lietots</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Balss meklēšana</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-snarveier</string>
     <string name="duck_ai_shortcut_settings_description">Velg hvilke Duck.ai-snarveier du vil skal vises</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Plassering av Ny fane-bryter</string>
+    <string name="duckAiDefaultTogglePositionSearch">Søk</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Sist brukt</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Talesøk</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-snelkoppelingen</string>
     <string name="duck_ai_shortcut_settings_description">Kies welke Duck.ai-snelkoppelingen je wilt weergeven</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Positie nieuw tabblad wisselen</string>
+    <string name="duckAiDefaultTogglePositionSearch">Zoeken</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Laatst gebruikt</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Zoeken via spraak</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Skróty Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Wybierz, które skróty Duck.ai chcesz wyświetlić</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Pozycja przełącznika nowej karty</string>
+    <string name="duckAiDefaultTogglePositionSearch">Szukaj</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Ostatnie użycie</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Wyszukiwanie głosowe</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Atalhos Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Escolhe os atalhos do Duck.ai a apresentar</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Nova posição de alternância de separador</string>
+    <string name="duckAiDefaultTogglePositionSearch">Pesquisar</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Última utilização</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Pesquisa por voz</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Comenzi rapide Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Alege ce comenzi rapide Duck.ai dorești să afișezi</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Poziția de comutare a filei noi</string>
+    <string name="duckAiDefaultTogglePositionSearch">Căutare</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Ultima utilizare</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Căutare vocală</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Ярлыки Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Выберите, какие ярлыки Duck.ai нужно показывать в интерфейсе</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Положение переключателя «Новая вкладка»</string>
+    <string name="duckAiDefaultTogglePositionSearch">Поиск</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Последнее использование</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Голосовой поиск</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Skratky Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Vyber, ktoré skratky Duck.ai sa majú zobraziť</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Nová poloha prepínača záložiek</string>
+    <string name="duckAiDefaultTogglePositionSearch">Vyhľadávať</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Naposledy použité</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Hlasové vyhľadávanie</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Bližnjice do Duck.ai</string>
     <string name="duck_ai_shortcut_settings_description">Izberite, katere bližnjice do Duck.ai naj bodo prikazane</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Preklop položaja za nov zavihek</string>
+    <string name="duckAiDefaultTogglePositionSearch">Iskanje</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Nazadnje uporabljeno</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Glasovno iskanje</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai-genvägar</string>
     <string name="duck_ai_shortcut_settings_description">Välj vilka Duck.ai-genvägar du vill visa</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Placering av reglage i ny flik</string>
+    <string name="duckAiDefaultTogglePositionSearch">Sökning</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Senast använt</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Röstsökning</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -48,6 +48,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai Kısayolları</string>
     <string name="duck_ai_shortcut_settings_description">Hangi Duck.ai kısayollarının gösterileceğini seçin</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Yeni Sekme Buton Konumu</string>
+    <string name="duckAiDefaultTogglePositionSearch">Arama yap</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Son Kullanılan</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Sesli Arama</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -17,10 +17,6 @@
 <resources>
     <string name="duckAiNativeInputFieldTitle">Native Input Field</string>
     <string name="duckAiNativeInputFieldMessage">Use the native input field for Duck.ai</string>
-    <string name="duckAiDefaultTogglePositionTitle">New tab toggle position</string>
-    <string name="duckAiDefaultTogglePositionSearch">Search</string>
-    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
-    <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
     <string name="input_screen_user_pref_without_ai_updated">Search only</string>
     <string name="input_screen_user_pref_with_ai_updated">Toggle between\nSearch and Duck.ai</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -47,6 +47,12 @@
     <string name="duck_ai_shortcut_settings_title">Duck.ai Shortcuts</string>
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
 
+    <!-- Default Toggle Position -->
+    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New tab toggle position</string>
+    <string name="duckAiDefaultTogglePositionSearch">Search</string>
+    <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
+    <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
+
     <!-- Duck AI Voice Search Shortcut Setting -->
     <string name="duckAiVoiceSearchVisibilitySetting">Voice Search</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Абонамент</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Няма достъп до функциите от ниво Plus или Pro</string>
     <string name="subscriptionsProUpgradeTitle">Надгради до Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Předplatné</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nemám přístup k funkcím úrovně Plus nebo Pro</string>
     <string name="subscriptionsProUpgradeTitle">Přejít na verzi Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnement</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Kan ikke få adgang til Plus- eller Pro-funktioner</string>
     <string name="subscriptionsProUpgradeTitle">Opgrader til Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnement</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Kein Zugriff auf Plus- oder Pro-Funktionen möglich</string>
     <string name="subscriptionsProUpgradeTitle">Upgrade auf Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Συνδρομή</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Δεν είναι δυνατή η πρόσβαση στις λειτουργίες επιπέδου Plus ή Pro</string>
     <string name="subscriptionsProUpgradeTitle">Αναβάθμιση σε Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Suscripción</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">No puedes acceder a las funciones de los niveles Plus o Pro</string>
     <string name="subscriptionsProUpgradeTitle">Actualiza a Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Püsitellimus</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Ei saa Plus või Pro taseme funktsioonidele ligi pääseda</string>
     <string name="subscriptionsProUpgradeTitle">Mine üle Pro-le</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Tilaus</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Plus- tai Pro-tason ominaisuuksia ei voi käyttää</string>
     <string name="subscriptionsProUpgradeTitle">Päivitä Pro-versioon</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnement</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Impossible d\'accéder aux fonctionnalités des niveaux Plus ou Pro</string>
     <string name="subscriptionsProUpgradeTitle">Passer à Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Pretplata</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Ne možeš pristupiti značajkama Plus ili Pro razine</string>
     <string name="subscriptionsProUpgradeTitle">Nadogradi na Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Előfizetés</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nem sikerült hozzáférni a Plusz vagy a Pro szintű funkciókhoz</string>
     <string name="subscriptionsProUpgradeTitle">Váltás Pro előfizetésre</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abbonamento</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Impossibile accedere alle funzionalità del livello Plus o Pro</string>
     <string name="subscriptionsProUpgradeTitle">Passa a Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Prenumerata</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nepavyksta pasiekti „Plus“ arba „Pro“ lygio funkcijų</string>
     <string name="subscriptionsProUpgradeTitle">Atnaujinkite į „Pro“</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonements</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nevar piekļūt Plus vai Pro līmeņa funkcijām</string>
     <string name="subscriptionsProUpgradeTitle">Jaunināt uz Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnement</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Får ikke tilgang til Plus- eller Pro-nivåfunksjoner</string>
     <string name="subscriptionsProUpgradeTitle">Oppgrader til Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnement</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Toegang tot Plus- of Pro-functies niet mogelijk</string>
     <string name="subscriptionsProUpgradeTitle">Upgraden naar Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Subskrypcja</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Brak dostępu do funkcji poziomu Plus lub Pro</string>
     <string name="subscriptionsProUpgradeTitle">Przejdź na poziom Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Subscrição</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Não é possível aceder às funcionalidades dos níveis Plus ou Pro</string>
     <string name="subscriptionsProUpgradeTitle">Atualizar para o Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonament</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nu poți accesa funcțiile de nivel Plus sau Pro</string>
     <string name="subscriptionsProUpgradeTitle">Fă upgrade la Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">По подписке</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Нет доступа к функциям уровня Plus или Pro</string>
     <string name="subscriptionsProUpgradeTitle">Перейти на Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Predplatné</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Nie je možné získať prístup k funkciám úrovne Plus alebo Pro</string>
     <string name="subscriptionsProUpgradeTitle">Aktualizovať na Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Naročnina</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Ne morem dostopati do funkcij naročnine Plus ali Pro</string>
     <string name="subscriptionsProUpgradeTitle">Nadgradi na Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonnemang</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Kan inte komma åt funktioner på Plus- eller Pro-nivå</string>
     <string name="subscriptionsProUpgradeTitle">Uppgradera till Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -180,8 +180,6 @@
 
     <string name="feedbackGeneralSubscription">Abonelik</string>
 
-    <!-- Switch plan-->
-
     <!-- Pro tier changes -->
     <string name="feedbackSubCategorySubsUnableToAccessProFeatures">Plus veya Pro seviye özelliklere erişilemiyor</string>
     <string name="subscriptionsProUpgradeTitle">Pro\'ya Yükseltin</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213800808542018?focus=true 

### Description
Adding translation for the "New tab toggle position" settings in the AI features settings page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds/moves Android string resources and removes unused comments, with no code or logic changes.
> 
> **Overview**
> Adds localized string resources for the Duck.ai settings option **“New tab toggle position”** (title + Search/Duck.ai/Last Used choices) across multiple `values-*` locales and the default `values` set.
> 
> Moves these strings out of `donottranslate.xml` so they become translatable, and removes a redundant `<!-- Switch plan-->` comment block from several localized subscriptions string files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8acf1b8a83993e7181baf6fcd9529b6f158ffbf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->