### PR TITLE
Add translation for Inactivity Timeout settings

### DIFF
--- a/app/src/main/res/values-bg/strings-settings.xml
+++ b/app/src/main/res/values-bg/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Експериментално меню на браузъра</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">След неактивност</string>
+    <string name="afterInactivityTimeoutRowTitle">Изберете таймер за бездействие</string>
+    <string name="afterInactivityScreenSectionHeader">Изберете какво да виждате, когато се върнете след неактивност</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Изберете какво да виждате, когато се върнете след %1$s минути неактивност.</string>
+    <string name="afterInactivityTimeoutAlways">Винаги</string>
+    <string name="afterInactivityTimeout1Minute">1 минута</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d минути</string>
+    <string name="afterInactivityTimeout1Hour">1 час</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d часа</string>
 </resources>

--- a/app/src/main/res/values-cs/strings-settings.xml
+++ b/app/src/main/res/values-cs/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimentální nabídka prohlížeče</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Po nečinnosti</string>
+    <string name="afterInactivityTimeoutRowTitle">Vyber časovač nečinnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Vyber, co se má zobrazit, když se vrátíš po nečinnosti</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Vyber, co se má zobrazit, když se vrátíš po %1$s minutách nečinnosti.</string>
+    <string name="afterInactivityTimeoutAlways">Vždy</string>
+    <string name="afterInactivityTimeout1Minute">1 minuta</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minut(y)</string>
+    <string name="afterInactivityTimeout1Hour">1 hodina</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d hodin(y)</string>
 </resources>

--- a/app/src/main/res/values-da/strings-settings.xml
+++ b/app/src/main/res/values-da/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentel browsermenu</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Efter inaktivitet</string>
+    <string name="afterInactivityTimeoutRowTitle">Vælg en inaktivitetstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Vælg, hvad du ser, når du vender tilbage efter inaktivitet</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Vælg, hvad du ser, når du vender tilbage efter %1$s minutters inaktivitet.</string>
+    <string name="afterInactivityTimeoutAlways">Altid</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutter</string>
+    <string name="afterInactivityTimeout1Hour">1 time</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d timer</string>
 </resources>

--- a/app/src/main/res/values-de/strings-settings.xml
+++ b/app/src/main/res/values-de/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimentelles Browser-Menü</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Nach Inaktivität</string>
+    <string name="afterInactivityTimeoutRowTitle">Wähle einen Inaktivitätstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Wähle aus, was dir nach Inaktivität angezeigt werden soll.</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Wähle aus, was dir nach %1$s Minuten Inaktivität angezeigt werden soll.</string>
+    <string name="afterInactivityTimeoutAlways">Immer</string>
+    <string name="afterInactivityTimeout1Minute">1 Minute</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d Minuten</string>
+    <string name="afterInactivityTimeout1Hour">1 Stunde</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d Stunden</string>
 </resources>

--- a/app/src/main/res/values-el/strings-settings.xml
+++ b/app/src/main/res/values-el/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Πειραματικό μενού προγράμματος περιήγησης</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Μετά από αδράνεια</string>
+    <string name="afterInactivityTimeoutRowTitle">Επιλέξτε ένα χρονόμετρο αδράνειας</string>
+    <string name="afterInactivityScreenSectionHeader">Επιλέξτε τι θα βλέπετε όταν επιστρέφετε μετά από αδράνεια</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Επιλέξτε τι θα βλέπετε όταν επιστρέφετε μετά από %1$s λεπτά αδράνειας.</string>
+    <string name="afterInactivityTimeoutAlways">Πάντα</string>
+    <string name="afterInactivityTimeout1Minute">1 λεπτό</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d λεπτά</string>
+    <string name="afterInactivityTimeout1Hour">1 ώρα</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d ώρες</string>
 </resources>

--- a/app/src/main/res/values-es/strings-settings.xml
+++ b/app/src/main/res/values-es/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Menú del navegador experimental</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Después de inactividad</string>
+    <string name="afterInactivityTimeoutRowTitle">Elige un temporizador de inactividad</string>
+    <string name="afterInactivityScreenSectionHeader">Elige lo que ves cuando vuelves tras un periodo de inactividad</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Elige lo que ves cuando vuelves después de %1$s minutos de inactividad.</string>
+    <string name="afterInactivityTimeoutAlways">Siempre</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutos</string>
+    <string name="afterInactivityTimeout1Hour">1 hora</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d horas</string>
 </resources>

--- a/app/src/main/res/values-et/strings-settings.xml
+++ b/app/src/main/res/values-et/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentaalne brauseri menüü</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Pärast tegevusetust</string>
+    <string name="afterInactivityTimeoutRowTitle">Vali tegevusetusaja taimer</string>
+    <string name="afterInactivityScreenSectionHeader">Vali, mida näed, kui naased pärast tegevusetust</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Vali, mida näed pärast %1$s minutilisest tegevusetusest naasmist.</string>
+    <string name="afterInactivityTimeoutAlways">Alati</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutit</string>
+    <string name="afterInactivityTimeout1Hour">1 tund</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d tundi</string>
 </resources>

--- a/app/src/main/res/values-fi/strings-settings.xml
+++ b/app/src/main/res/values-fi/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Kokeellinen selainvalikko</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Toimettomuuden jälkeen</string>
+    <string name="afterInactivityTimeoutRowTitle">Valitse passiivisuusajastin</string>
+    <string name="afterInactivityScreenSectionHeader">Valitse, mitä näet, kun palaat palveluun</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Valitse, mitä näet, kun palaat palveluun %1$s minuutin jälkeen.</string>
+    <string name="afterInactivityTimeoutAlways">Aina</string>
+    <string name="afterInactivityTimeout1Minute">1 minuutti</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minuuttia</string>
+    <string name="afterInactivityTimeout1Hour">1 tunti</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d tuntia</string>
 </resources>

--- a/app/src/main/res/values-fr/strings-settings.xml
+++ b/app/src/main/res/values-fr/strings-settings.xml
@@ -22,8 +22,8 @@
     <!-- Inactivity timeout -->
     <string name="afterInactivityOptionTitle">Après l\'inactivité</string>
     <string name="afterInactivityTimeoutRowTitle">Choisissez un minuteur d\'inactivité</string>
-    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d’inactivité.</string>
-    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d’inactivité.</string>
+    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d\'inactivité.</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d\'inactivité.</string>
     <string name="afterInactivityTimeoutAlways">Toujours</string>
     <string name="afterInactivityTimeout1Minute">1 minute</string>
     <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutes</string>

--- a/app/src/main/res/values-fr/strings-settings.xml
+++ b/app/src/main/res/values-fr/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Menu expérimental du navigateur</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Après l\'inactivité</string>
+    <string name="afterInactivityTimeoutRowTitle">Choisissez un minuteur d\'inactivité</string>
+    <string name="afterInactivityScreenSectionHeader">Choisissez ce que vous voyez lorsque vous revenez après une période d’inactivité.</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Choisissez ce que vous voyez lorsque vous revenez après %1$s minutes d’inactivité.</string>
+    <string name="afterInactivityTimeoutAlways">Toujours</string>
+    <string name="afterInactivityTimeout1Minute">1 minute</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutes</string>
+    <string name="afterInactivityTimeout1Hour">1 heure</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d heures</string>
 </resources>

--- a/app/src/main/res/values-hr/strings-settings.xml
+++ b/app/src/main/res/values-hr/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentalni izbornik preglednika</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Nakon neaktivnosti</string>
+    <string name="afterInactivityTimeoutRowTitle">Odaberi mjerač vremena neaktivnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Odaberi što ćeš vidjeti kada se vratiš nakon neaktivnosti</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Odaberi što ćeš vidjeti kada se vratiš nakon %1$s minuta neaktivnosti.</string>
+    <string name="afterInactivityTimeoutAlways">Uvijek</string>
+    <string name="afterInactivityTimeout1Minute">1 minutu</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minuta</string>
+    <string name="afterInactivityTimeout1Hour">1 sat</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d sati</string>
 </resources>

--- a/app/src/main/res/values-hu/strings-settings.xml
+++ b/app/src/main/res/values-hu/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Kísérleti böngészési menü</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Inaktivitás után</string>
+    <string name="afterInactivityTimeoutRowTitle">Válaszd ki a tétlenségi időzítőt</string>
+    <string name="afterInactivityScreenSectionHeader">Válaszd ki, hogy mit jelenjen meg, ha inaktivitás után visszatérsz</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Válaszd ki, hogy mi jelenjen meg, amikor %1$s perc inaktivitás után visszatérsz.</string>
+    <string name="afterInactivityTimeoutAlways">Mindig</string>
+    <string name="afterInactivityTimeout1Minute">1 perc</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d perc</string>
+    <string name="afterInactivityTimeout1Hour">1 óra</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d óra</string>
 </resources>

--- a/app/src/main/res/values-it/strings-settings.xml
+++ b/app/src/main/res/values-it/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Menu sperimentale del browser</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Dopo l\'inattività</string>
+    <string name="afterInactivityTimeoutRowTitle">Scegli un timer di inattività</string>
+    <string name="afterInactivityScreenSectionHeader">Scegli cosa visualizzare quando torni dopo un periodo di inattività</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Scegli cosa vedi quando torni dopo %1$s minuti di inattività.</string>
+    <string name="afterInactivityTimeoutAlways">Sempre</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minuti</string>
+    <string name="afterInactivityTimeout1Hour">1 ora</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d ore</string>
 </resources>

--- a/app/src/main/res/values-lt/strings-settings.xml
+++ b/app/src/main/res/values-lt/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentinis naršyklės meniu</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Po neaktyvumo</string>
+    <string name="afterInactivityTimeoutRowTitle">Pasirinkite neaktyvumo laikmatį</string>
+    <string name="afterInactivityScreenSectionHeader">Pasirink, ką matysi, kai grįši po neaktyvumo</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Pasirink, ką matysi, kai grįši po %1$s min. neaktyvumo</string>
+    <string name="afterInactivityTimeoutAlways">Visada</string>
+    <string name="afterInactivityTimeout1Minute">1 min.</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d min.</string>
+    <string name="afterInactivityTimeout1Hour">1 val.</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d val.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings-settings.xml
+++ b/app/src/main/res/values-lv/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentāla pārlūka izvēlne</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Pēc neaktivitātes perioda</string>
+    <string name="afterInactivityTimeoutRowTitle">Izvēlies neaktivitātes taimeri</string>
+    <string name="afterInactivityScreenSectionHeader">Izvēlies, ko redzēt, atgriežoties pēc neaktivitātes</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Izvēlies, ko redzēt, kad atgriezies pēc %1$s minūšu neaktivitātes.</string>
+    <string name="afterInactivityTimeoutAlways">Vienmēr</string>
+    <string name="afterInactivityTimeout1Minute">1 minūte</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minūtes</string>
+    <string name="afterInactivityTimeout1Hour">1 stunda</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d stundas</string>
 </resources>

--- a/app/src/main/res/values-nb/strings-settings.xml
+++ b/app/src/main/res/values-nb/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentell nettlesermeny</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Etter inaktivitet</string>
+    <string name="afterInactivityTimeoutRowTitle">Velg en inaktivitetstidtaker</string>
+    <string name="afterInactivityScreenSectionHeader">Velg hva du vil se når du kommer tilbake etter inaktivitet</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Velg hva du vil se når du kommer tilbake etter %1$s minutter med inaktivitet.</string>
+    <string name="afterInactivityTimeoutAlways">Alltid</string>
+    <string name="afterInactivityTimeout1Minute">1 minutt</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutter</string>
+    <string name="afterInactivityTimeout1Hour">1 time</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d timer</string>
 </resources>

--- a/app/src/main/res/values-nl/strings-settings.xml
+++ b/app/src/main/res/values-nl/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimenteel browsermenu</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Na inactiviteit</string>
+    <string name="afterInactivityTimeoutRowTitle">Kies een inactiviteitstimer</string>
+    <string name="afterInactivityScreenSectionHeader">Kies wat je ziet als je terugkeert na inactiviteit</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Kies wat je wilt zien als je terugkeert na %1$s minuten inactiviteit.</string>
+    <string name="afterInactivityTimeoutAlways">Altijd</string>
+    <string name="afterInactivityTimeout1Minute">1 minuut</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minuten</string>
+    <string name="afterInactivityTimeout1Hour">1 uur</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d uur</string>
 </resources>

--- a/app/src/main/res/values-pl/strings-settings.xml
+++ b/app/src/main/res/values-pl/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperymentalne menu przeglądarki</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Po braku aktywności</string>
+    <string name="afterInactivityTimeoutRowTitle">Ustaw czas bezczynności</string>
+    <string name="afterInactivityScreenSectionHeader">Wybierz, co zobaczysz, gdy wrócisz po braku aktywności</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Wybierz, co zobaczysz, gdy wrócisz po %1$s min braku aktywności.</string>
+    <string name="afterInactivityTimeoutAlways">Zawsze</string>
+    <string name="afterInactivityTimeout1Minute">1 minuta</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d min</string>
+    <string name="afterInactivityTimeout1Hour">1 godzina</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d godz.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings-settings.xml
+++ b/app/src/main/res/values-pt/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Menu experimental do navegador</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Após Inatividade</string>
+    <string name="afterInactivityTimeoutRowTitle">Escolher um temporizador de inatividade</string>
+    <string name="afterInactivityScreenSectionHeader">Escolhe o que vês quando voltares após inatividade</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Escolhe o que vês quando voltares após %1$s minutos de inatividade.</string>
+    <string name="afterInactivityTimeoutAlways">Sempre</string>
+    <string name="afterInactivityTimeout1Minute">1 minuto</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minutos</string>
+    <string name="afterInactivityTimeout1Hour">1 hora</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d horas</string>
 </resources>

--- a/app/src/main/res/values-ro/strings-settings.xml
+++ b/app/src/main/res/values-ro/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Meniu browser experimental</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">După inactivitate</string>
+    <string name="afterInactivityTimeoutRowTitle">Alege un cronometru de inactivitate</string>
+    <string name="afterInactivityScreenSectionHeader">Alege ce vezi când revii după inactivitate</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Alege ce vezi când te întorci după %1$s minute de inactivitate.</string>
+    <string name="afterInactivityTimeoutAlways">Întotdeauna</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minute</string>
+    <string name="afterInactivityTimeout1Hour">1 oră</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d ore</string>
 </resources>

--- a/app/src/main/res/values-ru/strings-settings.xml
+++ b/app/src/main/res/values-ru/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Пробное меню браузера</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">После бездействия</string>
+    <string name="afterInactivityTimeoutRowTitle">Выберите таймер бездействия</string>
+    <string name="afterInactivityScreenSectionHeader">Выберите, что вы увидите, когда вернетесь после бездействия</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Выберите, что вы увидите, когда вернетесь после %1$s минут бездействия.</string>
+    <string name="afterInactivityTimeoutAlways">Всегда</string>
+    <string name="afterInactivityTimeout1Minute">1 мин.</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d минут</string>
+    <string name="afterInactivityTimeout1Hour">1 ч.</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d ч.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings-settings.xml
+++ b/app/src/main/res/values-sk/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimentálna ponuka prehliadača</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Po nečinnosti</string>
+    <string name="afterInactivityTimeoutRowTitle">Vyber časovač nečinnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Vyber si, čo sa ti ukáže po návrate z nečinnosti</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Vyber si, čo sa ti ukáže po návrate po %1$s minútach nečinnosti.</string>
+    <string name="afterInactivityTimeoutAlways">Vždy</string>
+    <string name="afterInactivityTimeout1Minute">1 min.</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minút</string>
+    <string name="afterInactivityTimeout1Hour">1 hod.</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d hodín</string>
 </resources>

--- a/app/src/main/res/values-sl/strings-settings.xml
+++ b/app/src/main/res/values-sl/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Eksperimentalni meni brskalnika</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Po neaktivnosti</string>
+    <string name="afterInactivityTimeoutRowTitle">Izberite časovnik neaktivnosti</string>
+    <string name="afterInactivityScreenSectionHeader">Izberite, kaj želite videti, ko se vrnete po nedejavnosti</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Izberite, kaj želite videti, ko se vrnete po %1$s min. nedejavnosti.</string>
+    <string name="afterInactivityTimeoutAlways">Vedno</string>
+    <string name="afterInactivityTimeout1Minute">1 minuti</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d min</string>
+    <string name="afterInactivityTimeout1Hour">1 uri</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d h</string>
 </resources>

--- a/app/src/main/res/values-sv/strings-settings.xml
+++ b/app/src/main/res/values-sv/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimentell webbläsarmeny</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Efter inaktivitet</string>
+    <string name="afterInactivityTimeoutRowTitle">Välj en timer för inaktivitet</string>
+    <string name="afterInactivityScreenSectionHeader">Välj vad du ser när du återgår efter inaktivitet</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">Välj vad du ser när du återgår efter %1$s minuter av inaktivitet.</string>
+    <string name="afterInactivityTimeoutAlways">Alltid</string>
+    <string name="afterInactivityTimeout1Minute">1 minut</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d minuter</string>
+    <string name="afterInactivityTimeout1Hour">1 timme</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d timmar</string>
 </resources>

--- a/app/src/main/res/values-tr/strings-settings.xml
+++ b/app/src/main/res/values-tr/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Deneysel Tarayıcı Menüsü</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">Hareketsizlik Sonrası</string>
+    <string name="afterInactivityTimeoutRowTitle">Bir hareketsizlik zamanlayıcısı seçin</string>
+    <string name="afterInactivityScreenSectionHeader">Hareketsizlikten sonra geri döndüğünüzde ne göreceğinizi seçin</string>
+    <string name="afterInactivityOptionMessage" instruction="&apos;%1$s&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;after 5 minutes of inactivity&apos;">%1$s dakika hareketsiz kaldıktan sonra geri döndüğünüzde ne göreceğinizi seçin</string>
+    <string name="afterInactivityTimeoutAlways">Her zaman</string>
+    <string name="afterInactivityTimeout1Minute">1 dakika</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of minutes, e.g. &apos;5 minutes&apos;">%1$d dakika</string>
+    <string name="afterInactivityTimeout1Hour">1 saat</string>
+    <string name="afterInactivityTimeoutXHours" instruction="&apos;%1$d&apos; is a placeholder and will be replaced with the number of hours, e.g. &apos;2 hours&apos;">%1$d saat</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -94,17 +94,6 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
-    <!-- Inactivity timeout -->
-    <string name="afterInactivityOptionTitle">After Inactivity</string>
-    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
-    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return after inactivity</string>
-    <string name="afterInactivityOptionMessage" translatable="false">Choose what you see when you return after %1$s minutes of inactivity.</string>
-    <string name="afterInactivityTimeoutAlways" translatable="false">Always</string>
-    <string name="afterInactivityTimeout1Minute" translatable="false">1 minute</string>
-    <string name="afterInactivityTimeoutXMinutes" translatable="false">%1$d minutes</string>
-    <string name="afterInactivityTimeout1Hour" translatable="false">1 hour</string>
-    <string name="afterInactivityTimeoutXHours" translatable="false">%1$d hours</string>
-
     <!--Onboarding Rebrand Design Update-->
     <string name="preOnboardingWelcomeDialogTitle">Hi there!</string>
     <string name="preOnboardingWelcomeDialogBody">Ready for a faster browser that protects you and lets you decide when and how to use AI?</string>

--- a/app/src/main/res/values/strings-settings.xml
+++ b/app/src/main/res/values/strings-settings.xml
@@ -18,4 +18,15 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="showExperimentalBrowserMenu">Experimental Browser Menu</string>
+
+    <!-- Inactivity timeout -->
+    <string name="afterInactivityOptionTitle">After Inactivity</string>
+    <string name="afterInactivityTimeoutRowTitle">Choose an inactivity timer</string>
+    <string name="afterInactivityScreenSectionHeader">Choose what you see when you return after inactivity</string>
+    <string name="afterInactivityOptionMessage" instruction="'%1$s' is a placeholder and will be replaced with the number of minutes, e.g. 'after 5 minutes of inactivity'">Choose what you see when you return after %1$s minutes of inactivity.</string>
+    <string name="afterInactivityTimeoutAlways">Always</string>
+    <string name="afterInactivityTimeout1Minute">1 minute</string>
+    <string name="afterInactivityTimeoutXMinutes" instruction="'%1$d' is a placeholder and will be replaced with the number of minutes, e.g. '5 minutes'">%1$d minutes</string>
+    <string name="afterInactivityTimeout1Hour">1 hour</string>
+    <string name="afterInactivityTimeoutXHours" instruction="'%1$d' is a placeholder and will be replaced with the number of hours, e.g. '2 hours'">%1$d hours</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213800909789712?focus=true

### Description

Add translation for the settings that enables the user to chose their inactivity timeout timer

### Steps to test this PR

- Change the language of your phone
- Enable `showNTPAfterIdleReturn` feature flag
- Go to Settings -> General -> After Inactivity
- Verify "Choose an inactivity timer" setting is translated to yoru selected language (if supported)
- Tap on it and verify that all the options in the popup are translated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only moves/introduces localized string resources and removes the previous non-translatable placeholders, with no behavioral code changes.
> 
> **Overview**
> Adds translatable string resources for the **"After Inactivity" (inactivity timeout) settings UI**, including the option title, row title, section header, message, and time-unit labels.
> 
> Moves the English versions of these strings out of `values/donottranslate.xml` (where they were marked non-translatable) into `values/strings-settings.xml`, and provides translations in multiple `values-*/strings-settings.xml` locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4902fe28b8b6c07db940eeb4e52cbc0b534cee28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->