### PR TITLE
Fixes the continuous repaint of the favorites section

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/DuckDuckGoFaviconManager.kt
@@ -167,12 +167,20 @@ class DuckDuckGoFaviconManager constructor(
         view: ImageView,
         placeholder: String?,
     ) {
-        val bitmap = loadFromDisk(tabId = null, url = url)
-        if (bitmap == null && faviconsFetchingStore.isFaviconsFetchingEnabled) {
+        val domain = url.extractDomain() ?: return
+        var faviconFile = withContext(dispatcherProvider.io()) {
+            faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
+        }
+        if (faviconFile == null && faviconsFetchingStore.isFaviconsFetchingEnabled) {
             tryFetchFaviconForUrl(url)
-            view.loadFavicon(loadFromDisk(tabId = null, url = url), url, placeholder)
+            faviconFile = withContext(dispatcherProvider.io()) {
+                faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
+            }
+        }
+        if (faviconFile != null) {
+            view.loadFavicon(faviconFile, url, placeholder)
         } else {
-            view.loadFavicon(bitmap, url, placeholder)
+            view.loadFavicon(null as Bitmap?, url, placeholder)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FaviconImageView.kt
@@ -63,12 +63,16 @@ fun ImageView.loadFavicon(
     runCatching {
         val defaultDrawable = generateDefaultDrawable(this.context, domain, placeholder)
         Glide.with(context).clear(this)
-        Glide.with(context)
-            .load(bitmap)
-            .transform(RoundedCorners(context.resources.getDimensionPixelSize(CommonR.dimen.verySmallShapeCornerRadius)))
-            .placeholder(defaultDrawable)
-            .error(defaultDrawable)
-            .into(this)
+        if (bitmap != null) {
+            Glide.with(context)
+                .load(bitmap)
+                .transform(RoundedCorners(context.resources.getDimensionPixelSize(CommonR.dimen.verySmallShapeCornerRadius)))
+                .placeholder(defaultDrawable)
+                .error(defaultDrawable)
+                .into(this)
+        } else {
+            setImageDrawable(defaultDrawable)
+        }
     }.onFailure {
         logcat(ERROR) { "Error loading favicon: ${it.asLog()}" }
     }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionFixFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionFixFeature.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.newtab
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Kill switch for the fix that prevents favourite favicons from repainting on the new tab page.
+ * If the fix causes issues, disable this flag remotely to revert to the previous behaviour.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "favouritesNewTabSectionFix",
+)
+interface FavouritesNewTabSectionFixFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -115,6 +115,9 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
     @Inject
     lateinit var favoritesSwipeHandling: FavoritesSwipeHandling
 
+    @Inject
+    lateinit var feature: FavouritesNewTabSectionFixFeature
+
     private var isExpandable = true
     private var showPlaceholders = false
     private var placement: FavoritesPlacement = FavoritesPlacement.NEW_TAB_PAGE
@@ -173,7 +176,9 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
+        if (!feature.self().isEnabled()) {
+            findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
+        }
 
         val coroutineScope = findViewTreeLifecycleOwner()?.lifecycleScope
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -44,12 +44,15 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
@@ -64,6 +67,7 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
     private val pixel: Pixel,
     private val faviconManager: FaviconManager,
     private val syncEngine: SyncEngine,
+    private val feature: FavouritesNewTabSectionFixFeature,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(val favourites: List<Favorite> = emptyList())
@@ -85,8 +89,42 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
 
     val hiddenIds = MutableStateFlow(HiddenBookmarksIds())
 
-    private val _viewState = MutableStateFlow(ViewState())
-    val viewState = _viewState.asStateFlow()
+    private val favouritesFlow
+        get() = savedSitesRepository.getFavorites()
+            .combine(hiddenIds) { favorites, hiddenIds ->
+                favorites.filter { it.id !in hiddenIds.favorites }
+            }
+            .flowOn(dispatchers.io())
+            .onEach { favourites -> logcat { "New Tab: Favourites $favourites" } }
+
+    private val _legacyViewState = MutableStateFlow(ViewState())
+
+    val viewState: StateFlow<ViewState> = if (feature.self().isEnabled()) {
+        favouritesFlow
+            .map { favourites -> ViewState(favourites = favourites) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.Lazily,
+                initialValue = ViewState(),
+            )
+    } else {
+        _legacyViewState
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        if (feature.self().isEnabled()) return
+        viewModelScope.launch(dispatchers.io()) {
+            favouritesFlow
+                .onEach { favourites ->
+                    withContext(dispatchers.main()) {
+                        _legacyViewState.emit(ViewState(favourites = favourites))
+                    }
+                }
+                .launchIn(viewModelScope)
+        }
+    }
+
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
     internal fun commands(): Flow<Command> = command.receiveAsFlow()
 
@@ -95,30 +133,6 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
     private var initialTouchX = 0f
     private var initialTouchY = 0f
     private var longPressActivated = false
-
-    override fun onResume(owner: LifecycleOwner) {
-        super.onResume(owner)
-
-        viewModelScope.launch(dispatchers.io()) {
-            savedSitesRepository.getFavorites()
-                .combine(hiddenIds) { favorites, hiddenIds ->
-                    favorites.filter { it.id !in hiddenIds.favorites }
-                }
-                .flowOn(dispatchers.io())
-                .onEach { favourites ->
-                    logcat { "New Tab: Favourites $favourites" }
-                    withContext(dispatchers.main()) {
-                        _viewState.emit(
-                            viewState.value.copy(
-                                favourites = favourites,
-                            ),
-                        )
-                    }
-                }
-                .flowOn(dispatchers.main())
-                .launchIn(viewModelScope)
-        }
-    }
 
     fun onQuickAccessListChanged(newList: List<Favorite>) {
         viewModelScope.launch(dispatchers.io()) {

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
@@ -21,6 +21,7 @@ import app.cash.turbine.test
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
@@ -39,6 +40,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -48,11 +50,12 @@ class FavouritesNewTabSectionViewModelTests {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
-    private var mockLifecycleOwner: LifecycleOwner = mock()
     private val mockSavedSitesRepository: SavedSitesRepository = mock()
     private val faviconManager: FaviconManager = mock()
     private val syncEngine: SyncEngine = mock()
     private val pixel: Pixel = mock()
+    private val feature: FavouritesNewTabSectionFixFeature = mock()
+    private val featureToggle: com.duckduckgo.feature.toggles.api.Toggle = mock()
 
     private lateinit var testee: FavouritesNewTabSectionViewModel
 
@@ -62,19 +65,20 @@ class FavouritesNewTabSectionViewModelTests {
     @Before
     fun setup() {
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
+        whenever(feature.self()).thenReturn(featureToggle)
+        whenever(featureToggle.isEnabled()).thenReturn(true)
         testee = FavouritesNewTabSectionViewModel(
             coroutinesTestRule.testDispatcherProvider,
             mockSavedSitesRepository,
             pixel,
             faviconManager,
             syncEngine,
+            feature,
         )
     }
 
     @Test
     fun whenViewModelIsInitializedThenViewStateShouldEmitInitialState() = runTest {
-        testee.onResume(mockLifecycleOwner)
-
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertTrue(it.favourites.isEmpty())
@@ -85,10 +89,16 @@ class FavouritesNewTabSectionViewModelTests {
     @Test
     fun whenViewModelIsInitializedAndFavouritesPresentThenViewStateShouldEmitCorrectState() = runTest {
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(listOf(favorite1)))
+        val testeeWithFavourites = FavouritesNewTabSectionViewModel(
+            coroutinesTestRule.testDispatcherProvider,
+            mockSavedSitesRepository,
+            pixel,
+            faviconManager,
+            syncEngine,
+            feature,
+        )
 
-        testee.onResume(mockLifecycleOwner)
-
-        testee.viewState.test {
+        testeeWithFavourites.viewState.test {
             expectMostRecentItem().also {
                 assertFalse(it.favourites.isEmpty())
                 assertTrue(it.favourites.first() == favorite1)
@@ -277,5 +287,44 @@ class FavouritesNewTabSectionViewModelTests {
         val decision = testee.onTouchMove(x = 1f, y = 1f, touchSlop = 1)
 
         assertNull(decision)
+    }
+
+    @Test
+    fun `when feature flag enabled and onResume called multiple times then no additional flow collections started`() = runTest {
+        val lifecycleOwner: LifecycleOwner = mock()
+
+        testee.viewState.test {
+            awaitItem() // initial empty state from stateIn
+            testee.onResume(lifecycleOwner)
+            testee.onResume(lifecycleOwner)
+            testee.onResume(lifecycleOwner)
+            expectNoEvents()
+        }
+
+        // getFavorites() called once by the stateIn flow, not once per onResume
+        verify(mockSavedSitesRepository, times(1)).getFavorites()
+    }
+
+    @Test
+    fun `when feature flag disabled and onResume called then viewState emits favourites`() = runTest {
+        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(listOf(favorite1)))
+        whenever(featureToggle.isEnabled()).thenReturn(false)
+        val lifecycleOwner: LifecycleOwner = mock()
+        val viewModelWithFixDisabled = FavouritesNewTabSectionViewModel(
+            coroutinesTestRule.testDispatcherProvider,
+            mockSavedSitesRepository,
+            pixel,
+            faviconManager,
+            syncEngine,
+            feature,
+        )
+
+        viewModelWithFixDisabled.viewState.test {
+            awaitItem() // initial empty state from _legacyViewState
+            viewModelWithFixDisabled.onResume(lifecycleOwner)
+            val state = awaitItem()
+            assertFalse(state.favourites.isEmpty())
+            assertTrue(state.favourites.first() == favorite1)
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1213900742645567?focus=true 

### Description
1. Accumulating flow collectors

FavouritesNewTabSectionViewModel.onResume was launching a new flow collector on every call via launchIn(viewModelScope). Because viewModelScope outlives the lifecycle, these collectors were never cancelled on pause so they accumulated.

This is more a defensive thing to fix.

2. Letter-icon flash

When a site had no stored favicon (bitmap == null), loadFavicon still routed through Glide's async pipeline. Glide would clear the view synchronously, then schedule the placeholder drawable asynchronously, producing a blank frame before the letter icon appeared.

When bitmap is null we can call setImageDrawable(defaultDrawable) synchronously, skipping Glide entirely.

3. Favicon loading delay when switching to focus mode

The previous approach decoded each favicon to a Bitmap with skipMemoryCache(true), then loaded that bitmap object into Glide. Since each call produces a new Bitmap reference, Glide's cache key changed every call, so there was no cache sharing between the NewTabPageView and FocusedView instances.

We now pass the favicon File directly to Glide instead of going through the bitmap decode step. Glide's cache key for a file load is the file path, which is stable. When NewTabPageView loads a favicon, Glide caches the decoded+transformed result. When FocusedView becomes visible and requests the same file, it hits the memory cache rather than reading from disk.


### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the New Tab favourites list is observed (switching to a `stateIn`-backed `StateFlow` behind a remote toggle), which could affect update timing and lifecycle behavior on the NTP. A remote kill switch is added to quickly revert if regressions appear.
> 
> **Overview**
> Prevents continuous repainting of New Tab favourites (and their favicons) by changing favourites state propagation to a lazily shared `StateFlow` (`stateIn`) instead of re-collecting the repository flow on every `onResume`.
> 
> Adds a remote kill switch (`favouritesNewTabSectionFix`) default-enabled, and gates the old lifecycle-observer/on-resume collection path behind it (including in `FavouritesNewTabSectionView`). Updates unit tests to cover both flag-enabled and flag-disabled behavior and to ensure repeated `onResume` calls don’t trigger extra flow collections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5f0c2dc4696757dde95e95b32cffacd874a926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->