### PR TITLE
PIR: Add broker step action handler logic

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEf
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.PushJsAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.common.toParams
+import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
@@ -46,6 +47,7 @@ import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Click
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.EmailConfirmation
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.FillForm
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GenerateEmail
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GetCaptchaInfo
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.SolveCaptcha
 import com.duckduckgo.pir.impl.scripts.models.DataSource.EXTRACTED_PROFILE
@@ -121,6 +123,30 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
                         extractedProfile = extractedProfile!!,
+                        profileQuery = state.profileQuery,
+                    ),
+                )
+            } else if (actionToExecute is GenerateEmail) {
+                val extractedProfile = when (currentBrokerStep) {
+                    is OptOutStep -> currentBrokerStep.profileToOptOut
+                    is EmailConfirmationStep -> currentBrokerStep.profileToOptOut
+                    is ScanStep -> ExtractedProfile(
+                        profileQueryId = state.profileQuery.id,
+                        brokerName = currentBrokerStep.broker.name,
+                    )
+                }
+
+                Next(
+                    nextState = state.copy(
+                        stageStatus = PirStageStatus(
+                            currentStage = PirStage.EMAIL_GENERATE,
+                            stageStartMs = currentTimeProvider.currentTimeMillis(),
+                        ),
+                    ),
+                    sideEffect = GetEmailForProfile(
+                        actionId = actionToExecute.id,
+                        brokerName = currentBrokerStep.broker.name,
+                        extractedProfile = extractedProfile,
                         profileQuery = state.profileQuery,
                     ),
                 )

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEf
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.PushJsAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.common.toParams
-import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
@@ -99,18 +98,6 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                 actionToExecute.needsEmail &&
                 !hasEmail(currentBrokerStep)
             ) {
-                val extractedProfile = when (currentBrokerStep) {
-                    is OptOutStep -> {
-                        currentBrokerStep.profileToOptOut
-                    }
-
-                    is EmailConfirmationStep -> {
-                        currentBrokerStep.profileToOptOut
-                    }
-
-                    else -> null // Invalid state
-                }
-
                 Next(
                     nextState = state.copy(
                         stageStatus = PirStageStatus(
@@ -122,20 +109,10 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     GetEmailForProfile(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
-                        extractedProfile = extractedProfile!!,
                         profileQuery = state.profileQuery,
                     ),
                 )
             } else if (actionToExecute is GenerateEmail) {
-                val extractedProfile = when (currentBrokerStep) {
-                    is OptOutStep -> currentBrokerStep.profileToOptOut
-                    is EmailConfirmationStep -> currentBrokerStep.profileToOptOut
-                    is ScanStep -> ExtractedProfile(
-                        profileQueryId = state.profileQuery.id,
-                        brokerName = currentBrokerStep.broker.name,
-                    )
-                }
-
                 Next(
                     nextState = state.copy(
                         stageStatus = PirStageStatus(
@@ -146,7 +123,6 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     sideEffect = GetEmailForProfile(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
-                        extractedProfile = extractedProfile,
                         profileQuery = state.profileQuery,
                     ),
                 )

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -109,7 +109,6 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     GetEmailForProfile(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
-                        profileQuery = state.profileQuery,
                     ),
                 )
             } else if (actionToExecute is GenerateEmail) {
@@ -123,7 +122,6 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     sideEffect = GetEmailForProfile(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
-                        profileQuery = state.profileQuery,
                     ),
                 )
             } else {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/PirActionsRunnerStateEngine.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/PirActionsRunnerStateEngine.kt
@@ -174,7 +174,6 @@ interface PirActionsRunnerStateEngine {
         data class GetEmailForProfile(
             override val actionId: String,
             val brokerName: String,
-            val profileQuery: ProfileQuery?,
         ) : SideEffect(),
             BrokerActionSideEffect
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/PirActionsRunnerStateEngine.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/PirActionsRunnerStateEngine.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.pir.impl.common.actions
 
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep
 import com.duckduckgo.pir.impl.common.PirJob.RunType
-import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
@@ -175,7 +174,6 @@ interface PirActionsRunnerStateEngine {
         data class GetEmailForProfile(
             override val actionId: String,
             val brokerName: String,
-            val extractedProfile: ExtractedProfile,
             val profileQuery: ProfileQuery?,
         ) : SideEffect(),
             BrokerActionSideEffect

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -224,7 +224,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-1", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
 
@@ -721,7 +720,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
 
@@ -756,7 +754,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
 
@@ -793,7 +790,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -224,7 +224,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-1", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testExtractedProfile.copy(email = ""), sideEffect.extractedProfile)
         assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
@@ -722,7 +721,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testExtractedProfile, sideEffect.extractedProfile)
         assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
@@ -758,8 +756,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testProfileQueryId, sideEffect.extractedProfile.profileQueryId)
-        assertEquals(testBrokerName, sideEffect.extractedProfile.brokerName)
         assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }
@@ -797,7 +793,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
-        assertEquals(testExtractedProfile, sideEffect.extractedProfile)
         assertEquals(testProfileQuery, sideEffect.profileQuery)
         assertNull(result.nextEvent)
     }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -689,4 +689,116 @@ class ExecuteBrokerStepActionEventHandlerTest {
         assertEquals("John Doe", userData.extractedProfile?.name)
         assertEquals("john@example.com", userData.extractedProfile?.email)
     }
+
+    @Test
+    fun whenOptOutStepGenerateEmailActionThenRequestsEmailGeneration() = runTest {
+        val action = BrokerAction.GenerateEmail(id = "action-gen-email")
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_GENERATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as GetEmailForProfile
+        assertEquals("action-gen-email", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals(testExtractedProfile, sideEffect.extractedProfile)
+        assertEquals(testProfileQuery, sideEffect.profileQuery)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenScanStepGenerateEmailActionThenRequestsEmailGeneration() = runTest {
+        val action = BrokerAction.GenerateEmail(id = "action-gen-email")
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_GENERATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as GetEmailForProfile
+        assertEquals("action-gen-email", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals(testProfileQueryId, sideEffect.extractedProfile.profileQueryId)
+        assertEquals(testBrokerName, sideEffect.extractedProfile.brokerName)
+        assertEquals(testProfileQuery, sideEffect.profileQuery)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenEmailConfirmationStepGenerateEmailActionThenRequestsEmailGeneration() = runTest {
+        val action = BrokerAction.GenerateEmail(id = "action-gen-email")
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_GENERATE, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as GetEmailForProfile
+        assertEquals("action-gen-email", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals(testExtractedProfile, sideEffect.extractedProfile)
+        assertEquals(testProfileQuery, sideEffect.profileQuery)
+        assertNull(result.nextEvent)
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
@@ -928,7 +928,6 @@ class RealPirActionsRunnerStateEngineTest {
         val testSideEffect = SideEffect.GetEmailForProfile(
             actionId = "action-1",
             brokerName = testBrokerName,
-            profileQuery = testProfileQuery,
         )
 
         whenever(mockEventHandler.event).thenReturn(Event.Started::class)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RealPirActionsRunnerStateEngineTest.kt
@@ -928,7 +928,6 @@ class RealPirActionsRunnerStateEngineTest {
         val testSideEffect = SideEffect.GetEmailForProfile(
             actionId = "action-1",
             brokerName = testBrokerName,
-            extractedProfile = mock(),
             profileQuery = testProfileQuery,
         )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213886961787939?focus=true

### Description
Adds logic for the new GenerateEmail action.

### Steps to test this PR
Will be testable later on the top stacked PR

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR broker automation around email generation for opt-out/scan flows; scope is limited to the state engine handler and side-effect shape, with unit test coverage.
> 
> **Overview**
> Adds **broker step handling** for the new **`GenerateEmail`** action: when that action runs, the actions runner moves to **`PirStage.EMAIL_GENERATE`** and emits **`GetEmailForProfile`** (same path as opt-out/email-confirmation steps that need an email but have none).
> 
> **`GetEmailForProfile`** is narrowed to **`actionId`** and **`brokerName`** only—**`extractedProfile`** and **`profileQuery`** are no longer passed on the side effect (call sites and tests updated accordingly).
> 
> Unit tests cover **`GenerateEmail`** on scan, opt-out, and email-confirmation steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6537d7a14e2b4f758a050cadadaddc6498e125d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->