### PR TITLE
add input preview step to brand design onboarding variant

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager.DuckAiOnboardingExperimentVariant
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -43,12 +44,21 @@ interface DuckAiOnboardingExperimentManager {
 class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
     private val browserConfig: AndroidBrowserConfigFeature,
     private val dispatcherProvider: DispatcherProvider,
+    private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
 ) : DuckAiOnboardingExperimentManager {
 
     override suspend fun enroll(): DuckAiOnboardingExperimentVariant? {
         if (!arePrerequisitesMet()) return null
 
-        // TODO experiment setup
+        val isBrandDesignEnabled = withContext(dispatcherProvider.io()) {
+            onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
+        }
+        if (isBrandDesignEnabled) {
+            // TODO experiment 2 setup
+        } else {
+            // TODO experiment 1 setup
+        }
+
         return null
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -94,7 +94,7 @@ class OnboardingStoreImpl @Inject constructor(
             ),
             DaxDialogIntroOption(
                 optionText = context.getString(R.string.preOnboardingInputModeDemoChatSuggestion3),
-                iconRes = drawable.ic_ai_chat_16,
+                iconRes = drawable.ic_wand_16,
                 link = context.getString(R.string.preOnboardingInputModeDemoChatSuggestion3Prompt),
             ),
         )

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -33,10 +33,10 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
-import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class OnboardingActivity : DuckDuckGoActivity() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -93,7 +93,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
 
     fun finishAndSubmitChatPrompt(prompt: String) {
         viewModel.onOnboardingDone()
-        val duckChatUrl = duckChat.getDuckChatUrl(prompt, autoPrompt = true) + "&flow=mobile-app-onboarding"
+        val duckChatUrl = duckChat.getDuckChatUrl(prompt, autoPrompt = true)
         startActivity(BrowserActivity.intent(this@OnboardingActivity, duckChatUrl = duckChatUrl, openDuckChat = true))
         finish()
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -32,12 +32,17 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckChat
+import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @InjectWith(ActivityScope::class)
 class OnboardingActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var duckChat: DuckChat
 
     private lateinit var viewPageAdapter: PagerAdapter
 
@@ -77,6 +82,19 @@ class OnboardingActivity : DuckDuckGoActivity() {
     fun onSkipClicked() {
         viewModel.onOnboardingSkipped()
         startActivity(BrowserActivity.intent(this@OnboardingActivity))
+        finish()
+    }
+
+    fun finishAndSubmitSearchQuery(query: String) {
+        viewModel.onOnboardingDone()
+        startActivity(BrowserActivity.intent(this@OnboardingActivity, queryExtra = query))
+        finish()
+    }
+
+    fun finishAndSubmitChatPrompt(prompt: String) {
+        viewModel.onOnboardingDone()
+        val duckChatUrl = duckChat.getDuckChatUrl(prompt, autoPrompt = true) + "&flow=mobile-app-onboarding"
+        startActivity(BrowserActivity.intent(this@OnboardingActivity, duckChatUrl = duckChatUrl, openDuckChat = true))
         finish()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -292,7 +292,8 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                     if (inputSelected) {
                         when (duckAiOnboardingExperimentManager.enroll()) {
                             null,
-                            CONTROL -> _commands.send(Command.Finish)
+                            CONTROL,
+                            -> _commands.send(Command.Finish)
                             TREATMENT_WITH_DUCK_AI_DEFAULT -> setInputScreenPreviewDialog(isSearchDefault = false)
                             TREATMENT_WITH_SEARCH_DEFAULT -> setInputScreenPreviewDialog(isSearchDefault = true)
                         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -23,8 +23,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager.DuckAiOnboardingExperimentVariant.CONTROL
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager.DuckAiOnboardingExperimentVariant.TREATMENT_WITH_DUCK_AI_DEFAULT
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager.DuckAiOnboardingExperimentVariant.TREATMENT_WITH_SEARCH_DEFAULT
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.*
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.ADDRESS_BAR_POSITION
@@ -87,6 +92,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val duckChat: DuckChat,
     private val inputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent,
+    private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager,
 ) : ViewModel() {
 
     data class ViewState(
@@ -97,6 +103,9 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         val inputScreenSelected: Boolean = true,
         val showSplitOption: Boolean = false,
         val isReinstallUser: Boolean = false,
+        val inputScreenPreviewSearchSuggestions: List<DaxDialogIntroOption> = emptyList(),
+        val inputScreenPreviewChatSuggestions: List<DaxDialogIntroOption> = emptyList(),
+        val inputScreenPreviewIsSearchSelected: Boolean = false,
     )
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -121,6 +130,8 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         data object RequestNotificationPermissions : Command
         data class ShowDefaultBrowserDialog(val intent: Intent) : Command
         data object Finish : Command
+        data class FinishAndSubmitSearchQuery(val query: String) : Command
+        data class FinishAndSubmitChatPrompt(val prompt: String) : Command
         data object OnboardingSkipped : Command
         data object SkipDialogAnimation : Command
     }
@@ -140,6 +151,19 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private fun setCurrentDialog(dialogType: PreOnboardingDialogType) {
         _viewState.update { it.copy(currentDialog = dialogType, hasAnimatedCurrentDialog = false) }
         fireDialogShownPixel(dialogType)
+    }
+
+    private fun setInputScreenPreviewDialog(isSearchDefault: Boolean) {
+        _viewState.update {
+            it.copy(
+                currentDialog = INPUT_SCREEN_PREVIEW,
+                hasAnimatedCurrentDialog = false,
+                inputScreenPreviewSearchSuggestions = onboardingStore.getSearchOptions(),
+                inputScreenPreviewChatSuggestions = onboardingStore.getChatSuggestions(),
+                inputScreenPreviewIsSearchSelected = isSearchDefault,
+            )
+        }
+        fireDialogShownPixel(INPUT_SCREEN_PREVIEW)
     }
 
     private fun fireDialogShownPixel(dialogType: PreOnboardingDialogType) {
@@ -265,12 +289,33 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                     }
                     duckChat.setCosmeticInputScreenUserSetting(inputSelected)
                     onboardingStore.storeInputScreenSelection(inputSelected)
-                    _commands.send(Command.Finish)
+                    if (inputSelected) {
+                        when (duckAiOnboardingExperimentManager.enroll()) {
+                            null,
+                            CONTROL -> _commands.send(Command.Finish)
+                            TREATMENT_WITH_DUCK_AI_DEFAULT -> setInputScreenPreviewDialog(isSearchDefault = false)
+                            TREATMENT_WITH_SEARCH_DEFAULT -> setInputScreenPreviewDialog(isSearchDefault = true)
+                        }
+                    } else {
+                        _commands.send(Command.Finish)
+                    }
                 }
             }
 
             INPUT_SCREEN_PREVIEW -> {
-                // no-op
+                viewModelScope.launch {
+                    _commands.send(Command.Finish)
+                }
+            }
+        }
+    }
+
+    fun onInputModeDemoQuerySubmitted(query: String, isChat: Boolean) {
+        viewModelScope.launch {
+            if (isChat) {
+                _commands.send(Command.FinishAndSubmitChatPrompt(prompt = query))
+            } else {
+                _commands.send(Command.FinishAndSubmitSearchQuery(query = query))
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.ADDRESS_BAR_POSITION
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.COMPARISON_CHART
@@ -69,14 +70,13 @@ import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.SYNC_RESTOR
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.TypeAnimationTextView
-import com.duckduckgo.common.ui.view.quietlySetIsChecked
 import com.duckduckgo.common.ui.view.addBottomShadow
+import com.duckduckgo.common.ui.view.quietlySetIsChecked
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.isTablet
-import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.FragmentScope

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -124,6 +124,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
     private var addressBarFadeInAnimatorSet: AnimatorSet? = null
     private var inputScreenFadeInAnimatorSet: AnimatorSet? = null
     private var inputScreenPreviewFadeInAnimatorSet: AnimatorSet? = null
+    private var stepIndicatorFadeOutAnimator: ObjectAnimator? = null
     private var suggestionButtonsAnimatorSet: AnimatorSet? = null
     private var inputToggleLottieJob: Job? = null
     private var bobbingDaxAnimator: ValueAnimator? = null
@@ -548,6 +549,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         inputScreenPreviewFadeInAnimatorSet?.removeAllListeners()
         inputScreenPreviewFadeInAnimatorSet?.cancel()
         inputScreenPreviewFadeInAnimatorSet = null
+        stepIndicatorFadeOutAnimator?.removeAllListeners()
+        stepIndicatorFadeOutAnimator?.cancel()
+        stepIndicatorFadeOutAnimator = null
         suggestionButtonsAnimatorSet?.cancel()
         suggestionButtonsAnimatorSet = null
         binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.cancelAnimation()
@@ -996,11 +1000,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 INPUT_SCREEN_PREVIEW -> {
                     dismissLeftWingAnimation()
 
-                    ObjectAnimator.ofFloat(binding.daxDialogCta.stepIndicator, View.ALPHA, 0f)
+                    stepIndicatorFadeOutAnimator = ObjectAnimator.ofFloat(binding.daxDialogCta.stepIndicator, View.ALPHA, 0f)
                         .apply {
                             duration = OUTRO_FADE_DURATION
                             addListener(object : AnimatorListenerAdapter() {
                                 override fun onAnimationEnd(animation: Animator) {
+                                    if (view == null) return
                                     binding.daxDialogCta.stepIndicator.isVisible = false
                                 }
                             })

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ContentOnboardingWelcomePageUpdateBinding
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.ADDRESS_BAR_POSITION
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.COMPARISON_CHART
 import com.duckduckgo.app.onboarding.ui.page.PreOnboardingDialogType.INITIAL
@@ -69,12 +70,15 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.TypeAnimationTextView
 import com.duckduckgo.common.ui.view.quietlySetIsChecked
+import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.isTablet
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.FragmentScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -119,12 +123,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
     private var arrowSlideAnimator: android.animation.ValueAnimator? = null
     private var addressBarFadeInAnimatorSet: AnimatorSet? = null
     private var inputScreenFadeInAnimatorSet: AnimatorSet? = null
+    private var inputScreenPreviewFadeInAnimatorSet: AnimatorSet? = null
     private var inputToggleLottieJob: Job? = null
     private var bobbingDaxAnimator: ValueAnimator? = null
     private var backgroundAnimator: OnboardingBackgroundAnimator? = null
     private var changeBoundsTransition: androidx.transition.Transition? = null
     private var changeBoundsTransitionListener: TransitionListenerAdapter? = null
     private var textIntroScale = 1f
+    private var currentInputMode = InputMode.SEARCH
     private var isAnimating = false
         set(value) {
             field = value
@@ -486,6 +492,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     BrandDesignUpdatePageViewModel.Command.RequestNotificationPermissions -> requestNotificationsPermissions()
                     is BrandDesignUpdatePageViewModel.Command.ShowDefaultBrowserDialog -> showDefaultBrowserDialog(command.intent)
                     is BrandDesignUpdatePageViewModel.Command.Finish -> onContinuePressed()
+                    is BrandDesignUpdatePageViewModel.Command.FinishAndSubmitSearchQuery -> {
+                        (activity as? OnboardingActivity)?.finishAndSubmitSearchQuery(command.query)
+                    }
+                    is BrandDesignUpdatePageViewModel.Command.FinishAndSubmitChatPrompt -> {
+                        (activity as? OnboardingActivity)?.finishAndSubmitChatPrompt(command.prompt)
+                    }
                     is BrandDesignUpdatePageViewModel.Command.OnboardingSkipped -> onSkipPressed()
                     BrandDesignUpdatePageViewModel.Command.SkipDialogAnimation -> skipCurrentDialogAnimation()
                 }
@@ -532,6 +544,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         inputScreenFadeInAnimatorSet?.removeAllListeners()
         inputScreenFadeInAnimatorSet?.cancel()
         inputScreenFadeInAnimatorSet = null
+        inputScreenPreviewFadeInAnimatorSet?.removeAllListeners()
+        inputScreenPreviewFadeInAnimatorSet?.cancel()
+        inputScreenPreviewFadeInAnimatorSet = null
+        binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.cancelAnimation()
         inputToggleLottieJob?.cancel()
         inputToggleLottieJob = null
         binding.daxDialogCta.inputScreenContent.inputScreenWithAiAnimationFront.apply {
@@ -975,7 +991,153 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
 
                 INPUT_SCREEN_PREVIEW -> {
-                    // TODO
+                    dismissLeftWingAnimation()
+
+                    ObjectAnimator.ofFloat(binding.daxDialogCta.stepIndicator, View.ALPHA, 0f)
+                        .apply {
+                            duration = OUTRO_FADE_DURATION
+                            addListener(object : AnimatorListenerAdapter() {
+                                override fun onAnimationEnd(animation: Animator) {
+                                    binding.daxDialogCta.stepIndicator.isVisible = false
+                                }
+                            })
+                            start()
+                        }
+
+                    binding.daxDialogCta.root.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                        if (deviceInfo.isTablet()) {
+                            verticalBias = 0.5f
+                            bottomToTop = ConstraintLayout.LayoutParams.UNSET
+                            bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                        } else {
+                            verticalBias = 0f
+                            bottomToTop = ConstraintLayout.LayoutParams.UNSET
+                            bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                        }
+                    }
+
+                    val transition = ChangeBounds().apply {
+                        duration = DIALOG_TRANSITION_DURATION
+                    }
+                    changeBoundsTransition = transition
+                    val listener = object : TransitionListenerAdapter() {
+                        override fun onTransitionEnd(transition: androidx.transition.Transition) {
+                            if (view == null) return
+                            val previewContent = binding.daxDialogCta.inputScreenPreviewContent
+                            previewContent.inputScreenPreviewTitle.startOnboardingTypingAnimation(
+                                getString(R.string.preOnboardingInputModeDemoTitle),
+                            ) {
+                                inputScreenPreviewFadeInAnimatorSet = AnimatorSet().apply {
+                                    playTogether(
+                                        ObjectAnimator.ofFloat(previewContent.inputModeToggle, View.ALPHA, 1f)
+                                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
+                                        ObjectAnimator.ofFloat(previewContent.inputModeDemoCard, View.ALPHA, 1f)
+                                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
+                                    )
+                                    addListener(object : AnimatorListenerAdapter() {
+                                        override fun onAnimationEnd(animation: Animator) {
+                                            if (view == null) return
+
+                                            previewContent.inputText.apply {
+                                                isFocusable = true
+                                                isFocusableInTouchMode = true
+
+                                                if (resources.configuration.screenHeightDp >= MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP) {
+                                                    post {
+                                                        if (view == null) return@post
+                                                        activity?.showKeyboard(previewContent.inputText)
+                                                    }
+                                                }
+                                            }
+
+                                            val buttons = listOf(
+                                                previewContent.suggestion1,
+                                                previewContent.suggestion2,
+                                                previewContent.suggestion3,
+                                            )
+
+                                            fun animateButton(index: Int) {
+                                                if (view == null) return
+                                                if (index < buttons.size) {
+                                                    buttons[index].alpha = 0f
+                                                    TransitionManager.beginDelayedTransition(
+                                                        binding.daxDialogCta.cardView,
+                                                        ChangeBounds().apply { duration = INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION },
+                                                    )
+                                                    buttons[index].isVisible = true
+                                                    buttons[index].animate()
+                                                        .alpha(1f)
+                                                        .setDuration(INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION)
+                                                        .withEndAction {
+                                                            if (index == buttons.size - 1) {
+                                                                isAnimating = false
+                                                            }
+                                                            animateButton(index + 1)
+                                                        }
+                                                        .start()
+                                                }
+                                            }
+
+                                            viewLifecycleOwner.lifecycleScope.launch {
+                                                delay(INPUT_SCREEN_PREVIEW_SUGGESTIONS_ANIMATION_DELAY)
+                                                animateButton(0)
+                                            }
+                                        }
+                                    })
+                                    start()
+                                }
+                            }
+                        }
+                    }
+                    changeBoundsTransitionListener = listener
+                    transition.addListener(listener)
+
+                    TransitionManager.beginDelayedTransition(binding.root as ViewGroup, transition)
+
+                    binding.daxDialogCta.cardView.setShowArrow(false)
+                    binding.daxDialogCta.inputScreenContent.root.isVisible = false
+                    binding.daxDialogCta.inputScreenPreviewContent.root.isVisible = true
+
+                    if (android.os.Build.VERSION.SDK_INT >= 28) {
+                        binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.addBottomShadow()
+                    }
+
+                    binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.alpha = 0f
+                    binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.alpha = 0f
+                    binding.daxDialogCta.primaryCta.isVisible = false
+
+                    val state = viewModel.viewState.value
+                    val defaultMode = if (state.inputScreenPreviewIsSearchSelected) InputMode.SEARCH else InputMode.CHAT
+                    val suggestions = if (state.inputScreenPreviewIsSearchSelected) {
+                        state.inputScreenPreviewSearchSuggestions
+                    } else {
+                        state.inputScreenPreviewChatSuggestions
+                    }
+                    setInputScreenPreviewInputMode(defaultMode, suggestions)
+
+                    if (!state.inputScreenPreviewIsSearchSelected) {
+                        binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.getTabAt(1)?.select()
+                    }
+
+                    binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.addOnTabSelectedListener(
+                        object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
+                            override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
+                                val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
+                                TransitionManager.beginDelayedTransition(
+                                    binding.daxDialogCta.cardView,
+                                    changeBounds,
+                                )
+                                val tabState = viewModel.viewState.value
+                                if (tab.position == 0) {
+                                    setInputScreenPreviewInputMode(InputMode.SEARCH, tabState.inputScreenPreviewSearchSuggestions)
+                                } else {
+                                    setInputScreenPreviewInputMode(InputMode.CHAT, tabState.inputScreenPreviewChatSuggestions)
+                                }
+                            }
+                            override fun onTabUnselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+                            override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+                        },
+                    )
                 }
             }
         }
@@ -1270,7 +1432,101 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             }
 
             INPUT_SCREEN_PREVIEW -> {
-                // TODO
+                if (binding.daxDialogCta.inputScreenPreviewContent.root.isVisible) {
+                    return
+                }
+
+                binding.logoAnimation.alpha = 0f
+                binding.welcomeTitle.alpha = 0f
+
+                binding.leftWingAnimation.isVisible = false
+                binding.bottomWingAnimation.isVisible = false
+
+                backgroundAnimator?.snapTo(OnboardingBackgroundStep.InputType)
+
+                binding.welcomeScreenWalkingDax.isVisible = false
+                binding.daxDialogCta.root.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                    if (deviceInfo.isTablet()) {
+                        verticalBias = 0.5f
+                        bottomToTop = ConstraintLayout.LayoutParams.UNSET
+                        bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                    } else {
+                        verticalBias = 0f
+                        bottomToTop = ConstraintLayout.LayoutParams.UNSET
+                        bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
+                    }
+                }
+
+                binding.daxDialogCta.cardView.setShowArrow(false)
+
+                binding.daxDialogCta.welcomeContent.root.isVisible = false
+                binding.daxDialogCta.secondaryCta.isVisible = false
+                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+                binding.daxDialogCta.addressBarContent.root.isVisible = false
+                binding.daxDialogCta.inputScreenContent.root.isVisible = false
+
+                binding.daxDialogCta.inputScreenPreviewContent.root.isVisible = true
+
+                if (android.os.Build.VERSION.SDK_INT >= 28) {
+                    binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.addBottomShadow()
+                }
+
+                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.cancelAnimation()
+                binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.text =
+                    getString(R.string.preOnboardingInputModeDemoTitle).html(requireContext())
+                binding.daxDialogCta.inputScreenPreviewContent.inputModeToggle.alpha = 1f
+                binding.daxDialogCta.inputScreenPreviewContent.inputModeDemoCard.alpha = 1f
+
+                binding.daxDialogCta.inputScreenPreviewContent.inputText.apply {
+                    isFocusable = true
+                    isFocusableInTouchMode = true
+                }
+
+                val previewContent = binding.daxDialogCta.inputScreenPreviewContent
+                listOf(previewContent.suggestion1, previewContent.suggestion2, previewContent.suggestion3).forEach {
+                    it.alpha = 1f
+                    it.isVisible = true
+                }
+
+                val state = viewModel.viewState.value
+                val defaultMode = if (state.inputScreenPreviewIsSearchSelected) InputMode.SEARCH else InputMode.CHAT
+                val suggestions = if (state.inputScreenPreviewIsSearchSelected) {
+                    state.inputScreenPreviewSearchSuggestions
+                } else {
+                    state.inputScreenPreviewChatSuggestions
+                }
+                setInputScreenPreviewInputMode(defaultMode, suggestions)
+
+                if (!state.inputScreenPreviewIsSearchSelected) {
+                    previewContent.inputModeToggle.getTabAt(1)?.select()
+                }
+
+                previewContent.inputModeToggle.addOnTabSelectedListener(
+                    object : com.google.android.material.tabs.TabLayout.OnTabSelectedListener {
+                        override fun onTabSelected(tab: com.google.android.material.tabs.TabLayout.Tab) {
+                            val changeBounds = ChangeBounds().apply { duration = DIALOG_TRANSITION_DURATION }
+                            TransitionManager.beginDelayedTransition(
+                                binding.daxDialogCta.cardView,
+                                changeBounds,
+                            )
+                            val tabState = viewModel.viewState.value
+                            if (tab.position == 0) {
+                                setInputScreenPreviewInputMode(InputMode.SEARCH, tabState.inputScreenPreviewSearchSuggestions)
+                            } else {
+                                setInputScreenPreviewInputMode(InputMode.CHAT, tabState.inputScreenPreviewChatSuggestions)
+                            }
+                        }
+                        override fun onTabUnselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+                        override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
+                    },
+                )
+
+                binding.daxDialogCta.stepIndicator.isVisible = false
+                binding.daxDialogCta.primaryCta.isVisible = false
+
+                binding.daxDialogCta.root.isVisible = true
+                binding.daxDialogCta.root.translationZ = 1f.toPx()
+                binding.daxDialogCta.daxCtaContainer.alpha = 1f
             }
         }
     }
@@ -1419,6 +1675,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 comparisonChartContent.comparisonChartTitle,
                 addressBarContent.addressBarTitle,
                 inputScreenContent.inputScreenTitle,
+                inputScreenPreviewContent.inputScreenPreviewTitle,
             ).filter { it.hasAnimationStarted() }.forEach { it.performClick() }
         }
 
@@ -1429,6 +1686,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         skipOnboardingFadeInAnimatorSet?.end()
         addressBarFadeInAnimatorSet?.end()
         inputScreenFadeInAnimatorSet?.end()
+        inputScreenPreviewFadeInAnimatorSet?.end()
 
         // Snap check icons to final state — the postDelayed AVD runnables would otherwise animate them in one by one
         snapCheckIconsToFinalState()
@@ -1522,6 +1780,60 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         }
     }
 
+    private fun dismissLeftWingAnimation() {
+        binding.leftWingAnimation.apply {
+            if (!isVisible) return
+            setMinProgress(WING_STOP_PROGRESS)
+            setMaxProgress(1f)
+            speed = 1f
+            addAnimatorListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    isGone = true
+                    removeAnimatorListener(this)
+                }
+            })
+            playAnimation()
+        }
+    }
+
+    private fun setInputScreenPreviewInputMode(
+        inputMode: InputMode,
+        suggestions: List<DaxDialogIntroOption>,
+    ) {
+        currentInputMode = inputMode
+        val previewContent = binding.daxDialogCta.inputScreenPreviewContent
+
+        listOf(previewContent.suggestion1, previewContent.suggestion2, previewContent.suggestion3)
+            .forEachIndexed { index, button ->
+                suggestions[index].setOptionView(button)
+                button.setOnClickListener {
+                    viewModel.onInputModeDemoQuerySubmitted(suggestions[index].link, isChat = inputMode == InputMode.CHAT)
+                }
+            }
+
+        previewContent.inputModeDemoActionIcon.setOnClickListener {
+            val query = previewContent.inputText.text?.toString().orEmpty().trim()
+            if (query.isNotEmpty()) {
+                viewModel.onInputModeDemoQuerySubmitted(query, isChat = currentInputMode == InputMode.CHAT)
+            }
+        }
+
+        when (inputMode) {
+            InputMode.SEARCH -> {
+                previewContent.inputText.minLines = 1
+                previewContent.inputText.maxLines = 1
+                previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoSearchHint)
+                previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
+            }
+            InputMode.CHAT -> {
+                previewContent.inputText.minLines = 3
+                previewContent.inputText.maxLines = 3
+                previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoChatHint)
+                previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
+            }
+        }
+    }
+
     private fun playLeftWingAnimation() {
         binding.leftWingAnimation?.apply {
             isVisible = true
@@ -1557,6 +1869,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
          */
         CROSSFADE_ANIMATE,
     }
+
+    private enum class InputMode { SEARCH, CHAT }
 
     private fun updateAiChatToggleState(
         binding: ContentOnboardingWelcomePageUpdateBinding,
@@ -1698,6 +2012,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         private const val DIALOG_TRANSITION_DURATION = 400L
         private const val INPUT_TOGGLE_LOTTIE_REPEAT_DELAY = 2000L
         private const val INPUT_TOGGLE_LOTTIE_INITIAL_DELAY = 2000L
+        private const val INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION = 500L
+        private const val INPUT_SCREEN_PREVIEW_SUGGESTIONS_ANIMATION_DELAY = 500L
+        private const val MIN_SCREEN_HEIGHT_FOR_KEYBOARD_DP = 600
         private const val ARROW_TARGET_OFFSET_END_DP = 80
 
         private const val WING_START_DELAY = 300L

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -124,6 +124,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
     private var addressBarFadeInAnimatorSet: AnimatorSet? = null
     private var inputScreenFadeInAnimatorSet: AnimatorSet? = null
     private var inputScreenPreviewFadeInAnimatorSet: AnimatorSet? = null
+    private var suggestionButtonsAnimatorSet: AnimatorSet? = null
     private var inputToggleLottieJob: Job? = null
     private var bobbingDaxAnimator: ValueAnimator? = null
     private var backgroundAnimator: OnboardingBackgroundAnimator? = null
@@ -547,6 +548,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         inputScreenPreviewFadeInAnimatorSet?.removeAllListeners()
         inputScreenPreviewFadeInAnimatorSet?.cancel()
         inputScreenPreviewFadeInAnimatorSet = null
+        suggestionButtonsAnimatorSet?.cancel()
+        suggestionButtonsAnimatorSet = null
         binding.daxDialogCta.inputScreenPreviewContent.inputScreenPreviewTitle.cancelAnimation()
         inputToggleLottieJob?.cancel()
         inputToggleLottieJob = null
@@ -1050,38 +1053,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                                 }
                                             }
 
-                                            val buttons = listOf(
-                                                previewContent.suggestion1,
-                                                previewContent.suggestion2,
-                                                previewContent.suggestion3,
-                                            )
-
-                                            fun animateButton(index: Int) {
-                                                if (view == null) return
-                                                if (index < buttons.size) {
-                                                    buttons[index].alpha = 0f
-                                                    TransitionManager.beginDelayedTransition(
-                                                        binding.daxDialogCta.cardView,
-                                                        ChangeBounds().apply { duration = INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION },
-                                                    )
-                                                    buttons[index].isVisible = true
-                                                    buttons[index].animate()
-                                                        .alpha(1f)
-                                                        .setDuration(INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION)
-                                                        .withEndAction {
-                                                            if (index == buttons.size - 1) {
-                                                                isAnimating = false
-                                                            }
-                                                            animateButton(index + 1)
-                                                        }
-                                                        .start()
-                                                }
-                                            }
-
-                                            viewLifecycleOwner.lifecycleScope.launch {
-                                                delay(INPUT_SCREEN_PREVIEW_SUGGESTIONS_ANIMATION_DELAY)
-                                                animateButton(0)
-                                            }
+                                            playSuggestionButtonsAnimation()
                                         }
                                     })
                                     start()
@@ -1483,10 +1455,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
 
                 val previewContent = binding.daxDialogCta.inputScreenPreviewContent
-                listOf(previewContent.suggestion1, previewContent.suggestion2, previewContent.suggestion3).forEach {
-                    it.alpha = 1f
-                    it.isVisible = true
-                }
 
                 val state = viewModel.viewState.value
                 val defaultMode = if (state.inputScreenPreviewIsSearchSelected) InputMode.SEARCH else InputMode.CHAT
@@ -1520,6 +1488,13 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         override fun onTabReselected(tab: com.google.android.material.tabs.TabLayout.Tab) {}
                     },
                 )
+
+                with(binding.daxDialogCta.inputScreenPreviewContent) {
+                    listOf(suggestion1, suggestion2, suggestion3).forEach { button ->
+                        button.alpha = 1f
+                        button.isVisible = true
+                    }
+                }
 
                 binding.daxDialogCta.stepIndicator.isVisible = false
                 binding.daxDialogCta.primaryCta.isVisible = false
@@ -1687,6 +1662,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         addressBarFadeInAnimatorSet?.end()
         inputScreenFadeInAnimatorSet?.end()
         inputScreenPreviewFadeInAnimatorSet?.end()
+        suggestionButtonsAnimatorSet?.end()
 
         // Snap check icons to final state — the postDelayed AVD runnables would otherwise animate them in one by one
         snapCheckIconsToFinalState()
@@ -1796,6 +1772,21 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         }
     }
 
+    private fun playLeftWingAnimation() {
+        binding.leftWingAnimation?.apply {
+            isVisible = true
+            alpha = 0f
+            setMaxProgress(WING_STOP_PROGRESS)
+            leftWingDelayedRunnable = postDelayed(WING_START_DELAY) {
+                animate()
+                    .alpha(1f)
+                    .setDuration(WING_FADE_IN_DURATION)
+                    .start()
+                playAnimation()
+            }
+        }
+    }
+
     private fun setInputScreenPreviewInputMode(
         inputMode: InputMode,
         suggestions: List<DaxDialogIntroOption>,
@@ -1834,18 +1825,39 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         }
     }
 
-    private fun playLeftWingAnimation() {
-        binding.leftWingAnimation?.apply {
-            isVisible = true
-            alpha = 0f
-            setMaxProgress(WING_STOP_PROGRESS)
-            leftWingDelayedRunnable = postDelayed(WING_START_DELAY) {
-                animate()
-                    .alpha(1f)
-                    .setDuration(WING_FADE_IN_DURATION)
-                    .start()
-                playAnimation()
+    private fun playSuggestionButtonsAnimation() {
+        val previewContent = binding.daxDialogCta.inputScreenPreviewContent
+        val buttons = listOf(
+            previewContent.suggestion1,
+            previewContent.suggestion2,
+            previewContent.suggestion3,
+        )
+
+        TransitionManager.beginDelayedTransition(
+            binding.daxDialogCta.cardView,
+            ChangeBounds().apply { duration = INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION },
+        )
+        buttons.forEach { button ->
+            button.alpha = 0f
+            button.isVisible = true
+        }
+
+        val buttonAnimators = buttons.mapIndexed { index, button ->
+            ObjectAnimator.ofFloat(button, View.ALPHA, 0f, 1f).apply {
+                duration = INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION
+                startDelay = index * INPUT_SCREEN_PREVIEW_SUGGESTION_ANIMATION_DURATION
             }
+        }
+
+        suggestionButtonsAnimatorSet = AnimatorSet().apply {
+            playTogether(buttonAnimators)
+            this.startDelay = INPUT_SCREEN_PREVIEW_SUGGESTIONS_ANIMATION_DELAY
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    isAnimating = false
+                }
+            })
+            start()
         }
     }
 

--- a/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
+++ b/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="28dp"
+        android:paddingHorizontal="12dp">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/inputScreenPreviewTitleHidden"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/preOnboardingInputModeDemoTitle"
+            android:visibility="invisible"
+            app:typography="onboarding_title" />
+
+        <com.duckduckgo.common.ui.view.TypeAnimationTextView
+            android:id="@+id/inputScreenPreviewTitle"
+            style="@style/Typography.DuckDuckGo.Onboarding.Title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            android:textColor="?attr/daxColorPrimaryText" />
+
+    </FrameLayout>
+
+    <com.duckduckgo.browser.ui.inputmode.InputModeTabLayout
+        android:id="@+id/inputModeToggle"
+        style="@style/Widget.DuckDuckGo.TabLayout.Rounded"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/inputModeSwitchHeight">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout="@layout/view_search_tab_indicator" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout="@layout/view_chat_tab_indicator" />
+
+    </com.duckduckgo.browser.ui.inputmode.InputModeTabLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/inputModeDemoCard"
+        style="@style/Widget.DuckDuckGo.OmnibarCardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_3"
+        app:cardElevation="0dp"
+        app:strokeColor="?attr/daxColorLines"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="@dimen/keyline_0">
+
+            <EditText
+                android:id="@+id/inputText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="10dp"
+                android:layout_weight="1"
+                android:background="@null"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:fontFamily="sans-serif"
+                android:gravity="start|top"
+                android:hint="@string/preOnboardingInputModeDemoSearchHint"
+                android:importantForAutofill="no"
+                android:maxLines="1"
+                android:minHeight="@dimen/toolbarIcon"
+                android:paddingVertical="@dimen/keyline_2"
+                android:textColor="?attr/daxColorPrimaryText"
+                android:textColorHint="?attr/daxColorSecondaryText"
+                android:textCursorDrawable="@drawable/text_cursor"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                tools:ignore="Autofill,LabelFor,TextFields" />
+
+            <ImageView
+                android:id="@+id/inputModeDemoActionIcon"
+                android:layout_width="@dimen/toolbarIcon"
+                android:layout_height="@dimen/toolbarIcon"
+                android:layout_gravity="bottom"
+                android:background="@drawable/selectable_item_rounded_corner_background"
+                android:gravity="center"
+                android:importantForAccessibility="no"
+                android:scaleType="center"
+                app:srcCompat="@drawable/ic_find_search_24"
+                app:tint="?attr/daxColorSecondaryIcon" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingSelectionButton
+        android:id="@+id/suggestion1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:alpha="0"
+        android:gravity="start|center_vertical"
+        android:visibility="gone"
+        app:icon="@drawable/ic_find_search_16"
+        tools:alpha="1"
+        tools:text="how to say duck in spanish"
+        tools:visibility="visible" />
+
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingSelectionButton
+        android:id="@+id/suggestion2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:alpha="0"
+        android:gravity="start|center_vertical"
+        android:visibility="gone"
+        app:icon="@drawable/ic_find_search_16"
+        tools:alpha="1"
+        tools:text="mighty ducks cast"
+        tools:visibility="visible" />
+
+    <com.duckduckgo.app.onboarding.ui.view.OnboardingSelectionButton
+        android:id="@+id/suggestion3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:alpha="0"
+        android:gravity="start|center_vertical"
+        android:visibility="gone"
+        app:icon="@drawable/ic_wand_16"
+        tools:alpha="1"
+        tools:text="Surprise me!"
+        tools:visibility="visible" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
+++ b/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
@@ -92,8 +92,6 @@
                 android:layout_marginStart="10dp"
                 android:layout_weight="1"
                 android:background="@null"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
                 android:fontFamily="sans-serif"
                 android:gravity="start|top"
                 android:hint="@string/preOnboardingInputModeDemoSearchHint"

--- a/app/src/main/res/layout/pre_onboarding_dax_dialog_cta_brand_design_update.xml
+++ b/app/src/main/res/layout/pre_onboarding_dax_dialog_cta_brand_design_update.xml
@@ -80,6 +80,13 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone" />
 
+                <include
+                    android:id="@+id/inputScreenPreviewContent"
+                    layout="@layout/include_brand_design_input_screen_preview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
+
                 <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
                     android:id="@+id/primaryCta"
                     android:layout_width="match_parent"

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -21,8 +21,11 @@ import android.content.Context
 import android.content.Intent
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentManager.DuckAiOnboardingExperimentVariant
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.BrandDesignUpdatePageViewModel.Command
 import com.duckduckgo.app.pixels.AppPixelName
@@ -83,6 +86,7 @@ class BrandDesignUpdatePageViewModelTest {
     )
     private val mockDuckChat: DuckChat = mock()
     private val mockInputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent = mock()
+    private val mockDuckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager = mock()
 
     private fun createViewModel(): BrandDesignUpdatePageViewModel {
         return BrandDesignUpdatePageViewModel(
@@ -97,6 +101,7 @@ class BrandDesignUpdatePageViewModelTest {
             mockAndroidBrowserConfigFeature,
             mockDuckChat,
             mockInputScreenOnboardingWideEvent,
+            mockDuckAiOnboardingExperimentManager,
         )
     }
 
@@ -711,6 +716,159 @@ class BrandDesignUpdatePageViewModelTest {
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
         testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
         verify(mockPixel).fire(PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE, type = Unique())
+    }
+
+    // endregion
+
+    // region onPrimaryCtaClicked - input screen enrollment
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsNullThenFinish() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(null)
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(true)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.commands.test {
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN -> Finish
+            val command = awaitItem()
+            assertTrue(command is Command.Finish)
+        }
+    }
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsControlThenFinish() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.CONTROL)
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(true)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.commands.test {
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN -> Finish
+            val command = awaitItem()
+            assertTrue(command is Command.Finish)
+        }
+    }
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsTreatmentDuckAiThenShowInputScreenPreview() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_DUCK_AI_DEFAULT)
+        val searchOptions = listOf(DaxDialogIntroOption("search1", 0, "link1"))
+        val chatSuggestions = listOf(DaxDialogIntroOption("chat1", 0, "link2"))
+        whenever(mockOnboardingStore.getSearchOptions()).thenReturn(searchOptions)
+        whenever(mockOnboardingStore.getChatSuggestions()).thenReturn(chatSuggestions)
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(true)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.viewState.test {
+            val preInputScreen = awaitItem()
+            assertEquals(PreOnboardingDialogType.INPUT_SCREEN, preInputScreen.currentDialog)
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN -> INPUT_SCREEN_PREVIEW
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.INPUT_SCREEN_PREVIEW, state.currentDialog)
+            assertFalse(state.inputScreenPreviewIsSearchSelected)
+            assertEquals(searchOptions, state.inputScreenPreviewSearchSuggestions)
+            assertEquals(chatSuggestions, state.inputScreenPreviewChatSuggestions)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsTreatmentSearchThenShowInputScreenPreviewWithSearchDefault() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_SEARCH_DEFAULT)
+        val searchOptions = listOf(DaxDialogIntroOption("search1", 0, "link1"))
+        val chatSuggestions = listOf(DaxDialogIntroOption("chat1", 0, "link2"))
+        whenever(mockOnboardingStore.getSearchOptions()).thenReturn(searchOptions)
+        whenever(mockOnboardingStore.getChatSuggestions()).thenReturn(chatSuggestions)
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(true)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.viewState.test {
+            val preInputScreen = awaitItem()
+            assertEquals(PreOnboardingDialogType.INPUT_SCREEN, preInputScreen.currentDialog)
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN -> INPUT_SCREEN_PREVIEW
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.INPUT_SCREEN_PREVIEW, state.currentDialog)
+            assertTrue(state.inputScreenPreviewIsSearchSelected)
+            assertEquals(searchOptions, state.inputScreenPreviewSearchSuggestions)
+            assertEquals(chatSuggestions, state.inputScreenPreviewChatSuggestions)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenWithSearchOnlySelectedThenDoNotEnrollAndFinish() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(false)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.commands.test {
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN -> Finish
+            val command = awaitItem()
+            assertTrue(command is Command.Finish)
+        }
+        verify(mockDuckAiOnboardingExperimentManager, never()).enroll()
+    }
+
+    // endregion
+
+    // region onPrimaryCtaClicked - input screen preview
+
+    @Test
+    fun whenPrimaryCtaFromInputScreenPreviewThenFinish() = runTest {
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_SEARCH_DEFAULT)
+        whenever(mockOnboardingStore.getSearchOptions()).thenReturn(emptyList())
+        whenever(mockOnboardingStore.getChatSuggestions()).thenReturn(emptyList())
+        val testee = createViewModel()
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        testee.onInputScreenOptionSelected(true)
+        testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> INPUT_SCREEN
+        testee.onPrimaryCtaClicked() // INPUT_SCREEN -> INPUT_SCREEN_PREVIEW
+        testee.commands.test {
+            testee.onPrimaryCtaClicked() // INPUT_SCREEN_PREVIEW -> Finish
+            val command = awaitItem()
+            assertTrue(command is Command.Finish)
+        }
+    }
+
+    // endregion
+
+    // region onInputModeDemoQuerySubmitted
+
+    @Test
+    fun whenInputModeDemoQuerySubmittedWithChatThenSendFinishAndSubmitChatPromptCommand() = runTest {
+        val testee = createViewModel()
+        testee.commands.test {
+            testee.onInputModeDemoQuerySubmitted("hello world", isChat = true)
+            val command = awaitItem()
+            assertTrue(command is Command.FinishAndSubmitChatPrompt)
+            assertEquals("hello world", (command as Command.FinishAndSubmitChatPrompt).prompt)
+        }
+    }
+
+    @Test
+    fun whenInputModeDemoQuerySubmittedWithSearchThenSendFinishAndSubmitSearchQueryCommand() = runTest {
+        val testee = createViewModel()
+        testee.commands.test {
+            testee.onInputModeDemoQuerySubmitted("search query", isChat = false)
+            val command = awaitItem()
+            assertTrue(command is Command.FinishAndSubmitSearchQuery)
+            assertEquals("search query", (command as Command.FinishAndSubmitSearchQuery).query)
+        }
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1213978992592365

### Description
Builds on top of https://github.com/duckduckgo/Android/pull/8277 to port changes first introduced in https://github.com/duckduckgo/Android/pull/8206 and reskin them with the new brand design.

As of now, interacting with the toggle and submitting a search query/prompt just moves forward to the `BrowserActivity` without making any other onboarding consideration - those will be added later.

### Steps to test this PR

Apply below changes to the codebase before building:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
index e6989766ea..d9810a3fd3 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -45,7 +45,8 @@ class OnboardingViewModel @Inject constructor(
     val viewState = _viewState.asStateFlow()
 
     fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+        // pageLayoutManager.buildPageBlueprints()
+        pageLayoutManager.buildBrandDesignUpdatePageBlueprints()
     }
 
     fun pageCount(): Int {
@@ -70,6 +71,7 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun initializeOnboardingSkipper() {
+        return
         if (!appBuildConfig.canSkipOnboarding) return
 
         // delay showing skip button until privacy config downloaded
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index d0ad527e58..0798d3f69a 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -34,13 +34,13 @@ interface OnboardingBrandDesignUpdateToggles {
      * Main toggle for the onboarding brand design update feature.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
      * Toggle for the brand design update variant.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 }
```
- [x] Clear data and install the app.
- [x] Go through onboarding until the search/toggle input selection screen.
- [x] Pick the toggle and continue.
- [x] Verify the browser opens and onboarding continues without input preview.
---
Additionally apply below changes to the codebase before building:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
index 06a316c8af..10efa279dd 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
@@ -54,6 +54,7 @@ class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
             onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
         }
         if (isBrandDesignEnabled) {
+            return DuckAiOnboardingExperimentVariant.TREATMENT_WITH_DUCK_AI_DEFAULT
             // TODO experiment 2 setup
         } else {
             // TODO experiment 1 setup
```
- [x] Clear data and install the app.
- [x] Go through onboarding until the search/toggle input selection screen and pick the toggle.
- [x] Verify that:
  - [x] The input preview animates in smoothly,
  - [x] The Dax wing is dismissed.
  - [x] The card arrow is dismissed and it becomes just a rectangle with rounded corners.
  - [x] Once the typing animation finishes and input box shows, suggestions are faded-in one-by-one.
- [x] Switch to "Search" tab.
- [x] Verify that suggestions change and input box collapses to 1 line.
- [x] Switch to "Duck.ai" tab.
- [x] Verify that suggestions change and input box expands to 3 lines.
- [x] Rotate the screen and verify everything remains in place without any transitions.
- [x] Change theme between light/dark and verify it matches design.
- [x] Submit a prompt.
- [x] Verify browser opens and immediately loads Duck.ai.
---
- [x] Clear data and install the app.
- [x] Go through the flow again.
- [x] By the end, switch to "Search" tab and submit a query.
- [x] Verify browser opens and immediately searches.
---
- [x] Clear data and install the app.
- [x] Go through the flow again until the search/toggle input selection screen.
- [x] Pick the toggle but once the elements transition, rotate the screen.
- [x] Verify that the content snaps into place.
---
- [x] Clear data and install the app.
- [x] Go through the flow again until the search/toggle input selection screen. On each screen, tap the background or the card to skip animations.
- [x] Pick the toggle but once the elements transition, click the background/card.
- [x] Verify that the content snaps into place.
---
- [x] Clear data and install the app.
- [x] Go through the flow again until the search/toggle input selection screen.
- [x] Pick search-only and continue.
- [x] Verify that browser opens and onboarding flow continues (no toggle preview).

### UI changes

https://github.com/user-attachments/assets/28592850-9617-45a6-87b2-c83a8b684774





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding navigation and adds a new interactive preview step that can launch `BrowserActivity` with either a search query or Duck.ai prompt; issues could break or regress the onboarding flow/animations across rotations and lifecycle events.
> 
> **Overview**
> Adds a new `INPUT_SCREEN_PREVIEW` step to the brand design update onboarding flow, shown after the input-mode selection when `DuckAiOnboardingExperimentManager.enroll()` assigns a treatment variant.
> 
> The preview UI includes a search/chat tab toggle, an editable input field, and animated suggestion buttons; selecting a suggestion or submitting text now finishes onboarding and launches `BrowserActivity` with either `queryExtra` (search) or a generated Duck.ai URL.
> 
> Also updates the experiment manager to branch on the brand-design toggle (setup still TODO), tweaks a chat suggestion icon, adds the new preview layout include, and expands unit tests to cover enrollment/preview and the new finish-and-submit commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e7ebb02865bcb1a46e10efd1fe4c94e6cd6861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->