### PR TITLE
Move tasks in LGC to a new section

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -81,3 +81,55 @@ jobs:
           TAG_NAME="LGC-$(date -u +'%Y-%m-%dT%H%M%S')"
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
+
+  collect_lgc_tasks:
+    name: Collect Asana tasks since last release
+    runs-on: ubuntu-latest
+    needs: [ resolve-commit, tag_lgc_when_successful ]
+    if: ${{ success() }}
+    outputs:
+      task_ids: ${{ steps.collect.outputs.task_ids }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-commit.outputs.commit_sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/release/requirements.txt
+
+      - name: Collect task IDs
+        id: collect
+        run: |
+          TASK_IDS=$(python ./scripts/release/collect-lgc-asana-tasks.py \
+          --android-repo-path . \
+          --end-commit '${{ needs.resolve-commit.outputs.commit_sha }}' \
+          --trigger-phrase 'Task/Issue URL:')
+          echo "task_ids=$TASK_IDS" >> $GITHUB_OUTPUT
+
+  move_tasks_in_lgc:
+    name: Move tasks to release candidate section
+    runs-on: ubuntu-latest
+    needs: [ collect_lgc_tasks ]
+    if: ${{ success() && needs.collect_lgc_tasks.outputs.task_ids != '[]' }}
+    strategy:
+      matrix:
+        task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
+      fail-fast: false
+    steps:
+      - name: Add task to release board in the release candidate section
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_LGC_SECTION_ID }}
+          asana-task-id: ${{ matrix.task_id }}
+          action: 'add-task-asana-project'

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -13,14 +13,91 @@ env:
   GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
 
 jobs:
-  test-workflow:
-    runs-on: ubuntu-latest
-    name: Add here whatever steps you want to test
+  resolve-commit:
+    name: Resolve commit SHA
+    runs-on: android-large-runner
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
+    steps:
+      - name: Resolve commit SHA
+        id: resolve
+        run: |
+          echo "Using commit: ${{ github.sha }}"
+          echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
 
+  tag_lgc_when_successful:
+    name: Tag last good commit when successful
+    runs-on: ubuntu-latest
+    needs: [ resolve-commit ]
+    if: ${{ success() }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.resolve-commit.outputs.commit_sha }}
+          fetch-depth: 0
           submodules: recursive
-          token: ${{ secrets.GT_DAXMOBILE }}
-          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up git config
+        run: |
+          git remote set-url origin https://${{ secrets.GT_DAXMOBILE }}@github.com/duckduckgo/Android.git/
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Create tag
+        run: |
+          TAG_NAME="LGC-$(date -u +'%Y-%m-%dT%H%M%S')"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
+  collect_lgc_tasks:
+    name: Collect Asana tasks since last release
+    runs-on: ubuntu-latest
+    needs: [ resolve-commit, tag_lgc_when_successful ]
+    if: ${{ success() }}
+    outputs:
+      task_ids: ${{ steps.collect.outputs.task_ids }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-commit.outputs.commit_sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/release/requirements.txt
+
+      - name: Collect task IDs
+        id: collect
+        run: |
+          TASK_IDS=$(python ./scripts/release/collect-lgc-asana-tasks.py \
+          --android-repo-path . \
+          --end-commit '${{ needs.resolve-commit.outputs.commit_sha }}' \
+          --trigger-phrase 'Task/Issue URL:')
+          echo "task_ids=$TASK_IDS" >> $GITHUB_OUTPUT
+
+  move_tasks_in_lgc:
+    name: Move tasks to release candidate section
+    runs-on: ubuntu-latest
+    needs: [ collect_lgc_tasks ]
+    if: ${{ success() && needs.collect_lgc_tasks.outputs.task_ids != '[]' }}
+    strategy:
+      matrix:
+        task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
+      fail-fast: false
+    steps:
+      - name: Add task to release board in the release candidate section
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_FAKE_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_FAKE_RELEASES_LGC_SECTION_ID }}
+          asana-task-id: ${{ matrix.task_id }}
+          action: 'add-task-asana-project'

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -13,91 +13,14 @@ env:
   GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
 
 jobs:
-  resolve-commit:
-    name: Resolve commit SHA
-    runs-on: android-large-runner
-    outputs:
-      commit_sha: ${{ steps.resolve.outputs.commit_sha }}
-    steps:
-      - name: Resolve commit SHA
-        id: resolve
-        run: |
-          echo "Using commit: ${{ github.sha }}"
-          echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-
-  tag_lgc_when_successful:
-    name: Tag last good commit when successful
+  test-workflow:
     runs-on: ubuntu-latest
-    needs: [ resolve-commit ]
-    if: ${{ success() }}
+    name: Add here whatever steps you want to test
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve-commit.outputs.commit_sha }}
-          fetch-depth: 0
           submodules: recursive
-
-      - name: Set up git config
-        run: |
-          git remote set-url origin https://${{ secrets.GT_DAXMOBILE }}@github.com/duckduckgo/Android.git/
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-      - name: Create tag
-        run: |
-          TAG_NAME="LGC-$(date -u +'%Y-%m-%dT%H%M%S')"
-          git tag "$TAG_NAME"
-          git push origin "$TAG_NAME"
-
-  collect_lgc_tasks:
-    name: Collect Asana tasks since last release
-    runs-on: ubuntu-latest
-    needs: [ resolve-commit, tag_lgc_when_successful ]
-    if: ${{ success() }}
-    outputs:
-      task_ids: ${{ steps.collect.outputs.task_ids }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.resolve-commit.outputs.commit_sha }}
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scripts/release/requirements.txt
-
-      - name: Collect task IDs
-        id: collect
-        run: |
-          TASK_IDS=$(python ./scripts/release/collect-lgc-asana-tasks.py \
-          --android-repo-path . \
-          --end-commit '${{ needs.resolve-commit.outputs.commit_sha }}' \
-          --trigger-phrase 'Task/Issue URL:')
-          echo "task_ids=$TASK_IDS" >> $GITHUB_OUTPUT
-
-  move_tasks_in_lgc:
-    name: Move tasks to release candidate section
-    runs-on: ubuntu-latest
-    needs: [ collect_lgc_tasks ]
-    if: ${{ success() && needs.collect_lgc_tasks.outputs.task_ids != '[]' }}
-    strategy:
-      matrix:
-        task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
-      fail-fast: false
-    steps:
-      - name: Add task to release board in the release candidate section
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_FAKE_RELEASES_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_FAKE_RELEASES_LGC_SECTION_ID }}
-          asana-task-id: ${{ matrix.task_id }}
-          action: 'add-task-asana-project'
+          token: ${{ secrets.GT_DAXMOBILE }}
+          ref: ${{ github.event.inputs.ref }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -541,23 +541,6 @@ platform :android do
             end
        end
 
-    desc "Prepares the Asana release board with a new release task, tags tasks waiting for release etc.."
-    lane :asana_release_prep do
-        begin
-            sh aarbExecutable, "action=verify"
-        rescue => ex
-            UI.user_error!("#{aarbExecutable} not installed. Install the tool and ensure it can be executed by executing `#{aarbExecutable}`")
-        end
-
-        newVersion = determine_version_number()
-        if UI.confirm("About to create a new release task for #{newVersion}. Ready to continue?")
-            UI.message("Creating release task...")
-            sh aarbExecutable, "version=#{newVersion}", "action=createRelease,tagPendingTasks,addLinksToDescription,removePendingTasks", "board=real"
-        else
-            UI.error(errorMessageCancelled)
-        end
-    end
-
     private_lane :"convert_version" do |options|
         original = options[:release_number]
         major, minor, patch = original.downcase.split('.')

--- a/scripts/release/asana_release_utils.py
+++ b/scripts/release/asana_release_utils.py
@@ -4,6 +4,7 @@ Shared utilities for Asana release scripts.
 """
 
 import re
+import subprocess
 import sys
 from typing import List
 import git
@@ -54,6 +55,47 @@ def extract_asana_task_links(commits: List[git.Commit], url_prefix: str) -> List
         ))
     
     return task_links
+
+
+def get_public_release_tags(repo_path: str) -> List[str]:
+    """
+    Return all public release tags sorted by semantic version (ascending).
+    Public release tags match the pattern: X.Y.Z (e.g., 5.264.0)
+    """
+    public_pattern = re.compile(r'^\d+\.\d+\.\d+$')
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, "for-each-ref", "--sort=version:refname",
+             "--format=%(refname:short)", "refs/tags"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tags = result.stdout.strip().splitlines()
+        return [tag for tag in tags if public_pattern.match(tag)]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def get_latest_public_release_tag(repo_path: str) -> str | None:
+    """Return the most recent public release tag, or None."""
+    tags = get_public_release_tags(repo_path)
+    return tags[-1] if tags else None
+
+
+def get_public_release_tag_before(repo_path: str, current_tag: str) -> str | None:
+    """
+    Return the public release tag immediately before `current_tag` by semantic version.
+    Returns None if `current_tag` is not found or is the earliest tag.
+    """
+    tags = get_public_release_tags(repo_path)
+
+    if current_tag not in tags:
+        return None
+
+    idx = tags.index(current_tag)
+    return tags[idx - 1] if idx > 0 else None
 
 
 def extract_task_id_from_url(url: str) -> str:

--- a/scripts/release/collect-lgc-asana-tasks.py
+++ b/scripts/release/collect-lgc-asana-tasks.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Collect Asana task IDs from commits since the last public release.
+
+Finds all Asana task URLs in commit messages between the latest public release
+tag and a given end commit, extracts task IDs, and prints them as a JSON array
+to stdout. This output is intended to be consumed by GitHub Actions workflows.
+"""
+
+import json
+import argparse
+
+from asana_release_utils import (
+    log,
+    get_commits_between,
+    extract_asana_task_links,
+    extract_task_id_from_url,
+    get_latest_public_release_tag,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect Asana task IDs from commits since the last release",
+    )
+    parser.add_argument(
+        "--end-commit",
+        required=True,
+        help="End commit SHA or tag (e.g. the LGC tag or HEAD)",
+    )
+    parser.add_argument(
+        "--android-repo-path",
+        default=".",
+        help="Path to Android git repository (default: current directory)",
+    )
+    parser.add_argument(
+        "--trigger-phrase",
+        required=True,
+        help="Prefix for Asana task URLs in commit messages",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        start_tag = get_latest_public_release_tag(args.android_repo_path)
+        if not start_tag:
+            log("Error: No public release tag found")
+            return 1
+
+        log(f"Using tag {start_tag} as start commit (latest release)")
+        log(f"Using {args.end_commit} as end commit")
+
+        commits = get_commits_between(args.android_repo_path, start_tag, args.end_commit)
+        log(f"Found {len(commits)} commits between {start_tag} and {args.end_commit}")
+
+        task_links = extract_asana_task_links(commits, args.trigger_phrase)
+        task_links_with_url = [link for link in task_links if link.url]
+
+        task_ids = [extract_task_id_from_url(link.url) for link in task_links_with_url]
+
+        log(f"Found {len(task_ids)} Asana tasks")
+        for link in task_links_with_url:
+            log(f"  - {link.commit_hash[:9]}: {link.url}")
+
+        print(json.dumps(task_ids))
+
+        return 0
+
+    except Exception as e:
+        import traceback
+        log(f"Unexpected error: {e}")
+        log(f"Stack trace:\n{traceback.format_exc()}")
+        return 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/scripts/release/create-asana-public-release.py
+++ b/scripts/release/create-asana-public-release.py
@@ -5,7 +5,6 @@ import re
 import argparse
 from typing import List
 import asana
-import subprocess
 import time
 
 from asana_release_utils import (
@@ -14,6 +13,7 @@ from asana_release_utils import (
     get_commits_between,
     extract_asana_task_links,
     extract_task_id_from_url,
+    get_public_release_tag_before,
 )
 
 
@@ -176,34 +176,6 @@ def remove_tasks_from_project(client: asana.ApiClient, task_links: List[AsanaTas
     log(f"Removed {removed_count} tasks from project")
 
 
-def get_latest_public_release_tag_before_commit(repo_path: str, current_tag: str) -> str | None:
-    """
-    Return the previous public release tag before `current_tag`, sorted by semantic version.
-    Public release tags match the pattern: X.Y.Z (e.g., 5.264.0)
-    """
-    public_pattern = re.compile(r'^\d+\.\d+\.\d+$')
-
-    try:
-        result = subprocess.run(
-            ["git", "-C", repo_path, "for-each-ref", "--sort=version:refname", "--format=%(refname:short)", "refs/tags"],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        tags = result.stdout.strip().splitlines()
-
-        # Filter to only public release tags (X.Y.Z format)
-        public_tags = [tag for tag in tags if public_pattern.match(tag)]
-
-        if current_tag not in public_tags:
-            return None
-
-        idx = public_tags.index(current_tag)
-        return public_tags[idx - 1] if idx > 0 else None
-    except subprocess.CalledProcessError:
-        return None
-
-
 def main():
     parser = argparse.ArgumentParser(description='Create an Asana task for public releases with links to tasks from git commits')
     parser.add_argument('--tag', required=True, help='Tag to use as end commit (e.g., 5.264.0)')
@@ -231,8 +203,7 @@ def main():
         configuration.access_token = asana_api_key
         client = asana.ApiClient(configuration)
 
-        # Get the start tag (latest public release tag before the specified tag)
-        start_tag = get_latest_public_release_tag_before_commit(args.android_repo_path, args.tag)
+        start_tag = get_public_release_tag_before(args.android_repo_path, args.tag)
         if not start_tag:
             log(f"Error: No previous public release tag found before {args.tag}")
             return 1

--- a/scripts/release/test_asana_release_utils.py
+++ b/scripts/release/test_asana_release_utils.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for asana_release_utils and lgc-asana-tasks."""
+
+from unittest.mock import MagicMock, patch
+from asana_release_utils import (
+    get_public_release_tags,
+    get_latest_public_release_tag,
+    get_public_release_tag_before,
+)
+
+def _mock_git_tags_result(tags: list[str]):
+    """Create a mock subprocess result with the given tag list."""
+    result = MagicMock()
+    result.stdout = "\n".join(tags)
+    return result
+
+
+
+# --- get_public_release_tags / get_latest_public_release_tag / get_public_release_tag_before ---
+
+
+class TestGetPublicReleaseTags:
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_only_release_tags(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result([
+            "5.262.0",
+            "5.263.0-internal",
+            "LGC-2025-01-01T000000",
+            "5.264.0",
+        ])
+        assert get_public_release_tags(".") == ["5.262.0", "5.264.0"]
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_empty_when_no_release_tags(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result(["LGC-2025-01-01T000000"])
+        assert get_public_release_tags(".") == []
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_empty_on_empty_repo(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result([])
+        assert get_public_release_tags(".") == []
+
+
+class TestGetLatestPublicReleaseTag:
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_latest_release_tag(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result([
+            "5.262.0",
+            "5.263.0",
+            "5.264.0",
+        ])
+        assert get_latest_public_release_tag(".") == "5.264.0"
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_none_when_no_release_tags(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result(["5.263.0-internal"])
+        assert get_latest_public_release_tag(".") is None
+
+
+class TestGetPublicReleaseTagBefore:
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_previous_tag(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result([
+            "5.262.0",
+            "5.263.0",
+            "5.264.0",
+        ])
+        assert get_public_release_tag_before(".", "5.264.0") == "5.263.0"
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_none_when_first_tag(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result(["5.262.0", "5.263.0"])
+        assert get_public_release_tag_before(".", "5.262.0") is None
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_none_when_tag_not_found(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result(["5.262.0", "5.263.0"])
+        assert get_public_release_tag_before(".", "5.999.0") is None
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_ignores_non_release_tags(self, mock_run):
+        mock_run.return_value = _mock_git_tags_result([
+            "5.262.0",
+            "5.263.0-internal",
+            "LGC-2025-01-01T000000",
+            "5.264.0",
+        ])
+        assert get_public_release_tag_before(".", "5.264.0") == "5.262.0"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1213243276846331?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] Check [test workflow](https://github.com/duckduckgo/Android/actions/runs/24397552481) executed correctly and moved tasks to the [fake board](https://app.asana.com/1/137249556945/project/1200415422192046/board/1205110402423006) (In LGC section)
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the nightly GitHub Actions flow to parse git history/tags and mutate Asana boards, so mistakes could move or miss tasks across releases.
> 
> **Overview**
> After the nightly pipeline succeeds and the LGC tag is pushed, the workflow now **collects Asana task IDs from commit messages since the latest public release tag** and then **moves each task into the release board’s LGC section** via `duckduckgo/native-github-asana-sync`.
> 
> This introduces `scripts/release/collect-lgc-asana-tasks.py` plus new tag-discovery helpers in `scripts/release/asana_release_utils.py` (with unit tests), and refactors `create-asana-public-release.py` to reuse the shared “previous public release tag” logic. It also removes the legacy Fastlane `asana_release_prep` lane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09f05a64e8a9b9d14361a62af28fef8808419a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->