### PR TITLE
Update gradle develocity plugin to 4.4.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,8 +7,8 @@ pluginManagement {
 
 plugins {
     id("de.fayard.refreshVersions") version "0.60.5"
-    id("com.gradle.develocity") version "4.3.2"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
+    id("com.gradle.develocity") version "4.4.0"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
 }
 
 rootProject.name = "androidRoot"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1214118231182761?focus=true

### Description
Develocity instance was updated recently, so we can update to latest gradle plugin which is 4.4.0. 
Also updates the custom-user-data gradle plugin to 2.6.0.

### Steps to test this PR
QA optional - can see if the build scan from this PR publishes

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bumps in build tooling only; primary risk is potential build scan/cache behavior changes or incompatibilities introduced by the new plugin versions.
> 
> **Overview**
> Updates build tooling by bumping `com.gradle.develocity` from `4.3.2` to `4.4.0` and `com.gradle.common-custom-user-data-gradle-plugin` from `2.4.0` to `2.6.0` in `settings.gradle`.
> 
> No other build configuration or project logic changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c4f2d6444ee137a03fc75a477d03e2ad34f976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->