### PR TITLE
Duck.Ai/Voice chat: Launch voice chat from digital assistant

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -62,9 +62,12 @@ import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.DeleteFavor
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.DeleteSavedSiteConfirmation
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.DismissKeyboard
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.EditQuery
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchAssistSearch
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchBrowser
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchBrowserAndSwitchToTab
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDeviceApplication
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckAi
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckAiVoiceChat
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchEditDialog
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.ShowAppNotFoundMessage
@@ -85,6 +88,7 @@ import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
@@ -154,6 +158,9 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var duckAiFeatureState: DuckAiFeatureState
 
+    @Inject
+    lateinit var duckChat: DuckChat
+
     private val inputScreenLauncher =
         registerForActivityResult(StartActivityForResult()) { result ->
             when (result.resultCode) {
@@ -215,9 +222,13 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         if (savedInstanceState == null) {
             intent?.let {
                 sendLaunchPixels(it)
-                val inputScreenLaunched = launchInputScreen(isTopOmnibar = viewModel.isOmnibarAtTop, intent = it)
-                if (!inputScreenLaunched) {
-                    handleVoiceSearchLaunch(it)
+                if (launchedFromAssist(it)) {
+                    handleDigitalAssistIntent(it)
+                } else {
+                    val inputScreenLaunched = launchInputScreen(isTopOmnibar = viewModel.isOmnibarAtTop, intent = it)
+                    if (!inputScreenLaunched) {
+                        handleVoiceSearchLaunch(it)
+                    }
                 }
             }
         }
@@ -250,6 +261,10 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         viewModel.resetViewState()
         viewModel.setLaunchedFromSearchOnlyWidget(launchedFromSearchOnlyWidget(intent))
         sendLaunchPixels(intent)
+        if (launchedFromAssist(intent)) {
+            handleDigitalAssistIntent(intent)
+            return
+        }
         val inputScreenLaunched = launchInputScreen(isTopOmnibar = viewModel.isOmnibarAtTop, intent = intent)
         if (!inputScreenLaunched) {
             handleVoiceSearchLaunch(intent)
@@ -259,7 +274,10 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     /**
      * @return `true` if the Input Screen was successfully launched, `false` otherwise.
      */
-    private fun launchInputScreen(isTopOmnibar: Boolean, intent: Intent): Boolean {
+    private fun launchInputScreen(
+        isTopOmnibar: Boolean,
+        intent: Intent,
+    ): Boolean {
         return if (duckAiFeatureState.showInputScreenOnSystemSearchLaunch.value && !launchedFromSearchOnlyWidget(intent)) {
             globalActivityStarter.startIntent(
                 this,
@@ -293,6 +311,10 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         if (launchVoice(intent)) {
             voiceSearchLauncher.launch(this)
         }
+    }
+
+    private fun handleDigitalAssistIntent(intent: Intent) {
+        viewModel.onDigitalAssistOpened(intent)
     }
 
     private fun configureFlowCollectors() {
@@ -418,6 +440,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                     is VoiceSearchLauncher.VoiceRecognitionResult.SearchResult -> {
                         viewModel.onVoiceSearchResult(result.query)
                     }
+
                     is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult -> {
                         viewModel.onDuckAiRequested(result.query)
                     }
@@ -553,6 +576,18 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             AutocompleteItemRemoved -> autocompleteItemRemoved()
 
             SystemSearchViewModel.Command.ExitSearch -> finish()
+
+            LaunchDuckAiVoiceChat -> {
+                duckChat.openVoiceDuckChat()
+                finish()
+            }
+
+            LaunchDuckAi -> {
+                duckChat.openDuckChat()
+                finish()
+            }
+
+            is LaunchAssistSearch -> launchInputScreen(isTopOmnibar = viewModel.isOmnibarAtTop, intent = command.intent)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.systemsearch
 
+import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -166,6 +167,12 @@ class SystemSearchViewModel @Inject constructor(
         data object AutocompleteItemRemoved : Command()
 
         data object ExitSearch : Command()
+
+        data object LaunchDuckAiVoiceChat : Command()
+
+        data object LaunchDuckAi : Command()
+
+        data class LaunchAssistSearch(val intent: Intent) : Command()
     }
 
     private val isSearchOnly = MutableStateFlow(false)
@@ -308,6 +315,16 @@ class SystemSearchViewModel @Inject constructor(
         command.value = Command.ExitSearch
     }
 
+    fun onDigitalAssistOpened(intent: Intent) {
+        viewModelScope.launch {
+            command.value = when {
+                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isVoiceChatEnabled() -> Command.LaunchDuckAiVoiceChat
+                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isEnabled() -> Command.LaunchDuckAi
+                else -> Command.LaunchAssistSearch(intent)
+            }
+        }
+    }
+
     fun userUpdatedQuery(query: String) {
         if (autoCompleteSettings.autoCompleteSuggestionsEnabled) {
             queryFlow.update { query }
@@ -349,13 +366,16 @@ class SystemSearchViewModel @Inject constructor(
                 command.value = Command.LaunchBrowserAndSwitchToTab(suggestion.phrase, suggestion.tabId)
                 pixel.fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
             }
+
             is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> {
                 onDuckAiRequested(suggestion.phrase)
             }
+
             is AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion -> {
                 command.value = Command.LaunchDeviceApplication(deviceAppSuggestion = suggestion)
                 pixel.fire(INTERSTITIAL_LAUNCH_DEVICE_APP)
             }
+
             else -> {
                 command.value = Command.LaunchBrowser(suggestion.phrase)
                 pixel.fire(INTERSTITIAL_LAUNCH_BROWSER_QUERY)
@@ -388,9 +408,11 @@ class SystemSearchViewModel @Inject constructor(
                 is AutoCompleteHistorySuggestion -> {
                     history.removeHistoryEntryByUrl(suggestion.url)
                 }
+
                 is AutoCompleteHistorySearchSuggestion -> {
                     history.removeHistoryEntryByQuery(suggestion.phrase)
                 }
+
                 else -> {}
             }
             withContext(dispatchers.main()) {

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -51,10 +51,8 @@ import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.*
 import kotlinx.coroutines.test.runTest
 import org.junit.*
 import org.junit.Assert.*
@@ -99,6 +97,7 @@ class SystemSearchViewModelTest {
         doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
         whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(false)
         whenever(mockDuckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(MutableStateFlow(false))
+        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(false))
 
         testee = SystemSearchViewModel(
             mockDuckAiFeatureState,
@@ -850,6 +849,49 @@ class SystemSearchViewModelTest {
                 issuedCommand,
             )
         }
+    }
+
+    @Test
+    fun `when onDigitalAssistOpened and digital assist and voice search enabled then LaunchDuckAiVoiceChat command sent`() = runTest {
+        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
+        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(true)
+
+        testee.onDigitalAssistOpened(mock())
+
+        verify(commandObserver).onChanged(Command.LaunchDuckAiVoiceChat)
+    }
+
+    @Test
+    fun `when onDigitalAssistOpened and digital assist enabled and voice search disabled then LaunchDuckAi command sent`() = runTest {
+        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
+        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(false)
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+
+        testee.onDigitalAssistOpened(mock())
+
+        verify(commandObserver).onChanged(Command.LaunchDuckAi)
+    }
+
+    @Test
+    fun `when onDigitalAssistOpened and duck chat disabled then LaunchAssistSearch command sent`() = runTest {
+        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
+        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(false)
+        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+        val intent = mock<Intent>()
+
+        testee.onDigitalAssistOpened(intent)
+
+        verify(commandObserver).onChanged(Command.LaunchAssistSearch(intent))
+    }
+
+    @Test
+    fun `when onDigitalAssistOpened and kill switch disabled then LaunchAssistSearch command sent`() = runTest {
+        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(false))
+        val intent = mock<Intent>()
+
+        testee.onDigitalAssistOpened(intent)
+
+        verify(commandObserver).onChanged(Command.LaunchAssistSearch(intent))
     }
 
     companion object {

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -83,4 +83,9 @@ interface DuckAiFeatureState {
      * Indicates whether Duck.ai should be open in Contextual mode
      */
     val showContextualMode: StateFlow<Boolean>
+
+    /**
+     * Indicates whether Duck.ai should be used as digital assistant
+     */
+    val allowDuckAiAsDigitalAssistant: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -138,4 +138,11 @@ interface DuckChat {
      * Returns `true` if a voice session is currently active.
      */
     fun isVoiceSessionActive(): Boolean
+
+    /**
+     * Checks whether DuckChat Voice chat is enabled based on remote config flag
+     *
+     * @return true if DuckChat AI voice chat is enabled, false otherwise.
+     */
+    suspend fun isVoiceChatEnabled(): Boolean
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -366,7 +366,7 @@ class RealDuckChat @Inject constructor(
     private val _showFullScreenMode = MutableStateFlow(false)
     private val _showFullScreenModeToggle = MutableStateFlow(false)
     private val _showContextualMode = MutableStateFlow(false)
-    private val _allowDuckAiVoiceDigitalAssistant = MutableStateFlow(false)
+    private val _allowDuckAiAsDigitalAssistant = MutableStateFlow(false)
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
         moshi.adapter(DuckChatSettingJson::class.java)
@@ -568,7 +568,7 @@ class RealDuckChat @Inject constructor(
 
     override val showContextualMode: StateFlow<Boolean> = _showContextualMode.asStateFlow()
 
-    override val allowDuckAiAsDigitalAssistant: StateFlow<Boolean> = _allowDuckAiVoiceDigitalAssistant.asStateFlow()
+    override val allowDuckAiAsDigitalAssistant: StateFlow<Boolean> = _allowDuckAiAsDigitalAssistant.asStateFlow()
 
     override val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 
@@ -851,7 +851,7 @@ class RealDuckChat @Inject constructor(
                 }
             isAddressBarEntryPointEnabled = settingsJson?.addressBarEntryPoint ?: false
             isVoiceSearchEntryPointEnabled = duckChatFeature.duckAiVoiceSearch().isEnabled()
-            _allowDuckAiVoiceDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
+            _allowDuckAiAsDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
             isImageUploadEnabled = imageUploadFeature.self().isEnabled()
             isStandaloneMigrationEnabled = duckChatFeature.standaloneMigration().isEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -366,6 +366,7 @@ class RealDuckChat @Inject constructor(
     private val _showFullScreenMode = MutableStateFlow(false)
     private val _showFullScreenModeToggle = MutableStateFlow(false)
     private val _showContextualMode = MutableStateFlow(false)
+    private val _allowDuckAiVoiceDigitalAssistant = MutableStateFlow(false)
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
         moshi.adapter(DuckChatSettingJson::class.java)
@@ -566,6 +567,8 @@ class RealDuckChat @Inject constructor(
     override val showFullScreenModeToggle: StateFlow<Boolean> = _showFullScreenModeToggle.asStateFlow()
 
     override val showContextualMode: StateFlow<Boolean> = _showContextualMode.asStateFlow()
+
+    override val allowDuckAiAsDigitalAssistant: StateFlow<Boolean> = _allowDuckAiVoiceDigitalAssistant.asStateFlow()
 
     override val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 
@@ -782,6 +785,10 @@ class RealDuckChat @Inject constructor(
 
     override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
+    override suspend fun isVoiceChatEnabled(): Boolean = withContext(dispatchers.io()) {
+        isEnabled() && duckChatFeature.duckAiVoiceSearch().isEnabled()
+    }
+
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)
     }
@@ -844,6 +851,7 @@ class RealDuckChat @Inject constructor(
                 }
             isAddressBarEntryPointEnabled = settingsJson?.addressBarEntryPoint ?: false
             isVoiceSearchEntryPointEnabled = duckChatFeature.duckAiVoiceSearch().isEnabled()
+            _allowDuckAiVoiceDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
             isImageUploadEnabled = imageUploadFeature.self().isEnabled()
             isStandaloneMigrationEnabled = duckChatFeature.standaloneMigration().isEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -219,4 +219,13 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun useNativeStorageChatData(): Toggle
+
+    /**
+     * Kill switch for opening Duck.ai voice chat when the digital assistant intent is received.
+     * @return `true` when the remote config has the "digitalAssistantDuckAi"
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun digitalAssistantDuckAi(): Toggle
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1635,4 +1635,61 @@ class RealDuckChatTest {
 
         verify(mockDuckChatFeatureRepository, never()).setDefaultTogglePosition(any())
     }
+
+    @Test
+    fun `when duck chat enabled and duckAiVoiceSearch enabled then isVoiceChatEnabled returns true`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.isVoiceChatEnabled())
+    }
+
+    @Test
+    fun `when duck chat enabled and duckAiVoiceSearch disabled then isVoiceChatEnabled returns false`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = false))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isVoiceChatEnabled())
+    }
+
+    @Test
+    fun `when duck chat disabled and duckAiVoiceSearch enabled then isVoiceChatEnabled returns false`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = false))
+        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isVoiceChatEnabled())
+    }
+
+    @Test
+    fun `when global feature flag and digitalAssistantDuckAiVoiceChat both enabled then allowDuckAiAsDigitalAssistant emits true`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.digitalAssistantDuckAi().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.allowDuckAiAsDigitalAssistant.value)
+    }
+
+    @Test
+    fun `when digitalAssistantDuckAiVoiceChat disabled then allowDuckAiAsDigitalAssistant emits false`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.digitalAssistantDuckAi().setRawStoredState(State(enable = false))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.allowDuckAiAsDigitalAssistant.value)
+    }
+
+    @Test
+    fun `when global feature flag disabled then allowDuckAiAsDigitalAssistant emits false`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = false))
+        duckChatFeature.digitalAssistantDuckAi().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.allowDuckAiAsDigitalAssistant.value)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1439,6 +1439,7 @@ class DuckChatContextualViewModelTest {
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(): Boolean = false
+        override suspend fun isVoiceChatEnabled(): Boolean = true
     }
 
     private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 class FakeDuckChat(
     private var enabled: Boolean = true,
+    private var voiceChatEnabled: Boolean = false,
 ) : DuckChat {
 
     private val openDuckChatCalls = mutableListOf<Unit>()
@@ -41,6 +42,8 @@ class FakeDuckChat(
     var standaloneMigrationCompleted: Boolean = false
 
     override fun isEnabled(): Boolean = enabled
+
+    override suspend fun isVoiceChatEnabled(): Boolean = voiceChatEnabled
 
     override fun openDuckChat() {
         openDuckChatCalls.add(Unit)
@@ -117,5 +120,9 @@ class FakeDuckChat(
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled
+    }
+
+    fun setVoiceChatEnabled(enabled: Boolean) {
+        this.voiceChatEnabled = enabled
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -192,4 +192,6 @@ class FakeDuckChatInternal(
     fun setDuckChatUserEnabled(enabled: Boolean) {
         enableDuckChatUserSetting.value = enabled
     }
+
+    override suspend fun isVoiceChatEnabled(): Boolean = true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1214072346939309?focus=true 

### Description
This PR updates the functionality of DDG as digital assistant:
- Kill switch OFF (prior to this change): Digital assistant launches the DDG app with the input screen shown with Search selected.
- Feature enabled + DuckAi enabled + VoiceChat enabled: Digital assistant launches the Duck.AI voice chat
- Feature enabled + DuckAi enabled+ VoiceChat disabled: Digital assistant launches the Duck.AI 
- Feature enabled + DuckAi disabled: Digital assistant launches the DDG app

Before: https://github.com/user-attachments/assets/7d8ee17e-b31f-439f-847b-08a0cead55b2
After:
- Feature enabled + DuckAi enabled + VoiceChat enabled: https://github.com/user-attachments/assets/46e916bd-1550-4706-a0d7-851ead316aa3
- Feature enabled + DuckAi enabled+ VoiceChat disabled: https://github.com/user-attachments/assets/a580190f-78ef-4a01-ba27-37411a2c93a4
- Feature enabled + DuckAi disabled: https://github.com/user-attachments/assets/97eb06c0-3ecc-4723-b0a9-39604202db97
- Kill switch OFF: https://github.com/user-attachments/assets/c92275b5-83ea-4b6b-a298-a9b452eef3d4

### Steps to test this PR

 ### Setup                                                                                                                                                                                                          
  - Install an **internal** build
  - Enable Duck.ai: **Settings → Duck.ai** → toggle on                                                                                                                                                               
  - Use Internal Settings to override remote feature flags as needed                                                                                                                                                 
   
  To trigger the digital assistant intent, use one of:                                                                                                                                                               
  - Long-press the home button (devices with Google Assistant)                                                                                                                                                     
  - `adb shell am start -a android.intent.action.ASSIST -n com.duckduckgo.mobile.android.debug/com.duckduckgo.app.browser.BrowserActivity`
                                                                                                                                                                                                                     
  ---
                                                                                                                                                                                                                     
  ### Test Cases                                                                                                                                                                                                   
NOTE: You might need to reset the assistant to force changes to apply

  #### TC1 — All enabled → Duck.ai Voice Chat launches                                                                                                                                                               
  > `digitalAssistantDuckAiVoiceChat` = enabled · `duckAiVoiceSearch` = enabled · Duck.ai = on
  - [ ] Set both feature flags to enabled via internal settings                                                                                                                                                      
  - [ ] Trigger the digital assistant intent                                                                                                                                                                       
  - [ ] Duck.ai voice chat screen opens                                                                                                                                                                              
                                                                                                                                                                                                                   
  #### TC2 — Voice search disabled → Duck.ai launches (no voice)                                                                                                                                                     
  > `digitalAssistantDuckAiVoiceChat` = enabled · `duckAiVoiceSearch` = **disabled** · Duck.ai = on
  - [ ] Set `duckAiVoiceSearch` to disabled via internal settings                                                                                                                                                    
  - [ ] Trigger the digital assistant intent                                                                                                                                                                         
  - [ ] Duck.ai opens without voice chat
                                                                                                                                                                                                                     
  #### TC3 — Duck.ai off → Old system search opens                                                                                                                                                                           
  > `digitalAssistantDuckAiVoiceChat` = enabled · `duckAiVoiceSearch` = enabled · Duck.ai = **off**
  - [ ] Disable Duck.ai in Settings                                                                                                                                                                                  
  - [ ] Trigger the digital assistant intent
  - [ ] System search opens                                                                                                                                                                                    
                                                                                                                                                                                                                   
  #### TC4 — Kill switch → Input tab opens in Search
  > `digitalAssistantDuckAiVoiceChat` = **disabled** · Duck.ai = on
  - [ ] Set `digitalAssistantDuckAiVoiceChat` to disabled via internal settings                                                                                                                                      
  - [ ] Trigger the digital assistant intent
  - [ ] DDG app opens with Search tab selected                 
 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app entry-point behavior for `ACTION_ASSIST` and adds new remote-config gates for Duck.ai/voice chat, which could affect launch flows and user expectations if misconfigured.
> 
> **Overview**
> Updates the `ACTION_ASSIST` (digital assistant) launch path in `SystemSearchActivity` to delegate to the `SystemSearchViewModel`, which now decides between **opening Duck.ai voice chat**, **opening Duck.ai**, or **falling back to the existing assist search/input screen**.
> 
> Introduces a new kill-switch/feature state (`DuckAiFeatureState.allowDuckAiAsDigitalAssistant`) backed by a new remote toggle (`DuckChatFeature.digitalAssistantDuckAi`) and adds `DuckChat.isVoiceChatEnabled()` to gate voice-chat launches. Test coverage is extended across app and duckchat modules for the new decision logic and flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92303b49ab0e63a6bef1dc3ef789d21154d18994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->