### PR TITLE
Move max suggestion out of the chat reader interface

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
@@ -46,7 +46,6 @@ import javax.inject.Inject
 
 interface ChatSuggestionsReader {
     suspend fun fetchSuggestions(query: String = ""): List<ChatSuggestion>
-    fun getMaxUrlSuggestionsCount(): Int
     fun tearDown()
 }
 
@@ -143,14 +142,6 @@ class RealChatSuggestionsReader @Inject constructor(
                 JSONObject(it).optInt(MAX_HISTORY_COUNT_KEY, DEFAULT_MAX_SUGGESTIONS)
             }
         }.getOrNull() ?: DEFAULT_MAX_SUGGESTIONS
-    }
-
-    override fun getMaxUrlSuggestionsCount(): Int {
-        return runCatching {
-            duckAiChatHistoryFeature.self().getSettings()?.let {
-                JSONObject(it).optInt(MAX_URL_SUGGESTIONS_KEY, DEFAULT_MAX_URL_SUGGESTIONS)
-            }
-        }.getOrNull() ?: DEFAULT_MAX_URL_SUGGESTIONS
     }
 
     private fun getUserPreferencesJson(): String {
@@ -326,8 +317,6 @@ class RealChatSuggestionsReader @Inject constructor(
         private const val METHOD_CHATS_RESULT = "duckAiChatsResult"
         private const val MAX_HISTORY_COUNT_KEY = "maxHistoryCount"
         private const val DEFAULT_MAX_SUGGESTIONS = 10
-        private const val MAX_URL_SUGGESTIONS_KEY = "maxUrlSuggestions"
-        private const val DEFAULT_MAX_URL_SUGGESTIONS = 3
         private const val FETCH_TIMEOUT_MS = 3000L
         private const val SEVEN_DAYS_MS = 7L * 24 * 60 * 60 * 1000
         private const val EMPTY_HTML = "<html></html>"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
@@ -143,6 +144,7 @@ class InputScreenViewModel @AssistedInject constructor(
     private val duckChat: DuckChatInternal,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckChatFeature: DuckChatFeature,
+    private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature,
     private val pixel: Pixel,
     private val sessionStore: InputScreenSessionStore,
     private val inputScreenDiscoveryFunnel: InputScreenDiscoveryFunnel,
@@ -297,7 +299,7 @@ class InputScreenViewModel @AssistedInject constructor(
                                         it is AutoCompleteSwitchToTabSuggestion ||
                                         it is AutoCompleteHistorySuggestion ||
                                         (it is AutoCompleteSearchSuggestion && it.isUrl)
-                                }.take(chatSuggestionsReader.getMaxUrlSuggestionsCount()),
+                                }.take(getMaxUrlSuggestionsCount()),
                             )
                         }
                     } else {
@@ -1046,10 +1048,20 @@ class InputScreenViewModel @AssistedInject constructor(
         fun create(currentOmnibarText: String): InputScreenViewModel
     }
 
+    private fun getMaxUrlSuggestionsCount(): Int {
+        return runCatching {
+            duckAiChatHistoryFeature.self().getSettings()?.let {
+                JSONObject(it).optInt(MAX_URL_SUGGESTIONS_KEY, DEFAULT_MAX_URL_SUGGESTIONS)
+            }
+        }.getOrNull() ?: DEFAULT_MAX_URL_SUGGESTIONS
+    }
+
     companion object {
         const val DUCK_SCHEME = "duck"
         private const val CHAT_SUGGESTIONS_DEBOUNCE_MS = 150L
         private const val MAX_TAG_TITLE_LENGTH = 20
+        private const val MAX_URL_SUGGESTIONS_KEY = "maxUrlSuggestions"
+        private const val DEFAULT_MAX_URL_SUGGESTIONS = 3
 
         // TODO Read this from the privacy configs once the frontend defines it
         private const val MAX_POPUP_TABS = 5

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
@@ -107,6 +108,7 @@ class InputScreenViewModelTest {
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val chatSuggestionsReader: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader = mock()
     private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
+    private val duckAiChatHistoryFeature = FakeFeatureToggleFactory.create(DuckAiChatHistoryFeature::class.java)
     private val fullScreenModeDisabledFlow = MutableStateFlow(false)
     private val fullScreenModeEnabledFlow = MutableStateFlow(true)
     private val duckChatURL = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
@@ -129,7 +131,6 @@ class InputScreenViewModelTest {
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)
-            whenever(chatSuggestionsReader.getMaxUrlSuggestionsCount()).thenReturn(3)
         }
 
     private fun createViewModel(currentOmnibarText: String = ""): InputScreenViewModel =
@@ -150,6 +151,7 @@ class InputScreenViewModelTest {
             omnibarRepository = omnibarRepository,
             duckAiFeatureState = duckAiFeatureState,
             duckChatFeature = duckChatFeature,
+            duckAiChatHistoryFeature = duckAiChatHistoryFeature,
             chatSuggestionsReader = chatSuggestionsReader,
             queryUrlPredictor = queryUrlPredictor,
             tabRepository = tabRepository,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
@@ -548,43 +548,4 @@ class RealChatSuggestionsReaderTest {
     }
 
     // endregion
-
-    // region getMaxUrlSuggestionsCount
-
-    @Suppress("DenyListedApi")
-    @Test
-    fun `when settings has maxUrlSuggestions then returns that value`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = """{"maxUrlSuggestions":5}"""),
-        )
-
-        assertEquals(5, reader.getMaxUrlSuggestionsCount())
-    }
-
-    @Suppress("DenyListedApi")
-    @Test
-    fun `when settings has no maxUrlSuggestions then returns default`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = """{}"""),
-        )
-
-        assertEquals(3, reader.getMaxUrlSuggestionsCount())
-    }
-
-    @Test
-    fun `when settings is null then returns default for maxUrlSuggestions`() {
-        assertEquals(3, reader.getMaxUrlSuggestionsCount())
-    }
-
-    @Suppress("DenyListedApi")
-    @Test
-    fun `when settings has invalid json then returns default for maxUrlSuggestions`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = "invalid"),
-        )
-
-        assertEquals(3, reader.getMaxUrlSuggestionsCount())
-    }
-
-    // endregion
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214061291115652?focus=true

### Description
When https://github.com/duckduckgo/Android/pull/8265 was merged it changed one of the chat reader interface, but other classes were implementing this interface. We don't need that function in that interface as it has different purpose than intended for that reader.

Fixes:
- Removes getMaxUrlSuggestionsCount() from the ChatSuggestionsReader interface to avoid forcing new implementations (ChatSuggestionsNativeReader, DelegatingChatSuggestionsReader) to implement a method unrelated to their responsibility
- Moves the config read into InputScreenViewModel where the value is actually consumed

This should fix the build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves a settings read from `ChatSuggestionsReader` into `InputScreenViewModel` and updates tests accordingly; behavior should remain the same aside from potential DI wiring issues if a binding is missed.
> 
> **Overview**
> Removes `getMaxUrlSuggestionsCount()` from the `ChatSuggestionsReader` interface and deletes its implementation/constants from `RealChatSuggestionsReader`, so reader implementations are no longer responsible for URL-suggestion limits.
> 
> `InputScreenViewModel` now owns reading `maxUrlSuggestions` from `DuckAiChatHistoryFeature` settings and uses it to cap chat URL autocomplete suggestions; tests were updated to inject the new feature dependency, and the reader unit tests drop coverage for the removed method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004b767e6dccc263a6da18c487ad16769547dce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->