### PR TITLE
Suppress favicon prompt straight after sync auto-restore

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/RealSyncAutoRestore.kt
@@ -34,14 +34,17 @@ import logcat.logcat
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = SyncAutoRestore::class)
+@ContributesBinding(AppScope::class, boundType = SyncOnboardingRestoreState::class)
 class RealSyncAutoRestore @Inject constructor(
     private val manager: SyncAutoRestoreManager,
     private val syncFeature: SyncFeature,
     private val syncAccountRepository: SyncAccountRepository,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-) : SyncAutoRestore {
+) : SyncAutoRestore, SyncOnboardingRestoreState {
+
+    @Volatile private var restoreTimestamp: Long? = null
 
     override suspend fun canRestore(): Boolean {
         return withContext(dispatcherProvider.io()) {
@@ -71,6 +74,7 @@ class RealSyncAutoRestore @Inject constructor(
                 when (val result = syncAccountRepository.processCode(parsedCode, existingDeviceId = payload.deviceId)) {
                     is Result.Success -> {
                         logcat(LogPriority.INFO) { "Sync-Recovery: account restored successfully" }
+                        restoreTimestamp = System.currentTimeMillis()
                         manager.saveAutoRestoreData(payload.recoveryCode, payload.deviceId)
                     }
                     is Result.Error -> logcat(LogPriority.WARN) { "Sync-Recovery: restore failed - code=${result.code}, reason=${result.reason}" }
@@ -81,4 +85,6 @@ class RealSyncAutoRestore @Inject constructor(
             }
         }
     }
+
+    override fun autoRestoredTimestamp(): Long? = restoreTimestamp
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncOnboardingRestoreState.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/autorestore/SyncOnboardingRestoreState.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.autorestore
+
+interface SyncOnboardingRestoreState {
+    /**
+     * Returns the timestamp at which a sync account restore was performed during onboarding,
+     * or null if no such restore has occurred this session.
+     */
+    fun autoRestoredTimestamp(): Long?
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.AppQREncoder
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.autorestore.SyncOnboardingRestoreState
 import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.impl.error.RealSyncApiErrorRepository
@@ -146,8 +147,9 @@ object SyncStoreModule {
     fun provideSyncFaviconsFetchingPrompt(
         faviconFetchingStore: FaviconsFetchingStore,
         syncAccountRepository: SyncAccountRepository,
+        syncOnboardingRestoreState: SyncOnboardingRestoreState,
     ): FaviconsFetchingPrompt {
-        return SyncFaviconsFetchingPrompt(faviconFetchingStore, syncAccountRepository)
+        return SyncFaviconsFetchingPrompt(faviconFetchingStore, syncAccountRepository, syncOnboardingRestoreState)
     }
 
     @Provides

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -22,6 +22,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
@@ -148,8 +149,9 @@ object SyncStoreModule {
         faviconFetchingStore: FaviconsFetchingStore,
         syncAccountRepository: SyncAccountRepository,
         syncOnboardingRestoreState: SyncOnboardingRestoreState,
+        currentTimeProvider: CurrentTimeProvider,
     ): FaviconsFetchingPrompt {
-        return SyncFaviconsFetchingPrompt(faviconFetchingStore, syncAccountRepository, syncOnboardingRestoreState)
+        return SyncFaviconsFetchingPrompt(faviconFetchingStore, syncAccountRepository, syncOnboardingRestoreState, currentTimeProvider)
     }
 
     @Provides

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/favicons/SyncFaviconsFethcingPrompt.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/favicons/SyncFaviconsFethcingPrompt.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.favicons
 
 import androidx.annotation.WorkerThread
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.Result
@@ -30,6 +31,7 @@ class SyncFaviconsFetchingPrompt(
     private val faviconsFetchingStore: FaviconsFetchingStore,
     private val syncAccountRepository: SyncAccountRepository,
     private val syncOnboardingRestoreState: SyncOnboardingRestoreState,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : FaviconsFetchingPrompt {
 
     // should show prompt when
@@ -73,7 +75,7 @@ class SyncFaviconsFetchingPrompt(
     }
 
     private fun Long.wasRecent(): Boolean =
-        System.currentTimeMillis() - this < QUICK_RESTORE_SUPPRESSION_WINDOW_MS
+        currentTimeProvider.currentTimeMillis() - this < QUICK_RESTORE_SUPPRESSION_WINDOW_MS
 
     companion object {
         private const val MIN_CONNECTED_DEVICES_FOR_PROMPT = 2

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/favicons/SyncFaviconsFethcingPrompt.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/favicons/SyncFaviconsFethcingPrompt.kt
@@ -22,12 +22,14 @@ import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.autorestore.SyncOnboardingRestoreState
 import logcat.logcat
-import java.lang.Error
+import java.util.concurrent.TimeUnit
 
 class SyncFaviconsFetchingPrompt(
     private val faviconsFetchingStore: FaviconsFetchingStore,
     private val syncAccountRepository: SyncAccountRepository,
+    private val syncOnboardingRestoreState: SyncOnboardingRestoreState,
 ) : FaviconsFetchingPrompt {
 
     // should show prompt when
@@ -44,6 +46,11 @@ class SyncFaviconsFetchingPrompt(
         }
 
         if (faviconsFetchingStore.isFaviconsFetchingEnabled) {
+            return false
+        }
+
+        if (syncOnboardingRestoreState.autoRestoredTimestamp()?.wasRecent() == true) {
+            logcat { "Sync-Favicon: Won't show prompt as quick restore just completed" }
             return false
         }
 
@@ -65,7 +72,11 @@ class SyncFaviconsFetchingPrompt(
         faviconsFetchingStore.isFaviconsFetchingEnabled = fetchingEnabled
     }
 
+    private fun Long.wasRecent(): Boolean =
+        System.currentTimeMillis() - this < QUICK_RESTORE_SUPPRESSION_WINDOW_MS
+
     companion object {
         private const val MIN_CONNECTED_DEVICES_FOR_PROMPT = 2
+        private val QUICK_RESTORE_SUPPRESSION_WINDOW_MS = TimeUnit.MINUTES.toMillis(3)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/favicons/FaviconsFetchingPromptTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/favicons/FaviconsFetchingPromptTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.favicons
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.sync.TestSyncFixtures
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
@@ -30,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class FaviconsFetchingPromptTest {
@@ -37,13 +39,19 @@ class FaviconsFetchingPromptTest {
     private var faviconsFetchingStore: FaviconsFetchingStore = mock()
     private var syncAccountRepository: SyncAccountRepository = mock()
     private var syncOnboardingRestoreState: SyncOnboardingRestoreState = mock()
+    private var currentTimeProvider: CurrentTimeProvider = mock()
 
     private lateinit var faviconsFetchingPrompt: FaviconsFetchingPrompt
 
     @Before
     fun setUp() {
         whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(null)
-        faviconsFetchingPrompt = SyncFaviconsFetchingPrompt(faviconsFetchingStore, syncAccountRepository, syncOnboardingRestoreState)
+        faviconsFetchingPrompt = SyncFaviconsFetchingPrompt(
+            faviconsFetchingStore,
+            syncAccountRepository,
+            syncOnboardingRestoreState,
+            currentTimeProvider,
+        )
     }
 
     @Test
@@ -113,7 +121,9 @@ class FaviconsFetchingPromptTest {
 
     @Test
     fun whenQuickRestoreJustCompletedThenShouldNotShow() {
-        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(System.currentTimeMillis())
+        val now = System.currentTimeMillis()
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(now)
+        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(now)
         whenever(faviconsFetchingStore.promptShown).thenReturn(false)
         whenever(faviconsFetchingStore.isFaviconsFetchingEnabled).thenReturn(false)
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
@@ -127,8 +137,9 @@ class FaviconsFetchingPromptTest {
 
     @Test
     fun whenQuickRestoreWasLongAgoThenShouldShow() {
-        val twoHoursAgo = System.currentTimeMillis() - (2 * 60 * 60 * 1000L)
-        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(twoHoursAgo)
+        val now = System.currentTimeMillis()
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(now)
+        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(now - TimeUnit.HOURS.toMillis(2))
         whenever(faviconsFetchingStore.promptShown).thenReturn(false)
         whenever(faviconsFetchingStore.isFaviconsFetchingEnabled).thenReturn(false)
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/favicons/FaviconsFetchingPromptTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/favicons/FaviconsFetchingPromptTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.autorestore.SyncOnboardingRestoreState
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -35,12 +36,14 @@ class FaviconsFetchingPromptTest {
 
     private var faviconsFetchingStore: FaviconsFetchingStore = mock()
     private var syncAccountRepository: SyncAccountRepository = mock()
+    private var syncOnboardingRestoreState: SyncOnboardingRestoreState = mock()
 
     private lateinit var faviconsFetchingPrompt: FaviconsFetchingPrompt
 
     @Before
     fun setUp() {
-        faviconsFetchingPrompt = SyncFaviconsFetchingPrompt(faviconsFetchingStore, syncAccountRepository)
+        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(null)
+        faviconsFetchingPrompt = SyncFaviconsFetchingPrompt(faviconsFetchingStore, syncAccountRepository, syncOnboardingRestoreState)
     }
 
     @Test
@@ -106,5 +109,34 @@ class FaviconsFetchingPromptTest {
         val shouldShow = faviconsFetchingPrompt.shouldShow()
 
         assertFalse(shouldShow)
+    }
+
+    @Test
+    fun whenQuickRestoreJustCompletedThenShouldNotShow() {
+        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(System.currentTimeMillis())
+        whenever(faviconsFetchingStore.promptShown).thenReturn(false)
+        whenever(faviconsFetchingStore.isFaviconsFetchingEnabled).thenReturn(false)
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val connectedDevices = listOf(TestSyncFixtures.connectedDevice, TestSyncFixtures.connectedDevice)
+        whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Result.Success(connectedDevices))
+
+        val shouldShow = faviconsFetchingPrompt.shouldShow()
+
+        assertFalse(shouldShow)
+    }
+
+    @Test
+    fun whenQuickRestoreWasLongAgoThenShouldShow() {
+        val twoHoursAgo = System.currentTimeMillis() - (2 * 60 * 60 * 1000L)
+        whenever(syncOnboardingRestoreState.autoRestoredTimestamp()).thenReturn(twoHoursAgo)
+        whenever(faviconsFetchingStore.promptShown).thenReturn(false)
+        whenever(faviconsFetchingStore.isFaviconsFetchingEnabled).thenReturn(false)
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        val connectedDevices = listOf(TestSyncFixtures.connectedDevice, TestSyncFixtures.connectedDevice)
+        whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Result.Success(connectedDevices))
+
+        val shouldShow = faviconsFetchingPrompt.shouldShow()
+
+        assertTrue(shouldShow)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213615738606188?focus=true

### Description
If the user chooses to restore their sync account (using "Restore my stuff" button) in onboarding, we don't want them to see the prompt asking if they want to fetch their icons immediately after onboarding is finished.

This PR will suppress that from showing for a few mins if the user auto-restores sync in the onboarding flow.

> [!TIP]
> Logcat filter: 
>`package:mine message~:"Sync-Recovery|Sync-AutoR|Sync-Engine: Sync finished|Sync-Favicon"`

### Steps to test this PR
To fully test this out you'll need to have another device with favorites, and join your test device to it so that you end up with 2 connected devices syncing favorites: 
- [x] On device A, e.g., your laptop: enable sync and add some favorites
- [x] On device B where you'll install this branch, ensure you are testing on a device which supports sync auto restore (w/ Play Services, signed into Google Account and backups allowed)
- [x] Fresh install from this branch onto device B
- [x] Set up sync (Settings -> Sync & Backup) using `Sync With Another Device` and sync with Device A. Wait to see `Sync-Engine: Sync finished` in logs
- [x] Uninstall from Device B (uninstall; not clearing data) and reinstall
- [x] Choose to "Restore my stuff" when prompted in onboarding
- [x] Wait for `Sync-Engine: Sync finished` in logs
- [x] Tap `Skip Onboarding`; verify you see the new tab page but **are not** prompted to download icons
- [x] Wait 3 mins, then open a new tab. Verify you are then prompted to download icons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a session-scoped timestamp check to gate an onboarding prompt, with small DI wiring changes and straightforward unit test coverage.
> 
> **Overview**
> Suppresses the favicons-fetching prompt for a short window immediately after a Sync account is auto-restored during onboarding.
> 
> Introduces `SyncOnboardingRestoreState` to expose the in-memory restore timestamp from `RealSyncAutoRestore`, injects it into `SyncFaviconsFetchingPrompt`, and adds a 3-minute “recent restore” guard (plus tests) to avoid prompting users right after restore completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a58c691522b3312f301a07c5b6c078366aadd96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->