### PR TITLE
Duck.ai/Voice chat: Simplify permission flow

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.websiteFromGeoLocationsApiOrigin
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.site.permissions.api.SitePermissionsDialogLauncher
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermissionRequest
@@ -63,6 +64,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private val pixel: Pixel,
     private val dispatcher: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val duckAiHostProvider: DuckAiHostProvider,
 ) : SitePermissionsDialogLauncher {
 
     private lateinit var sitePermissionRequest: PermissionRequest
@@ -116,15 +118,19 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
             }
 
             permissionsHandledByUser.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) -> {
-                showSitePermissionsRationaleDialog(
-                    R.string.sitePermissionsMicDialogTitle,
-                    R.string.sitePermissionsMicDialogSubtitle,
-                    url,
-                    SitePermissionsPixelValues.MICROPHONE,
-                    { rememberChoice ->
-                        askForMicPermissions(rememberChoice)
-                    },
-                )
+                if (request.origin.host == duckAiHostProvider.getHost()) {
+                    handleDuckAiAudioCapture()
+                } else {
+                    showSitePermissionsRationaleDialog(
+                        R.string.sitePermissionsMicDialogTitle,
+                        R.string.sitePermissionsMicDialogSubtitle,
+                        url,
+                        SitePermissionsPixelValues.MICROPHONE,
+                        { rememberChoice ->
+                            askForMicPermissions(rememberChoice)
+                        },
+                    )
+                }
             }
 
             permissionsHandledByUser.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE) -> {
@@ -407,6 +413,11 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 )
             }
         }
+    }
+
+    private fun handleDuckAiAudioCapture() {
+        // Grant mic access for this request only — never persist the site permission
+        askForMicPermissions(rememberChoice = false)
     }
 
     private fun askForMicPermissions(rememberChoice: Boolean = false) {

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncherTest.kt
@@ -17,14 +17,18 @@
 package com.duckduckgo.site.permissions.impl
 
 import android.app.Activity
+import android.net.Uri
 import android.webkit.PermissionRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Rule
@@ -42,6 +46,9 @@ class SitePermissionsDialogActivityLauncherTest {
     private val faviconManager: FaviconManager = mock()
     private val pixel: Pixel = mock()
     private val permissionsGrantedListener: SitePermissionsGrantedListener = mock()
+    private val duckAiHostProvider: DuckAiHostProvider = mock<DuckAiHostProvider>().also {
+        whenever(it.getHost()).thenReturn("duck.ai")
+    }
 
     private val testee = SitePermissionsDialogActivityLauncher(
         systemPermissionsHelper = systemPermissionsHelper,
@@ -50,6 +57,7 @@ class SitePermissionsDialogActivityLauncherTest {
         pixel = pixel,
         dispatcher = coroutineRule.testDispatcherProvider,
         appCoroutineScope = coroutineRule.testScope,
+        duckAiHostProvider = duckAiHostProvider,
     )
 
     @Test
@@ -97,5 +105,60 @@ class SitePermissionsDialogActivityLauncherTest {
         )
 
         verifyNoMoreInteractions(pixel)
+    }
+
+    @Test
+    fun whenDuckAiRequestsAudioCaptureAndMicNotGrantedThenRequestsMicPermissionWithoutPersisting() {
+        whenever(systemPermissionsHelper.hasMicPermissionsGranted()).thenReturn(false)
+
+        val activity: Activity = mock()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://duck.ai"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://duck.ai",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        // No impression pixel — no dialog shown for duck.ai
+        verifyNoMoreInteractions(pixel)
+        verify(systemPermissionsHelper).requestMultiplePermissions(
+            arrayOf(android.Manifest.permission.RECORD_AUDIO, android.Manifest.permission.MODIFY_AUDIO_SETTINGS),
+        )
+    }
+
+    @Test
+    fun whenDuckAiRequestsAudioCaptureAndMicGrantedThenGrantsDirectlyWithoutDialog() {
+        whenever(systemPermissionsHelper.hasMicPermissionsGranted()).thenReturn(true)
+
+        val activity: Activity = mock()
+        val request: PermissionRequest = mock()
+        whenever(request.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+        whenever(request.origin).thenReturn(Uri.parse("https://duck.ai"))
+
+        testee.askForSitePermission(
+            activity = activity,
+            url = "https://duck.ai",
+            tabId = "tabId",
+            permissionsRequested = SitePermissions(
+                autoAccept = emptyList(),
+                userHandled = listOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE),
+            ),
+            request = request,
+            permissionsGrantedListener = permissionsGrantedListener,
+        )
+
+        // No impression pixel — no dialog shown for duck.ai
+        verifyNoMoreInteractions(pixel)
+        // System permission not re-requested (already granted)
+        verify(systemPermissionsHelper, never()).requestMultiplePermissions(com.nhaarman.mockitokotlin2.any())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/492600419927320/task/1214050603436310?focus=true 

### Description
Simplify flow that when the microphone permission has been granted, site permission will be automatically granted as well.

### Steps to test this PR
_Precondition_
- [ ] Fresh Install build
- [ ] Enable `Ai Features -> Search & Duck.Ai`

_No permission granted yet_
- [ ] Go to Duck.AI tab
- [ ] Press the microphone icon
- [ ] Agree to Duck Ai terms
- [ ] Enable Voice Chat
- [ ] Verify that Android microphone permission is requested for DuckDuckGo
- [ ] Select While Using this App
- [ ] Verify that Duck.Ai voice chat works.
- [ ] Open a new tab and Duck.AI tab and select microphone icon again
- [ ] Verify that no permission is requested and Duck.Ai voice chat works

_Microphone permission granted on private voice search_
- [ ] Set permission of DDG app for microphone to “Ask Every time” (In Android Settings)
- [ ] Enable Private Voice Search via DDG Settings
- [ ] Go to Search tab
- [ ] Select microphone icon and grant permission
- [ ] Go to Duck.AI tab
- [ ] Press the microphone icon
- [ ] Verify that no permission is requested and Duck.Ai voice chat works


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 13c88e26391c2a095104afda38a8dc0c917f2907. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->