### PR TITLE
Make Next Steps section in Settings dismissable

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -389,7 +389,6 @@ class SettingsActivity : DuckDuckGoActivity() {
             viewsPrivacy.widgetPromptSetting.setStatus(isOn = widgetsInstalled)
         }
         viewsPrivacy.widgetPromptSetting.isVisible = isVisible
-        viewsNextSteps.addWidgetToHomeScreenSetting.isVisible = !isVisible
     }
 
     private fun updateNextStepsSection(viewState: SettingsViewModel.ViewState) {
@@ -406,12 +405,16 @@ class SettingsActivity : DuckDuckGoActivity() {
             if (viewState.nextStepsVoiceSearchDismissed) {
                 enableVoiceSearchSetting.gone()
             }
+            if (viewState.widgetsInstalled) {
+                viewsNextSteps.addWidgetToHomeScreenSetting.gone()
+            }
 
             // Check if all items are gone — hide the entire section
             val addressBarVisible = addressBarPositionSetting.isVisible
             val voiceSearchVisible = enableVoiceSearchSetting.isVisible
+            val addWidgetVisible = addWidgetToHomeScreenSetting.isVisible
             val widgetVisible = addWidgetToHomeScreenSetting.isVisible
-            if (!addressBarVisible && !voiceSearchVisible && !widgetVisible) {
+            if (!addressBarVisible && !voiceSearchVisible && !addWidgetVisible && !widgetVisible) {
                 settingsSectionOther.gone()
                 return
             }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.settings
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
 import androidx.core.view.children
@@ -80,6 +81,7 @@ import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
 import com.duckduckgo.browser.api.ui.BrowserScreens.PrivateSearchScreenNoParams
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.DaxListItem.IconSize.Small
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
@@ -229,6 +231,7 @@ class SettingsActivity : DuckDuckGoActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshWidgetsInstalledState()
+        viewModel.refreshNextStepsDismissals()
     }
 
     private fun configureUiEventHandlers() {
@@ -334,6 +337,7 @@ class SettingsActivity : DuckDuckGoActivity() {
                     updateAddWidgetInProtections(it.isAddWidgetInProtectionsVisible, it.widgetsInstalled)
                     updateWhatsNewVisibility(it.showWhatsNew)
                     updateGetDesktopBrowserItemVisibility(it.showGetDesktopBrowser)
+                    updateNextStepsSection(it)
                     sortSettingItemsAlphabetically()
                 }
             }.launchIn(lifecycleScope)
@@ -387,6 +391,53 @@ class SettingsActivity : DuckDuckGoActivity() {
         }
         viewsPrivacy.widgetPromptSetting.isVisible = isVisible
         viewsNextSteps.addWidgetToHomeScreenSetting.isVisible = !isVisible
+    }
+
+    private fun updateNextStepsSection(viewState: SettingsViewModel.ViewState) {
+        with(viewsNextSteps) {
+            if (viewState.nextStepsSectionHidden) {
+                settingsSectionOther.gone()
+                return
+            }
+
+            // Apply individual item dismissals
+            if (viewState.nextStepsAddressBarDismissed) {
+                addressBarPositionSetting.gone()
+            }
+            if (viewState.nextStepsVoiceSearchDismissed) {
+                enableVoiceSearchSetting.gone()
+            }
+
+            // Check if all items are gone — hide the entire section
+            val addressBarVisible = addressBarPositionSetting.isVisible
+            val voiceSearchVisible = enableVoiceSearchSetting.isVisible
+            val widgetVisible = addWidgetToHomeScreenSetting.isVisible
+            if (!addressBarVisible && !voiceSearchVisible && !widgetVisible) {
+                settingsSectionOther.gone()
+                return
+            }
+
+            settingsSectionOther.show()
+
+            // Show/hide the overflow menu on the section header
+            settingsNextStepsTitle.showOverflowMenuIcon(viewState.showNextStepsHideButton)
+            if (viewState.showNextStepsHideButton) {
+                settingsNextStepsTitle.setOverflowMenuClickListener { anchorView ->
+                    showNextStepsHidePopupMenu(anchorView)
+                }
+            }
+        }
+    }
+
+    private fun showNextStepsHidePopupMenu(anchorView: View) {
+        val layoutInflater = LayoutInflater.from(this)
+        val popupMenu = PopupMenu(layoutInflater, R.layout.popup_window_next_steps_menu)
+        val hideButton = popupMenu.contentView.findViewById<View>(R.id.hideNextSteps)
+
+        popupMenu.onMenuItemClicked(hideButton) {
+            viewModel.onNextStepsHideClicked()
+        }
+        popupMenu.show(viewsNextSteps.settingsNextStepsTitle, anchorView)
     }
 
     private fun updateWhatsNewVisibility(isVisible: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -231,7 +231,6 @@ class SettingsActivity : DuckDuckGoActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshWidgetsInstalledState()
-        viewModel.refreshNextStepsDismissals()
     }
 
     private fun configureUiEventHandlers() {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -405,16 +405,17 @@ class SettingsActivity : DuckDuckGoActivity() {
             if (viewState.nextStepsVoiceSearchDismissed) {
                 enableVoiceSearchSetting.gone()
             }
-            if (viewState.widgetsInstalled) {
+            if (viewState.isAddWidgetInProtectionsVisible || viewState.widgetsInstalled) {
                 viewsNextSteps.addWidgetToHomeScreenSetting.gone()
+            } else {
+                viewsNextSteps.addWidgetToHomeScreenSetting.show()
             }
 
             // Check if all items are gone — hide the entire section
             val addressBarVisible = addressBarPositionSetting.isVisible
             val voiceSearchVisible = enableVoiceSearchSetting.isVisible
-            val addWidgetVisible = addWidgetToHomeScreenSetting.isVisible
             val widgetVisible = addWidgetToHomeScreenSetting.isVisible
-            if (!addressBarVisible && !voiceSearchVisible && !addWidgetVisible && !widgetVisible) {
+            if (!addressBarVisible && !voiceSearchVisible && !widgetVisible) {
                 settingsSectionOther.gone()
                 return
             }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -213,6 +213,7 @@ class SettingsViewModel @Inject constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
+        refreshNextStepsDismissals()
         start()
         startPollingAppTPState()
     }
@@ -335,21 +336,17 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun refreshNextStepsDismissals() {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            omnibarTypeBeforeNavigation?.let { before ->
-                if (settingsDataStore.omnibarType != before) {
-                    settingsDataStore.nextStepsAddressBarDismissed = true
-                    viewState.update { it.copy(nextStepsAddressBarDismissed = true) }
-                }
-                omnibarTypeBeforeNavigation = null
+        omnibarTypeBeforeNavigation?.let { before ->
+            if (settingsDataStore.omnibarType != before) {
+                settingsDataStore.nextStepsAddressBarDismissed = true
             }
-            voiceSearchAvailableBeforeNavigation?.let { before ->
-                if (voiceSearchAvailability.isVoiceSearchAvailable != before) {
-                    settingsDataStore.nextStepsVoiceSearchDismissed = true
-                    viewState.update { it.copy(nextStepsVoiceSearchDismissed = true) }
-                }
-                voiceSearchAvailableBeforeNavigation = null
+            omnibarTypeBeforeNavigation = null
+        }
+        voiceSearchAvailableBeforeNavigation?.let { before ->
+            if (voiceSearchAvailability.isVoiceSearchAvailable != before) {
+                settingsDataStore.nextStepsVoiceSearchDismissed = true
             }
+            voiceSearchAvailableBeforeNavigation = null
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -24,6 +24,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED
 import com.duckduckgo.app.pixels.AppPixelName.PRODUCT_TELEMETRY_SURFACE_SETTINGS_OPENED_DAILY
@@ -68,6 +71,7 @@ import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchPrivateSearch
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchSubscriptionUnifiedFeedback
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchSyncSettings
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchWebTrackingProtectionScreen
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.autoconsent.api.Autoconsent
@@ -130,6 +134,8 @@ class SettingsViewModel @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val settingsPageFeature: SettingsPageFeature,
     private val widgetCapabilities: WidgetCapabilities,
+    private val settingsDataStore: SettingsDataStore,
+    private val appInstallStore: AppInstallStore,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -149,6 +155,10 @@ class SettingsViewModel @Inject constructor(
         val widgetsInstalled: Boolean = false,
         val showWhatsNew: Boolean = false,
         val showGetDesktopBrowser: Boolean = false,
+        val nextStepsAddressBarDismissed: Boolean = false,
+        val nextStepsVoiceSearchDismissed: Boolean = false,
+        val nextStepsSectionHidden: Boolean = false,
+        val showNextStepsHideButton: Boolean = false,
     )
 
     sealed class Command {
@@ -188,6 +198,8 @@ class SettingsViewModel @Inject constructor(
     private val appTPPollJob = ConflatedJob()
 
     private var widgetPromptShown = false
+    private var omnibarTypeBeforeNavigation: OmnibarType? = null
+    private var voiceSearchAvailableBeforeNavigation: Boolean? = null
 
     init {
         pixel.fire(SETTINGS_OPENED)
@@ -239,6 +251,18 @@ class SettingsViewModel @Inject constructor(
                     },
                     showGetDesktopBrowser = withContext(dispatcherProvider.io()) {
                         settingsPageFeature.newDesktopBrowserSettingEnabled().isEnabled()
+                    },
+                    nextStepsAddressBarDismissed = withContext(dispatcherProvider.io()) {
+                        settingsDataStore.nextStepsAddressBarDismissed
+                    },
+                    nextStepsVoiceSearchDismissed = withContext(dispatcherProvider.io()) {
+                        settingsDataStore.nextStepsVoiceSearchDismissed
+                    },
+                    nextStepsSectionHidden = withContext(dispatcherProvider.io()) {
+                        settingsDataStore.nextStepsSectionHidden
+                    },
+                    showNextStepsHideButton = withContext(dispatcherProvider.io()) {
+                        appInstallStore.hasInstallTimestampRecorded() && appInstallStore.daysInstalled() >= NEXT_STEPS_HIDE_BUTTON_DAYS_THRESHOLD
                     },
                 ),
             )
@@ -292,13 +316,41 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onChangeAddressBarPositionClicked() {
+        omnibarTypeBeforeNavigation = settingsDataStore.omnibarType
         viewModelScope.launch { command.send(LaunchAppearanceScreen) }
         pixel.fire(SETTINGS_NEXT_STEPS_ADDRESS_BAR)
     }
 
     fun onEnableVoiceSearchClicked() {
+        voiceSearchAvailableBeforeNavigation = voiceSearchAvailability.isVoiceSearchAvailable
         viewModelScope.launch { command.send(LaunchAccessibilitySettings) }
         pixel.fire(SETTINGS_NEXT_STEPS_VOICE_SEARCH)
+    }
+
+    fun onNextStepsHideClicked() {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            settingsDataStore.nextStepsSectionHidden = true
+            viewState.update { it.copy(nextStepsSectionHidden = true) }
+        }
+    }
+
+    fun refreshNextStepsDismissals() {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            omnibarTypeBeforeNavigation?.let { before ->
+                if (settingsDataStore.omnibarType != before) {
+                    settingsDataStore.nextStepsAddressBarDismissed = true
+                    viewState.update { it.copy(nextStepsAddressBarDismissed = true) }
+                }
+                omnibarTypeBeforeNavigation = null
+            }
+            voiceSearchAvailableBeforeNavigation?.let { before ->
+                if (voiceSearchAvailability.isVoiceSearchAvailable != before) {
+                    settingsDataStore.nextStepsVoiceSearchDismissed = true
+                    viewState.update { it.copy(nextStepsVoiceSearchDismissed = true) }
+                }
+                voiceSearchAvailableBeforeNavigation = null
+            }
+        }
     }
 
     fun onDefaultBrowserSettingClicked() {
@@ -449,5 +501,6 @@ class SettingsViewModel @Inject constructor(
         const val EMAIL_PROTECTION_URL = "https://duckduckgo.com/email"
 
         private const val GET_DESKTOP_BROWSER_SOURCE_SETTINGS = "settings"
+        private const val NEXT_STEPS_HIDE_BUTTON_DAYS_THRESHOLD = 14L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -111,6 +111,9 @@ interface SettingsDataStore {
     var hasNewDownload: Boolean
     var singleTabFireDialogShownCount: Int
     var getDesktopBrowserSettingDismissed: Boolean
+    var nextStepsAddressBarDismissed: Boolean
+    var nextStepsVoiceSearchDismissed: Boolean
+    var nextStepsSectionHidden: Boolean
 
     /**
      * Check if a value has been set to the URL display preference.
@@ -310,6 +313,18 @@ class SettingsSharedPreferences @Inject constructor(
         get() = preferences.getBoolean(KEY_GET_DESKTOP_BROWSER_SETTING_DISMISSED, false)
         set(value) = preferences.edit { putBoolean(KEY_GET_DESKTOP_BROWSER_SETTING_DISMISSED, value) }
 
+    override var nextStepsAddressBarDismissed: Boolean
+        get() = preferences.getBoolean(KEY_NEXT_STEPS_ADDRESS_BAR_DISMISSED, false)
+        set(value) = preferences.edit { putBoolean(KEY_NEXT_STEPS_ADDRESS_BAR_DISMISSED, value) }
+
+    override var nextStepsVoiceSearchDismissed: Boolean
+        get() = preferences.getBoolean(KEY_NEXT_STEPS_VOICE_SEARCH_DISMISSED, false)
+        set(value) = preferences.edit { putBoolean(KEY_NEXT_STEPS_VOICE_SEARCH_DISMISSED, value) }
+
+    override var nextStepsSectionHidden: Boolean
+        get() = preferences.getBoolean(KEY_NEXT_STEPS_SECTION_HIDDEN, false)
+        set(value) = preferences.edit { putBoolean(KEY_NEXT_STEPS_SECTION_HIDDEN, value) }
+
     override fun hasBackgroundTimestampRecorded(): Boolean = preferences.contains(KEY_APP_BACKGROUNDED_TIMESTAMP)
 
     override fun clearAppBackgroundTimestamp() = preferences.edit { remove(KEY_APP_BACKGROUNDED_TIMESTAMP) }
@@ -395,6 +410,9 @@ class SettingsSharedPreferences @Inject constructor(
         const val KEY_SINGLE_TAB_FIRE_DIALOG_SHOWN_COUNT = "KEY_SINGLE_TAB_FIRE_DIALOG_SHOWN_COUNT"
         const val KEY_GET_DESKTOP_BROWSER_SETTING_DISMISSED = "KEY_GET_DESKTOP_BROWSER_SETTING_DISMISSED"
         const val KEY_HAS_NEW_DOWNLOAD = "KEY_HAS_NEW_DOWNLOAD"
+        const val KEY_NEXT_STEPS_ADDRESS_BAR_DISMISSED = "KEY_NEXT_STEPS_ADDRESS_BAR_DISMISSED"
+        const val KEY_NEXT_STEPS_VOICE_SEARCH_DISMISSED = "KEY_NEXT_STEPS_VOICE_SEARCH_DISMISSED"
+        const val KEY_NEXT_STEPS_SECTION_HIDDEN = "KEY_NEXT_STEPS_SECTION_HIDDEN"
     }
 
     private class FireAnimationPrefsMapper {

--- a/app/src/main/res/layout/content_settings_next_steps.xml
+++ b/app/src/main/res/layout/content_settings_next_steps.xml
@@ -31,7 +31,8 @@
         android:id="@+id/settingsNextStepsTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:primaryText="@string/settingsHeadingNextSteps" />
+        app:primaryText="@string/settingsHeadingNextSteps"
+        app:showOverflowMenu="false" />
 
     <com.duckduckgo.common.ui.view.listitem.OneLineListItem
         android:id="@+id/addWidgetToHomeScreenSetting"

--- a/app/src/main/res/layout/popup_window_next_steps_menu.xml
+++ b/app/src/main/res/layout/popup_window_next_steps_menu.xml
@@ -26,5 +26,5 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:leadingIcon="@drawable/ic_eye_closed_24"
-        app:primaryText="@string/getDesktopBrowserHideItem" />
+        app:primaryText="@string/settingsNextStepsHideItem" />
 </LinearLayout>

--- a/app/src/main/res/layout/popup_window_next_steps_menu.xml
+++ b/app/src/main/res/layout/popup_window_next_steps_menu.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/hideNextSteps"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:leadingIcon="@drawable/ic_eye_closed_24"
+        app:primaryText="@string/getDesktopBrowserHideItem" />
+</LinearLayout>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Изпратете отзив</string>
     <string name="settingsEmailProtectionTitle">Защита на имейл</string>
     <string name="settingsHeadingNextSteps">Следващи стъпки</string>
+    <string name="settingsNextStepsHideItem">Скрий</string>
     <string name="settingsLightTheme">Светла</string>
     <string name="settingsTheme">Тема</string>
     <string name="settingsDarkTheme">Тъмен</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Odeslat zpětnou vazbu</string>
     <string name="settingsEmailProtectionTitle">Ochrana e-mailu</string>
     <string name="settingsHeadingNextSteps">Další kroky</string>
+    <string name="settingsNextStepsHideItem">Skrýt</string>
     <string name="settingsLightTheme">Světlo</string>
     <string name="settingsTheme">Barevný motiv</string>
     <string name="settingsDarkTheme">Tmavé</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Send tilbagemelding</string>
     <string name="settingsEmailProtectionTitle">E-mailbeskyttelse</string>
     <string name="settingsHeadingNextSteps">Næste trin</string>
+    <string name="settingsNextStepsHideItem">Skjul</string>
     <string name="settingsLightTheme">Let</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Mørk</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Rückmeldung senden</string>
     <string name="settingsEmailProtectionTitle">E-Mail-Schutz</string>
     <string name="settingsHeadingNextSteps">Nächste Schritte</string>
+    <string name="settingsNextStepsHideItem">Ausblenden</string>
     <string name="settingsLightTheme">Hell</string>
     <string name="settingsTheme">Thema</string>
     <string name="settingsDarkTheme">Dunkel</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Αποστολή σχολίου</string>
     <string name="settingsEmailProtectionTitle">Προστασία email</string>
     <string name="settingsHeadingNextSteps">Επόμενα βήματα</string>
+    <string name="settingsNextStepsHideItem">Αποκρυψη</string>
     <string name="settingsLightTheme">Φωτεινό</string>
     <string name="settingsTheme">Θέμα</string>
     <string name="settingsDarkTheme">Σκοτεινό</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Enviar comentarios</string>
     <string name="settingsEmailProtectionTitle">Protección del correo electrónico</string>
     <string name="settingsHeadingNextSteps">Próximos pasos</string>
+    <string name="settingsNextStepsHideItem">Ocultar</string>
     <string name="settingsLightTheme">Claro</string>
     <string name="settingsTheme">Temas</string>
     <string name="settingsDarkTheme">Oscuro</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Saada tagasisidet</string>
     <string name="settingsEmailProtectionTitle">E-posti kaitse</string>
     <string name="settingsHeadingNextSteps">Järgmised sammud</string>
+    <string name="settingsNextStepsHideItem">Peida</string>
     <string name="settingsLightTheme">Hele</string>
     <string name="settingsTheme">Teema</string>
     <string name="settingsDarkTheme">Tume</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Lähetä palautetta</string>
     <string name="settingsEmailProtectionTitle">Sähköpostisuojaus</string>
     <string name="settingsHeadingNextSteps">Seuraavat vaiheet</string>
+    <string name="settingsNextStepsHideItem">Piilota</string>
     <string name="settingsLightTheme">Vaalea</string>
     <string name="settingsTheme">Teema</string>
     <string name="settingsDarkTheme">Tumma</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Envoyer vos remarques</string>
     <string name="settingsEmailProtectionTitle">Protection des e-mails</string>
     <string name="settingsHeadingNextSteps">Étapes suivantes</string>
+    <string name="settingsNextStepsHideItem">Masquer</string>
     <string name="settingsLightTheme">Clair</string>
     <string name="settingsTheme">Thème</string>
     <string name="settingsDarkTheme">Sombre</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Pošalji povratnu informaciju</string>
     <string name="settingsEmailProtectionTitle">Zaštita e-pošte</string>
     <string name="settingsHeadingNextSteps">Sljedeći koraci</string>
+    <string name="settingsNextStepsHideItem">Sakrij</string>
     <string name="settingsLightTheme">Svijetla</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Tamna</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Visszajelzés küldése</string>
     <string name="settingsEmailProtectionTitle">E-mail védelem</string>
     <string name="settingsHeadingNextSteps">Következő lépések</string>
+    <string name="settingsNextStepsHideItem">Elrejtés</string>
     <string name="settingsLightTheme">Világos</string>
     <string name="settingsTheme">Kinézet</string>
     <string name="settingsDarkTheme">Sötét</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Invia feedback</string>
     <string name="settingsEmailProtectionTitle">Protezione email</string>
     <string name="settingsHeadingNextSteps">Passaggi successivi</string>
+    <string name="settingsNextStepsHideItem">Nascondi</string>
     <string name="settingsLightTheme">Chiaro</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Scuro</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Siųsti atsiliepimą</string>
     <string name="settingsEmailProtectionTitle">El. pašto apsauga</string>
     <string name="settingsHeadingNextSteps">Tolesni veiksmai</string>
+    <string name="settingsNextStepsHideItem">Slėpti</string>
     <string name="settingsLightTheme">Šviesi</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Tamsi</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -140,6 +140,7 @@
     <string name="leaveFeedbackNew">Sūtīt atsauksmi</string>
     <string name="settingsEmailProtectionTitle">E-pasta aizsardzība</string>
     <string name="settingsHeadingNextSteps">Nākamie soļi</string>
+    <string name="settingsNextStepsHideItem">Paslēpt</string>
     <string name="settingsLightTheme">Gaišs</string>
     <string name="settingsTheme">Fons</string>
     <string name="settingsDarkTheme">Tumšs</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Send tilbakemelding</string>
     <string name="settingsEmailProtectionTitle">E-postbeskyttelse</string>
     <string name="settingsHeadingNextSteps">Neste trinn</string>
+    <string name="settingsNextStepsHideItem">Skjul</string>
     <string name="settingsLightTheme">Lyst</string>
     <string name="settingsTheme">Utseende</string>
     <string name="settingsDarkTheme">Mørk</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Verstuur feedback</string>
     <string name="settingsEmailProtectionTitle">E-mailbescherming</string>
     <string name="settingsHeadingNextSteps">Volgende stappen</string>
+    <string name="settingsNextStepsHideItem">Verbergen</string>
     <string name="settingsLightTheme">Licht</string>
     <string name="settingsTheme">Thema</string>
     <string name="settingsDarkTheme">Donker</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Wyślij opinię</string>
     <string name="settingsEmailProtectionTitle">Ochrona poczty e-mail</string>
     <string name="settingsHeadingNextSteps">Dalsze kroki</string>
+    <string name="settingsNextStepsHideItem">Ukryj</string>
     <string name="settingsLightTheme">Jasny</string>
     <string name="settingsTheme">Motyw</string>
     <string name="settingsDarkTheme">Ciemny</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Enviar comentário</string>
     <string name="settingsEmailProtectionTitle">Proteção de e-mail</string>
     <string name="settingsHeadingNextSteps">Passos seguintes</string>
+    <string name="settingsNextStepsHideItem">Ocultar</string>
     <string name="settingsLightTheme">Claro</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Escuro</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -140,6 +140,7 @@
     <string name="leaveFeedbackNew">Trimite feedback</string>
     <string name="settingsEmailProtectionTitle">Protecția comunicațiilor prin e-mail</string>
     <string name="settingsHeadingNextSteps">Pașii următori</string>
+    <string name="settingsNextStepsHideItem">Ascunde</string>
     <string name="settingsLightTheme">Luminoasă</string>
     <string name="settingsTheme">Temă</string>
     <string name="settingsDarkTheme">Intunecată</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Отправить отзыв</string>
     <string name="settingsEmailProtectionTitle">Защита электронной почты</string>
     <string name="settingsHeadingNextSteps">Дальнейшие шаги</string>
+    <string name="settingsNextStepsHideItem">Скрыть</string>
     <string name="settingsLightTheme">Светлая</string>
     <string name="settingsTheme">Тема</string>
     <string name="settingsDarkTheme">Тёмная</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Odoslať spätnú väzbu</string>
     <string name="settingsEmailProtectionTitle">Ochrana e-mailu</string>
     <string name="settingsHeadingNextSteps">Ďalšie kroky</string>
+    <string name="settingsNextStepsHideItem">Skryť</string>
     <string name="settingsLightTheme">Svetlá</string>
     <string name="settingsTheme">Motív</string>
     <string name="settingsDarkTheme">Tmavý</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -141,6 +141,7 @@
     <string name="leaveFeedbackNew">Pošljite povratne informacije</string>
     <string name="settingsEmailProtectionTitle">Zaščita e-pošte</string>
     <string name="settingsHeadingNextSteps">Naslednji koraki</string>
+    <string name="settingsNextStepsHideItem">Skrij se</string>
     <string name="settingsLightTheme">Luč</string>
     <string name="settingsTheme">Videz</string>
     <string name="settingsDarkTheme">Temna</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Skicka återkoppling</string>
     <string name="settingsEmailProtectionTitle">E-postskydd</string>
     <string name="settingsHeadingNextSteps">Nästa steg</string>
+    <string name="settingsNextStepsHideItem">Dölj</string>
     <string name="settingsLightTheme">Ljus</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Mörk</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -139,6 +139,7 @@
     <string name="leaveFeedbackNew">Geri Bildirim gönder</string>
     <string name="settingsEmailProtectionTitle">E-posta Koruması</string>
     <string name="settingsHeadingNextSteps">Sonraki Adımlar</string>
+    <string name="settingsNextStepsHideItem">Gizle</string>
     <string name="settingsLightTheme">Açık</string>
     <string name="settingsTheme">Tema</string>
     <string name="settingsDarkTheme">Koyu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="leaveFeedbackNew">Send Feedback</string>
     <string name="settingsEmailProtectionTitle">Email Protection</string>
     <string name="settingsHeadingNextSteps">Next Steps</string>
+    <string name="settingsNextStepsHideItem">Hide</string>
     <string name="settingsLightTheme">Light</string>
     <string name="settingsTheme">Theme</string>
     <string name="settingsDarkTheme">Dark</string>

--- a/app/src/test/java/com/duckduckgo/app/Fakes.kt
+++ b/app/src/test/java/com/duckduckgo/app/Fakes.kt
@@ -260,6 +260,24 @@ class FakeSettingsDataStore :
             store["getDesktopBrowserSettingDismissed"] = value
         }
 
+    override var nextStepsAddressBarDismissed: Boolean
+        get() = store["nextStepsAddressBarDismissed"] as Boolean? ?: false
+        set(value) {
+            store["nextStepsAddressBarDismissed"] = value
+        }
+
+    override var nextStepsVoiceSearchDismissed: Boolean
+        get() = store["nextStepsVoiceSearchDismissed"] as Boolean? ?: false
+        set(value) {
+            store["nextStepsVoiceSearchDismissed"] = value
+        }
+
+    override var nextStepsSectionHidden: Boolean
+        get() = store["nextStepsSectionHidden"] as Boolean? ?: false
+        set(value) {
+            store["nextStepsSectionHidden"] = value
+        }
+
     override fun isCurrentlySelected(clearWhatOption: ClearWhatOption): Boolean {
         val currentlySelected = store["automaticallyClearWhatOption"] as ClearWhatOption?
         return currentlySelected == clearWhatOption

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -18,7 +18,10 @@ package com.duckduckgo.app.settings
 
 import android.annotation.SuppressLint
 import app.cash.turbine.test
+import com.duckduckgo.app.FakeSettingsDataStore
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchAddHomeScreenWidget
@@ -27,6 +30,7 @@ import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchAutofillSetti
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchDataClearingSettingsScreen
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchFireButtonScreen
 import com.duckduckgo.app.settings.SettingsViewModel.Command.LaunchWhatsNew
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
@@ -62,6 +66,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
 
 @SuppressLint("DenyListedApi")
 class SettingsViewModelTest {
@@ -112,6 +117,10 @@ class SettingsViewModelTest {
 
     private val modalSurfaceStoreMock: ModalSurfaceStore = mock()
 
+    private val fakeSettingsDataStore: SettingsDataStore = FakeSettingsDataStore()
+
+    private val mockAppInstallStore: AppInstallStore = mock()
+
     @Before
     fun before() = runTest {
         whenever(dispatcherProviderMock.io()).thenReturn(coroutineTestRule.testDispatcher)
@@ -119,6 +128,8 @@ class SettingsViewModelTest {
         whenever(autofillCapabilityCheckerMock.canAccessCredentialManagementScreen()).thenReturn(true)
         whenever(subscriptionsMock.isEligible()).thenReturn(true)
         whenever(mockDuckAiFeatureState.showSettings).thenReturn(duckAiShowSettingsFlow)
+        whenever(mockAppInstallStore.hasInstallTimestampRecorded()).thenReturn(true)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
         testee = SettingsViewModel(
             defaultWebBrowserCapability = defaultWebBrowserCapabilityMock,
@@ -141,6 +152,8 @@ class SettingsViewModelTest {
             androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
             settingsPageFeature = fakeSettingsPageFeature,
             widgetCapabilities = mockWidgetCapabilities,
+            settingsDataStore = fakeSettingsDataStore,
+            appInstallStore = mockAppInstallStore,
         )
     }
 
@@ -425,5 +438,109 @@ class SettingsViewModelTest {
             eq(emptyMap()),
             eq(Count),
         )
+    }
+
+    @Test
+    fun `when address bar position changes after click then next step is dismissed`() = runTest {
+        fakeSettingsDataStore.omnibarType = OmnibarType.SINGLE_TOP
+
+        testee.onChangeAddressBarPositionClicked()
+
+        // Simulate user changed position
+        fakeSettingsDataStore.omnibarType = OmnibarType.SINGLE_BOTTOM
+        testee.refreshNextStepsDismissals()
+
+        assertTrue(testee.viewState().first().nextStepsAddressBarDismissed)
+        assertTrue(fakeSettingsDataStore.nextStepsAddressBarDismissed)
+    }
+
+    @Test
+    fun `when address bar position does not change after click then next step is not dismissed`() = runTest {
+        fakeSettingsDataStore.omnibarType = OmnibarType.SINGLE_TOP
+
+        testee.onChangeAddressBarPositionClicked()
+
+        // User did not change position
+        testee.refreshNextStepsDismissals()
+
+        assertFalse(testee.viewState().first().nextStepsAddressBarDismissed)
+        assertFalse(fakeSettingsDataStore.nextStepsAddressBarDismissed)
+    }
+
+    @Test
+    fun `when voice search availability changes after click then next step is dismissed`() = runTest {
+        whenever(voiceSearchAvailabilityMock.isVoiceSearchAvailable).thenReturn(false)
+
+        testee.onEnableVoiceSearchClicked()
+
+        // Simulate user enabled voice search
+        whenever(voiceSearchAvailabilityMock.isVoiceSearchAvailable).thenReturn(true)
+        testee.refreshNextStepsDismissals()
+
+        assertTrue(testee.viewState().first().nextStepsVoiceSearchDismissed)
+        assertTrue(fakeSettingsDataStore.nextStepsVoiceSearchDismissed)
+    }
+
+    @Test
+    fun `when voice search availability does not change after click then next step is not dismissed`() = runTest {
+        whenever(voiceSearchAvailabilityMock.isVoiceSearchAvailable).thenReturn(false)
+
+        testee.onEnableVoiceSearchClicked()
+
+        // User did not enable voice search
+        testee.refreshNextStepsDismissals()
+
+        assertFalse(testee.viewState().first().nextStepsVoiceSearchDismissed)
+        assertFalse(fakeSettingsDataStore.nextStepsVoiceSearchDismissed)
+    }
+
+    @Test
+    fun `when hide next steps clicked then section is hidden`() = runTest {
+        testee.onNextStepsHideClicked()
+
+        assertTrue(testee.viewState().first().nextStepsSectionHidden)
+        assertTrue(fakeSettingsDataStore.nextStepsSectionHidden)
+    }
+
+    @Test
+    fun `when app installed for 14 days then show hide button`() = runTest {
+        whenever(mockAppInstallStore.hasInstallTimestampRecorded()).thenReturn(true)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(
+            System.currentTimeMillis() - TimeUnit.DAYS.toMillis(14),
+        )
+
+        testee.start()
+
+        assertTrue(testee.viewState().first().showNextStepsHideButton)
+    }
+
+    @Test
+    fun `when app installed for less than 14 days then do not show hide button`() = runTest {
+        whenever(mockAppInstallStore.hasInstallTimestampRecorded()).thenReturn(true)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(
+            System.currentTimeMillis() - TimeUnit.DAYS.toMillis(13),
+        )
+
+        testee.start()
+
+        assertFalse(testee.viewState().first().showNextStepsHideButton)
+    }
+
+    @Test
+    fun `when section previously hidden then start returns hidden state`() = runTest {
+        fakeSettingsDataStore.nextStepsSectionHidden = true
+
+        testee.start()
+
+        assertTrue(testee.viewState().first().nextStepsSectionHidden)
+    }
+
+    @Test
+    fun `when address bar previously dismissed then start returns dismissed state`() = runTest {
+        fakeSettingsDataStore.nextStepsAddressBarDismissed = true
+
+        testee.start()
+
+        assertTrue(testee.viewState().first().nextStepsAddressBarDismissed)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -549,4 +549,34 @@ class SettingsViewModelTest {
 
         assertTrue(testee.viewState().first().nextStepsAddressBarDismissed)
     }
+
+    @Test
+    fun `when widgets installed then widgetsInstalled is true in view state`() = runTest {
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+
+        testee.start()
+
+        assertTrue(testee.viewState().first().widgetsInstalled)
+    }
+
+    @Test
+    fun `when widgets not installed then widgetsInstalled is false in view state`() = runTest {
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
+
+        testee.start()
+
+        assertFalse(testee.viewState().first().widgetsInstalled)
+    }
+
+    @Test
+    fun `when widget installed after refresh then widgetsInstalled updates to true`() = runTest {
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
+        testee.start()
+        assertFalse(testee.viewState().first().widgetsInstalled)
+
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        testee.refreshWidgetsInstalledState()
+
+        assertTrue(testee.viewState().first().widgetsInstalled)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsViewModelTest.kt
@@ -450,8 +450,11 @@ class SettingsViewModelTest {
         fakeSettingsDataStore.omnibarType = OmnibarType.SINGLE_BOTTOM
         testee.refreshNextStepsDismissals()
 
-        assertTrue(testee.viewState().first().nextStepsAddressBarDismissed)
         assertTrue(fakeSettingsDataStore.nextStepsAddressBarDismissed)
+
+        // start() picks it up from DataStore
+        testee.start()
+        assertTrue(testee.viewState().first().nextStepsAddressBarDismissed)
     }
 
     @Test
@@ -477,8 +480,11 @@ class SettingsViewModelTest {
         whenever(voiceSearchAvailabilityMock.isVoiceSearchAvailable).thenReturn(true)
         testee.refreshNextStepsDismissals()
 
-        assertTrue(testee.viewState().first().nextStepsVoiceSearchDismissed)
         assertTrue(fakeSettingsDataStore.nextStepsVoiceSearchDismissed)
+
+        // start() picks it up from DataStore
+        testee.start()
+        assertTrue(testee.viewState().first().nextStepsVoiceSearchDismissed)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1213796904982004?focus=true 

### Description

Makes the Next Steps section in Settings dismissable. Individual items ("Set address bar position", "Enable voice search") are auto-dismissed when the user changes the corresponding setting. After 14 days since install, a "Hide" button appears on the section header overflow menu, allowing the user to hide the entire section permanently. The section also auto-hides when all individual items have been dismissed.

### Steps to test this PR

> [!NOTE]
> Think to reset your app storage between each scenario

_Auto-dismiss address bar position item_
- [x] Open Settings, tap "Set address bar position" in Next Steps
- [x] Change the address bar position on the Appearance screen
- [x] Go back to Settings — the "Set address bar position" item should be gone

_Auto-dismiss voice search item_
- [x] Open Settings, tap "Enable voice search" in Next Steps (if visible on your device)
- [x] Enable voice search on the Accessibility screen
- [x] Go back to Settings — the "Enable voice search" item should be gone

_Hide entire section after 14 days_ (you can change the date in system settings)
- [x] On a device with install date 14+ days ago, open Settings
- [x] The "Next Steps" section header should show a three-dot overflow menu
- [x] Tap the overflow menu, then tap "Hide"
- [x] The entire Next Steps section should disappear and stay hidden after reopening Settings

_Auto-hide section when all items dismissed_
- [x] Dismiss all individual items (change address bar, enable voice search, install widget)
- [x] The entire Next Steps section should disappear automatically

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6529126e-fe05-4cf6-8d08-585d5af84929" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/16b1e186-46e4-458f-ba43-420daf77e2bb" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6529126e-fe05-4cf6-8d08-585d5af84929" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/a01629fb-843a-4943-92db-64a300479095" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change limited to Settings, adding a few persisted flags and a new overflow hide action; main risk is unintended visibility logic/regressions in the Next Steps section display rules.
> 
> **Overview**
> Makes the Settings **Next Steps** section dismissible by persisting per-item and whole-section hide state and updating the UI to conditionally show/hide items and the section header.
> 
> Individual Next Steps items (address bar position, voice search, add widget) now auto-dismiss based on user actions/state changes, and after 14 days since install an overflow menu action allows permanently hiding the entire section. Adds a small popup menu layout plus localized "Hide" strings, and updates tests/fakes to cover the new dismissal and threshold behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8b5e4a2a094194ed475de7d4f82e2bf39cf013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->