### PR TITLE
Updates for sync recovery from ship review feedback / testing

### DIFF
--- a/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistentstorage/impl/BlockStoreWrapper.kt
+++ b/persistent-storage/persistent-storage-impl/src/main/java/com/duckduckgo/persistentstorage/impl/BlockStoreWrapper.kt
@@ -65,7 +65,7 @@ class RealBlockStoreWrapper @Inject constructor(
         val storeBytesData = StoreBytesData.Builder()
             .setKey(key)
             .setBytes(bytes)
-            .setShouldBackupToCloud(shouldBackupToCloud)
+            .setShouldBackupToCloud(false) // Cloud backup not yet supported
             .build()
         client.storeBytes(storeBytesData).await()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsActivity.kt
@@ -205,27 +205,13 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.secretKeyTextView.text = viewState.secretKey
         binding.recoveryCodeTextView.text = viewState.recoveryCode.ifEmpty { "(not signed in)" }
         binding.connectedDevicesList.removeAllViews()
-        binding.blockStoreFeatureFlag.text = if (viewState.syncAutoRestoreEnabled) {
-            "✅ syncAutoRestore flag enabled"
-        } else {
-            "❌ syncAutoRestore flag disabled"
-        }
-        binding.blockStoreAvailability.text = when (viewState.blockStoreAvailable) {
-            null -> "Checking..."
-            true -> "✅ Available"
-            false -> "❌ Unavailable (Play Services missing)"
-        }
-        binding.blockStoreE2eStatus.text = when {
-            viewState.blockStoreAvailable == null -> ""
-            viewState.blockStoreAvailable == false -> ""
-            viewState.blockStoreE2ESupported == true -> "✅ E2E encryption supported"
-            else -> "❌ E2E encryption not supported"
-        }
-        binding.blockStoreCurrentValue.text = when (val value = viewState.blockStoreCurrentValue) {
-            is SyncInternalSettingsViewModel.BlockStoreValue.Loading -> "Loading..."
-            is SyncInternalSettingsViewModel.BlockStoreValue.NotSet -> "(key not set)"
-            is SyncInternalSettingsViewModel.BlockStoreValue.HasValue -> value.value
-        }
+        binding.blockStoreFeatureFlag.text = viewState.blockStoreFeatureFlagText
+        binding.blockStoreAvailability.text = viewState.blockStoreAvailabilityText
+        binding.blockStoreApiInUse.text = viewState.blockStoreApiLevelText
+        binding.blockStoreDeviceLockStatus.text = viewState.blockStoreDeviceLockText
+        binding.blockStoreE2eStatus.text = viewState.blockStoreE2eText
+        binding.blockStoreInferredBackupStatus.text = viewState.blockStoreInferredBackupText
+        binding.blockStoreCurrentValue.text = viewState.blockStoreCurrentValueText
 
         binding.syncInternalEnvironment.quietlySetIsChecked(viewState.useDevEnvironment) { _, enabled ->
             viewModel.onEnvironmentChanged(enabled)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncInternalSettingsViewModel.kt
@@ -16,9 +16,13 @@
 
 package com.duckduckgo.sync.impl.ui
 
+import android.annotation.SuppressLint
+import android.app.KeyguardManager
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.persistentstorage.api.PersistentStorage
@@ -68,6 +72,8 @@ constructor(
     private val persistentStorage: PersistentStorage,
     private val syncAutoRestoreManager: SyncAutoRestoreManager,
     private val syncFeature: SyncFeature,
+    private val appBuildConfig: AppBuildConfig,
+    @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
@@ -93,6 +99,13 @@ constructor(
         val blockStoreAvailable: Boolean? = null,
         val blockStoreE2ESupported: Boolean? = null,
         val blockStoreCurrentValue: BlockStoreValue = BlockStoreValue.Loading,
+        val blockStoreFeatureFlagText: String = "",
+        val blockStoreAvailabilityText: String = "",
+        val blockStoreApiLevelText: String = "",
+        val blockStoreDeviceLockText: String = "",
+        val blockStoreE2eText: String = "",
+        val blockStoreInferredBackupText: String = "",
+        val blockStoreCurrentValueText: String = "Loading...",
     )
 
     sealed class BlockStoreValue {
@@ -121,6 +134,8 @@ constructor(
 
     fun onResume() {
         viewModelScope.launch(dispatchers.io()) {
+            checkSyncAutoRestoreFlag()
+            checkBlockStoreAvailability()
             refreshBlockStoreValue()
         }
     }
@@ -371,16 +386,37 @@ constructor(
 
     private fun checkSyncAutoRestoreFlag() {
         val enabled = syncFeature.syncAutoRestore().isEnabled()
-        viewState.update { it.copy(syncAutoRestoreEnabled = enabled) }
+        viewState.update { state ->
+            state.copy(syncAutoRestoreEnabled = enabled).withBlockStoreChecklistText(
+                apiLevel = appBuildConfig.sdkInt,
+                hasSecureLock = isDeviceSecureLockEnabled(),
+            )
+        }
     }
 
     private suspend fun checkBlockStoreAvailability() {
         when (val availability = persistentStorage.checkAvailability()) {
             is PersistentStorageAvailability.Unavailable -> {
-                viewState.update { it.copy(blockStoreAvailable = false, blockStoreE2ESupported = false) }
+                viewState.update { state ->
+                    state.copy(
+                        blockStoreAvailable = false,
+                        blockStoreE2ESupported = false,
+                    ).withBlockStoreChecklistText(
+                        apiLevel = appBuildConfig.sdkInt,
+                        hasSecureLock = isDeviceSecureLockEnabled(),
+                    )
+                }
             }
             is PersistentStorageAvailability.Available -> {
-                viewState.update { it.copy(blockStoreAvailable = true, blockStoreE2ESupported = availability.isEndToEndEncryptionSupported) }
+                viewState.update { state ->
+                    state.copy(
+                        blockStoreAvailable = true,
+                        blockStoreE2ESupported = availability.isEndToEndEncryptionSupported,
+                    ).withBlockStoreChecklistText(
+                        apiLevel = appBuildConfig.sdkInt,
+                        hasSecureLock = isDeviceSecureLockEnabled(),
+                    )
+                }
             }
         }
     }
@@ -391,7 +427,12 @@ constructor(
             bytes == null -> BlockStoreValue.NotSet
             else -> BlockStoreValue.HasValue(String(bytes, Charsets.UTF_8))
         }
-        viewState.update { it.copy(blockStoreCurrentValue = blockStoreValue) }
+        viewState.update { state ->
+            state.copy(blockStoreCurrentValue = blockStoreValue).withBlockStoreChecklistText(
+                apiLevel = appBuildConfig.sdkInt,
+                hasSecureLock = isDeviceSecureLockEnabled(),
+            )
+        }
     }
 
     fun onBlockStoreWriteRecoveryCode() {
@@ -451,5 +492,69 @@ constructor(
             refreshBlockStoreValue()
             command.send(ShowMessage("Cleared successfully"))
         }
+    }
+
+    private fun ViewState.withBlockStoreChecklistText(
+        apiLevel: Int,
+        hasSecureLock: Boolean,
+    ): ViewState {
+        val apiSupportsE2e = apiLevel >= 28
+        val featureFlagText = if (syncAutoRestoreEnabled) {
+            "✅ syncAutoRestore flag: enabled"
+        } else {
+            "❌ syncAutoRestore flag: disabled"
+        }
+        val availabilityText = when (blockStoreAvailable) {
+            null -> "Checking..."
+            true -> "✅ Block Store API: Available"
+            false -> "❌ Block Store API: Unavailable (Play Services missing)"
+        }
+        val apiLevelText = if (blockStoreAvailable == null) {
+            ""
+        } else {
+            val e2eApiLevelStatus = if (apiSupportsE2e) {
+                "(supports E2E encryption)"
+            } else {
+                "(no E2E encryption support)"
+            }
+            "Android API level: $apiLevel $e2eApiLevelStatus"
+        }
+        val deviceLockText = when (blockStoreAvailable) {
+            null -> ""
+            true -> if (hasSecureLock) "✅ Device screen lock: Enabled" else "❌ Device screen lock: Disabled"
+            false -> ""
+        }
+        val e2eText = when {
+            blockStoreAvailable == null -> ""
+            !blockStoreAvailable -> ""
+            blockStoreE2ESupported == true -> "✅ E2E encryption: Available"
+            else -> "❌ E2E encryption: Unavailable"
+        }
+        val inferredBackupText = when {
+            blockStoreAvailable == null -> ""
+            blockStoreE2ESupported == true -> "✅ Backup setting (inferred): Enabled"
+            blockStoreAvailable && apiSupportsE2e && hasSecureLock ->
+                "❌ Backup setting (inferred): Disabled\n(E2E unavailable despite meeting prerequisites)"
+            else -> "❓ Backup setting (inferred): Unknown"
+        }
+        val currentValueText = when (val value = blockStoreCurrentValue) {
+            is BlockStoreValue.Loading -> "Loading..."
+            is BlockStoreValue.NotSet -> "(key not set)"
+            is BlockStoreValue.HasValue -> value.value
+        }
+        return copy(
+            blockStoreFeatureFlagText = featureFlagText,
+            blockStoreAvailabilityText = availabilityText,
+            blockStoreApiLevelText = apiLevelText,
+            blockStoreDeviceLockText = deviceLockText,
+            blockStoreE2eText = e2eText,
+            blockStoreInferredBackupText = inferredBackupText,
+            blockStoreCurrentValueText = currentValueText,
+        )
+    }
+
+    private fun isDeviceSecureLockEnabled(): Boolean {
+        val keyguardManager = context.getSystemService(KeyguardManager::class.java)
+        return keyguardManager?.isDeviceSecure == true
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/RecoverDataFragment.kt
@@ -101,7 +101,7 @@ class RecoverDataFragment : DuckDuckGoFragment(R.layout.fragment_recover_data) {
         binding.footerNextButton.setOnClickListener {
             viewModel.onNextClicked()
         }
-        binding.copyCodeButton.setOnClickListener {
+        binding.recoveryCodeItem.setClickListener {
             viewModel.onCopyCodeClicked()
         }
         binding.restoreOnReinstallToggle.setOnCheckedChangeListener { _, isChecked ->
@@ -181,7 +181,13 @@ class RecoverDataFragment : DuckDuckGoFragment(R.layout.fragment_recover_data) {
                 binding.recoveryCodeSkeleton.stopShimmer()
                 binding.recoveryCodeSkeleton.gone()
                 binding.recoverCodeContainer.show()
-                binding.recoveryCodeText.text = viewMode.b64RecoveryCode
+
+                val truncatedCode = if (viewMode.b64RecoveryCode.length > RECOVERY_CODE_MAX_CHAR_BEFORE_TRUNCATION) {
+                    viewMode.b64RecoveryCode.take(RECOVERY_CODE_MAX_CHAR_BEFORE_TRUNCATION) + "…"
+                } else {
+                    viewMode.b64RecoveryCode
+                }
+                binding.recoveryCodeItem.setSecondaryText(truncatedCode)
             }
 
             CreatingAccount -> {
@@ -201,5 +207,6 @@ class RecoverDataFragment : DuckDuckGoFragment(R.layout.fragment_recover_data) {
 
     companion object {
         fun instance() = RecoverDataFragment()
+        private const val RECOVERY_CODE_MAX_CHAR_BEFORE_TRUNCATION = 56
     }
 }

--- a/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_internal_sync_settings.xml
@@ -78,6 +78,14 @@
                 app:primaryText="@string/sync_internal_block_store_header" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreApiInUse"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/blockStoreFeatureFlag"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -94,7 +102,23 @@
                 app:typography="body1" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreDeviceLockStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/blockStoreE2eStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/blockStoreInferredBackupStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/keyline_4"

--- a/sync/sync-impl/src/main/res/layout/fragment_recover_data.xml
+++ b/sync/sync-impl/src/main/res/layout/fragment_recover_data.xml
@@ -124,78 +124,14 @@
                 android:paddingBottom="@dimen/keyline_4"
                 android:visibility="visible">
 
-                <!-- Recovery code list item row -->
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/recoveryCodeItem"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:minHeight="64dp"
-                    android:paddingStart="@dimen/keyline_4"
-                    android:paddingEnd="@dimen/keyline_4"
-                    android:paddingTop="@dimen/keyline_3"
-                    android:paddingBottom="@dimen/keyline_3">
-
-                    <!-- QR icon with container background -->
-                    <FrameLayout
-                        android:id="@+id/recoveryCodeIcon"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
-                        android:background="@drawable/list_item_image_round_background"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent">
-
-                        <ImageView
-                            android:layout_width="24dp"
-                            android:layout_height="24dp"
-                            android:layout_gravity="center"
-                            android:src="@drawable/ic_qr_24"
-                            tools:ignore="ContentDescription" />
-
-                    </FrameLayout>
-
-                    <!-- Recovery code label + text -->
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/keyline_4"
-                        android:layout_marginEnd="@dimen/keyline_4"
-                        android:orientation="vertical"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toStartOf="@id/copyCodeButton"
-                        app:layout_constraintStart_toEndOf="@id/recoveryCodeIcon"
-                        app:layout_constraintTop_toTopOf="parent">
-
-                        <com.duckduckgo.common.ui.view.text.DaxTextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/sync_recover_data_recovery_code_label"
-                            app:textType="secondary"
-                            app:typography="body1" />
-
-                        <com.duckduckgo.common.ui.view.text.DaxTextView
-                            android:id="@+id/recoveryCodeText"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="2dp"
-                            android:ellipsize="end"
-                            android:maxLines="2"
-                            app:textType="secondary"
-                            app:typography="body1_mono" />
-
-                    </LinearLayout>
-
-                    <!-- Copy button -->
-                    <com.duckduckgo.common.ui.view.button.IconButton
-                        android:id="@+id/copyCodeButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:background="?selectableItemBackgroundBorderless"
-                        app:srcCompat="@drawable/ic_copy_24"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                    app:primaryText="@string/sync_recover_data_recovery_code_label"
+                    app:leadingIcon="@drawable/ic_qr_24"
+                    app:leadingIconBackground="circular"
+                    app:trailingIcon="@drawable/ic_copy_24" />
 
                 <!-- Download as PDF button -->
                 <com.duckduckgo.common.ui.view.button.DaxButtonSecondary

--- a/sync/sync-impl/src/main/res/layout/fragment_recovery_code.xml
+++ b/sync/sync-impl/src/main/res/layout/fragment_recovery_code.xml
@@ -144,6 +144,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
+                    app:textType="primary"
                     app:typography="body1_mono" />
 
                 <com.duckduckgo.common.ui.view.button.DaxButtonSecondary


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214085962508098?focus=true 

### Description
- UI changes to address design review comments
- explicitly disabling should backup to cloud flag (deferred to milestone 3)
- added more capability checks to the internal dev settings screen

### Steps to test this PR
- QA optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistent storage write behavior by forcing Block Store `shouldBackupToCloud` off, which could affect recovery-code durability on devices expecting cloud backup. Remaining changes are mostly UI/diagnostic refactors in internal settings and recovery screens.
> 
> **Overview**
> Refines the sync recovery data screen based on design feedback by replacing the custom recovery-code row with a `TwoLineListItem`, making the whole row copyable, and truncating long recovery codes in the UI.
> 
> Improves the internal Sync settings Block Store section by moving status-string construction into `SyncInternalSettingsViewModel` and expanding the checklist to show Android API level, device lock status, and an inferred backup/E2E readiness status.
> 
> Updates persistent storage Block Store writes to always set `shouldBackupToCloud=false` (with a note that cloud backup isn’t supported yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb8b69a64b4e404d1dca6ac3cefd34933c51606. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->