### PR TITLE
Add free_trial param to purchase pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -113,6 +113,33 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "returningUser", "privacyDashboardOpened", "subscriptionPromoShown"]
     },
+    "m_privacy-pro_app_subscription-purchase_success": {
+        "description": "Fired when a subscription purchase completes successfully.",
+        "owners": ["nalcalag"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["atb", "appVersion", "freeTrial"]
+    },
+    "m_subscribe": {
+        "description": "Fired when a subscription purchase completes, capturing purchase origin and locale.",
+        "owners": ["nalcalag"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "locale",
+                "description": "The sanitized BCP 47 language tag of the device locale.",
+                "type": "string"
+            },
+            {
+                "key": "origin",
+                "description": "The origin from which the user initiated the purchase, if available.",
+                "type": "string"
+            },
+            "freeTrial"
+        ]
+    },
     "m_privacy-pro_app_subscription_active_d": {
         "description": "Fired once daily on app start for an active subscription",
         "owners": ["lmac012"],

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -121,5 +121,10 @@
         "key": "error",
         "type": "string",
         "description": "The stacktrace for the error thrown, sanitized to remove potentially sensitive data"
+    },
+    "freeTrial": {
+        "key": "free_trial",
+        "type": "boolean",
+        "description": "Whether the subscription purchase is a free trial"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -643,15 +643,16 @@ class RealSubscriptionsManager @Inject constructor(
             }
 
             if (subscription.isActive()) {
-                pixelSender.reportPurchaseSuccess()
+                val isFreeTrial = subscription.activeOffers.contains(ActiveOfferType.TRIAL)
+                pixelSender.reportPurchaseSuccess(isFreeTrial)
                 pixelSender.reportSubscriptionActivated()
                 emitEntitlementsValues()
-                _currentPurchaseState.emit(CurrentPurchase.Success)
+                _currentPurchaseState.emit(CurrentPurchase.Success(isFreeTrial))
                 authRepository.registerLocalPurchasedAt()
 
                 subscriptionSwitchWideEvent.onSwitchConfirmationSuccess()
                 subscriptionPurchaseWideEvent.onPurchaseConfirmationSuccess()
-                if (subscription.activeOffers.contains(ActiveOfferType.TRIAL)) {
+                if (isFreeTrial) {
                     freeTrialConversionWideEvent.onFreeTrialStarted(subscription.productId)
                     if (subscriptionsFeature.get().vpnReminderNotification().isEnabled()) {
                         vpnReminderNotificationScheduler.scheduleVpnReminderNotification()
@@ -1406,7 +1407,7 @@ sealed class CurrentPurchase {
     data object PreFlowInProgress : CurrentPurchase()
     data object PreFlowFinished : CurrentPurchase()
     data object InProgress : CurrentPurchase()
-    data object Success : CurrentPurchase()
+    data class Success(val isFreeTrial: Boolean) : CurrentPurchase()
     data object Waiting : CurrentPurchase()
     data object Recovered : CurrentPurchase()
     data object Canceled : CurrentPurchase()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -336,6 +336,7 @@ object SubscriptionPixelParameter {
     const val RETURNING_USER = "returning_user"
     const val PRIVACY_DASHBOARD_EVER_OPENED = "privacy_dashboard_opened"
     const val SUBSCRIPTION_PROMO_SHOWN = "subscription_promo_shown"
+    const val FREE_TRIAL = "free_trial"
 }
 
 internal val PixelType.pixelNameSuffix: String

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -92,8 +92,8 @@ interface SubscriptionPixelSender {
     fun reportPurchaseFailureStore(errorType: String)
     fun reportPurchaseFailureBackend()
     fun reportPurchaseFailureAccountCreation()
-    fun reportPurchaseSuccess()
-    fun reportPurchaseSuccessOrigin(origin: String?)
+    fun reportPurchaseSuccess(isFreeTrial: Boolean)
+    fun reportPurchaseSuccessOrigin(origin: String?, isFreeTrial: Boolean)
     fun reportOfferRestorePurchaseClick()
     fun reportActivateSubscriptionEnterEmailClick()
     fun reportActivateSubscriptionRestorePurchaseClick()
@@ -183,12 +183,13 @@ class SubscriptionPixelSenderImpl @Inject constructor(
     override fun reportPurchaseFailureAccountCreation() =
         fire(PURCHASE_FAILURE_ACCOUNT_CREATION)
 
-    override fun reportPurchaseSuccess() =
-        fire(PURCHASE_SUCCESS)
+    override fun reportPurchaseSuccess(isFreeTrial: Boolean) =
+        fire(PURCHASE_SUCCESS, mapOf(SubscriptionPixelParameter.FREE_TRIAL to isFreeTrial.toString()))
 
-    override fun reportPurchaseSuccessOrigin(origin: String?) {
+    override fun reportPurchaseSuccessOrigin(origin: String?, isFreeTrial: Boolean) {
         val map = mutableMapOf(
             "locale" to appBuildConfig.deviceLocale.toSanitizedLanguageTag(),
+            SubscriptionPixelParameter.FREE_TRIAL to isFreeTrial.toString(),
         )
         origin?.let {
             map.put("origin", origin)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -141,6 +141,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
                             PURCHASE_COMPLETED_SUBSCRIPTION_NAME,
                             JSONObject(PURCHASE_COMPLETED_JSON),
                         ),
+                        isFreeTrial = it.isFreeTrial,
                     )
                 }
                 is CurrentPurchase.InProgress, CurrentPurchase.PreFlowInProgress -> InProgress
@@ -705,7 +706,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     sealed class PurchaseStateView {
         data object Inactive : PurchaseStateView()
         data object InProgress : PurchaseStateView()
-        data class Success(val subscriptionEventData: SubscriptionEventData) : PurchaseStateView()
+        data class Success(val subscriptionEventData: SubscriptionEventData, val isFreeTrial: Boolean) : PurchaseStateView()
         data object Waiting : PurchaseStateView()
         data object Recovered : PurchaseStateView()
         data object Failure : PurchaseStateView()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -553,7 +553,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                 onPurchaseSuccess(null)
             }
             is PurchaseStateView.Success -> {
-                pixelSender.reportPurchaseSuccessOrigin(params.origin)
+                pixelSender.reportPurchaseSuccessOrigin(params.origin, purchaseState.isFreeTrial)
                 onPurchaseSuccess(purchaseState.subscriptionEventData)
             }
             is PurchaseStateView.Recovered -> {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1322,7 +1322,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             assertTrue(awaitItem() is CurrentPurchase.InProgress)
             assertTrue(awaitItem() is CurrentPurchase.Success)
 
-            verify(pixelSender).reportPurchaseSuccess()
+            verify(pixelSender).reportPurchaseSuccess(isFreeTrial = false)
             verify(pixelSender).reportSubscriptionActivated()
             verifyNoMoreInteractions(pixelSender)
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.subscriptions.impl.repository.Subscription
 import com.duckduckgo.subscriptions.impl.serp_promo.FakeSerpPromo
 import com.duckduckgo.subscriptions.impl.services.AccessTokenResponse
 import com.duckduckgo.subscriptions.impl.services.AccountResponse
+import com.duckduckgo.subscriptions.impl.services.ActiveOfferResponse
 import com.duckduckgo.subscriptions.impl.services.AuthService
 import com.duckduckgo.subscriptions.impl.services.ConfirmationEntitlement
 import com.duckduckgo.subscriptions.impl.services.ConfirmationResponse
@@ -1331,6 +1332,26 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
+    fun whenPurchaseIsSuccessfulWithFreeTrialThenPixelIsSentWithFreeTrialTrue() = runTest {
+        givenUserIsSignedIn()
+        givenValidateTokenSucceedsWithEntitlements()
+        givenConfirmPurchaseSucceedsWithFreeTrial()
+        givenV2AccessTokenRefreshSucceeds()
+
+        whenever(playBillingManager.purchaseState).thenReturn(flowOf(Purchased("any", "any")))
+
+        subscriptionsManager.currentPurchaseState.test {
+            assertTrue(awaitItem() is CurrentPurchase.InProgress)
+            assertTrue(awaitItem() is CurrentPurchase.Success)
+
+            verify(pixelSender).reportPurchaseSuccess(isFreeTrial = true)
+            verify(pixelSender).reportSubscriptionActivated()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenSubscriptionIsRestoredOnPurchaseAttemptThenPixelIsSent() = runTest {
         givenUserIsNotSignedIn()
         givenPurchaseStored()
@@ -1973,6 +1994,26 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
                     startedAt = 1000000L,
                     expiresOrRenewsAt = 1000000L,
                     activeOffers = listOf(),
+                ),
+            ),
+        )
+    }
+
+    private suspend fun givenConfirmPurchaseSucceedsWithFreeTrial() {
+        whenever(subscriptionsService.confirm(any())).thenReturn(
+            ConfirmationResponse(
+                email = "test@duck.com",
+                entitlements = listOf(
+                    ConfirmationEntitlement(NetP.value, NetP.value),
+                ),
+                subscription = SubscriptionResponse(
+                    productId = "id",
+                    billingPeriod = "Monthly",
+                    platform = "google",
+                    status = "Auto-Renewable",
+                    startedAt = 1000000L,
+                    expiresOrRenewsAt = 1000000L,
+                    activeOffers = listOf(ActiveOfferResponse("Trial")),
                 ),
             ),
         )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -111,7 +111,7 @@ class SubscriptionWebViewViewModelTest {
             flowTest.emit(CurrentPurchase.Failure("test"))
             assertTrue(awaitItem().purchaseState is PurchaseStateView.Failure)
 
-            flowTest.emit(CurrentPurchase.Success)
+            flowTest.emit(CurrentPurchase.Success(isFreeTrial = false))
             val success = awaitItem().purchaseState
             assertTrue(success is Success)
             assertEquals(Companion.PURCHASE_COMPLETED_FEATURE_NAME, (success as Success).subscriptionEventData.featureName)
@@ -728,7 +728,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenAddEmailClickedAndInPurchaseFlowThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -756,7 +756,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenFeatureSelectedAndFeatureIsNetPAndInPurchaseFlowThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -784,7 +784,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenFeatureSelectedAndFeatureIsItrAndInPurchaseFlowThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -813,7 +813,7 @@ class SubscriptionWebViewViewModelTest {
     fun whenFeatureSelectedAndFeatureIsPirAndInPurchaseFlowAndPirDisabledThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
         whenever(pirFeature.getPirFeatureState()).thenReturn(PirFeatureState.DISABLED)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -829,7 +829,7 @@ class SubscriptionWebViewViewModelTest {
     fun whenFeatureSelectedAndFeatureIsPirAndInPurchaseFlowAndPirEnabledThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
         whenever(pirFeature.getPirFeatureState()).thenReturn(PirFeatureState.ENABLED)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -857,7 +857,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenFeatureSelectedAndFeatureIsDuckAiAndInPurchaseFlowThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -885,7 +885,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenSubscriptionsWelcomeFaqClickedAndInPurchaseFlowThenPixelIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.processJsCallbackMessage(
@@ -913,7 +913,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenOnSubscriptionRestoredFromEmailAndSubscriptionExpiredThenCommandIsSent() = runTest {
         givenSubscriptionStatus(EXPIRED)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.commands().test {
@@ -926,7 +926,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenOnSubscriptionRestoredFromEmailAndSubscriptionActiveThenCommandIsSent() = runTest {
         givenSubscriptionStatus(AUTO_RENEWABLE)
-        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success))
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowOf(CurrentPurchase.Success(isFreeTrial = false)))
         viewModel.start()
 
         viewModel.commands().test {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214085261365771?focus=true

### Description
Add free_trial to purchase pixels

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Not Free Trial Eligible_
- [x] Install from branch
- [x] Purchase a test subscription
- [x] Check in logcat that m_subscribe pixel has param `free_trial` set to false

_Free Trial Eligible_
- [x] Cancel subscription
- [x] Wait until it expires 
- [x] Enable Introductory offer on Play Billing Lab app
- [x] Purchase a test subscription
- [x] Check in logcat that m_subscribe pixel has param `free_trial` set to true

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics payloads and state plumbing around purchase success; main risk is incorrect free-trial classification or missed pixel params.
> 
> **Overview**
> Purchase success telemetry now records whether the purchase started a free trial by adding the `freeTrial`/`free_trial` parameter to `m_privacy-pro_app_subscription-purchase_success` and `m_subscribe` pixel definitions.
> 
> The subscriptions purchase flow now derives `isFreeTrial` from `activeOffers`, passes it through `CurrentPurchase.Success` and the WebView view state, and includes it when firing `reportPurchaseSuccess(...)` and `reportPurchaseSuccessOrigin(...)`. Tests are updated and expanded to cover both free-trial and non-free-trial purchase confirmation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536d79f5eba17ccb059ef8b37765e1911531ef49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->