### PR TITLE
feat(onboarding): add brand design update for end CTA dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1173,6 +1173,7 @@ class BrowserTabFragment :
                 daxDialogIntroBubbleBrandDesign.optionsContent.brandDesignOption2.isSaveEnabled = false
                 daxDialogIntroBubbleBrandDesign.optionsContent.brandDesignOption3.isSaveEnabled = false
                 daxDialogIntroBubbleBrandDesign.optionsContent.brandDesignOption4.isSaveEnabled = false
+                daxDialogIntroBubbleBrandDesign.primaryCtaContent.brandDesignPrimaryCta.isSaveEnabled = false
 
                 daxDialogInContext.daxDialogOption1.isSaveEnabled = false
                 daxDialogInContext.daxDialogOption2.isSaveEnabled = false

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -235,6 +235,7 @@ import com.duckduckgo.app.cta.ui.BrokenSitePromptDialogCta
 import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
+import com.duckduckgo.app.cta.ui.DaxEndBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxTryASearchBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxVisitSiteOptionsBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
@@ -4646,7 +4647,9 @@ class BrowserTabViewModel @Inject constructor(
                     command.value = LaunchSubscription("https://duckduckgo.com/pro?origin=$origin".toUri())
                 }
             }
-            is DaxBubbleCta.DaxEndCta -> {
+            is DaxBubbleCta.DaxEndCta,
+            is DaxEndBrandDesignUpdateBubbleCta,
+            -> {
                 viewModelScope.launch {
                     val updatedCta = refreshCta()
                     ctaViewState.value = currentCtaViewState().copy(cta = updatedCta)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -852,7 +852,7 @@ sealed class DaxBubbleCta(
 
         private fun getAllContentIncludes(view: View): List<View> = listOfNotNull(
             view.findViewById<View>(R.id.optionsContent),
-            // Future: view.findViewById<View>(R.id.primaryCtaContent),
+            view.findViewById<View>(R.id.primaryCtaContent),
             // Future: view.findViewById<View>(R.id.dualButtonsContent),
         )
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -278,7 +278,11 @@ class CtaViewModel @Inject constructor(
 
             // End
             canShowDaxCtaEndOfJourney() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
+                if (isBrandDesignUpdateEnabled()) {
+                    DaxEndBrandDesignUpdateBubbleCta(onboardingStore, appInstallStore, appTheme.isLightModeEnabled())
+                } else {
+                    DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
+                }
             }
 
             // Subscription onboarding

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.view.View
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+
+data class DaxEndBrandDesignUpdateBubbleCta(
+    override val onboardingStore: OnboardingStore,
+    override val appInstallStore: AppInstallStore,
+    override val isLightTheme: Boolean,
+) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
+    ctaId = CtaId.DAX_END,
+    title = R.string.onboardingEndDaxDialogTitle,
+    description = R.string.onboardingEndDaxDialogDescription,
+    backgroundRes = 0, // TODO: Update background for brand design update
+    shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+    okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+    ctaPixelParam = Pixel.PixelValues.DAX_END_CTA,
+    onboardingStore = onboardingStore,
+    appInstallStore = appInstallStore,
+    isLightTheme = isLightTheme,
+) {
+    override val activeIncludeId: Int = R.id.primaryCtaContent
+
+    override fun configureContentViews(view: View) {
+        view.findViewById<DaxButtonPrimary>(R.id.brandDesignPrimaryCta)?.setText(R.string.onboardingEndDaxDialogButton)
+    }
+
+    override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {
+        ctaView?.findViewById<View>(R.id.brandDesignPrimaryCta)?.setOnClickListener {
+            onButtonClicked.invoke()
+        }
+    }
+}

--- a/app/src/main/res/layout/include_brand_design_dialog_primary_cta.xml
+++ b/app/src/main/res/layout/include_brand_design_dialog_primary_cta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/brandDesignPrimaryCta"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:daxButtonSize="large" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
@@ -83,8 +83,17 @@
                     android:visibility="gone"
                     tools:visibility="visible" />
 
+                <include
+                    android:id="@+id/primaryCtaContent"
+                    layout="@layout/include_brand_design_dialog_primary_cta"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="20dp"
+                    android:visibility="gone"
+                    tools:visibility="gone" />
+
                 <!-- Future content includes added here:
-                <include android:id="@+id/primaryCtaContent" layout="@layout/include_brand_design_dialog_primary_cta" ... />
                 <include android:id="@+id/dualButtonsContent" layout="@layout/include_brand_design_dialog_dual_buttons" ... />
                 -->
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1087,4 +1087,30 @@ class CtaViewModelTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertTrue(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
+
+    @Test
+    fun whenBrandDesignUpdateToggleEnabledAndEndCtaConditionsMetThenReturnEndBrandDesignUpdateCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        givenAtLeastOneDaxDialogCtaShown()
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxEndBrandDesignUpdateBubbleCta)
+    }
+
+    @Test
+    fun whenBrandDesignUpdateToggleDisabledAndEndCtaConditionsMetThenReturnLegacyEndCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        givenAtLeastOneDaxDialogCtaShown()
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxBubbleCta.DaxEndCta)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1212699268790186?focus=true

### Description
Adds the brand design update variant of the DaxEndCta dialog. This introduces a new `primaryCtaContent` include layout for dialogs with a single primary action button (no options).

The new `DaxEndBrandDesignUpdateBubbleCta` extends `BrandDesignUpdateBubbleCta` and shows the onboarding completion dialog with the updated brand design when the feature toggle is enabled.

Background image is not yet included (TODO added).

### Steps to test this PR

_Brand design update end CTA dialog_
- [ ] Enable the brand design update feature toggle
- [ ] Complete all onboarding steps (search, visit site, trackers, fire)
- [ ] Verify the end CTA dialog appears with the new brand design update layout
- [ ] Verify the primary CTA button is displayed with correct text
- [ ] Verify the dismiss button appears and works
- [ ] Verify the typing animation plays correctly
- [ ] Verify tap-to-skip works during animation
- [ ] Verify clicking the primary CTA button triggers the expected action
- [ ] Disable the brand design update toggle and verify the legacy dialog appears instead

### UI changes
| Before  | After |
| ------ | ----- |
| Legacy bubble dialog with primary button | Brand design update card dialog with primary button |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/onboarding change gated behind an existing feature toggle; main risk is regressions in CTA selection/rendering for the end-of-journey dialog.
> 
> **Overview**
> Adds a new brand design update variant of the end-of-journey onboarding CTA (`DaxEndBrandDesignUpdateBubbleCta`) and selects it from `CtaViewModel` when the brand-design toggle is enabled.
> 
> Introduces a new `primaryCtaContent` include (layout + button) in the brand-design dialog, updates the CTA view to manage this include, and ensures the end CTA OK-click handler refreshes correctly for both legacy and brand-design end CTAs. Tests are updated to cover toggle-enabled vs disabled end-CTA selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit addbe0aefe2e9af92e326c9fd99df7518fd41bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->