### PR TITLE
feat(onboarding): add brand design update for subscription CTA dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1175,6 +1175,9 @@ class BrowserTabFragment :
                 daxDialogIntroBubbleBrandDesign.optionsContent.brandDesignOption4.isSaveEnabled = false
                 daxDialogIntroBubbleBrandDesign.primaryCtaContent.brandDesignPrimaryCta.isSaveEnabled = false
 
+                daxDialogIntroBubbleBrandDesign.primaryCtaWithImageContent.brandDesignPlaceholder.isSaveEnabled = false
+                daxDialogIntroBubbleBrandDesign.primaryCtaWithImageContent.brandDesignPrimaryCta.isSaveEnabled = false
+
                 daxDialogInContext.daxDialogOption1.isSaveEnabled = false
                 daxDialogInContext.daxDialogOption2.isSaveEnabled = false
                 daxDialogInContext.daxDialogOption3.isSaveEnabled = false

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -236,6 +236,7 @@ import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
 import com.duckduckgo.app.cta.ui.DaxEndBrandDesignUpdateBubbleCta
+import com.duckduckgo.app.cta.ui.DaxSubscriptionBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxTryASearchBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxVisitSiteOptionsBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
@@ -3296,7 +3297,7 @@ class BrowserTabViewModel @Inject constructor(
     private fun showOrHideKeyboard(cta: Cta?) {
         // we hide the keyboard when showing a DialogCta and HomeCta type in the home screen otherwise we show it
         val shouldHideKeyboard =
-            cta is HomePanelCta || cta is DaxBubbleCta.DaxSubscriptionCta || cta is SubscriptionPromoModalCta ||
+            cta is HomePanelCta || cta is DaxBubbleCta.DaxSubscriptionCta || cta is DaxSubscriptionBrandDesignUpdateBubbleCta || cta is SubscriptionPromoModalCta ||
                 duckAiFeatureState.showInputScreen.value || currentBrowserViewState().lastQueryOrigin == QueryOrigin.FromBookmark ||
                 (settingsDataStore.omnibarType == OmnibarType.SPLIT && alreadyShownKeyboard)
 
@@ -4641,7 +4642,9 @@ class BrowserTabViewModel @Inject constructor(
     private fun onDaxBubbleCtaOkButtonClicked(cta: DaxBubbleCta) {
         onUserDismissedCta(cta)
         when (cta) {
-            is DaxBubbleCta.DaxSubscriptionCta -> {
+            is DaxBubbleCta.DaxSubscriptionCta,
+            is DaxSubscriptionBrandDesignUpdateBubbleCta,
+            -> {
                 viewModelScope.launch {
                     val origin = "funnel_onboarding_android"
                     command.value = LaunchSubscription("https://duckduckgo.com/pro?origin=$origin".toUri())

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -853,6 +853,7 @@ sealed class DaxBubbleCta(
         private fun getAllContentIncludes(view: View): List<View> = listOfNotNull(
             view.findViewById<View>(R.id.optionsContent),
             view.findViewById<View>(R.id.primaryCtaContent),
+            view.findViewById<View>(R.id.primaryCtaWithImageContent),
             // Future: view.findViewById<View>(R.id.dualButtonsContent),
         )
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -161,7 +161,7 @@ class CtaViewModel @Inject constructor(
             if (cta is BrokenSitePromptDialogCta) {
                 brokenSitePrompt.ctaShown()
             }
-            if (cta is DaxBubbleCta.DaxSubscriptionCta || cta is SubscriptionPromoModalCta) {
+            if (cta is DaxBubbleCta.DaxSubscriptionCta || cta is DaxSubscriptionBrandDesignUpdateBubbleCta || cta is SubscriptionPromoModalCta) {
                 subscriptionPromoCtaShownPlugins.getPlugins().forEach { it.onSubscriptionPromoCtaShown() }
             }
         }
@@ -287,11 +287,20 @@ class CtaViewModel @Inject constructor(
 
             // Subscription onboarding
             canShowSubscriptionCta() -> {
-                DaxBubbleCta.DaxSubscriptionCta(
-                    onboardingStore,
-                    appInstallStore,
-                    isFreeTrialCopy = freeTrialCopyAvailable(),
-                )
+                if (isBrandDesignUpdateEnabled()) {
+                    DaxSubscriptionBrandDesignUpdateBubbleCta(
+                        onboardingStore,
+                        appInstallStore,
+                        appTheme.isLightModeEnabled(),
+                        isFreeTrialCopy = freeTrialCopyAvailable(),
+                    )
+                } else {
+                    DaxBubbleCta.DaxSubscriptionCta(
+                        onboardingStore,
+                        appInstallStore,
+                        isFreeTrialCopy = freeTrialCopyAvailable(),
+                    )
+                }
             }
 
             // Subscription onboarding for returning users who skipped onboarding

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.view.View
+import android.widget.ImageView
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+
+data class DaxSubscriptionBrandDesignUpdateBubbleCta(
+    override val onboardingStore: OnboardingStore,
+    override val appInstallStore: AppInstallStore,
+    override val isLightTheme: Boolean,
+    val isFreeTrialCopy: Boolean,
+) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
+    ctaId = CtaId.DAX_INTRO_PRIVACY_PRO,
+    title = R.string.onboardingPrivacyProDaxDialogTitle,
+    description = R.string.onboardingPrivacyProDaxDialogDescription,
+    // TODO: Update background for brand design update
+    backgroundRes = 0,
+    shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+    okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+    ctaPixelParam = Pixel.PixelValues.DAX_SUBSCRIPTION,
+    onboardingStore = onboardingStore,
+    appInstallStore = appInstallStore,
+    isLightTheme = isLightTheme,
+) {
+    override val activeIncludeId: Int = R.id.primaryCtaWithImageContent
+
+    override fun configureContentViews(view: View) {
+        view.findViewById<ImageView>(R.id.brandDesignPlaceholder)
+            ?.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_privacy_pro_128)
+
+        val buttonTextRes = if (isFreeTrialCopy) {
+            R.string.onboardingPrivacyProDaxDialogFreeTrialOkButton
+        } else {
+            R.string.onboardingPrivacyProDaxDialogOkButton
+        }
+        view.findViewById<DaxButtonPrimary>(R.id.brandDesignPrimaryCta)?.setText(buttonTextRes)
+    }
+
+    override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {
+        ctaView?.findViewById<DaxButtonPrimary>(R.id.brandDesignPrimaryCta)?.setOnClickListener {
+            onButtonClicked.invoke()
+        }
+    }
+}

--- a/app/src/main/res/layout/include_brand_design_dialog_primary_cta_with_image.xml
+++ b/app/src/main/res/layout/include_brand_design_dialog_primary_cta_with_image.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/brandDesignPlaceholder"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:contentDescription="@null"
+        android:importantForAccessibility="no"
+        tools:src="@drawable/ic_privacy_pro_128" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/brandDesignPrimaryCta"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        tools:text="@string/onboardingPrivacyProDaxDialogOkButton" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
@@ -93,6 +93,16 @@
                     android:visibility="gone"
                     tools:visibility="gone" />
 
+                <include
+                    android:id="@+id/primaryCtaWithImageContent"
+                    layout="@layout/include_brand_design_dialog_primary_cta_with_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="20dp"
+                    android:visibility="gone"
+                    tools:visibility="gone" />
+
                 <!-- Future content includes added here:
                 <include android:id="@+id/dualButtonsContent" layout="@layout/include_brand_design_dialog_dual_buttons" ... />
                 -->

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1113,4 +1113,42 @@ class CtaViewModelTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertTrue(value is DaxBubbleCta.DaxEndCta)
     }
+
+    @Test
+    fun whenBrandDesignUpdateEnabledAndSubscriptionCtaThenReturnBrandDesignSubscriptionCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
+        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxSubscriptionBrandDesignUpdateBubbleCta)
+    }
+
+    @Test
+    fun whenBrandDesignUpdateDisabledAndSubscriptionCtaThenReturnLegacySubscriptionCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
+        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212699268790187

### Description
Adds the brand design update variant of the DaxSubscriptionCta dialog. This introduces a new `primaryCtaWithImageContent` include layout for dialogs with a placeholder image and primary action button.

The new `DaxSubscriptionBrandDesignUpdateBubbleCta` extends `BrandDesignUpdateBubbleCta` and shows the Privacy Pro subscription dialog with the updated brand design when the feature toggle is enabled. Supports conditional button text for free trial copy.

Background image is not yet included (TODO added).

**Note:** This is a stacked PR. The base should be updated to `onboarding-end-cta-brand-design` once that branch is pushed to the remote.

### Steps to test this PR

_Brand design update subscription CTA dialog_
- [ ] Enable the brand design update feature toggle
- [ ] Enable Privacy Pro subscription eligibility
- [ ] Complete onboarding steps until the subscription CTA appears
- [ ] Verify the subscription dialog appears with the new brand design update layout
- [ ] Verify the Privacy Pro placeholder image is displayed
- [ ] Verify the primary CTA button shows correct text (check both free trial and non-free trial variants)
- [ ] Verify the dismiss button appears and works
- [ ] Verify the typing animation plays correctly
- [ ] Verify tap-to-skip works during animation
- [ ] Verify clicking the primary CTA button triggers the expected action
- [ ] Disable the brand design update toggle and verify the legacy dialog appears instead

### UI changes
| Before  | After |
| ------ | ----- |
| Legacy bubble dialog with image and button | Brand design update card dialog with image and button |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new UI/layout variant for the subscription onboarding CTA and wires it into existing CTA selection/click handling, with minimal impact outside onboarding flows.
> 
> **Overview**
> Adds a new brand-design-update variant of the subscription onboarding bubble (`DaxSubscriptionBrandDesignUpdateBubbleCta`) that uses a new `primaryCtaWithImageContent` include (placeholder image + primary button, with optional free-trial copy).
> 
> Wires this CTA into `CtaViewModel.refreshCta` behind the brand-design-update toggle, and updates related UI plumbing (include resetting, accessibility save disabling, keyboard hide rules, OK-click handling, and subscription-promo shown hooks). Tests are extended to cover toggle-on vs toggle-off subscription CTA selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea3850368dae4065e37e50568acde87c4db43f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->