### PR TITLE
DuckAi/Voice chat: Voice deep links should open in a new tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -721,14 +721,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
             if (duckAiFeatureState.showFullScreenMode.value) {
                 val url = intent.getStringExtra(DUCK_CHAT_URL) ?: duckChat.getDuckChatUrl("", false)
-                if (currentTab != null) {
-                    currentTab?.submitQuery(url)
+                if (swipingTabsFeature.isEnabled) {
+                    launchNewTab(query = url, skipHome = true)
                 } else {
-                    if (swipingTabsFeature.isEnabled) {
-                        launchNewTab(query = url, skipHome = true)
-                    } else {
-                        lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, skipHome = true) }
-                    }
+                    lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, skipHome = true) }
                 }
             } else {
                 val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213968100249539?focus=true 

### Description
Ensure that Duck.AI voice chat opens in a new tab when coming from a deeplink

### Steps to test this PR

**Prerequisites**                                                                                                                                                                                                  
  - [x] Enabled Search & Duck.Ai in Ai Features
  - [x] Enable fullscreen Duck.ai mode (internal settings → Duck.ai → Full screen mode toggle ON)
  - [x] Add the DDG search widget to the home screen                                                                                                                                                                 
                                                                                                                                                                                                                     
  **Voice chat opens in a new tab (the fix)**
  - [x] Open the app and navigate to any webpage (e.g. `example.com`)                                                                                                                                                
  - [x] Open Duck.ai and start a conversation so there's an active session                                                                                                                                           
  - [x] Within Duck.ai, tap the microphone/voice chat button
  - [x] Verify Duck.ai voice mode opens in a **new tab** — existing conversation tab is preserved                                                                                                                    
  - [x] Verify the old behaviour is gone: voice mode no longer loads in the current tab                                                                                                                              
                                                                                                                                                                                                                     
  **Voice chat from InputScreen opens in a new tab**                                                                                                                                                                 
  - [x] Open a new tab so the Duck.ai InputScreen appears                                                                                                                                                            
  - [x] Select the AI/Chat tab in the input mode toggle                                                                                                                                                            
  - [x] Tap the voice chat microphone button                                                                                                                                                                         
  - [x] Verify Duck.ai voice mode opens in a **new tab**
                                                                                                                                                                                                                     
  **Regression — normal Duck.ai from widget**                                                                                                                                                                      
  - [x] With an existing tab open, tap the Duck.ai button in the home screen widget
  - [x] Verify Duck.ai opens and the existing tab is unaffected                                                                                                                                                      
   
  **Regression — no current tab**                                                                                                                                                                                    
  - [x] Close all tabs, then trigger Duck.ai voice chat                                                                                                                                                            
  - [x] Verify Duck.ai voice mode opens in a new tab                      

Before: https://github.com/user-attachments/assets/131c695e-7a13-4b17-8972-cdbc04470048
After: https://github.com/user-attachments/assets/f94e8445-c47c-4c1f-90ab-e38ae9fa0763
- https://github.com/duckduckgo/Android/pull/7567 test case still works


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to intent-handling logic for Duck.ai full-screen mode; low risk but could affect how Duck.ai deep links open across tab configurations.
> 
> **Overview**
> Ensures `OPEN_DUCK_CHAT` intents in Duck.ai *full-screen mode* always open the provided Duck.ai URL in a **new tab** rather than reusing the current tab.
> 
> This simplifies the branching so both swiping-tabs and non-swiping-tabs paths consistently route through the new-tab creation flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1425d5a78d1cc41393669280900f79d679c67b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->