### PR TITLE
RMF Survey Param: last search state

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.history.api.HistoryEntry
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.survey.api.SurveyParameterPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
@@ -149,7 +149,7 @@ class LastSearchStateSurveyParameterPlugin @Inject constructor(
     override fun matches(paramKey: String): Boolean = paramKey == "last_search_state"
 
     override suspend fun evaluate(paramKey: String): String {
-        val history = navigationHistory.getHistory().first()
+        val history = navigationHistory.getHistory().firstOrNull() ?: return "none"
         val mostRecentSearch = history
             .filterIsInstance<HistoryEntry.VisitedSERP>()
             .flatMap { it.visits }

--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
@@ -22,11 +22,16 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.survey.ui.SurveyActivity.Companion.SurveySource.IN_APP
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.history.api.HistoryEntry
+import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.survey.api.SurveyParameterPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
 
 @ContributesMultibinding(AppScope::class)
 class AtbSurveyParameterPlugin @Inject constructor(
@@ -133,5 +138,29 @@ class CohortSurveyParameterPlugin @Inject constructor(
         return matchingExperiment?.let {
             "${it.featureName().name}_${it.getCohort()?.name}"
         }.orEmpty()
+    }
+}
+
+@ContributesMultibinding(AppScope::class)
+class LastSearchStateSurveyParameterPlugin @Inject constructor(
+    private val navigationHistory: NavigationHistory,
+    private val currentTimeProvider: CurrentTimeProvider,
+) : SurveyParameterPlugin {
+    override fun matches(paramKey: String): Boolean = paramKey == "last_search_state"
+
+    override suspend fun evaluate(paramKey: String): String {
+        val history = navigationHistory.getHistory().first()
+        val mostRecentSearch = history
+            .filterIsInstance<HistoryEntry.VisitedSERP>()
+            .flatMap { it.visits }
+            .maxOrNull() ?: return "none"
+
+        val daysSinceLastSearch = ChronoUnit.DAYS.between(mostRecentSearch, currentTimeProvider.localDateTimeNow())
+
+        return when {
+            daysSinceLastSearch < 2 -> "day"
+            daysSinceLastSearch <= 7 -> "week"
+            else -> "none"
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
@@ -29,9 +29,9 @@ import com.duckduckgo.history.api.HistoryEntry
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.survey.api.SurveyParameterPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.first
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
-import kotlinx.coroutines.flow.first
 
 @ContributesMultibinding(AppScope::class)
 class AtbSurveyParameterPlugin @Inject constructor(

--- a/app/src/test/java/com/duckduckgo/app/survey/rmf/LastSearchStateSurveyParameterPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/rmf/LastSearchStateSurveyParameterPluginTest.kt
@@ -1,0 +1,121 @@
+package com.duckduckgo.app.survey.rmf
+
+import android.net.Uri
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.history.api.HistoryEntry
+import com.duckduckgo.history.api.NavigationHistory
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+
+class LastSearchStateSurveyParameterPluginTest {
+
+    @Mock private lateinit var navigationHistory: NavigationHistory
+
+    @Mock private lateinit var currentTimeProvider: CurrentTimeProvider
+
+    private lateinit var plugin: LastSearchStateSurveyParameterPlugin
+
+    private val now = LocalDateTime.of(2024, 6, 18, 12, 0)
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        plugin = LastSearchStateSurveyParameterPlugin(navigationHistory, currentTimeProvider)
+        whenever(currentTimeProvider.localDateTimeNow()).thenReturn(now)
+    }
+
+    @Test
+    fun whenNoHistoryThenReturnsNone() = runTest {
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(emptyList()))
+
+        assertEquals("none", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenNoSerpEntriesThenReturnsNone() = runTest {
+        val visitedPage = HistoryEntry.VisitedPage(
+            url = Uri.parse("https://example.com"),
+            title = "Example",
+            visits = listOf(now.minusDays(1)),
+        )
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(visitedPage)))
+
+        assertEquals("none", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenLastSearchWasLessThan2DaysAgoThenReturnsDay() = runTest {
+        val serp = serpEntry(lastVisit = now.minusHours(6))
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(serp)))
+
+        assertEquals("day", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenLastSearchWas1DayAgoThenReturnsDay() = runTest {
+        val serp = serpEntry(lastVisit = now.minusDays(1))
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(serp)))
+
+        assertEquals("day", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenLastSearchWas2DaysAgoThenReturnsWeek() = runTest {
+        val serp = serpEntry(lastVisit = now.minusDays(2))
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(serp)))
+
+        assertEquals("week", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenLastSearchWas7DaysAgoThenReturnsWeek() = runTest {
+        val serp = serpEntry(lastVisit = now.minusDays(7))
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(serp)))
+
+        assertEquals("week", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenLastSearchWas8DaysAgoThenReturnsNone() = runTest {
+        val serp = serpEntry(lastVisit = now.minusDays(8))
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(serp)))
+
+        assertEquals("none", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenMultipleSerpEntriesUseMostRecentVisit() = runTest {
+        val recentSerp = serpEntry(lastVisit = now.minusDays(3))
+        val oldSerp = serpEntry(lastVisit = now.minusDays(10), query = "old query")
+        whenever(navigationHistory.getHistory()).thenReturn(flowOf(listOf(oldSerp, recentSerp)))
+
+        assertEquals("week", plugin.evaluate("last_search_state"))
+    }
+
+    @Test
+    fun whenMatchesReturnsTrueForCorrectKey() {
+        assertEquals(true, plugin.matches("last_search_state"))
+    }
+
+    @Test
+    fun whenMatchesReturnsFalseForOtherKeys() {
+        assertEquals(false, plugin.matches("some_other_key"))
+    }
+
+    private fun serpEntry(
+        lastVisit: LocalDateTime,
+        query: String = "duckduckgo",
+    ) = HistoryEntry.VisitedSERP(
+        url = Uri.parse("https://duckduckgo.com/?q=$query"),
+        title = "Search results",
+        query = query,
+        visits = listOf(lastVisit),
+    )
+}

--- a/app/src/test/java/com/duckduckgo/app/survey/rmf/LastSearchStateSurveyParameterPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/rmf/LastSearchStateSurveyParameterPluginTest.kt
@@ -1,6 +1,7 @@
 package com.duckduckgo.app.survey.rmf
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.history.api.HistoryEntry
 import com.duckduckgo.history.api.NavigationHistory
@@ -9,11 +10,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 
+@RunWith(AndroidJUnit4::class)
 class LastSearchStateSurveyParameterPluginTest {
 
     @Mock private lateinit var navigationHistory: NavigationHistory


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213965548478118?focus=true

### Description
Add new survey param for last search state

### Steps to test this PR

_Pre steps_
- [ ] Create a JSONBlob with json pinned in https://app.asana.com/1/137249556945/project/488551667048375/task/1213965548478118?focus=true

_No search_
- [ ] Fresh install
- [ ] Skip onboarding
- [ ] Start survey and check last_search_state param is `none`

_Search within 2 days_
- [ ] Fresh install
- [ ] Skip onboarding
- [ ] Perform a search
- [ ] Open a new tab
- [ ] Start survey and check last_search_state param is `day`

_Search in the past 2–7 days_
- [ ] Fresh install
- [ ] Skip onboarding
- [ ] Perform a search
- [ ] Change device date to 5 days later
- [ ] Open a new tab
- [ ] Start survey and check last_search_state param is `week`

_Search > 7 days ago_
- [ ] Fresh install
- [ ] Skip onboarding
- [ ] Perform a search
- [ ] Change device date to > 7 days later
- [ ] Open a new tab
- [ ] Start survey and check last_search_state param is `none`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new survey parameter derived from existing navigation history and current time, plus tests; no changes to core browsing, storage, or network behavior.
> 
> **Overview**
> Adds a new `SurveyParameterPlugin` for `last_search_state` that inspects `NavigationHistory` SERP visits and returns `day` (<2 days), `week` (2–7 days), or `none` (no/old searches).
> 
> Introduces unit tests covering empty history, non-SERP history, boundary conditions, and selecting the most recent SERP visit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e2f8c1594ec19d3d14e40f399356a690897024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->