### PR TITLE
Skip pre-onboarding dev feature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -109,8 +109,10 @@ class OnboardingActivity : DuckDuckGoActivity() {
         viewModel.viewState.flowWithLifecycle(lifecycle, STARTED)
             .onEach {
                 if (it.canShowSkipOnboardingButton) {
+                    binding.skipPreOnboardingButton.show()
                     binding.skipOnboardingButton.show()
                 } else {
+                    binding.skipPreOnboardingButton.gone()
                     binding.skipOnboardingButton.gone()
                 }
             }
@@ -118,6 +120,13 @@ class OnboardingActivity : DuckDuckGoActivity() {
     }
 
     private fun configureSkipButton() {
+        binding.skipPreOnboardingButton.setOnClickListener {
+            lifecycleScope.launch {
+                viewModel.devOnlySkipPreOnboarding()
+                startActivity(BrowserActivity.intent(this@OnboardingActivity))
+                finish()
+            }
+        }
         binding.skipOnboardingButton.setOnClickListener {
             lifecycleScope.launch {
                 viewModel.devOnlyFullyCompleteAllOnboarding()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.newaddressbaroption.RealNewAddressBarOptionManager
 import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -29,6 +30,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ContributesViewModel(ActivityScope::class)
@@ -39,6 +41,7 @@ class OnboardingViewModel @Inject constructor(
     private val onboardingSkipper: OnboardingSkipper,
     private val appBuildConfig: AppBuildConfig,
     private val newAddressBarOptionManager: RealNewAddressBarOptionManager,
+    private val onboardingStore: OnboardingStore,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -82,6 +85,14 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun devOnlyFullyCompleteAllOnboarding() {
         onboardingSkipper.markOnboardingAsCompleted()
+        newAddressBarOptionManager.setAsShown()
+    }
+
+    suspend fun devOnlySkipPreOnboarding() {
+        withContext(dispatchers.io()) {
+            onboardingStore.storeInputScreenSelection(true)
+            userStageStore.stageCompleted(AppStage.NEW)
+        }
         newAddressBarOptionManager.setAsShown()
     }
 

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -42,15 +42,32 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/skipPreOnboardingButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_marginTop="30dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="8dp"
+        app:daxButtonSize="large"
+        app:layout_constraintTop_toTopOf="parent"
+        android:text="@string/skipPreOnboarding"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/skipOnboardingButton"
+        app:layout_constraintHorizontal_chainStyle="packed" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
         android:id="@+id/skipOnboardingButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        android:layout_margin="30dp"
+        android:layout_marginTop="30dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
         app:daxButtonSize="large"
         app:layout_constraintTop_toTopOf="parent"
         android:text="@string/skipOnboarding"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/skipPreOnboardingButton"
         app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -51,8 +51,9 @@
     <string name="newTabPageIndonesiaMessageBody">The government may be blocking access to duckduckgo.com on this network provider, which could affect this app\'s functionality. Other providers may not be affected.</string>
     <string name="newTabPageIndonesiaMessageCta">Okay</string>
 
-    <!-- Skip Onboarding (not user-facing) -->
+    <!-- Skip Onboarding / Skip Pre-Onboarding (not user-facing) -->
     <string name="skipOnboarding">Skip Onboarding</string>"
+    <string name="skipPreOnboarding">Skip Pre-Onboarding</string>
 
     <!-- Pre-onboarding Address Bar Position -->
     <string name="preOnboardingAddressBarPositionTop">Top</string>

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.duckduckgo.app.browser.newaddressbaroption.RealNewAddressBarOptionManager
 import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.FullOnboardingSkipper.ViewState
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -53,6 +54,7 @@ class OnboardingViewModelTest {
     private val appBuildConfig: AppBuildConfig = mock()
 
     private val newAddressBarOptionManager: RealNewAddressBarOptionManager = mock()
+    private val onboardingStore: OnboardingStore = mock()
 
     private val testee: OnboardingViewModel by lazy {
         OnboardingViewModel(
@@ -62,6 +64,7 @@ class OnboardingViewModelTest {
             onboardingSkipper = onboardingSkipper,
             appBuildConfig = appBuildConfig,
             newAddressBarOptionManager = newAddressBarOptionManager,
+            onboardingStore = onboardingStore,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1214079742050482?focus=true

### Description
Add skip pre-onboarding dev button

### Steps to test this PR
- [ ] Fresh install
- [ ] Wait for the skip buttons to appear
- [ ] Tap on skip pre-onboarding
- [ ] Check you navigate to the browser and still see context dialog there
- [ ] Once onboarding finished check duck.ai toggle is enabled by default

### UI changes
| Before  | After |
| ------ | ----- |
<img width="376" height="840" alt="Screenshot 2026-04-16 at 00 04 38" src="https://github.com/user-attachments/assets/53dee587-6b96-4363-8d99-7a32150936fe" />|<img width="378" height="839" alt="Screenshot 2026-04-16 at 00 02 35" src="https://github.com/user-attachments/assets/9a6ddf93-8192-479b-80c9-a608765dbebd" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding completion/state persistence and introduces a new dev-only fast-path; a malformed string resource (`skipOnboarding` has a trailing quote) could also break builds or runtime resource parsing.
> 
> **Overview**
> Adds a second *dev-only* skip action on the onboarding screen: **“Skip Pre-Onboarding”** appears alongside the existing skip button when skipping is enabled, and immediately navigates to `BrowserActivity`.
> 
> Implements `devOnlySkipPreOnboarding()` in `OnboardingViewModel` to persist an input-screen selection (`OnboardingStore.storeInputScreenSelection(true)`), mark `AppStage.NEW` complete, and mark the new address bar option as shown; updates the onboarding layout/strings and wires the new dependency in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0586af2213a130706673321bf73af4fca542c5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->