### PR TITLE
Add translation for Inactivity Timeout settings

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -94,17 +94,6 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
-    <!-- Inactivity timeout -->
-    <string name="afterInactivityOptionTitle">After Inactivity</string>
-    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
-    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return after inactivity</string>
-    <string name="afterInactivityOptionMessage" translatable="false">Choose what you see when you return after %1$s minutes of inactivity.</string>
-    <string name="afterInactivityTimeoutAlways" translatable="false">Always</string>
-    <string name="afterInactivityTimeout1Minute" translatable="false">1 minute</string>
-    <string name="afterInactivityTimeoutXMinutes" translatable="false">%1$d minutes</string>
-    <string name="afterInactivityTimeout1Hour" translatable="false">1 hour</string>
-    <string name="afterInactivityTimeoutXHours" translatable="false">%1$d hours</string>
-
     <!--Onboarding Rebrand Design Update-->
     <string name="preOnboardingWelcomeDialogTitle">Hi there!</string>
     <string name="preOnboardingWelcomeDialogBody">Ready for a faster browser that protects you and lets you decide when and how to use AI?</string>

--- a/app/src/main/res/values/strings-settings.xml
+++ b/app/src/main/res/values/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimental Browser Menu</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">After Inactivity</string>
+    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
+    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return after inactivity</string>
+    <string name="afterInactivityOptionMessage" instruction="'%1$s' is a placeholder and will be replaced with the number of minutes, e.g. 'after 5 minutes of inactivity'">Choose what you see when you return after %1$s minutes of inactivity.</string>
+    <string name="afterInactivityTimeoutAlways">Always</string>
+    <string name="afterInactivityTimeout1Minute">1 minute</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="'%1$d' is a placeholder and will be replaced with the number of minutes, e.g. '5 minutes'">%1$d minutes</string>
+    <string name="afterInactivityTimeout1Hour">1 hour</string>
+    <string name="afterInactivityTimeoutXHours" instruction="'%1$d' is a placeholder and will be replaced with the number of hours, e.g. '2 hours'">%1$d hours</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213800909789712?focus=true
### Description
Add translation for the settings that enables the user to chose their inactivity timeout timer

### Steps to test this PR

- Change the language of your phone
- Enable `showNTPAfterIdleReturn` feature flag
- Go to Settings -> General -> After Inactivity
- Verify "Choose an inactivity timer" setting is translated to yoru selected language (if supported)
- Tap on it and verify that all the options in the popup are translated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-only changes that affect localization metadata and string placement, with no functional logic changes.
> 
> **Overview**
> Moves the **Inactivity timeout** UI strings out of `donottranslate.xml` into `strings-settings.xml` so they become translatable.
> 
> Adds Smartling `instruction` metadata for the placeholder-based strings (`afterInactivityOptionMessage`, `afterInactivityTimeoutXMinutes`, `afterInactivityTimeoutXHours`) and removes `translatable="false"` from the affected resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19908a46c442317ab83b972fbc8923fdee3115f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->