### PR TITLE
PIR: Add handling of GenerateEmail action

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandler.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.common.actions
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageGenerateEmailReceived
@@ -28,6 +29,8 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.common.toParams
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GenerateEmail
+import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -47,37 +50,53 @@ class EmailReceivedEventHandler @Inject constructor(
         state: State,
         event: Event,
     ): Next {
-        /**
-         * Once we have received the email address, we update the current extracted profile with the information.
-         * We now re-do the last Broker action passing the updated extracted profile into the [State] and also the
-         * [UserProfile] for the action.
-         */
-        val currentBrokerStep = state.brokerStepsToExecute[state.currentBrokerStepIndex] as OptOutStep
-
-        val updatedProfileWithEmail = currentBrokerStep.profileToOptOut.copy(
-            email = (event as EmailReceived).generatedEmailData.emailAddress,
-        )
-
-        val updatedBrokerSteps = state.brokerStepsToExecute.toMutableList().apply {
-            this[state.currentBrokerStepIndex] = currentBrokerStep.copy(
-                profileToOptOut = updatedProfileWithEmail,
-            )
-        }
+        val currentBrokerStep = state.brokerStepsToExecute[state.currentBrokerStepIndex]
+        val emailReceived = event as EmailReceived
+        val currentAction = currentBrokerStep.step.actions[state.currentActionIndex]
 
         attemptFireOptOutStagePixel(currentBrokerStep, state)
 
-        return Next(
-            nextState = state.copy(
-                brokerStepsToExecute = updatedBrokerSteps,
-                generatedEmailData = event.generatedEmailData,
-            ),
-            nextEvent = ExecuteBrokerStepAction(
-                actionRequestData = UserProfile(
-                    userProfile = state.profileQuery,
-                    extractedProfile = updatedProfileWithEmail.toParams(state.profileQuery.fullName),
+        return if (currentAction is GenerateEmail) {
+            // Explicit generateEmail flow: advance to the next action
+            Next(
+                nextState = state.copy(
+                    currentActionIndex = state.currentActionIndex + 1,
+                    generatedEmailData = emailReceived.generatedEmailData,
                 ),
-            ),
-        )
+                nextEvent = ExecuteBrokerStepAction(
+                    actionRequestData = UserProfile(
+                        userProfile = state.profileQuery,
+                    ),
+                ),
+            )
+        } else {
+            // Implicit needsEmail flow (FillForm): re-execute the same action with email
+            val extractedProfileParams = when (currentBrokerStep) {
+                is OptOutStep -> currentBrokerStep.profileToOptOut.toParams(state.profileQuery.fullName).copy(
+                    email = emailReceived.generatedEmailData.emailAddress,
+                )
+
+                is EmailConfirmationStep -> currentBrokerStep.profileToOptOut.toParams(state.profileQuery.fullName).copy(
+                    email = emailReceived.generatedEmailData.emailAddress,
+                )
+
+                is BrokerStep.ScanStep -> ExtractedProfileParams(
+                    email = emailReceived.generatedEmailData.emailAddress,
+                )
+            }
+
+            Next(
+                nextState = state.copy(
+                    generatedEmailData = emailReceived.generatedEmailData,
+                ),
+                nextEvent = ExecuteBrokerStepAction(
+                    actionRequestData = UserProfile(
+                        userProfile = state.profileQuery,
+                        extractedProfile = extractedProfileParams,
+                    ),
+                ),
+            )
+        }
     }
 
     private suspend fun attemptFireOptOutStagePixel(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandler.kt
@@ -25,12 +25,14 @@ import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageGenerateEmailReceived
 import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailReceived
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.common.toParams
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GenerateEmail
-import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
+import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -70,20 +72,24 @@ class EmailReceivedEventHandler @Inject constructor(
                 ),
             )
         } else {
-            // Implicit needsEmail flow (FillForm): re-execute the same action with email
-            val extractedProfileParams = when (currentBrokerStep) {
-                is OptOutStep -> currentBrokerStep.profileToOptOut.toParams(state.profileQuery.fullName).copy(
-                    email = emailReceived.generatedEmailData.emailAddress,
-                )
-
-                is EmailConfirmationStep -> currentBrokerStep.profileToOptOut.toParams(state.profileQuery.fullName).copy(
-                    email = emailReceived.generatedEmailData.emailAddress,
-                )
-
-                is BrokerStep.ScanStep -> ExtractedProfileParams(
-                    email = emailReceived.generatedEmailData.emailAddress,
-                )
+            // Implicit needsEmail flow (FillForm): re-execute the same action with email.
+            // Only OptOutStep and EmailConfirmationStep reach this path; ScanStep uses the explicit GenerateEmail flow above.
+            val profileToOptOut = when (currentBrokerStep) {
+                is OptOutStep -> currentBrokerStep.profileToOptOut
+                is EmailConfirmationStep -> currentBrokerStep.profileToOptOut
+                is BrokerStep.ScanStep -> {
+                    return Next(
+                        nextState = state,
+                        nextEvent = BrokerStepCompleted(
+                            needsEmailConfirmation = false,
+                            stepStatus = StepStatus.Failure(error = PirError.Unknown("Trying to use decoupled email flow in ScanStep!")),
+                        ),
+                    )
+                }
             }
+            val extractedProfileParams = profileToOptOut.toParams(state.profileQuery.fullName).copy(
+                email = emailReceived.generatedEmailData.emailAddress,
+            )
 
             Next(
                 nextState = state.copy(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -96,7 +96,7 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
 
             if ((currentBrokerStep is OptOutStep || currentBrokerStep is EmailConfirmationStep) &&
                 actionToExecute.needsEmail &&
-                !hasEmail(currentBrokerStep)
+                state.generatedEmailData == null
             ) {
                 Next(
                     nextState = state.copy(
@@ -260,16 +260,6 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     )
                 }
             }
-        }
-    }
-
-    private fun hasEmail(brokerStep: BrokerStep): Boolean {
-        return if (brokerStep is OptOutStep) {
-            brokerStep.profileToOptOut.email.isNotEmpty()
-        } else if (brokerStep is EmailConfirmationStep) {
-            brokerStep.profileToOptOut.email.isNotEmpty()
-        } else {
-            false
         }
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.pir.impl.scripts.models.DataSource.EXTRACTED_PROFILE
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import com.duckduckgo.pir.impl.store.PirRepository.GeneratedEmailData
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlin.reflect.KClass
@@ -223,29 +224,37 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                         )
                     }
 
-                    val nextState = if (actionToExecute is GetCaptchaInfo) {
-                        state.copy(
-                            stageStatus = PirStageStatus(
-                                currentStage = PirStage.CAPTCHA_PARSE,
-                                stageStartMs = currentTimeProvider.currentTimeMillis(),
-                            ),
-                        )
-                    } else if (actionToExecute is Expectation) {
-                        state.copy(
-                            stageStatus = PirStageStatus(
-                                currentStage = PirStage.SUBMIT,
-                                stageStartMs = currentTimeProvider.currentTimeMillis(),
-                            ),
-                        )
-                    } else if (actionToExecute is FillForm || actionToExecute is Click) {
-                        state.copy(
-                            stageStatus = PirStageStatus(
-                                currentStage = PirStage.FILL_FORM,
-                                stageStartMs = currentTimeProvider.currentTimeMillis(),
-                            ),
-                        )
-                    } else {
-                        state
+                    val nextState = when (actionToExecute) {
+                        is GetCaptchaInfo -> {
+                            state.copy(
+                                stageStatus = PirStageStatus(
+                                    currentStage = PirStage.CAPTCHA_PARSE,
+                                    stageStartMs = currentTimeProvider.currentTimeMillis(),
+                                ),
+                            )
+                        }
+
+                        is Expectation -> {
+                            state.copy(
+                                stageStatus = PirStageStatus(
+                                    currentStage = PirStage.SUBMIT,
+                                    stageStartMs = currentTimeProvider.currentTimeMillis(),
+                                ),
+                            )
+                        }
+
+                        is FillForm, is Click -> {
+                            state.copy(
+                                stageStatus = PirStageStatus(
+                                    currentStage = PirStage.FILL_FORM,
+                                    stageStartMs = currentTimeProvider.currentTimeMillis(),
+                                ),
+                            )
+                        }
+
+                        else -> {
+                            state
+                        }
                     }
 
                     Next(
@@ -255,7 +264,7 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                             actionToExecute.id,
                             actionToExecute,
                             pushDelay,
-                            completeRequestData(currentBrokerStep, actionToExecute, state.profileQuery, requestData),
+                            completeRequestData(currentBrokerStep, actionToExecute, state.profileQuery, requestData, state.generatedEmailData),
                         ),
                     )
                 }
@@ -268,6 +277,7 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
         actionToExecute: BrokerAction,
         profileQuery: ProfileQuery,
         requestData: PirScriptRequestData,
+        generatedEmailData: GeneratedEmailData?,
     ): PirScriptRequestData {
         val extractedProfile = if (brokerStep is OptOutStep && actionToExecute.dataSource == EXTRACTED_PROFILE &&
             (requestData as UserProfile).extractedProfile == null
@@ -282,9 +292,14 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
         }
 
         return if (extractedProfile != null && requestData is UserProfile) {
+            val params = extractedProfile.toParams(profileQuery.fullName)
             UserProfile(
                 userProfile = requestData.userProfile,
-                extractedProfile = extractedProfile.toParams(profileQuery.fullName),
+                extractedProfile = if (generatedEmailData != null) {
+                    params.copy(email = generatedEmailData.emailAddress)
+                } else {
+                    params
+                },
             )
         } else {
             requestData

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
@@ -18,8 +18,11 @@ package com.duckduckgo.pir.impl.common.actions
 
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageGenerateEmailReceived
@@ -30,6 +33,10 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.models.Broker
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.EmailData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.JobAttemptData
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.EmailConfirmationJobRecord.LinkFetchData
 import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
@@ -43,6 +50,7 @@ import org.junit.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class EmailReceivedEventHandlerTest {
@@ -89,16 +97,42 @@ class EmailReceivedEventHandlerTest {
         removedAt = 0L,
     )
 
-    private val testAction = BrokerAction.FillForm(
+    private val testFillFormAction = BrokerAction.FillForm(
         id = "fillform-action-1",
         elements = emptyList(),
         selector = "form",
+    )
+
+    private val testGenerateEmailAction = BrokerAction.GenerateEmail(
+        id = "generate-email-action-1",
     )
 
     private val testGeneratedEmailData = GeneratedEmailData(
         emailAddress = "generated@example.com",
         pattern = "pattern-123",
     )
+
+    private val testEmailConfirmationJob =
+        EmailConfirmationJobRecord(
+            brokerName = testBrokerName,
+            userProfileId = testProfileQueryId,
+            extractedProfileId = 456L,
+            emailData = EmailData(
+                email = "john@example.com",
+                attemptId = "test-attempt-id",
+            ),
+            linkFetchData = LinkFetchData(
+                emailConfirmationLink = "https://example.com/confirm",
+                linkFetchAttemptCount = 0,
+                lastLinkFetchDateInMillis = 0L,
+            ),
+            jobAttemptData = JobAttemptData(
+                jobAttemptCount = 0,
+                lastJobAttemptDateInMillis = 0L,
+                lastJobAttemptActionId = "",
+            ),
+            dateCreatedInMillis = 10000000L,
+        )
 
     @Before
     fun setUp() {
@@ -114,58 +148,11 @@ class EmailReceivedEventHandlerTest {
         assertEquals(EmailReceived::class, testee.event)
     }
 
-    @Test
-    fun whenEmailReceivedThenUpdatesProfileWithEmailAddress() = runTest {
-        val optOutStep = OptOutStep(
-            broker = testBroker,
-            step = OptOutStepActions(
-                stepType = "optout",
-                actions = listOf(testAction),
-                optOutType = "form",
-            ),
-            profileToOptOut = testExtractedProfile.copy(email = ""),
-        )
-        val state = State(
-            runType = RunType.OPTOUT,
-            brokerStepsToExecute = listOf(optOutStep),
-            profileQuery = testProfileQuery,
-            currentBrokerStepIndex = 0,
-            currentActionIndex = 0,
-            stageStatus = PirStageStatus(
-                currentStage = PirStage.EMAIL_GENERATE,
-                stageStartMs = testStageStartMs,
-            ),
-        )
-        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
-
-        val result = testee.invoke(state, event)
-
-        val updatedOptOutStep = result.nextState.brokerStepsToExecute[0] as OptOutStep
-        assertEquals("generated@example.com", updatedOptOutStep.profileToOptOut.email)
-    }
+    // region Implicit needsEmail flow (FillForm action)
 
     @Test
-    fun whenEmailReceivedThenUpdatesGeneratedEmailDataInState() = runTest {
-        val optOutStep = OptOutStep(
-            broker = testBroker,
-            step = OptOutStepActions(
-                stepType = "optout",
-                actions = listOf(testAction),
-                optOutType = "form",
-            ),
-            profileToOptOut = testExtractedProfile,
-        )
-        val state = State(
-            runType = RunType.OPTOUT,
-            brokerStepsToExecute = listOf(optOutStep),
-            profileQuery = testProfileQuery,
-            currentBrokerStepIndex = 0,
-            generatedEmailData = null,
-            stageStatus = PirStageStatus(
-                currentStage = PirStage.EMAIL_GENERATE,
-                stageStartMs = testStageStartMs,
-            ),
-        )
+    fun whenEmailReceivedForFillFormOnOptOutStepThenUpdatesGeneratedEmailDataInState() = runTest {
+        val state = createOptOutState(testFillFormAction)
         val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
 
         val result = testee.invoke(state, event)
@@ -174,12 +161,37 @@ class EmailReceivedEventHandlerTest {
     }
 
     @Test
-    fun whenEmailReceivedThenReturnsExecuteBrokerStepActionWithExtractedProfile() = runTest {
+    fun whenEmailReceivedForFillFormOnOptOutStepThenKeepsSameActionIndex() = runTest {
+        val state = createOptOutState(testFillFormAction)
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+    }
+
+    @Test
+    fun whenEmailReceivedForFillFormOnOptOutStepThenReturnsExtractedProfileWithEmail() = runTest {
+        val state = createOptOutState(testFillFormAction)
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertEquals(testProfileQuery, userProfile.userProfile)
+        assertEquals("generated@example.com", userProfile.extractedProfile?.email)
+        assertEquals("John Doe", userProfile.extractedProfile?.name)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenEmailReceivedForFillFormOnOptOutStepThenDoesNotModifyBrokerSteps() = runTest {
         val optOutStep = OptOutStep(
             broker = testBroker,
             step = OptOutStepActions(
                 stepType = "optout",
-                actions = listOf(testAction),
+                actions = listOf(testFillFormAction),
                 optOutType = "form",
             ),
             profileToOptOut = testExtractedProfile.copy(email = ""),
@@ -189,6 +201,7 @@ class EmailReceivedEventHandlerTest {
             brokerStepsToExecute = listOf(optOutStep),
             profileQuery = testProfileQuery,
             currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
             stageStatus = PirStageStatus(
                 currentStage = PirStage.EMAIL_GENERATE,
                 stageStartMs = testStageStartMs,
@@ -198,20 +211,57 @@ class EmailReceivedEventHandlerTest {
 
         val result = testee.invoke(state, event)
 
-        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
-        val userProfile = nextEvent.actionRequestData as UserProfile
-        assertEquals(testProfileQuery, userProfile.userProfile)
-        assertEquals("generated@example.com", userProfile.extractedProfile?.email)
-        assertNull(result.sideEffect)
+        // Broker steps should be unchanged — profileToOptOut.email is NOT updated (KDL3)
+        val unchangedOptOutStep = result.nextState.brokerStepsToExecute[0] as OptOutStep
+        assertEquals("", unchangedOptOutStep.profileToOptOut.email)
     }
 
     @Test
-    fun whenEmailReceivedWithOptOutStepThenEmitsPixel() = runTest {
+    fun whenEmailReceivedForFillFormOnEmailConfirmationStepThenKeepsSameActionIndex() = runTest {
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testFillFormAction),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(0, result.nextState.currentActionIndex)
+        assertEquals(testGeneratedEmailData, result.nextState.generatedEmailData)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertEquals("generated@example.com", userProfile.extractedProfile?.email)
+    }
+
+    // endregion
+
+    // region Explicit GenerateEmail flow
+
+    @Test
+    fun whenEmailReceivedForGenerateEmailOnOptOutStepThenAdvancesActionIndex() = runTest {
+        val fillFormAction = BrokerAction.FillForm(id = "fillform-2", elements = emptyList(), selector = "form")
         val optOutStep = OptOutStep(
             broker = testBroker,
             step = OptOutStepActions(
                 stepType = "optout",
-                actions = listOf(testAction),
+                actions = listOf(testGenerateEmailAction, fillFormAction),
                 optOutType = "form",
             ),
             profileToOptOut = testExtractedProfile,
@@ -222,13 +272,94 @@ class EmailReceivedEventHandlerTest {
             profileQuery = testProfileQuery,
             currentBrokerStepIndex = 0,
             currentActionIndex = 0,
-            actionRetryCount = 1,
-            attemptId = "attempt-456",
             stageStatus = PirStageStatus(
                 currentStage = PirStage.EMAIL_GENERATE,
                 stageStartMs = testStageStartMs,
             ),
         )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(testGeneratedEmailData, result.nextState.generatedEmailData)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertNull(userProfile.extractedProfile)
+    }
+
+    @Test
+    fun whenEmailReceivedForGenerateEmailOnScanStepThenAdvancesActionIndex() = runTest {
+        val fillFormAction = BrokerAction.FillForm(id = "fillform-2", elements = emptyList(), selector = "form")
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testGenerateEmailAction, fillFormAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(testGeneratedEmailData, result.nextState.generatedEmailData)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertNull(userProfile.extractedProfile)
+    }
+
+    @Test
+    fun whenEmailReceivedForGenerateEmailOnEmailConfirmationStepThenAdvancesActionIndex() = runTest {
+        val fillFormAction = BrokerAction.FillForm(id = "fillform-2", elements = emptyList(), selector = "form")
+        val emailConfirmationStep = EmailConfirmationStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testGenerateEmailAction, fillFormAction),
+                optOutType = "form",
+            ),
+            emailConfirmationJob = testEmailConfirmationJob,
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.EMAIL_CONFIRMATION,
+            brokerStepsToExecute = listOf(emailConfirmationStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(testGeneratedEmailData, result.nextState.generatedEmailData)
+    }
+
+    // endregion
+
+    // region Pixel emission
+
+    @Test
+    fun whenEmailReceivedWithOptOutStepThenEmitsPixel() = runTest {
+        val state = createOptOutState(testFillFormAction, actionRetryCount = 1, attemptId = "attempt-456")
         val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
 
         testee.invoke(state, event)
@@ -239,23 +370,56 @@ class EmailReceivedEventHandlerTest {
         assertEquals("fillform-action-1", capturedState.firstValue.actionID)
         assertEquals("attempt-456", capturedState.firstValue.attemptId)
         assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedState.firstValue.durationMs)
-        assertEquals(2, capturedState.firstValue.currentActionAttemptCount) // actionRetryCount + 1
+        assertEquals(2, capturedState.firstValue.currentActionAttemptCount)
     }
 
     @Test
-    fun whenEmailReceivedThenPreservesOtherStateFields() = runTest {
-        val optOutStep = OptOutStep(
+    fun whenEmailReceivedWithScanStepThenDoesNotEmitPixel() = runTest {
+        val scanStep = ScanStep(
             broker = testBroker,
-            step = OptOutStepActions(
-                stepType = "optout",
-                actions = listOf(testAction),
-                optOutType = "form",
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testGenerateEmailAction),
+                scanType = "initial",
             ),
-            profileToOptOut = testExtractedProfile,
         )
         val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        testee.invoke(state, event)
+
+        verifyNoInteractions(mockPirRunStateHandler)
+    }
+
+    // endregion
+
+    // region State preservation
+
+    @Test
+    fun whenEmailReceivedThenPreservesOtherStateFields() = runTest {
+        val state = State(
             runType = RunType.OPTOUT,
-            brokerStepsToExecute = listOf(optOutStep),
+            brokerStepsToExecute = listOf(
+                OptOutStep(
+                    broker = testBroker,
+                    step = OptOutStepActions(
+                        stepType = "optout",
+                        actions = listOf(testFillFormAction),
+                        optOutType = "form",
+                    ),
+                    profileToOptOut = testExtractedProfile,
+                ),
+            ),
             profileQuery = testProfileQuery,
             currentBrokerStepIndex = 0,
             currentActionIndex = 0,
@@ -284,12 +448,12 @@ class EmailReceivedEventHandlerTest {
     }
 
     @Test
-    fun whenEmailReceivedWithMultipleBrokerStepsThenOnlyUpdatesCurrentStep() = runTest {
+    fun whenEmailReceivedWithMultipleBrokerStepsThenDoesNotModifyAnyStep() = runTest {
         val optOutStep1 = OptOutStep(
             broker = testBroker,
             step = OptOutStepActions(
                 stepType = "optout",
-                actions = listOf(testAction),
+                actions = listOf(testFillFormAction),
                 optOutType = "form",
             ),
             profileToOptOut = testExtractedProfile.copy(email = ""),
@@ -298,7 +462,7 @@ class EmailReceivedEventHandlerTest {
             broker = testBroker.copy(name = "broker-2"),
             step = OptOutStepActions(
                 stepType = "optout",
-                actions = listOf(testAction),
+                actions = listOf(testFillFormAction),
                 optOutType = "form",
             ),
             profileToOptOut = testExtractedProfile.copy(email = "old@example.com"),
@@ -317,9 +481,41 @@ class EmailReceivedEventHandlerTest {
 
         val result = testee.invoke(state, event)
 
-        val updatedOptOutStep1 = result.nextState.brokerStepsToExecute[0] as OptOutStep
-        val unchangedOptOutStep2 = result.nextState.brokerStepsToExecute[1] as OptOutStep
-        assertEquals("generated@example.com", updatedOptOutStep1.profileToOptOut.email)
-        assertEquals("old@example.com", unchangedOptOutStep2.profileToOptOut.email)
+        // Neither step should be modified
+        val unchangedStep1 = result.nextState.brokerStepsToExecute[0] as OptOutStep
+        val unchangedStep2 = result.nextState.brokerStepsToExecute[1] as OptOutStep
+        assertEquals("", unchangedStep1.profileToOptOut.email)
+        assertEquals("old@example.com", unchangedStep2.profileToOptOut.email)
+    }
+
+    // endregion
+
+    private fun createOptOutState(
+        action: BrokerAction,
+        actionRetryCount: Int = 0,
+        attemptId: String = "",
+    ): State {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        return State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = actionRetryCount,
+            attemptId = attemptId,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailReceivedEventHandlerTest.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanSt
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutStageGenerateEmailReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailReceived
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
@@ -44,6 +46,7 @@ import com.duckduckgo.pir.impl.store.PirRepository.GeneratedEmailData
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -248,6 +251,36 @@ class EmailReceivedEventHandlerTest {
         val nextEvent = result.nextEvent as ExecuteBrokerStepAction
         val userProfile = nextEvent.actionRequestData as UserProfile
         assertEquals("generated@example.com", userProfile.extractedProfile?.email)
+    }
+
+    @Test
+    fun whenEmailReceivedForFillFormOnScanStepThenFailsGracefully() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testFillFormAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = EmailReceived(generatedEmailData = testGeneratedEmailData)
+
+        val result = testee.invoke(state, event)
+
+        val nextEvent = result.nextEvent as BrokerStepCompleted
+        assertEquals(false, nextEvent.needsEmailConfirmation)
+        assertTrue(nextEvent.stepStatus is StepStatus.Failure)
     }
 
     // endregion

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.pir.impl.scripts.models.ElementSelector
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import com.duckduckgo.pir.impl.store.PirRepository.GeneratedEmailData
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -790,6 +791,61 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as GetEmailForProfile
         assertEquals("action-gen-email", sideEffect.actionId)
         assertEquals(testBrokerName, sideEffect.brokerName)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenOptOutActionNeedsEmailButGeneratedEmailDataExistsThenDoesNotRequestEmailGeneration() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-1",
+            elements = listOf(
+                ElementSelector(
+                    type = "email",
+                    selector = "input[name='email']",
+                    parent = null,
+                    multiple = null,
+                    min = null,
+                    max = null,
+                    failSilently = null,
+                ),
+            ),
+            selector = "form",
+        )
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "already-generated@example.com",
+                pattern = "pattern-123",
+            ),
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_GENERATE,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(
+            UserProfile(
+                userProfile = testProfileQuery,
+                extractedProfile = null,
+            ),
+        )
+
+        val result = testee.invoke(state, event)
+
+        // Should NOT request email generation; should fall through to PushJsAction
+        assertTrue(result.sideEffect is PushJsAction)
         assertNull(result.nextEvent)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -848,4 +848,51 @@ class ExecuteBrokerStepActionEventHandlerTest {
         assertTrue(result.sideEffect is PushJsAction)
         assertNull(result.nextEvent)
     }
+
+    @Test
+    fun whenFillFormRetryWithGeneratedEmailDataThenIncludesEmailInRequestData() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-1",
+            elements = emptyList(),
+            selector = "form",
+            dataSource = DataSource.EXTRACTED_PROFILE,
+        )
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile.copy(email = ""),
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "generated@example.com",
+                pattern = "pattern-123",
+            ),
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        // Retry dispatches fresh UserProfile without extractedProfile (mimics BrokerActionFailedEventHandler)
+        val event = ExecuteBrokerStepAction(
+            UserProfile(
+                userProfile = testProfileQuery,
+                extractedProfile = null,
+            ),
+        )
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val userData = sideEffect.requestParamsData as UserProfile
+        assertEquals("generated@example.com", userData.extractedProfile?.email)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1213993026941869?focus=true

### Description
Adds logic for GenerateEmail action and refactors the implicit email handling to use same approach as the new explicit one.

### Steps to test this PR
Will be testable later when feature is complete.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes opt-out/scan email state-machine behavior (when to request email, what gets sent to JS, and profile mutation), which could affect broker automation success though coverage is expanded in unit tests.
> 
> **Overview**
> Adds first-class handling for the **`GenerateEmail`** broker action and refactors how generated emails flow through the PIR actions runner.
> 
> For an explicit **`GenerateEmail`** step, **`EmailReceivedEventHandler`** now stores **`generatedEmailData`** on state, increments **`currentActionIndex`**, and continues with **`ExecuteBrokerStepAction`** without embedding the email in the next request payload. For the legacy implicit **`needsEmail`** path (e.g. **`FillForm`**), it re-runs the **same** action with an **`extractedProfile`** that includes the generated address, and no longer mutates **`profileToOptOut.email`** on broker steps. **`ScanStep`** hitting the implicit path completes the step with a failure instead of continuing.
> 
> **`ExecuteBrokerStepActionEventHandler`** triggers email generation when **`generatedEmailData`** is null (not when the stored profile lacks an email), and **`completeRequestData`** applies **`generatedEmailData`** when building **`EXTRACTED_PROFILE`** payloads so retries still get the generated address. Tests cover explicit vs implicit flows, scan-step guardrails, and skip re-fetch when email is already in state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e810d3a950daecfeee9400b5aaf5251045fd1209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->