### PR TITLE
DuckAi/Voice chat: Guard NTP creation against active voice session

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -29,6 +29,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -72,10 +73,10 @@ class FirstScreenHandlerImpl @Inject constructor(
         }
     }
 
-    private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean {
-        if (!duckChat.isVoiceSessionActive()) return false
+    private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean = withContext(dispatcherProvider.io()) {
+        if (!duckChat.isVoiceSessionActive()) return@withContext false
         val selectedTab = tabRepository.getSelectedTab()
-        return selectedTab?.url?.toUri()?.let {
+        return@withContext selectedTab?.url?.toUri()?.let {
             duckChat.isDuckChatUrl(it)
         } == true
     }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -61,7 +61,7 @@ class FirstScreenHandlerImpl @Inject constructor(
             val elapsed = System.currentTimeMillis() - lastBackgrounded
             if (lastBackgrounded == 0L || elapsed >= timeoutMs) {
                 if (!isVoiceSessionActiveOnCurrentTab()) {
-                    showOnAppLaunchOptionHandler.handleAppLaunchOption()
+                    showOnAppLaunchOptionHandler.handleAfterInactivityOption()
                 }
                 return
             }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -16,12 +16,15 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
+import androidx.core.net.toUri
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -40,6 +43,8 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler,
     private val dispatcherProvider: DispatcherProvider,
+    private val duckChat: DuckChat,
+    private val tabRepository: TabRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : BrowserLifecycleObserver {
 
@@ -55,12 +60,24 @@ class FirstScreenHandlerImpl @Inject constructor(
             val lastBackgrounded = settingsDataStore.lastSessionBackgroundTimestamp
             val elapsed = System.currentTimeMillis() - lastBackgrounded
             if (lastBackgrounded == 0L || elapsed >= timeoutMs) {
-                showOnAppLaunchOptionHandler.handleAfterInactivityOption()
+                if (!isVoiceSessionActiveOnCurrentTab()) {
+                    showOnAppLaunchOptionHandler.handleAppLaunchOption()
+                }
                 return
             }
         } else if (isFreshLaunch && showOnAppLaunchFeature.self().isEnabled()) {
-            showOnAppLaunchOptionHandler.handleAppLaunchOption()
+            if (!isVoiceSessionActiveOnCurrentTab()) {
+                showOnAppLaunchOptionHandler.handleAppLaunchOption()
+            }
         }
+    }
+
+    private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean {
+        if (!duckChat.isVoiceSessionActive()) return false
+        val selectedTab = tabRepository.getSelectedTab()
+        return selectedTab?.url?.toUri()?.let {
+            duckChat.isDuckChatUrl(it)
+        } == true
     }
 
     override fun onClose() {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -19,12 +19,16 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -40,6 +44,8 @@ class FirstScreenHandlerImplTest {
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature = mock()
     private val settingsDataStore: SettingsDataStore = mock()
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler = mock()
+    private val duckChat: DuckChat = mock()
+    private val tabRepository: TabRepository = mock()
     private val idleReturnToggle: Toggle = mock()
     private val showOnAppLaunchToggle: Toggle = mock()
     private val testScope = TestScope()
@@ -51,12 +57,16 @@ class FirstScreenHandlerImplTest {
         whenever(androidBrowserConfigFeature.showNTPAfterIdleReturn()).thenReturn(idleReturnToggle)
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+        whenever(tabRepository.getSelectedTab()).thenReturn(null)
 
         testee = FirstScreenHandlerImpl(
             androidBrowserConfigFeature = androidBrowserConfigFeature,
             showOnAppLaunchFeature = showOnAppLaunchFeature,
             settingsDataStore = settingsDataStore,
             showOnAppLaunchOptionHandler = showOnAppLaunchOptionHandler,
+            duckChat = duckChat,
+            tabRepository = tabRepository,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
         )
@@ -239,6 +249,68 @@ class FirstScreenHandlerImplTest {
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
         verify(showOnAppLaunchToggle, never()).isEnabled()
+    }
+
+    // --- Voice session active (idle return path) ---
+
+    @Test
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndVoiceSessionActiveOnDuckAiTabThenDoesNothing() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
+        whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
+    }
+
+    @Test
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndNoVoiceSessionActiveThenDelegates() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
+    }
+
+    // --- Voice session active (legacy fresh launch path) ---
+
+    @Test
+    fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndVoiceSessionActiveOnDuckAiTabThenDoesNothing() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
+        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
+        whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
+    }
+
+    @Test
+    fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndNoVoiceSessionActiveThenDelegates() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
+        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
     }
 
     // --- onClose ---

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -16,18 +16,19 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
-import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -35,6 +36,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
 class FirstScreenHandlerImplTest {
 
     @get:Rule
@@ -48,7 +50,7 @@ class FirstScreenHandlerImplTest {
     private val tabRepository: TabRepository = mock()
     private val idleReturnToggle: Toggle = mock()
     private val showOnAppLaunchToggle: Toggle = mock()
-    private val testScope = TestScope()
+    private val testScope = coroutineTestRule.testScope
 
     private lateinit var testee: FirstScreenHandlerImpl
 
@@ -58,7 +60,6 @@ class FirstScreenHandlerImplTest {
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
         whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
-        whenever(tabRepository.getSelectedTab()).thenReturn(null)
 
         testee = FirstScreenHandlerImpl(
             androidBrowserConfigFeature = androidBrowserConfigFeature,
@@ -260,14 +261,31 @@ class FirstScreenHandlerImplTest {
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
         whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
-        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
 
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+    }
+
+    @Test
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndVoiceSessionActiveOnNonDuckAiTabThenDelegates() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        val nonDuckAiTab = TabEntity(tabId = "tab1", url = "https://example.com")
+        whenever(tabRepository.getSelectedTab()).thenReturn(nonDuckAiTab)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).handleAfterInactivityOption()
     }
 
     @Test
@@ -281,7 +299,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
+        verify(showOnAppLaunchOptionHandler).handleAfterInactivityOption()
     }
 
     // --- Voice session active (legacy fresh launch path) ---
@@ -291,14 +309,29 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
         whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
-        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+    }
+
+    @Test
+    fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndVoiceSessionActiveOnNonDuckAiTabThenDelegates() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
+        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
+        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        val nonDuckAiTab = TabEntity(tabId = "tab1", url = "https://example.com")
+        whenever(tabRepository.getSelectedTab()).thenReturn(nonDuckAiTab)
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
     }
 
     @Test

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -135,7 +135,7 @@ interface DuckChat {
     fun openVoiceDuckChat()
 
     /**
-     * Returns `true` if the voice shortcut feature is available and a voice session is currently active.
+     * Returns `true` if a voice session is currently active.
      */
     fun isVoiceSessionActive(): Boolean
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -133,4 +133,9 @@ interface DuckChat {
      * Opens Duck.ai directly in voice mode (duck.ai/?mode=voice-mode).
      */
     fun openVoiceDuckChat()
+
+    /**
+     * Returns `true` if the voice shortcut feature is available and a voice session is currently active.
+     */
+    fun isVoiceSessionActive(): Boolean
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BA
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.sync.api.DeviceSyncState
@@ -343,6 +344,7 @@ class RealDuckChat @Inject constructor(
     private val syncEngine: SyncEngine,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val appBuildConfig: AppBuildConfig,
+    private val voiceSessionStateManager: VoiceSessionStateManager,
 ) : DuckChatInternal,
     DuckAiFeatureState,
     PrivacyConfigCallbackPlugin {
@@ -778,6 +780,9 @@ class RealDuckChat @Inject constructor(
 
     override fun isChatSuggestionsFeatureAvailable(): Boolean =
         duckChatFeature.aiChatSuggestions().isEnabled()
+
+    override fun isVoiceSessionActive(): Boolean =
+        _showVoiceSearchToggle.value && voiceSessionStateManager.isVoiceSessionActive
 
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -393,7 +393,6 @@ class RealDuckChat @Inject constructor(
     private var isContextualModeEnabled: Boolean = false
     private var isAutomaticContextAttachmentEnabled: Boolean = false
     private var areMultipleContentAttachmentsEnabled: Boolean = false
-
     init {
         if (isMainProcess) {
             cacheConfig()
@@ -781,8 +780,7 @@ class RealDuckChat @Inject constructor(
     override fun isChatSuggestionsFeatureAvailable(): Boolean =
         duckChatFeature.aiChatSuggestions().isEnabled()
 
-    override fun isVoiceSessionActive(): Boolean =
-        _showVoiceSearchToggle.value && voiceSessionStateManager.isVoiceSessionActive
+    override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatDataStore
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.squareup.anvil.annotations.ContributesBinding
@@ -94,6 +95,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val pendingNativePromptStore: PendingNativePromptStore,
     private val faviconManager: FaviconManager,
     private val duckChatFeature: DuckChatFeature,
+    private val voiceSessionStateManager: VoiceSessionStateManager,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -223,7 +225,13 @@ class RealDuckChatJSHelper @Inject constructor(
             }
 
             METHOD_VOICE_SESSION_STARTED -> {
+                voiceSessionStateManager.onVoiceSessionStarted()
                 duckChatPixels.reportVoiceSessionStarted()
+                null
+            }
+
+            METHOD_VOICE_SESSION_ENDED -> {
+                voiceSessionStateManager.onVoiceSessionEnded()
                 null
             }
 
@@ -458,6 +466,7 @@ class RealDuckChatJSHelper @Inject constructor(
         const val METHOD_OPEN_KEYBOARD = "openKeyboard"
         private const val METHOD_TOGGLE_PAGE_CONTEXT = "togglePageContextTelemetry"
         private const val METHOD_VOICE_SESSION_STARTED = "voiceSessionStarted"
+        private const val METHOD_VOICE_SESSION_ENDED = "voiceSessionEnded"
         private const val AI_CHAT_PAYLOAD = "aiChatPayload"
         private const val METHOD_OPEN_KEYBOARD_PAYLOAD = "selector"
         private const val IS_HANDOFF_ENABLED = "isAIChatHandoffEnabled"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
@@ -66,6 +66,7 @@ class DuckChatContentScopeJsMessageHandler @Inject constructor(
                     "userDidAcceptTermsAndConditions",
                     "getAIChatNativePrompt",
                     "voiceSessionStarted",
+                    "voiceSessionEnded",
                 )
         }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -18,13 +18,10 @@ package com.duckduckgo.duckchat.impl.voice
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 interface VoiceSessionStateManager {
-    val isVoiceSessionActive: StateFlow<Boolean>
+    val isVoiceSessionActive: Boolean
     fun onVoiceSessionStarted()
     fun onVoiceSessionEnded()
 }
@@ -32,14 +29,14 @@ interface VoiceSessionStateManager {
 @ContributesBinding(AppScope::class)
 class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager {
 
-    private val _isVoiceSessionActive = MutableStateFlow(false)
-    override val isVoiceSessionActive: StateFlow<Boolean> = _isVoiceSessionActive.asStateFlow()
+    override var isVoiceSessionActive: Boolean = false
+        private set
 
     override fun onVoiceSessionStarted() {
-        _isVoiceSessionActive.value = true
+        isVoiceSessionActive = true
     }
 
     override fun onVoiceSessionEnded() {
-        _isVoiceSessionActive.value = false
+        isVoiceSessionActive = false
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -16,8 +16,10 @@
 
 package com.duckduckgo.duckchat.impl.voice
 
+import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 
@@ -28,8 +30,9 @@ interface VoiceSessionStateManager {
 }
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager {
+@ContributesBinding(AppScope::class, boundType = VoiceSessionStateManager::class)
+@ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
+class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager, BrowserLifecycleObserver {
 
     @Volatile
     // NOTE: We are unable to detect that voice chat has ended IF the user closes the tab running voice chat.
@@ -42,5 +45,11 @@ class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateMana
 
     override fun onVoiceSessionEnded() {
         isVoiceSessionActive = false
+    }
+
+    override fun onOpen(isFreshLaunch: Boolean) {
+        if (isFreshLaunch) {
+            isVoiceSessionActive = false
+        }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.voice
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+interface VoiceSessionStateManager {
+    val isVoiceSessionActive: StateFlow<Boolean>
+    fun onVoiceSessionStarted()
+    fun onVoiceSessionEnded()
+}
+
+@ContributesBinding(AppScope::class)
+class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager {
+
+    private val _isVoiceSessionActive = MutableStateFlow(false)
+    override val isVoiceSessionActive: StateFlow<Boolean> = _isVoiceSessionActive.asStateFlow()
+
+    override fun onVoiceSessionStarted() {
+        _isVoiceSessionActive.value = true
+    }
+
+    override fun onVoiceSessionEnded() {
+        _isVoiceSessionActive.value = false
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.voice
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface VoiceSessionStateManager {
@@ -26,6 +27,7 @@ interface VoiceSessionStateManager {
     fun onVoiceSessionEnded()
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager {
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -31,6 +31,8 @@ interface VoiceSessionStateManager {
 @ContributesBinding(AppScope::class)
 class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager {
 
+    @Volatile
+    // NOTE: We are unable to detect that voice chat has ended IF the user closes the tab running voice chat.
     override var isVoiceSessionActive: Boolean = false
         private set
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BA
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -110,6 +111,7 @@ class RealDuckChatTest {
     private val mockSyncEngine: SyncEngine = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
 
     private lateinit var testee: RealDuckChat
 
@@ -152,6 +154,7 @@ class RealDuckChatTest {
                 mockSyncEngine,
                 mockDuckAiHostProvider,
                 mockAppBuildConfig,
+                mockVoiceSessionStateManager,
             ),
         )
         coroutineRule.testScope.advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1438,6 +1438,7 @@ class DuckChatContextualViewModelTest {
         override fun isChatSuggestionsFeatureAvailable(): Boolean = true
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
+        override fun isVoiceSessionActive(): Boolean = false
     }
 
     private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1625,7 +1625,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenVoiceSessionEndedThenPixelFiredAndStateUpdated() = runTest {
+    fun whenVoiceSessionEndedThenNoPixelFiredAndStateUpdated() = runTest {
         val result = testee.processJsCallbackMessage(
             "aiChat",
             "voiceSessionEnded",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper.Companion.DUCK_C
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper.Companion.METHOD_GET_PAGE_CONTEXT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatDataStore
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -72,6 +73,7 @@ class RealDuckChatJSHelperTest {
     private val mockFaviconManager: FaviconManager = mock()
     private val mockDuckChatFeature: DuckChatFeature =
         FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
+    private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -82,6 +84,7 @@ class RealDuckChatJSHelperTest {
         pendingNativePromptStore = mockPendingNativePromptStore,
         faviconManager = mockFaviconManager,
         duckChatFeature = mockDuckChatFeature,
+        voiceSessionStateManager = mockVoiceSessionStateManager,
     )
     private val viewModel =
         object {
@@ -1604,5 +1607,35 @@ class RealDuckChatJSHelperTest {
         )
 
         assertNull(result)
+    }
+
+    @Test
+    fun whenVoiceSessionStartedThenPixelFiredAndStateUpdated() = runTest {
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "voiceSessionStarted",
+            null,
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertNull(result)
+        verify(mockDuckChatPixels).reportVoiceSessionStarted()
+        verify(mockVoiceSessionStateManager).onVoiceSessionStarted()
+    }
+
+    @Test
+    fun whenVoiceSessionEndedThenPixelFiredAndStateUpdated() = runTest {
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "voiceSessionEnded",
+            null,
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertNull(result)
+        verify(mockVoiceSessionStateManager).onVoiceSessionEnded()
+        verifyNoInteractions(mockDuckChatPixels)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
@@ -43,7 +43,7 @@ class DuckChatContentScopeJsMessageHandlerTest {
     @Test
     fun `only contains valid methods`() {
         val methods = handler.methods
-        assertTrue(methods.size == 16)
+        assertTrue(methods.size == 17)
         assertTrue(methods[0] == "getAIChatNativeHandoffData")
         assertTrue(methods[1] == "getAIChatNativeConfigValues")
         assertTrue(methods[2] == "openAIChat")
@@ -60,6 +60,7 @@ class DuckChatContentScopeJsMessageHandlerTest {
         assertTrue(methods[13] == "userDidAcceptTermsAndConditions")
         assertTrue(methods[14] == "getAIChatNativePrompt")
         assertTrue(methods[15] == "voiceSessionStarted")
+        assertTrue(methods[16] == "voiceSessionEnded")
     }
 
     private val callback = object : JsMessageCallback() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -113,6 +113,7 @@ class FakeDuckChat(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
+    override fun isVoiceSessionActive(): Boolean = false
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -174,6 +174,7 @@ class FakeDuckChatInternal(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
+    override fun isVoiceSessionActive(): Boolean = false
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -18,11 +18,17 @@ package com.duckduckgo.duckchat.impl.voice
 
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 class RealVoiceSessionStateManagerTest {
 
-    private val testee = RealVoiceSessionStateManager()
+    private lateinit var testee: RealVoiceSessionStateManager
+
+    @Before
+    fun setup() {
+        testee = RealVoiceSessionStateManager()
+    }
 
     @Test
     fun whenCreatedThenVoiceSessionIsNotActive() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -26,14 +26,14 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenCreatedThenVoiceSessionIsNotActive() {
-        assertFalse(testee.isVoiceSessionActive.value)
+        assertFalse(testee.isVoiceSessionActive)
     }
 
     @Test
     fun whenVoiceSessionStartedThenIsVoiceSessionActiveIsTrue() {
         testee.onVoiceSessionStarted()
 
-        assertTrue(testee.isVoiceSessionActive.value)
+        assertTrue(testee.isVoiceSessionActive)
     }
 
     @Test
@@ -41,14 +41,14 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted()
         testee.onVoiceSessionEnded()
 
-        assertFalse(testee.isVoiceSessionActive.value)
+        assertFalse(testee.isVoiceSessionActive)
     }
 
     @Test
     fun whenVoiceSessionEndedWithoutStartThenIsVoiceSessionActiveIsFalse() {
         testee.onVoiceSessionEnded()
 
-        assertFalse(testee.isVoiceSessionActive.value)
+        assertFalse(testee.isVoiceSessionActive)
     }
 
     @Test
@@ -56,6 +56,6 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted()
         testee.onVoiceSessionStarted()
 
-        assertTrue(testee.isVoiceSessionActive.value)
+        assertTrue(testee.isVoiceSessionActive)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -64,4 +64,20 @@ class RealVoiceSessionStateManagerTest {
 
         assertTrue(testee.isVoiceSessionActive)
     }
+
+    @Test
+    fun whenFreshLaunchAndVoiceSessionWasActiveThenIsVoiceSessionActiveIsFalse() {
+        testee.onVoiceSessionStarted()
+        testee.onOpen(isFreshLaunch = true)
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenNotFreshLaunchAndVoiceSessionWasActiveThenIsVoiceSessionActiveRemainsTrue() {
+        testee.onVoiceSessionStarted()
+        testee.onOpen(isFreshLaunch = false)
+
+        assertTrue(testee.isVoiceSessionActive)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.voice
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealVoiceSessionStateManagerTest {
+
+    private val testee = RealVoiceSessionStateManager()
+
+    @Test
+    fun whenCreatedThenVoiceSessionIsNotActive() {
+        assertFalse(testee.isVoiceSessionActive.value)
+    }
+
+    @Test
+    fun whenVoiceSessionStartedThenIsVoiceSessionActiveIsTrue() {
+        testee.onVoiceSessionStarted()
+
+        assertTrue(testee.isVoiceSessionActive.value)
+    }
+
+    @Test
+    fun whenVoiceSessionEndedThenIsVoiceSessionActiveIsFalse() {
+        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionEnded()
+
+        assertFalse(testee.isVoiceSessionActive.value)
+    }
+
+    @Test
+    fun whenVoiceSessionEndedWithoutStartThenIsVoiceSessionActiveIsFalse() {
+        testee.onVoiceSessionEnded()
+
+        assertFalse(testee.isVoiceSessionActive.value)
+    }
+
+    @Test
+    fun whenVoiceSessionStartedMultipleTimesThenIsVoiceSessionActiveIsTrue() {
+        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted()
+
+        assertTrue(testee.isVoiceSessionActive.value)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214072145685732?focus=true 

### Description
This change introduces an additional logic in the “Return to after inactivity feature” where if Duck.ai* is the last selected tab AND a voice chat session is active, we don’t launch the New Tab Page / Whatever new screen.

*Note: Since we can’t detect duck ai voice mode from the tab, we just guard this by the Duck.AI feature. The side effect is that if Duck.AI voice chat is active on a different tab AND another Duck.Ai (non-voice) chat is currently selected, the NTP is NOT going to be re-created.

**Note: We currently don’t have a way to detect if the voice session has ended IF the user closed the voice chat tab.


**Before:** https://github.com/user-attachments/assets/85e724e6-896e-44e7-b9ec-0ed2e794e84c

**After:** https://github.com/user-attachments/assets/df701179-ce18-4fc0-90c5-b11f9d137a98


### Steps to test this PR
_Preconditions_
- [ ] Enable FF: showNTPAfterIdleReturn
- [ ] Enable Search & Duck.AI
- [ ] Settings > General > After Inactivity > Set `New Tab Page` and timer to `Always`

_Non duck ai opened_
- [x] Open cnn.com
- [x] Close screen and open it again
- [x] Verify New Tab Page is shown

_Duck ai opened_
- [x] Open duck.ai
- [x] Close screen and open it again
- [x] Verify New Tab Page is shown

_Duck ai voice opened_
- [x] Open duck.ai voice mode
- [x] Close screen and open it again
- [x] Verify voice mode is preserved and is usable. No NTP or new screen created.

_Duck ai voice opened but tab closed_
- [ ] Close all tabs and open one with cnn.com
- [ ] Open duck.ai voice mode
- [ ] Close tab
- [ ] Close screen and open again
- [ ] Verify New Tab Page is shown
- [ ] Open Duck.ai in one tab
- [ ] Open duck.ai voice mode on another tab
- [ ] close tab
- [ ] Close screen and open again
- [ ] Verify duck.ai is still shown. No NTP or new screen created. (See * above)

_Set screen to cnn.com_
- [ ] Settings > General > After Inactivity > Set cnn.com
- [ ] Open cnn.com
- [ ] Close screen and open it again
- [ ] Verify no new screen with cnn.com is created.
- [ ] Close that tab.
- [ ] Open duck.ai voice mode
- [ ] Close screen and open it again
- [ ] Verify voice mode is preserved and is usable. No NTP or new screen created.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-launch/idle-return navigation behavior based on a new Duck.ai voice-session state, which could affect what users see on resume/launch and has edge cases if voice sessions aren’t correctly ended.
> 
> **Overview**
> Prevents the app’s *first-screen* logic from creating a New Tab Page (or other configured launch screen) when a Duck.ai voice chat session is active on the currently selected Duck.ai tab.
> 
> Introduces voice-session state tracking in DuckChat: adds `DuckChat.isVoiceSessionActive()`, wires it through `RealDuckChat`, and tracks start/end via new JS message `voiceSessionEnded` plus a new app-scoped `VoiceSessionStateManager` (reset on fresh launch). Tests are updated/added to cover the new guard and voice session state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c6eecd45b13a6bd0f97ef6dc21c98cd8f8e8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->