### PR TITLE
Show combined suggestions on Duck.ai tab with URL matches

### DIFF
--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.browser.ui.autocomplete
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
 import androidx.recyclerview.widget.DiffUtil
@@ -32,6 +33,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
+import com.duckduckgo.browser.ui.R
 import com.duckduckgo.browser.ui.autocomplete.AutoCompleteViewHolder.EmptySuggestionViewHolder
 
 private sealed interface AutoCompleteItem {
@@ -52,6 +54,8 @@ class BrowserAutoCompleteSuggestionsAdapter(
     private val autoCompleteOpenSettingsClickListener: () -> Unit,
     private val autoCompleteLongPressClickListener: (AutoCompleteSuggestion) -> Unit,
     omnibarType: OmnibarType,
+    private val hideEditQueryArrow: Boolean = false,
+    private val hideSectionDividers: Boolean = false,
 ) : RecyclerView.Adapter<AutoCompleteViewHolder>() {
     private val deleteClickListener: (AutoCompleteSuggestion) -> Unit = {
         val suggestions = getSuggestions().filter { suggestion -> suggestion != it }
@@ -156,6 +160,9 @@ class BrowserAutoCompleteSuggestionsAdapter(
                         autoCompleteOpenSettingsClickListener,
                         autoCompleteLongPressClickListener,
                     )
+                if (hideEditQueryArrow) {
+                    holder.itemView.findViewById<View>(R.id.editQueryImage)?.visibility = View.GONE
+                }
             }
         }
     }
@@ -195,8 +202,10 @@ class BrowserAutoCompleteSuggestionsAdapter(
     private fun needsDivider(
         current: AutoCompleteSuggestion,
         next: AutoCompleteSuggestion,
-    ): Boolean = (current.isSearchItem != next.isSearchItem) ||
-        (current is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion) != (next is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion)
+    ): Boolean = !hideSectionDividers && (
+        (current.isSearchItem != next.isSearchItem) ||
+            (current is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion) != (next is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion)
+        )
 
     object Type {
         const val EMPTY_TYPE = 1

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -773,7 +773,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 hideOverlayImmediately(binding.autoCompleteOverlay, ::invalidateAutoCompleteBlurView)
             }
             updateChatSuggestionsVisibility(
-                viewModel.chatSuggestions.value.isNotEmpty() || viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty(),
+                viewModel.visibilityState.value.chatSuggestionsVisible,
             )
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSearchSuggestionAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSearchSuggestionAdapter.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.duckchat.impl.databinding.ItemChatSearchSuggestionBinding
+
+class ChatSearchSuggestionAdapter(
+    private val onSearchClicked: (String) -> Unit,
+) : RecyclerView.Adapter<ChatSearchSuggestionAdapter.ViewHolder>() {
+
+    private var query: String = ""
+    private var visible: Boolean = false
+
+    fun update(query: String, visible: Boolean) {
+        val wasVisible = this.visible
+        val oldQuery = this.query
+        this.query = query
+        this.visible = visible
+        when {
+            wasVisible && !visible -> notifyItemRemoved(0)
+            !wasVisible && visible -> notifyItemInserted(0)
+            wasVisible && visible && oldQuery != query -> notifyItemChanged(0)
+        }
+    }
+
+    override fun getItemCount(): Int = if (visible) 1 else 0
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemChatSearchSuggestionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(query, onSearchClicked)
+    }
+
+    class ViewHolder(
+        private val binding: ItemChatSearchSuggestionBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(query: String, onSearchClicked: (String) -> Unit) {
+            binding.queryText.text = query
+            binding.root.setOnClickListener { onSearchClicked(query) }
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/SectionDividerAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/SectionDividerAdapter.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.browser.ui.R
+
+class SectionDividerAdapter : RecyclerView.Adapter<SectionDividerAdapter.ViewHolder>() {
+
+    private var visible: Boolean = false
+
+    fun setVisible(visible: Boolean) {
+        val wasVisible = this.visible
+        this.visible = visible
+        when {
+            wasVisible && !visible -> notifyItemRemoved(0)
+            !wasVisible && visible -> notifyItemInserted(0)
+        }
+    }
+
+    override fun getItemCount(): Int = if (visible) 1 else 0
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_autocomplete_divider, parent, false)
+        return ViewHolder(view as ViewGroup)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {}
+
+    class ViewHolder(view: ViewGroup) : RecyclerView.ViewHolder(view)
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
@@ -46,6 +46,7 @@ import javax.inject.Inject
 
 interface ChatSuggestionsReader {
     suspend fun fetchSuggestions(query: String = ""): List<ChatSuggestion>
+    fun getMaxUrlSuggestionsCount(): Int
     fun tearDown()
 }
 
@@ -142,6 +143,14 @@ class RealChatSuggestionsReader @Inject constructor(
                 JSONObject(it).optInt(MAX_HISTORY_COUNT_KEY, DEFAULT_MAX_SUGGESTIONS)
             }
         }.getOrNull() ?: DEFAULT_MAX_SUGGESTIONS
+    }
+
+    override fun getMaxUrlSuggestionsCount(): Int {
+        return runCatching {
+            duckAiChatHistoryFeature.self().getSettings()?.let {
+                JSONObject(it).optInt(MAX_URL_SUGGESTIONS_KEY, DEFAULT_MAX_URL_SUGGESTIONS)
+            }
+        }.getOrNull() ?: DEFAULT_MAX_URL_SUGGESTIONS
     }
 
     private fun getUserPreferencesJson(): String {
@@ -317,6 +326,8 @@ class RealChatSuggestionsReader @Inject constructor(
         private const val METHOD_CHATS_RESULT = "duckAiChatsResult"
         private const val MAX_HISTORY_COUNT_KEY = "maxHistoryCount"
         private const val DEFAULT_MAX_SUGGESTIONS = 10
+        private const val MAX_URL_SUGGESTIONS_KEY = "maxUrlSuggestions"
+        private const val DEFAULT_MAX_URL_SUGGESTIONS = 3
         private const val FETCH_TIMEOUT_MS = 3000L
         private const val SEVEN_DAYS_MS = 7L * 24 * 60 * 60 * 1000
         private const val EMPTY_HTML = "<html></html>"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -39,7 +40,9 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenFragment
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSearchSuggestionAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.SwipeableRecyclerView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
@@ -68,6 +71,10 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     private var chatSuggestionsRecyclerView: SwipeableRecyclerView? = null
     private lateinit var chatSuggestionsAdapter: ChatSuggestionsAdapter
     private var chatUrlSuggestionsAdapter: BrowserAutoCompleteSuggestionsAdapter? = null
+    private var chatSearchSuggestionAdapter: ChatSearchSuggestionAdapter? = null
+    private var chatUrlDividerAdapter: SectionDividerAdapter? = null
+    private var searchDividerAdapter: SectionDividerAdapter? = null
+    private var concatAdapter: ConcatAdapter? = null
     private var bottomBlurView: BottomBlurView? = null
     private var bottomBlurLayoutListener: View.OnLayoutChangeListener? = null
     private var bottomBlurDataObserver: RecyclerView.AdapterDataObserver? = null
@@ -117,27 +124,33 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         combine(
             viewModel.chatSuggestions,
             viewModel.chatUrlSuggestions,
-        ) { chatSuggestions, urlSuggestions ->
-            Pair(chatSuggestions, urlSuggestions)
+            viewModel.chatInputText,
+        ) { chatSuggestions, urlSuggestions, chatInput ->
+            Triple(chatSuggestions, urlSuggestions, chatInput)
         }.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-            .onEach { (chatSuggestions, urlSuggestions) ->
+            .onEach { (chatSuggestions, urlSuggestions, chatInput) ->
                 if (viewModel.visibilityState.value.searchMode) return@onEach
+                val isTyping = chatInput.isNotEmpty()
                 val hasChatSuggestions = chatSuggestions.isNotEmpty()
                 val hasUrlSuggestions = urlSuggestions.suggestions.isNotEmpty()
 
-                if (hasChatSuggestions) {
-                    chatSuggestionsRecyclerView?.adapter = chatSuggestionsAdapter
-                    chatSuggestionsAdapter.submitList(chatSuggestions)
-                    parentFragment.updateChatSuggestionsVisibility(true)
-                } else if (hasUrlSuggestions) {
-                    chatSuggestionsRecyclerView?.adapter = chatUrlSuggestionsAdapter
+                chatSuggestionsAdapter.submitList(chatSuggestions)
+
+                val showUrlSuggestions = isTyping && hasUrlSuggestions
+                if (showUrlSuggestions) {
                     chatUrlSuggestionsAdapter?.updateData(urlSuggestions.query, urlSuggestions.suggestions)
-                    parentFragment.updateChatSuggestionsVisibility(true)
                 } else {
-                    chatSuggestionsRecyclerView?.adapter = chatSuggestionsAdapter
-                    chatSuggestionsAdapter.submitList(emptyList())
-                    parentFragment.updateChatSuggestionsVisibility(false)
+                    chatUrlSuggestionsAdapter?.updateData("", emptyList())
                 }
+
+                chatSearchSuggestionAdapter?.update(chatInput, visible = isTyping)
+
+                // Dividers show between non-empty adjacent sections
+                chatUrlDividerAdapter?.setVisible(hasChatSuggestions && showUrlSuggestions)
+                searchDividerAdapter?.setVisible((hasChatSuggestions || showUrlSuggestions) && isTyping)
+
+                val hasAnySuggestions = hasChatSuggestions || isTyping
+                parentFragment.updateChatSuggestionsVisibility(hasAnySuggestions)
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
@@ -155,12 +168,27 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     private fun configureChatUrlSuggestions() {
         chatUrlSuggestionsAdapter = BrowserAutoCompleteSuggestionsAdapter(
             immediateSearchClickListener = { viewModel.userSelectedAutocomplete(it, fromChatUrlSuggestions = true) },
-            editableSearchClickListener = { viewModel.onUserSelectedToEditQuery(it.phrase) },
+            editableSearchClickListener = { },
             autoCompleteInAppMessageDismissedListener = { },
             autoCompleteOpenSettingsClickListener = { },
             autoCompleteLongPressClickListener = { },
             omnibarType = if (inputScreenConfigResolver.useTopBar()) OmnibarType.SINGLE_TOP else OmnibarType.SINGLE_BOTTOM,
+            hideEditQueryArrow = true,
+            hideSectionDividers = true,
         )
+        chatSearchSuggestionAdapter = ChatSearchSuggestionAdapter { query ->
+            viewModel.onSearchSubmitted(query)
+        }
+        chatUrlDividerAdapter = SectionDividerAdapter()
+        searchDividerAdapter = SectionDividerAdapter()
+        concatAdapter = ConcatAdapter(
+            chatSuggestionsAdapter,
+            chatUrlDividerAdapter,
+            chatUrlSuggestionsAdapter,
+            searchDividerAdapter,
+            chatSearchSuggestionAdapter,
+        )
+        chatSuggestionsRecyclerView?.adapter = concatAdapter
     }
 
     private fun configureBottomBlur() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -192,6 +192,7 @@ class InputScreenViewModel @AssistedInject constructor(
     private val initialSearchInputText = currentOmnibarText.trim()
     private val searchInputTextState = MutableStateFlow(initialSearchInputText)
     private val chatInputTextState = MutableStateFlow("")
+    val chatInputText: StateFlow<String> = chatInputTextState.asStateFlow()
 
     private val _submitButtonIconState = MutableStateFlow(SubmitButtonIconState(SubmitButtonIcon.SEARCH))
     val submitButtonIconState: StateFlow<SubmitButtonIconState> = _submitButtonIconState.asStateFlow()
@@ -283,10 +284,9 @@ class InputScreenViewModel @AssistedInject constructor(
         if (duckChatFeature.rememberTogglePosition().isEnabled()) {
             combine(
                 chatInputTextState.debounceExceptFirst(timeoutMillis = 100),
-                _chatSuggestions,
                 autoCompleteSuggestionsEnabled,
-            ) { chatInput, chatSuggestions, autoCompleteEnabled ->
-                if (autoCompleteEnabled && chatInput.isNotEmpty() && chatSuggestions.isEmpty()) chatInput else null
+            ) { chatInput, autoCompleteEnabled ->
+                if (autoCompleteEnabled && chatInput.isNotEmpty()) chatInput else null
             }.distinctUntilChanged()
                 .flatMapLatest { query ->
                     if (query != null) {
@@ -297,7 +297,7 @@ class InputScreenViewModel @AssistedInject constructor(
                                         it is AutoCompleteSwitchToTabSuggestion ||
                                         it is AutoCompleteHistorySuggestion ||
                                         (it is AutoCompleteSearchSuggestion && it.isUrl)
-                                },
+                                }.take(chatSuggestionsReader.getMaxUrlSuggestionsCount()),
                             )
                         }
                     } else {
@@ -376,13 +376,17 @@ class InputScreenViewModel @AssistedInject constructor(
             }
         }.launchIn(viewModelScope)
 
-        combine(_chatSuggestions, chatUrlSuggestions) { chatSuggestions, urlSuggestions ->
-            Pair(chatSuggestions, urlSuggestions)
-        }.onEach { (chatSuggestions, urlSuggestions) ->
+        combine(_chatSuggestions, chatUrlSuggestions, chatInputTextState) { chatSuggestions, urlSuggestions, chatInput ->
+            Triple(chatSuggestions, urlSuggestions, chatInput)
+        }.onEach { (chatSuggestions, urlSuggestions, chatInput) ->
             val hasChatSuggestions = chatSuggestions.isNotEmpty()
             val hasUrlSuggestions = urlSuggestions.suggestions.isNotEmpty()
+            val hasSearchRow = duckChatFeature.rememberTogglePosition().isEnabled() && chatInput.isNotEmpty()
             _visibilityState.update {
-                it.copy(showChatLogo = !hasChatSuggestions && !hasUrlSuggestions, chatSuggestionsVisible = hasChatSuggestions || hasUrlSuggestions)
+                it.copy(
+                    showChatLogo = !hasChatSuggestions && !hasUrlSuggestions && !hasSearchRow,
+                    chatSuggestionsVisible = hasChatSuggestions || hasUrlSuggestions || hasSearchRow,
+                )
             }
         }.launchIn(viewModelScope)
 

--- a/duckchat/duckchat-impl/src/main/res/layout/item_chat_search_suggestion.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_chat_search_suggestion.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemEndPadding"
+    android:paddingVertical="?attr/autocompleteListItemVerticalPadding">
+
+    <ImageView
+        android:id="@+id/searchIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_find_search_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/queryText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/autocompleteListItemIconMargin"
+        android:ellipsize="end"
+        android:includeFontPadding="false"
+        android:gravity="center_vertical|start"
+        android:maxLines="1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/searchIcon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="example query" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subtitleText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/autocompleteListItemIconMargin"
+        android:text="@string/duckAiChatSearchDuckDuckGo"
+        android:ellipsize="end"
+        android:gravity="center_vertical|start"
+        android:maxLines="1"
+        app:typography="body2"
+        app:textType="secondary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/searchIcon"
+        app:layout_constraintTop_toBottomOf="@id/queryText"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -23,6 +23,7 @@
     <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
     <string name="input_screen_user_pref_without_ai_updated">Search only</string>
     <string name="input_screen_user_pref_with_ai_updated">Toggle between\nSearch and Duck.ai</string>
+    <string name="duckAiChatSearchDuckDuckGo">Search DuckDuckGo</string>
 
     <!-- Model Picker -->
     <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -129,6 +129,7 @@ class InputScreenViewModelTest {
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)
+            whenever(chatSuggestionsReader.getMaxUrlSuggestionsCount()).thenReturn(3)
         }
 
     private fun createViewModel(currentOmnibarText: String = ""): InputScreenViewModel =
@@ -3109,12 +3110,10 @@ class InputScreenViewModelTest {
 
     @Suppress("DenyListedApi")
     @Test
-    fun `chatUrlSuggestions is empty when chat suggestions exist`() =
+    fun `chatUrlSuggestions shows alongside chat suggestions when both exist`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
-            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
-            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(
                 listOf(ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false)),
             )
@@ -3127,7 +3126,37 @@ class InputScreenViewModelTest {
             viewModel.onChatInputTextChanged("test")
             advanceUntilIdle()
 
-            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
+            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty())
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatUrlSuggestions is limited to max configured count`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+            whenever(autoComplete.autoComplete(any())).thenReturn(
+                flowOf(
+                    AutoCompleteResult(
+                        "test",
+                        listOf(
+                            AutoCompleteSearchSuggestion("test1.com", isUrl = true, isAllowedInTopHits = false),
+                            AutoCompleteSearchSuggestion("test2.com", isUrl = true, isAllowedInTopHits = false),
+                            AutoCompleteSearchSuggestion("test3.com", isUrl = true, isAllowedInTopHits = false),
+                            AutoCompleteSearchSuggestion("test4.com", isUrl = true, isAllowedInTopHits = false),
+                            AutoCompleteSearchSuggestion("test5.com", isUrl = true, isAllowedInTopHits = false),
+                        ),
+                    ),
+                ),
+            )
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("test")
+            advanceUntilIdle()
+
+            assertEquals(3, viewModel.chatUrlSuggestions.value.suggestions.size)
         }
 
     @Suppress("DenyListedApi")
@@ -3171,6 +3200,37 @@ class InputScreenViewModelTest {
             assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty())
             assertTrue(viewModel.visibilityState.value.chatSuggestionsVisible)
             assertFalse(viewModel.visibilityState.value.showChatLogo)
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatSuggestionsVisible is true and logo hidden when typing with no results`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+            val viewModel = createViewModel()
+            viewModel.onChatSelected()
+            viewModel.onChatInputTextChanged("xyz")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.visibilityState.value.chatSuggestionsVisible)
+            assertFalse(viewModel.visibilityState.value.showChatLogo)
+        }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `chatInputText exposes current chat input`() =
+        runTest {
+            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
+            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+            val viewModel = createViewModel()
+            viewModel.onChatInputTextChanged("hello")
+
+            assertEquals("hello", viewModel.chatInputText.value)
         }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
@@ -548,4 +548,43 @@ class RealChatSuggestionsReaderTest {
     }
 
     // endregion
+
+    // region getMaxUrlSuggestionsCount
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when settings has maxUrlSuggestions then returns that value`() {
+        duckAiChatHistoryFeature.self().setRawStoredState(
+            State(enable = true, settings = """{"maxUrlSuggestions":5}"""),
+        )
+
+        assertEquals(5, reader.getMaxUrlSuggestionsCount())
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when settings has no maxUrlSuggestions then returns default`() {
+        duckAiChatHistoryFeature.self().setRawStoredState(
+            State(enable = true, settings = """{}"""),
+        )
+
+        assertEquals(3, reader.getMaxUrlSuggestionsCount())
+    }
+
+    @Test
+    fun `when settings is null then returns default for maxUrlSuggestions`() {
+        assertEquals(3, reader.getMaxUrlSuggestionsCount())
+    }
+
+    @Suppress("DenyListedApi")
+    @Test
+    fun `when settings has invalid json then returns default for maxUrlSuggestions`() {
+        duckAiChatHistoryFeature.self().setRawStoredState(
+            State(enable = true, settings = "invalid"),
+        )
+
+        assertEquals(3, reader.getMaxUrlSuggestionsCount())
+    }
+
+    // endregion
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214043381369782?focus=true 

### Description

**Before this change**
When typing on the Duck.ai tab, only recent chat matches were shown. If no chats matched the input, the user saw URL match. URL suggestions only appeared after all chat matches were filtered out.

**After this change**
When typing on the Duck.ai tab, the suggestion list now shows three sections with dividers between them:

1. Recent chats (up to 10): filter as the user types, disappear when no matches
2. URL suggestions (up to 3): bookmarks, history, open tabs, and URL-type search results, in the same order/rank as the Search tab. No edit arrow, no internal dividers.
3. "Search DuckDuckGo” row: always visible while typing, performs a web search when tapped
                                                                                                                        
When input is empty, only recent chats are shown (or the logo if none exist). The Search tab behavior is completely unchanged.                                                                                                            
                                                                                                                        
**Additional changes to note**                                                                                                  

- URL suggestion limit is configurable via duckAiChatHistory remote config (maxUrlSuggestions, default 3)                                                                           
- BrowserAutoCompleteSuggestionsAdapter added hideEditQueryArrow and hideSectionDividers flags for customization, as we’re using the same adapter as the search tab and other autocomplete views.
- All gated behind the rememberTogglePosition feature flag

### Steps to test this PR

#### 1. Basic flow

- Enable rememberTogglePosition FF, select "Search & Duck.ai” mode
- Have some chats in your duck.ai history
- Switch to Duck.ai tab, type a URL you've visited → verify recent chats, URL suggestions, and “Search DuckDuckGo” row all appear
- Verify dividers appear between non-empty sections
- Verify no divider appears between sections when one is empty
- Verify URL suggestions have no edit arrow and no internal dividers                                                  

#### 2. Section behavior                                                                                                      

- Type text matching recent chats → verify chats show at top, URL suggestions below, "Search DuckDuckGo" at bottom
- Keep typing until no chats match → verify chats disappear, URL suggestions and search row remain
- Type text with no chat or URL matches → verify only "Search DuckDuckGo" row appears, no logo
- Clear all text → verify only recent chats show (or logo if none), no URL suggestions or search row                  
  
#### 3. Interactions

- Tap a URL suggestion → verify it navigates to that URL
- Tap "Search DuckDuckGo" → verify it performs a web search (not a chat)
- Tap a recent chat → verify it opens the chat                                                                        
                                                                                                                        
#### 4. Limits and configuration

- Verify at most 3 URL suggestions are shown
- Verify URL suggestion order matches the top of the Search tab's results, without the autocomplete text matches
                                                                                                                        
#### 5. Settings and flags                                        

- Disable "Search Suggestions" in settings → verify no URL suggestions or search row on Duck.ai tab
- Disable rememberTogglePosition FF → verify Duck.ai tab behaves as before (no URL suggestions, no search row, chat suggestions only)
- Search tab behavior unchanged in all scenarios          

#### 6. Cross-tab                                                 

- Switch between Search and Duck.ai tabs with matching results → verify no interference between tabs
- Type on Duck.ai, switch to Search, switch back → verify results persist correctly

### UI changes

https://github.com/user-attachments/assets/4e39ee9c-5a0f-4439-aedc-932bb10f10d6

<!-- CURSOR_SUMMARY —>


—

> [!NOTE]
> **Medium Risk**
> Moderate UI/flow changes to Duck.ai suggestions rendering (new `ConcatAdapter` sections, new visibility logic, and new config-driven limits) which could affect suggestion ordering/visibility and RecyclerView update behavior.
> 
> **Overview**
> Updates Duck.ai tab suggestions to **show multiple sections at once** instead of choosing a single adapter: chat history suggestions, optional URL autocomplete matches while typing, and a new one-row "Search DuckDuckGo" action for the current input.
> 
> Adds lightweight section infrastructure (`ConcatAdapter` + `SectionDividerAdapter`) and a new `ChatSearchSuggestionAdapter`/layout, while extending `BrowserAutoCompleteSuggestionsAdapter` with flags to hide the edit-query arrow and internal dividers for the Duck.ai URL section.
> 
> Makes URL suggestion fetching independent of chat-suggestion presence, **caps URL results** via a new `maxUrlSuggestions` privacy-config setting exposed by `ChatSuggestionsReader`, and adjusts `InputScreenViewModel` visibility state so the logo hides and the suggestions area stays visible while typing even when there are no results (with updated/new tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7200de61573e880514b3b735522632274e3e1bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/flow changes to Duck.ai suggestions rendering and visibility state (new `ConcatAdapter` sections and config-driven URL limiting) that could affect RecyclerView updates and suggestion ordering/visibility.
> 
> **Overview**
> Updates the Duck.ai tab suggestions UI to **render multiple sections at once** (recent chats, URL autocomplete matches, and a new “Search DuckDuckGo” row) using a `ConcatAdapter` with conditional dividers, instead of swapping a single adapter based on results.
> 
> Makes URL suggestions independent of chat-suggestion presence, hides the edit-query arrow/internal dividers for that section via new `BrowserAutoCompleteSuggestionsAdapter` flags, and caps URL results using a new remote-config setting (`maxUrlSuggestions`, default 3) exposed through `ChatSuggestionsReader`.
> 
> Adjusts visibility logic so the suggestions overlay stays visible and the Duck.ai logo hides while typing even with no matches, and updates/adds unit tests to cover the new behavior and limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62999edb72a17065017587a0a4a0624c9a223132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->