### PR TITLE
launch inputscreen instead of keyboard when inputscreen flag is enabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1539,7 +1539,11 @@ class BrowserTabViewModel @Inject constructor(
                 }?.tabId
                 if (emptyTab != null) {
                     tabRepository.select(tabId = emptyTab)
-                    command.value = ShowKeyboard
+                    if (duckAiFeatureState.showInputScreen.value) {
+                        command.value = LaunchInputScreen
+                    } else {
+                        command.value = ShowKeyboard
+                    }
                 } else {
                     command.value = LaunchNewTab
                 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2857,7 +2857,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenNewTabMenuItemClickedAndEmptyTabWithBlankUrlAndBlankSourceTabIdExistsThenSelectEmptyTab() =
+    fun whenNewTabMenuItemClickedAndEmptyTabExistsAndInputScreenDisabledThenShowKeyboard() =
         runTest {
             swipingTabsFeature.self().setRawStoredState(State(enable = true))
             swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
@@ -2877,6 +2877,28 @@ class BrowserTabViewModelTest {
             assertNull(command)
             verify(mockTabRepository).select(emptyTabId)
             assertCommandIssued<ShowKeyboard>()
+        }
+
+    @Test
+    fun whenNewTabMenuItemClickedAndEmptyTabExistsAndInputScreenEnabledThenLaunchInputScreen() =
+        runTest {
+            swipingTabsFeature.self().setRawStoredState(State(enable = true))
+            swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
+            mockDuckAiFeatureStateInputScreenFlow.emit(true)
+
+            val emptyTabId = "EMPTY_TAB"
+            whenever(mockTabRepository.getTabs()).thenReturn(
+                listOf(
+                    TabEntity("1", "https://example.com", position = 0),
+                    TabEntity(emptyTabId, url = "", sourceTabId = null, position = 1),
+                ),
+            )
+
+            testee.onNewTabMenuItemClicked()
+
+            verify(mockTabRepository).select(emptyTabId)
+            assertCommandNotIssued<ShowKeyboard>()
+            assertCommandIssued<Command.LaunchInputScreen>()
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/715106103902962/task/1213841190002877?focus=true

### Description
Long press tab switcher button when inputscreen flag is enabled inputscreen instead of keyboard.

### Steps to test this PR
- open new tab
- while in NTP long press the tab switcher.
- should open keyboard with omnibar focused.


| Before  | After |
| ------ | ----- |
![before](https://github.com/user-attachments/assets/48e7368b-3eb4-4c0e-bbdf-c423d4601c3a)|![after](https://github.com/user-attachments/assets/b0fa00b4-122a-46d1-ab58-1b4dca15b18c)|
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX change limited to new-tab behavior when reselecting an existing empty tab; primary risk is unintended navigation/keyboard behavior regressions under the Duck AI input-screen feature flag.
> 
> **Overview**
> When opening a new tab while tab swiping is enabled and an existing *empty* tab is reused, the app now **launches the Duck AI `InputScreen`** (via `LaunchInputScreen`) instead of always showing the keyboard when `duckAiFeatureState.showInputScreen` is enabled.
> 
> Updates `BrowserTabViewModelTest` to split coverage for the two flag states: asserting `ShowKeyboard` when disabled and `LaunchInputScreen` when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60941840716d442dde06f97d7ff3c43b2af4bff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->