### PR TITLE
Quick Win: Android: Investigate Bug: Address Bar can be hidden on NTP by user and doesn't reappear until background/foreground

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -42,6 +43,24 @@ class TopAppBarBehavior(
             R.id.webViewFullScreenContainer,
             R.id.navigationBar,
         )
+    }
+
+    override fun onInterceptTouchEvent(
+        parent: CoordinatorLayout,
+        child: AppBarLayout,
+        ev: MotionEvent,
+    ): Boolean {
+        if (!omnibar.isOmnibarScrollingEnabled()) return false
+        return super.onInterceptTouchEvent(parent, child, ev)
+    }
+
+    override fun onTouchEvent(
+        parent: CoordinatorLayout,
+        child: AppBarLayout,
+        ev: MotionEvent,
+    ): Boolean {
+        if (!omnibar.isOmnibarScrollingEnabled()) return false
+        return super.onTouchEvent(parent, child, ev)
     }
 
     @SuppressLint("RestrictedApi")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1209003862601172?focus=true

### Description

Added touch event handling to `TopAppBarBehavior` to conditionally enable omnibar scrolling. The behavior now checks if omnibar scrolling is enabled before processing touch events through `onInterceptTouchEvent` and `onTouchEvent` methods. When omnibar scrolling is disabled, touch events are not intercepted or handled, preventing unwanted scrolling behavior.

### Steps to test this PR

_Omnibar Scrolling Control_
- [x] Verify that omnibar scrolling works normally when enabled
- [x] Confirm that touch events are blocked when omnibar scrolling is disabled
- [x] Test that the app bar behavior responds correctly to scroll state changes

See comments and video attached to https://app.asana.com/1/137249556945/project/1200581511062568/task/1209003862601172?focus=true.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI touch handling that only affects app-bar gesture behavior when scrolling is disabled.
> 
> **Overview**
> Prevents the top omnibar `AppBarLayout.Behavior` from intercepting or handling touch events when omnibar scrolling is disabled by adding guarded overrides for `onInterceptTouchEvent` and `onTouchEvent`.
> 
> This makes app-bar drag/scroll interactions consistently respect `isOmnibarScrollingEnabled()`, avoiding cases where the address bar could be hidden via touch gestures outside the intended scroll contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72937dd29c7267cde775828ccf79c435969a06b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->