### PR TITLE
Fix Espresso tests for bottom sheet browser menu

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserMenuUtils.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserMenuUtils.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.view.View
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.PerformException
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.duckduckgo.espresso.waitForView
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+import com.google.android.material.R as MaterialR
+
+/**
+ * Waits for a menu item to be visible in the popup menu or bottom sheet,
+ * then clicks it. Handles both menu types transparently so callers don't
+ * need to worry about which root the view is in.
+ *
+ * @param viewMatcher The matcher for the menu item to wait for and click.
+ */
+fun clickMenuItem(viewMatcher: Matcher<View>) {
+    try {
+        onView(isRoot()).perform(waitForView(viewMatcher, timeout = 2000))
+        onView(viewMatcher).perform(click())
+    } catch (_: PerformException) {
+        // Bottom sheet path: expand fully so the NestedScrollView has room, then scroll and click.
+        onView(withId(MaterialR.id.design_bottom_sheet))
+            .inRoot(isDialog())
+            .perform(expandBottomSheet())
+        onView(viewMatcher).inRoot(isDialog()).perform(scrollTo(), click())
+    }
+}
+
+private fun expandBottomSheet(): ViewAction {
+    return object : ViewAction {
+        override fun getConstraints(): Matcher<View> = Matchers.any(View::class.java)
+        override fun getDescription(): String = "expand bottom sheet to full height"
+        override fun perform(uiController: UiController, view: View) {
+            val behavior = BottomSheetBehavior.from(view)
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            // Wait for the expansion animation to complete
+            uiController.loopMainThreadForAtLeast(500)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/espresso/BasicJourneyTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/BasicJourneyTest.kt
@@ -18,37 +18,48 @@ package com.duckduckgo.espresso
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isClickable
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.clickMenuItem
 import org.hamcrest.Matchers.allOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import com.duckduckgo.browser.ui.R as BrowserUiR
 
 @RunWith(AndroidJUnit4::class)
 class BasicJourneyTest {
 
-    /**
-     * Use [ActivityScenarioRule] to create and launch the activity under test before each test,
-     * and close it after each test. This is a replacement for
-     * [androidx.test.rule.ActivityTestRule].
-     */
     @get:Rule
     var activityScenarioRule = activityScenarioRule<BrowserActivity>()
 
     @Test @UserJourney
     fun browser_openPopUp() {
+        // dismiss any first-run dialogs (e.g., widget promo)
+        dismissBlockingDialogs()
+
         // since we use a fake toolbar, we want to wait until the real one is visible
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
 
-        // tap on PopupMenu
+        // tap on menu
         onView(allOf(withId(R.id.browserMenu), isClickable())).perform(click())
 
-        // check that the forward arrow is visible
-        onView(withContentDescription("Forward")).check(matches(isDisplayed()))
+        // check that the forward button is visible
+        clickMenuItem(withId(BrowserUiR.id.forwardMenuItem))
+    }
+
+    private fun dismissBlockingDialogs() {
+        // dismiss the home screen widget promo if present
+        runCatching {
+            onView(isRoot()).inRoot(isDialog())
+                .perform(waitForView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton), timeout = 3000))
+            onView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton)).perform(click())
+        }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
-import androidx.test.core.app.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
@@ -30,6 +29,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.clickMenuItem
 import com.duckduckgo.espresso.*
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
@@ -87,8 +87,7 @@ class RequestBlockingTest {
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
         onView(allOf(withId(R.id.browserMenu), isClickable())).perform(click())
-        onView(isRoot()).perform(waitForView(withText("Disable Privacy Protection")))
-        onView(withText("Disable Privacy Protection")).perform(click())
+        clickMenuItem(withText("Disable Privacy Protection"))
 
         // handle the privacy protection toggle check screen showing
         onView(isRoot()).perform(ViewActions.pressBack())

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -27,6 +27,7 @@ import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.clickMenuItem
 import com.duckduckgo.espresso.*
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
@@ -93,8 +94,7 @@ class SurrogatesTest {
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
         onView(allOf(withId(R.id.browserMenu), isClickable())).perform(ViewActions.click())
-        onView(isRoot()).perform(waitForView(withText("Disable Privacy Protection")))
-        onView(withText("Disable Privacy Protection")).perform(ViewActions.click())
+        clickMenuItem(withText("Disable Privacy Protection"))
 
         // handle the privacy protection toggle check screen showing
         onView(isRoot()).perform(ViewActions.pressBack())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214056234610657?focus=true 

### Description

The new bottom sheet browser menu lives in a separate window and may require scrolling to reach items below the fold. The existing Espresso test helpers (`waitForView`) only traverse the activity's view tree and can't find views inside a `BottomSheetDialog`.

### Steps to test this PR

_BasicJourneyTest_
- [ ] Run `./gradlew :app:connectedInternalDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.BasicJourneyTest`

_SurrogatesTest_
- [ ] Run `./gradlew :app:connectedInternalDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.privacy.SurrogatesTest`

_RequestBlockingTest_
- [ ] Run `./gradlew :app:connectedInternalDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.espresso.privacy.RequestBlockingTest`

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to Android instrumented tests, but could introduce flaky behavior if bottom sheet expansion/scroll timing differs across devices.
> 
> **Overview**
> Adds a new Espresso test utility `clickMenuItem` that can click browser menu items whether they appear in a popup menu or a `BottomSheetDialog`, expanding the bottom sheet and scrolling when needed.
> 
> Updates `BasicJourneyTest`, `RequestBlockingTest`, and `SurrogatesTest` to use this helper (and to dismiss a potential first-run widget promo dialog) so tests keep working with the new bottom sheet browser menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a3c5220c839eb4ef028b415b9468406053b8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->