### PR TITLE
DuckAi/Voice chat: Add pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -365,15 +365,22 @@
         "parameters": ["appVersion"]
     },
     "m_aichat_voice_entry_tapped_count": {
-        "description": "User tapped the voice entry point button on the duck.ai tab in the input screen",
-        "owners": ["aitorvs"],
+        "description": "User tapped the voice entry point button to open Duck.ai voice mode",
+        "owners": ["aitorvs", "karlenDimla"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
     "m_aichat_voice_entry_tapped_daily": {
-        "description": "(Daily Pixel) User tapped the voice entry point button on the duck.ai tab in the input screen",
-        "owners": ["aitorvs"],
+        "description": "(Daily Pixel) User tapped the voice entry point button to open Duck.ai voice mode",
+        "owners": ["aitorvs", "karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_voice_session_started": {
+        "description": "Fires when the native layer receives a voiceSessionStarted bridge message from the Duck.ai frontend, indicating a voice session has actually begun",
+        "owners": ["karlenDimla"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -57,9 +57,15 @@ interface DuckChatJSHelper {
 
     fun onNativeAction(action: NativeAction): SubscriptionEventData
 
-    suspend fun enrichPageContextIfPossible(tabId: String, pageContext: String): String
+    suspend fun enrichPageContextIfPossible(
+        tabId: String,
+        pageContext: String,
+    ): String
 
-    fun storeTabContextPromptEvent(prompt: String, pageContexts: List<JSONObject>)
+    fun storeTabContextPromptEvent(
+        prompt: String,
+        pageContexts: List<JSONObject>,
+    )
 
     fun clearTabContextPromptEvent()
 
@@ -186,6 +192,7 @@ class RealDuckChatJSHelper @Inject constructor(
                                 duckChatPixels.reportContextualPageContextManuallyAttachedFrontend()
                                 getPageContextResponse(featureName, method, it, pageContext, tabId)
                             }
+
                             REASON_INIT -> {
                                 if (duckChat.isAutomaticContextAttachmentEnabled()) {
                                     getPageContextResponse(featureName, method, it, pageContext, tabId)
@@ -193,6 +200,7 @@ class RealDuckChatJSHelper @Inject constructor(
                                     null
                                 }
                             }
+
                             else -> {
                                 null
                             }
@@ -211,6 +219,11 @@ class RealDuckChatJSHelper @Inject constructor(
                         duckChatPixels.reportContextualPageContextRemovedFrontend()
                     }
                 }
+                null
+            }
+
+            METHOD_VOICE_SESSION_STARTED -> {
+                duckChatPixels.reportVoiceSessionStarted()
                 null
             }
 
@@ -235,7 +248,10 @@ class RealDuckChatJSHelper @Inject constructor(
         )
     }
 
-    override suspend fun enrichPageContextIfPossible(tabId: String, pageContext: String): String {
+    override suspend fun enrichPageContextIfPossible(
+        tabId: String,
+        pageContext: String,
+    ): String {
         val json = JSONObject(pageContext)
         val url = json.optString("url").takeIf { it.isNotBlank() }
         if (url != null) {
@@ -256,7 +272,10 @@ class RealDuckChatJSHelper @Inject constructor(
         return json.toString()
     }
 
-    override fun storeTabContextPromptEvent(prompt: String, pageContexts: List<JSONObject>) {
+    override fun storeTabContextPromptEvent(
+        prompt: String,
+        pageContexts: List<JSONObject>,
+    ) {
         if (!duckChatFeature.chatTabAttachments().isEnabled()) return
         pendingTabContextStore.store(prompt, pageContexts)
     }
@@ -438,6 +457,7 @@ class RealDuckChatJSHelper @Inject constructor(
         const val METHOD_GET_PAGE_CONTEXT = "getAIChatPageContext"
         const val METHOD_OPEN_KEYBOARD = "openKeyboard"
         private const val METHOD_TOGGLE_PAGE_CONTEXT = "togglePageContextTelemetry"
+        private const val METHOD_VOICE_SESSION_STARTED = "voiceSessionStarted"
         private const val AI_CHAT_PAYLOAD = "aiChatPayload"
         private const val METHOD_OPEN_KEYBOARD_PAYLOAD = "selector"
         private const val IS_HANDOFF_ENABLED = "isAIChatHandoffEnabled"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -725,8 +725,8 @@ class InputScreenViewModel @AssistedInject constructor(
 
     fun onVoiceEntryTapped() {
         pixel.fireCountAndDaily(
-            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT,
-            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY,
+            DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY,
         )
         duckChat.openVoiceDuckChat()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
@@ -65,6 +65,7 @@ class DuckChatContentScopeJsMessageHandler @Inject constructor(
                     "submitAIChatPageContext",
                     "userDidAcceptTermsAndConditions",
                     "getAIChatNativePrompt",
+                    "voiceSessionStarted",
                 )
         }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -144,6 +144,7 @@ interface DuckChatPixels {
 
     fun reportNativeStorageReaderUsed(native: Boolean)
     fun reportNativeStorageDeletionUsed(native: Boolean)
+    fun reportVoiceSessionStarted()
 }
 
 @ContributesBinding(AppScope::class)
@@ -391,6 +392,10 @@ class RealDuckChatPixels @Inject constructor(
         }
         pixel.fire(pixelName)
     }
+
+    override fun reportVoiceSessionStarted() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED)
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -550,7 +555,6 @@ object DuckChatPixelParameters {
     const val NEW_ADDRESS_BAR_SELECTION = "selection"
     const val DEFAULT_TOGGLE_POSITION = "default_position"
     const val DEFAULT_TOGGLE_POSITION_VALUE = "value"
-    const val SOURCE = "source"
 }
 
 @ContributesMultibinding(AppScope::class)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -519,8 +519,9 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY("m_aichat_recent_chat_selected_daily"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT("m_aichat_recent_chat_selected_pinned_count"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY("m_aichat_recent_chat_selected_pinned_daily"),
-    DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT("m_aichat_voice_entry_tapped_count"),
-    DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY("m_aichat_voice_entry_tapped_daily"),
+    DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT("m_aichat_voice_entry_tapped_count"),
+    DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY("m_aichat_voice_entry_tapped_daily"),
+    DUCK_CHAT_VOICE_SESSION_STARTED("m_aichat_voice_session_started"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_FIRST("m_aichat_contextual_fire_button_tapped_first"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_DAILY("m_aichat_contextual_fire_button_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_COUNT("m_aichat_contextual_fire_button_tapped_count"),
@@ -549,6 +550,7 @@ object DuckChatPixelParameters {
     const val NEW_ADDRESS_BAR_SELECTION = "selection"
     const val DEFAULT_TOGGLE_POSITION = "default_position"
     const val DEFAULT_TOGGLE_POSITION_VALUE = "value"
+    const val SOURCE = "source"
 }
 
 @ContributesMultibinding(AppScope::class)
@@ -673,8 +675,9 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_FIRST.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
@@ -43,7 +43,7 @@ class DuckChatContentScopeJsMessageHandlerTest {
     @Test
     fun `only contains valid methods`() {
         val methods = handler.methods
-        assertTrue(methods.size == 15)
+        assertTrue(methods.size == 16)
         assertTrue(methods[0] == "getAIChatNativeHandoffData")
         assertTrue(methods[1] == "getAIChatNativeConfigValues")
         assertTrue(methods[2] == "openAIChat")
@@ -59,6 +59,7 @@ class DuckChatContentScopeJsMessageHandlerTest {
         assertTrue(methods[12] == "submitAIChatPageContext")
         assertTrue(methods[13] == "userDidAcceptTermsAndConditions")
         assertTrue(methods[14] == "getAIChatNativePrompt")
+        assertTrue(methods[15] == "voiceSessionStarted")
     }
 
     private val callback = object : JsMessageCallback() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -2833,8 +2833,8 @@ class InputScreenViewModelTest {
             val viewModel = createViewModel()
             viewModel.onVoiceEntryTapped()
 
-            verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_COUNT)
-            verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_VOICE_ENTRY_TAPPED_DAILY, type = Daily())
+            verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT)
+            verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY, type = Daily())
             verify(duckChat).openVoiceDuckChat()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/492600419927320/task/1213968100249532?focus=true 

### Description
Adds voice session started pixel + few cleanups

### Steps to test this PR

_Start voice chat_
- [ ] Filter `m_aichat_voice_` in your logcat
- [ ] Click on DuckAi > microphone/voice chat
- [ ] Do all necessary steps to start voice session
- [ ] Verify that `m_aichat_voice_entry_tapped_daily`, `m_aichat_voice_entry_tapped_count `and `m_aichat_voice_session_started` are emitted.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds/renames telemetry pixels and a new JS bridge message handler, with minimal impact on user-facing behavior beyond analytics emission.
> 
> **Overview**
> Adds a new voice telemetry event, `m_aichat_voice_session_started`, fired when the WebView frontend sends the `voiceSessionStarted` JS bridge message to native.
> 
> Standardizes voice entry tap telemetry by switching the input screen to fire `DUCK_CHAT_VOICE_ENTRY_TAPPED_{COUNT,DAILY}` (same underlying pixel names) and updates pixel definitions/owners plus unit tests and allowed JS messaging methods accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a64211bb7fbef48086620b0525ab09bc9db43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->