### PR TITLE
Quick Win: Android: Investigate open in app setting not being honoured

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2678,6 +2678,7 @@ class BrowserTabFragment :
                     fallbackIntent = it.nonHttpAppLink.fallbackIntent,
                     useFirstActivityFound = false,
                     headers = it.headers,
+                    showConfirmation = it.showConfirmation,
                 )
             }
 
@@ -3161,6 +3162,7 @@ class BrowserTabFragment :
         fallbackIntent: Intent? = null,
         useFirstActivityFound: Boolean = true,
         headers: Map<String, String> = emptyMap(),
+        showConfirmation: Boolean = true,
     ) {
         context?.let {
             val pm = it.packageManager
@@ -3177,7 +3179,15 @@ class BrowserTabFragment :
                                 ).apply { addCategory(Intent.CATEGORY_BROWSABLE) }
 
                             if (pm.resolveActivity(playIntent, 0) != null) {
-                                launchDialogForIntent(it, pm, playIntent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
+                                launchExternalIntent(
+                                    it,
+                                    pm,
+                                    playIntent,
+                                    activities,
+                                    useFirstActivityFound,
+                                    viewModel.linkOpenedInNewTab(),
+                                    showConfirmation,
+                                )
                                 return
                             }
                         }
@@ -3185,7 +3195,15 @@ class BrowserTabFragment :
 
                     fallbackIntent != null -> {
                         val fallbackActivities = pm.queryIntentActivities(fallbackIntent, 0)
-                        launchDialogForIntent(it, pm, fallbackIntent, fallbackActivities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
+                        launchExternalIntent(
+                            it,
+                            pm,
+                            fallbackIntent,
+                            fallbackActivities,
+                            useFirstActivityFound,
+                            viewModel.linkOpenedInNewTab(),
+                            showConfirmation,
+                        )
                     }
 
                     fallbackUrl != null -> {
@@ -3205,34 +3223,38 @@ class BrowserTabFragment :
                     }
                 }
             } else {
-                launchDialogForIntent(it, pm, intent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
+                launchExternalIntent(it, pm, intent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab(), showConfirmation)
             }
         }
     }
 
-    private fun launchDialogForIntent(
+    private fun launchExternalIntent(
         context: Context,
         pm: PackageManager,
         intent: Intent,
         activities: List<ResolveInfo>,
         useFirstActivityFound: Boolean,
         isOpenedInNewTab: Boolean,
+        showConfirmation: Boolean = true,
     ) {
         if (!isActiveCustomTab() && !isActiveTab && !isOpenedInNewTab) {
-            logcat(VERBOSE) { "Will not launch a dialog for an inactive tab" }
+            logcat(VERBOSE) { "Will not launch an intent for an inactive tab" }
             return
         }
 
         runCatching {
-            if (activities.size == 1 || useFirstActivityFound) {
-                val activity = activities.first()
-                val appTitle = activity.loadLabel(pm)
+            val resolvedIntent = if (activities.size == 1 || useFirstActivityFound) {
+                val appTitle = activities.first().loadLabel(pm)
                 logcat(INFO) { "Exactly one app available for intent: $appTitle" }
-                launchExternalAppDialog(context) { context.startActivity(intent) }
+                intent
             } else {
-                val title = getString(R.string.openExternalApp)
-                val intentChooser = Intent.createChooser(intent, title)
-                launchExternalAppDialog(context) { context.startActivity(intentChooser) }
+                Intent.createChooser(intent, getString(R.string.openExternalApp))
+            }
+
+            if (showConfirmation) {
+                launchExternalAppDialog(context) { context.startActivity(resolvedIntent) }
+            } else {
+                context.startActivity(resolvedIntent)
             }
         }.onFailure { exception ->
             logcat(ERROR) { "Failed to launch external app: ${exception.asLog()}" }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2599,18 +2599,18 @@ class BrowserTabFragment :
             is Command.DialNumber -> {
                 val intent = Intent(Intent.ACTION_DIAL)
                 intent.data = Uri.parse("tel:${it.telephoneNumber}")
-                openExternalDialog(intent = intent, fallbackUrl = null, fallbackIntent = null, useFirstActivityFound = false)
+                handleExternalIntent(intent = intent, fallbackUrl = null, fallbackIntent = null, useFirstActivityFound = false)
             }
 
             is Command.SendEmail -> {
                 val intent = Intent(Intent.ACTION_SENDTO)
                 intent.data = Uri.parse(it.emailAddress)
-                openExternalDialog(intent)
+                handleExternalIntent(intent)
             }
 
             is Command.SendSms -> {
                 val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:${it.telephoneNumber}"))
-                openExternalDialog(intent)
+                handleExternalIntent(intent)
             }
 
             is Command.ShowKeyboard -> {
@@ -2672,7 +2672,7 @@ class BrowserTabFragment :
             }
 
             is Command.HandleNonHttpAppLink -> {
-                openExternalDialog(
+                handleExternalIntent(
                     intent = it.nonHttpAppLink.intent,
                     fallbackUrl = it.nonHttpAppLink.fallbackUrl,
                     fallbackIntent = it.nonHttpAppLink.fallbackIntent,
@@ -3156,7 +3156,7 @@ class BrowserTabFragment :
         appLinksSnackBar = null
     }
 
-    private fun openExternalDialog(
+    private fun handleExternalIntent(
         intent: Intent,
         fallbackUrl: String? = null,
         fallbackIntent: Intent? = null,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3417,6 +3417,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun appLinkClicked(appLink: AppLink) {
         command.value = when {
+            // When in custom tab, always open the app link directly, without prompting.
             isCustomTabScreen -> OpenAppLink(appLink)
             appSettingsPreferencesStore.showAppLinksPrompt -> ShowAppLinkPrompt(appLink)
             else -> OpenAppLink(appLink)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3416,17 +3416,12 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun appLinkClicked(appLink: AppLink) {
-        when {
-            // When in custom tab, always open the app link directly, without prompting.
-            isCustomTabScreen -> command.value = OpenAppLink(appLink)
-
-            appSettingsPreferencesStore.showAppLinksPrompt || appLinksHandler.isUserQuery() -> {
-                command.value = ShowAppLinkPrompt(appLink)
-                appLinksHandler.setUserQueryState(false)
-            }
-
-            else -> command.value = OpenAppLink(appLink)
+        command.value = when {
+            isCustomTabScreen -> OpenAppLink(appLink)
+            appSettingsPreferencesStore.showAppLinksPrompt -> ShowAppLinkPrompt(appLink)
+            else -> OpenAppLink(appLink)
         }
+        appLinksHandler.setUserQueryState(false)
     }
 
     override fun handleNonHttpAppLink(nonHttpAppLink: NonHttpAppLink): Boolean {
@@ -3436,7 +3431,13 @@ class BrowserTabViewModel @Inject constructor(
 
     fun nonHttpAppLinkClicked(appLink: NonHttpAppLink) {
         if (nonHttpAppLinkChecker.isPermitted(appLink.intent)) {
-            command.value = HandleNonHttpAppLink(appLink, getUrlHeaders(appLink.fallbackUrl))
+            if (!appSettingsPreferencesStore.appLinksEnabled) {
+                appLink.fallbackUrl?.let { fallbackUrl ->
+                    command.value = NavigationCommand.Navigate(fallbackUrl, getUrlHeaders(fallbackUrl))
+                }
+                return
+            }
+            command.value = HandleNonHttpAppLink(appLink, getUrlHeaders(appLink.fallbackUrl), appSettingsPreferencesStore.showAppLinksPrompt)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -211,6 +211,7 @@ sealed class Command {
     class HandleNonHttpAppLink(
         val nonHttpAppLink: NonHttpAppLink,
         val headers: Map<String, String>,
+        val showConfirmation: Boolean = true,
     ) : Command()
 
     class ShowAppLinkPrompt(

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4095,6 +4095,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenExternalAppLinkClickedIfGpcReturnsHeaderThenAddHeaderToUrl() {
         givenCustomHeadersProviderReturnsGpcHeader()
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(true)
         val intentType = SpecialUrlDetector.UrlType.NonHttpAppLink("query", mock(), "fallback")
 
         testee.nonHttpAppLinkClicked(intentType)
@@ -4107,6 +4108,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenExternalAppLinkClickedIfGpcReturnsNoHeaderThenDoNotAddHeaderToUrl() {
         givenCustomHeadersProviderReturnsNoHeaders()
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(true)
         val intentType = SpecialUrlDetector.UrlType.NonHttpAppLink("query", mock(), null)
 
         testee.nonHttpAppLinkClicked(intentType)
@@ -4369,14 +4371,14 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenHandleAppLinkCalledAndIsUserQueryThenShowAppLinkPromptAndUserQueryStateSetToFalse() {
+    fun whenHandleAppLinkCalledAndIsUserQueryAndShowAppLinksPromptIsFalseThenOpenAppLink() {
         val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
         testee.handleAppLink(urlType, isForMainFrame = true)
         whenever(mockAppLinksHandler.isUserQuery()).thenReturn(true)
         whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(false)
         verify(mockAppLinksHandler).handleAppLink(eq(true), eq(exampleUrl), eq(false), eq(true), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
-        assertCommandIssued<Command.ShowAppLinkPrompt>()
+        assertCommandIssued<Command.OpenAppLink>()
         verify(mockAppLinksHandler).setUserQueryState(false)
     }
 
@@ -4389,6 +4391,7 @@ class BrowserTabViewModelTest {
         verify(mockAppLinksHandler).handleAppLink(eq(true), eq(exampleUrl), eq(false), eq(true), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.OpenAppLink>()
+        verify(mockAppLinksHandler).setUserQueryState(false)
     }
 
     @Test
@@ -4401,13 +4404,49 @@ class BrowserTabViewModelTest {
         verify(mockAppLinksHandler).handleAppLink(eq(true), eq(exampleUrl), eq(false), eq(true), appLinkCaptor.capture())
         appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.OpenAppLink>()
+        verify(mockAppLinksHandler).setUserQueryState(false)
     }
 
     @Test
-    fun whenHandleNonHttpAppLinkCalledThenHandleNonHttpAppLink() {
+    fun whenHandleNonHttpAppLinkCalledAndAskEveryTimeThenShowConfirmation() {
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(true)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(true)
         val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink("market://details?id=com.example", Intent(), exampleUrl)
         assertTrue(testee.handleNonHttpAppLink(urlType))
-        assertCommandIssued<Command.HandleNonHttpAppLink>()
+        assertCommandIssued<Command.HandleNonHttpAppLink> {
+            assertTrue(this.showConfirmation)
+        }
+    }
+
+    @Test
+    fun whenHandleNonHttpAppLinkCalledAndAlwaysThenLaunchDirectly() {
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(true)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(false)
+        val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink("market://details?id=com.example", Intent(), exampleUrl)
+        assertTrue(testee.handleNonHttpAppLink(urlType))
+        assertCommandIssued<Command.HandleNonHttpAppLink> {
+            assertFalse(this.showConfirmation)
+        }
+    }
+
+    @Test
+    fun whenHandleNonHttpAppLinkCalledAndNeverThenNavigateToFallbackUrl() {
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(false)
+        val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink("market://details?id=com.example", Intent(), exampleUrl)
+        assertTrue(testee.handleNonHttpAppLink(urlType))
+        assertCommandNotIssued<Command.HandleNonHttpAppLink>()
+        assertCommandIssued<NavigationCommand.Navigate> {
+            assertEquals(exampleUrl, this.url)
+        }
+    }
+
+    @Test
+    fun whenHandleNonHttpAppLinkCalledAndNeverAndNoFallbackThenDoNothing() {
+        whenever(ctaViewModelMockSettingsStore.appLinksEnabled).thenReturn(false)
+        val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink("market://details?id=com.example", Intent(), null)
+        assertTrue(testee.handleNonHttpAppLink(urlType))
+        assertCommandNotIssued<Command.HandleNonHttpAppLink>()
+        assertCommandNotIssued<NavigationCommand.Navigate>()
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1200581511062568/task/1213726683105480?focus=true

### Description

This PR improves app link handling by respecting user preferences for app link behavior. The changes include:

- Added a `showConfirmation` parameter to control whether confirmation dialogs are shown when launching external apps
- Modified non-HTTP app link handling to respect the "Never" app links setting by navigating to fallback URLs instead of launching external apps
- Renamed `launchDialogForIntent` to `launchExternalIntent` to better reflect its functionality
- Updated app link logic to properly handle user query state and always reset it after processing
- Enhanced test coverage for different app link preference scenarios (Ask every time, Always, Never)

The implementation now properly handles three app link preference states:
- **Ask every time**: Shows confirmation dialog before launching external apps
- **Always**: Launches external apps directly without confirmation
- **Never**: Uses fallback URLs when available instead of launching external apps

### Steps to test this PR

_App Link Preferences - Ask Every Time_
- [x] Set app links preference to "Ask every time"
- [x] Click on an app link and verify confirmation dialog appears
- [x] Verify external app launches after confirming

_App Link Preferences - Always_
- [x] Set app links preference to "Always"
- [x] Click on an app link and verify it launches directly without confirmation

_App Link Preferences - Never_
- [x] Set app links preference to "Never"
- [x] Click on an app link with fallback URL and verify it navigates to fallback instead of launching external app
- [x] Click on an app link without fallback URL and verify nothing happens

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external intent/app-link launching behavior based on user settings, which can affect navigation flows and fallback handling across many link types. Risk is moderate due to potential regressions in intent resolution and confirmation/chooser behavior.
> 
> **Overview**
> **App link handling now honors user preferences** for non-HTTP app links: when app links are disabled, the app navigates to the `fallbackUrl` (if present) instead of launching an external intent.
> 
> External intent launching is refactored from `openExternalDialog`/`launchDialogForIntent` to `handleExternalIntent`/`launchExternalIntent`, adding a `showConfirmation` flag so links can bypass the confirmation dialog and start the resolved intent directly when configured.
> 
> `BrowserTabViewModel` simplifies app-link prompt logic (prompt only when `showAppLinksPrompt` is enabled) and always resets user-query state after handling. Tests are expanded/updated to cover *Ask every time / Always / Never* scenarios and the new `showConfirmation` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622aba6ba66851edc4c74175b38e0aba1666e194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->