### PR TITLE
feat(onboarding): add brand design update for visit site options dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -236,6 +236,7 @@ import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
 import com.duckduckgo.app.cta.ui.DaxTryASearchBrandDesignUpdateBubbleCta
+import com.duckduckgo.app.cta.ui.DaxVisitSiteOptionsBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta
 import com.duckduckgo.app.cta.ui.SubscriptionPromoModalCta
@@ -1305,6 +1306,7 @@ class BrowserTabViewModel @Inject constructor(
             }
 
             is DaxBubbleCta.DaxIntroVisitSiteOptionsCta,
+            is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta,
             is OnboardingDaxDialogCta.DaxSiteSuggestionsCta,
             -> {
                 if (!ctaViewModel.isSuggestedSiteOption(query)) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -269,7 +269,11 @@ class CtaViewModel @Inject constructor(
 
             // Site suggestions
             canShowDaxIntroVisitSiteCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore)
+                if (isBrandDesignUpdateEnabled()) {
+                    DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(onboardingStore, appInstallStore, appTheme.isLightModeEnabled())
+                } else {
+                    DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore)
+                }
             }
 
             // End

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.view.View
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.ui.view.OnboardingSelectionButton
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+
+data class DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
+    override val onboardingStore: OnboardingStore,
+    override val appInstallStore: AppInstallStore,
+    override val isLightTheme: Boolean,
+) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
+    ctaId = CtaId.DAX_INTRO_VISIT_SITE,
+    title = R.string.onboardingSitesDaxDialogTitle,
+    description = R.string.onboardingSitesDaxDialogDescription,
+    options = onboardingStore.getSitesOptions(),
+    backgroundRes = 0, // TODO: Update background for brand design update
+    shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+    okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+    ctaPixelParam = Pixel.PixelValues.DAX_INITIAL_VISIT_SITE_CTA,
+    onboardingStore = onboardingStore,
+    appInstallStore = appInstallStore,
+    isLightTheme = isLightTheme,
+) {
+    override val activeIncludeId: Int = R.id.optionsContent
+
+    override fun configureContentViews(view: View) {
+        val optionViews: List<OnboardingSelectionButton> = listOf(
+            view.findViewById(R.id.brandDesignOption1),
+            view.findViewById(R.id.brandDesignOption2),
+            view.findViewById(R.id.brandDesignOption3),
+            view.findViewById(R.id.brandDesignOption4),
+        )
+        options?.let {
+            optionViews.forEachIndexed { index, buttonView ->
+                buttonView.show()
+                if (it.size > index) {
+                    it[index].setOptionView(buttonView)
+                } else {
+                    buttonView.gone()
+                }
+            }
+        }
+    }
+
+    override fun setOnOptionClicked(
+        onboardingExperimentEnabled: Boolean,
+        configuration: DaxBubbleCta?,
+        onOptionClicked: (DaxDialogIntroOption, index: Int?) -> Unit,
+    ) {
+        options?.forEachIndexed { index, option ->
+            val optionViewId = when (index) {
+                0 -> R.id.brandDesignOption1
+                1 -> R.id.brandDesignOption2
+                2 -> R.id.brandDesignOption3
+                else -> R.id.brandDesignOption4
+            }
+            ctaView?.findViewById<OnboardingSelectionButton>(optionViewId)?.setOnClickListener {
+                onOptionClicked.invoke(option, index)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1065,4 +1065,26 @@ class CtaViewModelTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertTrue(value is DaxBubbleCta.DaxIntroSearchOptionsCta)
     }
+
+    @Test
+    fun whenBrandDesignUpdateToggleEnabledThenReturnVisitSiteBrandDesignUpdateCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
+    }
+
+    @Test
+    fun whenBrandDesignUpdateToggleDisabledThenReturnVisitSiteLegacyCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1214072694520134?focus=true

### Description
Adds the brand design update variant of the DaxIntroVisitSiteOptionsCta dialog. This follows the same pattern as the DaxTryASearchBrandDesignUpdateBubbleCta — an options-style dialog using the existing optionsContent include layout.

When the brand design update feature toggle is enabled, the new `DaxVisitSiteOptionsBrandDesignUpdateBubbleCta` is shown instead of the legacy `DaxIntroVisitSiteOptionsCta`.

Background image is not yet included (TODO added).

### Steps to test this PR

_Brand design update visit site options dialog_
- [ ] Enable the brand design update feature toggle
- [ ] Complete the search options step in onboarding
- [ ] Verify the visit site options dialog appears with the new brand design update layout
- [ ] Verify all site option buttons are displayed and clickable
- [ ] Verify the dismiss button appears and works
- [ ] Verify the typing animation plays correctly
- [ ] Verify tap-to-skip works during animation
- [ ] Disable the brand design update toggle and verify the legacy dialog appears instead

### UI changes
| Before  | After |
| ------ | ----- |
| Legacy bubble dialog | Brand design update card dialog |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: gated onboarding UI change that swaps in a new CTA variant behind an existing feature toggle, with small touchpoints to CTA selection and pixel classification.
> 
> **Overview**
> Adds a new `DaxVisitSiteOptionsBrandDesignUpdateBubbleCta` and updates onboarding CTA selection to show it (instead of the legacy `DaxIntroVisitSiteOptionsCta`) when the brand design update toggle is enabled.
> 
> Updates `BrowserTabViewModel` to treat the new CTA as a “visit site options” CTA for custom-entry pixel firing, and extends `CtaViewModelTest` to cover the new toggle-driven behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbfbbe3fbb1ba04326201c505e940a69b5f056f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->