### PR TITLE
Add defaultBrowserWinBackPrompt feature flag

### DIFF
--- a/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/ReactivateUsersToggles.kt
+++ b/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/ReactivateUsersToggles.kt
@@ -31,4 +31,7 @@ interface ReactivateUsersToggles {
 
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun browserComparisonPrompt(): Toggle
+
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    fun defaultBrowserWinBackPrompt(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1214070871750061?focus=true

### Description

Added a new feature toggle `defaultBrowserWinBackPrompt()` to the `ReactivateUsersToggles` interface. This toggle is disabled by default and will control the display of prompts aimed at winning back users to set the browser as their default.

### Steps to test this PR
CI passes

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new disabled-by-default feature toggle without changing any runtime behavior or data handling.
> 
> **Overview**
> Introduces a new `defaultBrowserWinBackPrompt()` feature flag in `ReactivateUsersToggles`, defaulting to **disabled**, to allow remote gating of a future default-browser win-back prompt independently of existing reactivation prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f11db3b8b3032ec40b85213aa82ede0683ed7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->