### PR TITLE
Treat "Always" idle option as 0 seconds (immediate)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -98,7 +98,7 @@ class FirstScreenHandlerImpl @Inject constructor(
 
     companion object {
         const val DEFAULT_IDLE_THRESHOLD_SECONDS = 300L
-        val DEFAULT_IDLE_THRESHOLD_OPTIONS = listOf(1L, 60L, 300L, 600L, 1800L, 3600L, 43200L, 86400L)
+        val DEFAULT_IDLE_THRESHOLD_OPTIONS = listOf(0L, 60L, 300L, 600L, 1800L, 3600L, 43200L, 86400L)
 
         fun parseDefaultIdleThresholdSeconds(settingsJson: String?): Long? {
             if (settingsJson == null) return null

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -168,7 +168,7 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
     }
 
     private fun Long.toTimeoutLabel(): String = when {
-        this == 1L -> getString(R.string.afterInactivityTimeoutAlways)
+        this == 0L -> getString(R.string.afterInactivityTimeoutAlways)
         this < 3600L -> {
             val minutes = this / 60
             if (minutes == 1L) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -166,7 +166,7 @@ class ShowOnAppLaunchViewModelTest {
 
     @Test
     fun whenUserPreferenceSetThenSelectedIsUserPreference() = runTest {
-        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(1L)
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(
             Toggle.State(true, settings = """{"defaultIdleThresholdSeconds":300}"""),
         )
@@ -176,7 +176,7 @@ class ShowOnAppLaunchViewModelTest {
 
         testee.viewState.test {
             val state = awaitItem()
-            assertEquals(1L, state.selectedIdleThresholdSeconds)
+            assertEquals(0L, state.selectedIdleThresholdSeconds)
         }
     }
 
@@ -216,12 +216,12 @@ class ShowOnAppLaunchViewModelTest {
 
     @Test
     fun whenTimeoutSelectedThenViewStateUpdated() = runTest {
-        testee.onTimeoutSelected(1L)
+        testee.onTimeoutSelected(0L)
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
         testee.viewState.test {
             val state = awaitItem()
-            assertEquals(1L, state.selectedIdleThresholdSeconds)
+            assertEquals(0L, state.selectedIdleThresholdSeconds)
         }
     }
 

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NtpAfterIdlePixelName.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NtpAfterIdlePixelName.kt
@@ -59,7 +59,7 @@ enum class NtpAfterIdlePixelName(override val pixelName: String) : Pixel.PixelNa
 object NtpAfterIdlePixels {
     /** Returns the count and daily pixel pair for the given timeout [seconds], or null if unknown. */
     fun timeoutPixelsForSeconds(seconds: Long): Pair<NtpAfterIdlePixelName, NtpAfterIdlePixelName>? = when (seconds) {
-        1L -> Pair(NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS, NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS_DAILY)
+        0L -> Pair(NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS, NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS_DAILY)
         60L -> Pair(NtpAfterIdlePixelName.TIMEOUT_SELECTED_60, NtpAfterIdlePixelName.TIMEOUT_SELECTED_60_DAILY)
         300L -> Pair(NtpAfterIdlePixelName.TIMEOUT_SELECTED_300, NtpAfterIdlePixelName.TIMEOUT_SELECTED_300_DAILY)
         600L -> Pair(NtpAfterIdlePixelName.TIMEOUT_SELECTED_600, NtpAfterIdlePixelName.TIMEOUT_SELECTED_600_DAILY)

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -181,7 +181,7 @@ class NtpAfterIdleManagerImplTest {
 
     @Test
     fun whenOnIdleTimeoutSelectedWithAlwaysValueThenFiresAlwaysPixelPair() {
-        testee.onIdleTimeoutSelected(1L)
+        testee.onIdleTimeoutSelected(0L)
 
         verify(pixel).fire(TIMEOUT_SELECTED_ALWAYS, type = Count)
         verify(pixel).fire(TIMEOUT_SELECTED_ALWAYS_DAILY, type = Daily())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214086381926895?focus=true

### Description
The idle-return "Always" option was mapped to 1L second. With a 1s timeout, a background+foreground cycle shorter than one second wouldn't trigger the return-to-NTP behaviour, which doesn't match what the label 'Always' implies.
This PR updates it to be 0 seconds instead (as immediate as possible)

Important notes ⚠️:
- Existing testers who had the "Always" option selected will see "0 minutes" upon update. They should reselect "Always" for the setting to apply. A proper migration was deemed unnecessary because it complicates the code and since this is not released yet, it's only internal. This only impacts people who downloaded the older version of the build and selected "Always" as their setting.
- There is a very short duration (~200ms) after the app is put in the background where android delays running the onStop lifecycle callback. If the user re-foregrounds within that window, we never observe a background event. So if you are REALLY fast in reopening the app, android did not have time to inform the app of the background status. In this case the app will reopen as if it was never put in the background. Nothing we can do about that. 


### Steps to test this PR
- Enable the showNTPAfterIdleReturn remote feature flag
- Select "Always" in Settings -> General -> AFter Inactivity -> Choose an inactivity timer
- Load any website
- Put the app in the background and quickly open it again. Note the timing is tricky here because you should still wait around 200ms for android to put the app in the background. 
- The NTP should show up


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the semantics of the "Always" after-inactivity timeout from 1s to 0s, which affects when the app returns to the NTP on background/foreground and could alter behavior for existing saved preferences and related analytics.
> 
> **Overview**
> Treats the after-inactivity "Always" setting as **0 seconds (immediate)** instead of `1L` across settings defaults, UI labeling, and pixel mapping.
> 
> Updates associated unit tests to expect `0L` for the "Always" option and verifies the corresponding timeout-selection pixel pair is fired for `0L`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051d890569e11e7e0ac103094ac86191e552619d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->