### PR TITLE
Fix favicons not showing on the favorites widget

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/WidgetFaviconProviderTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/favicon/WidgetFaviconProviderTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.favicon
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_WIDGET_PLACEHOLDERS_DIR
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.NO_SUBFOLDER
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.widget.WidgetFaviconProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+import com.duckduckgo.mobile.android.R as CommonR
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class WidgetFaviconProviderTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockFaviconPersister: FaviconPersister = mock()
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val mockFile: File = File("test")
+
+    private lateinit var testee: WidgetFaviconProvider
+
+    @Before
+    fun setup() {
+        testee = WidgetFaviconProvider(
+            context = context,
+            faviconPersister = mockFaviconPersister,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenPersistedFaviconExistsThenReturnItWithoutCheckingPlaceholders() = runTest {
+        whenever(mockFaviconPersister.faviconFile(eq(FAVICON_PERSISTED_DIR), any(), any())).thenReturn(mockFile)
+
+        val result = testee.getOrGenerateWidgetFavicon(
+            domain = "example.com",
+            placeholderSizePx = 128,
+            placeholderCornerRadius = CommonR.dimen.searchWidgetFavoritesCornerRadius,
+        )
+
+        assertSame(mockFile, result)
+        verify(mockFaviconPersister, never()).faviconFile(eq(FAVICON_WIDGET_PLACEHOLDERS_DIR), any(), any())
+        verify(mockFaviconPersister, never()).store(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenOnlyPlaceholderExistsThenReturnPlaceholder() = runTest {
+        whenever(mockFaviconPersister.faviconFile(eq(FAVICON_WIDGET_PLACEHOLDERS_DIR), any(), any())).thenReturn(mockFile)
+
+        val result = testee.getOrGenerateWidgetFavicon(
+            domain = "example.com",
+            placeholderSizePx = 128,
+            placeholderCornerRadius = CommonR.dimen.searchWidgetFavoritesCornerRadius,
+        )
+
+        assertSame(mockFile, result)
+        verify(mockFaviconPersister, never()).store(any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenNoFilesExistThenGenerateAndStorePlaceholder() = runTest {
+        val storedFile = File("stored")
+        whenever(mockFaviconPersister.store(eq(FAVICON_WIDGET_PLACEHOLDERS_DIR), eq(NO_SUBFOLDER), any(), eq("example.com")))
+            .thenReturn(storedFile)
+
+        val result = testee.getOrGenerateWidgetFavicon(
+            domain = "example.com",
+            placeholderSizePx = 128,
+            placeholderCornerRadius = CommonR.dimen.searchWidgetFavoritesCornerRadius,
+        )
+
+        assertSame(storedFile, result)
+        verify(mockFaviconPersister).store(eq(FAVICON_WIDGET_PLACEHOLDERS_DIR), eq(NO_SUBFOLDER), any(), eq("example.com"))
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconPersister.kt
@@ -289,6 +289,7 @@ class FileBasedFaviconPersister(
     companion object {
         const val FAVICON_TEMP_DIR = "faviconsTemp"
         const val FAVICON_PERSISTED_DIR = "favicons"
+        const val FAVICON_WIDGET_PLACEHOLDERS_DIR = "faviconsWidgetPlaceholders"
         const val NO_SUBFOLDER = ""
     }
 }

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
@@ -20,23 +20,16 @@ import android.annotation.SuppressLint
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import androidx.core.content.FileProvider
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.browser.favicon.FaviconPersister
-import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
-import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_WIDGET_PLACEHOLDERS_DIR
-import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.NO_SUBFOLDER
 import com.duckduckgo.app.global.DuckDuckGoApplication
-import com.duckduckgo.app.global.view.generateDefaultDrawable
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -63,7 +56,7 @@ class FavoritesWidgetItemFactory(
     lateinit var widgetPrefs: WidgetPreferences
 
     @Inject
-    lateinit var faviconPersister: FaviconPersister
+    lateinit var widgetFaviconProvider: WidgetFaviconProvider
 
     @Inject
     lateinit var dispatchers: DispatcherProvider
@@ -120,54 +113,16 @@ class FavoritesWidgetItemFactory(
         }
     }
 
-    /**
-     * Converts a SavedSite.Favorite to a WidgetFavorite by ensuring we have a bitmap URI for the favicon.
-     */
     private suspend fun SavedSite.Favorite.toWidgetFavorite(): WidgetFavorite {
         val domain = url.extractDomain().orEmpty()
-
-        // step 1: check if any file (real favicon or placeholder) already exists on disk to avoid fetching/generating it again
-        val persistedFile = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
-        if (persistedFile != null) {
-            if (persistedFile.isStaleWidgetPlaceholder()) {
-                persistedFile.delete()
-            } else {
-                val persistedUri = persistedFile.getContentUri()
-                if (persistedUri != null) {
-                    // found existing file on disk (favicon or placeholder) - use it without network call
-                    return WidgetFavorite(title = title, url = url, bitmapUri = persistedUri)
-                }
-            }
-        }
-
-        // step 2: check if there is an existing placeholder cached and use it
-        val existingPlaceholder = faviconPersister.faviconFile(FAVICON_WIDGET_PLACEHOLDERS_DIR, NO_SUBFOLDER, domain)
-        if (existingPlaceholder != null) {
-            val placeholderUri = existingPlaceholder.getContentUri()
-            if (placeholderUri != null) {
-                return WidgetFavorite(title = title, url = url, bitmapUri = placeholderUri)
-            }
-        }
-
-        // step 3: generate and save placeholder
-        val placeholderBitmap = generateDefaultDrawable(
-            context = context,
-            domain = domain,
-            cornerRadius = faviconItemCornerRadius,
-        ).toBitmap(faviconItemSize, faviconItemSize)
-
-        val uri = faviconPersister.store(FAVICON_WIDGET_PLACEHOLDERS_DIR, NO_SUBFOLDER, placeholderBitmap, domain)?.getContentUri()
-
-        return WidgetFavorite(title = title, url = url, bitmapUri = uri)
-    }
-
-    // Detects placeholders written to FAVICON_PERSISTED_DIR by the previous broken version
-    // (https://app.asana.com/1/137249556945/project/414730916066338/task/1214072492090532?focus=true).
-    // Real favicons virtually never match faviconItemSize × faviconItemSize exactly.
-    private fun File.isStaleWidgetPlaceholder(): Boolean {
-        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        BitmapFactory.decodeFile(absolutePath, options)
-        return options.outWidth == faviconItemSize && options.outHeight == faviconItemSize
+        val bitmapUri = runCatching {
+            widgetFaviconProvider.getOrGenerateWidgetFavicon(
+                domain = domain,
+                placeholderSizePx = faviconItemSize,
+                placeholderCornerRadius = faviconItemCornerRadius,
+            )?.getContentUri()
+        }.getOrNull()
+        return WidgetFavorite(title = title, url = url, bitmapUri = bitmapUri)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
+++ b/app/src/main/java/com/duckduckgo/widget/FavoritesWidgetItemFactory.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
@@ -32,11 +33,12 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.favicon.FaviconPersister
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_WIDGET_PLACEHOLDERS_DIR
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.NO_SUBFOLDER
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.global.view.generateDefaultDrawable
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.domain
+import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -125,38 +127,47 @@ class FavoritesWidgetItemFactory(
         val domain = url.extractDomain().orEmpty()
 
         // step 1: check if any file (real favicon or placeholder) already exists on disk to avoid fetching/generating it again
-        val existingFile = faviconPersister.faviconFile(
-            directory = FAVICON_PERSISTED_DIR,
-            subFolder = NO_SUBFOLDER,
-            domain = domain,
-        )
-        var uri: Uri? = null
-
-        if (existingFile != null) {
-            // found existing file on disk (favicon or placeholder) - use it without network call
-            uri = existingFile.getContentUri()
-        }
-        if (uri != null) {
-            return WidgetFavorite(
-                title = title,
-                url = url,
-                bitmapUri = uri,
-            )
+        val persistedFile = faviconPersister.faviconFile(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, domain)
+        if (persistedFile != null) {
+            if (persistedFile.isStaleWidgetPlaceholder()) {
+                persistedFile.delete()
+            } else {
+                val persistedUri = persistedFile.getContentUri()
+                if (persistedUri != null) {
+                    // found existing file on disk (favicon or placeholder) - use it without network call
+                    return WidgetFavorite(title = title, url = url, bitmapUri = persistedUri)
+                }
+            }
         }
 
-        // step 2: generate and save placeholder
+        // step 2: check if there is an existing placeholder cached and use it
+        val existingPlaceholder = faviconPersister.faviconFile(FAVICON_WIDGET_PLACEHOLDERS_DIR, NO_SUBFOLDER, domain)
+        if (existingPlaceholder != null) {
+            val placeholderUri = existingPlaceholder.getContentUri()
+            if (placeholderUri != null) {
+                return WidgetFavorite(title = title, url = url, bitmapUri = placeholderUri)
+            }
+        }
+
+        // step 3: generate and save placeholder
         val placeholderBitmap = generateDefaultDrawable(
             context = context,
             domain = domain,
             cornerRadius = faviconItemCornerRadius,
         ).toBitmap(faviconItemSize, faviconItemSize)
-        uri = faviconPersister.store(FAVICON_PERSISTED_DIR, NO_SUBFOLDER, placeholderBitmap, domain)?.getContentUri()
 
-        return WidgetFavorite(
-            title = title,
-            url = url,
-            bitmapUri = uri,
-        )
+        val uri = faviconPersister.store(FAVICON_WIDGET_PLACEHOLDERS_DIR, NO_SUBFOLDER, placeholderBitmap, domain)?.getContentUri()
+
+        return WidgetFavorite(title = title, url = url, bitmapUri = uri)
+    }
+
+    // Detects placeholders written to FAVICON_PERSISTED_DIR by the previous broken version
+    // (https://app.asana.com/1/137249556945/project/414730916066338/task/1214072492090532?focus=true).
+    // Real favicons virtually never match faviconItemSize × faviconItemSize exactly.
+    private fun File.isStaleWidgetPlaceholder(): Boolean {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(absolutePath, options)
+        return options.outWidth == faviconItemSize && options.outHeight == faviconItemSize
     }
 
     override fun onDestroy() {
@@ -169,7 +180,7 @@ class FavoritesWidgetItemFactory(
 
     private fun String.extractDomain(): String? {
         return if (this.startsWith("http")) {
-            this.toUri().domain()
+            this.toUri().baseHost
         } else {
             "https://$this".extractDomain()
         }

--- a/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
+++ b/app/src/main/java/com/duckduckgo/widget/SearchAndFavoritesWidget.kt
@@ -28,6 +28,8 @@ import android.widget.RemoteViews
 import androidx.core.widget.RemoteViewsCompat
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.favicon.FaviconPersister
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_WIDGET_PLACEHOLDERS_DIR
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DuckDuckGoApplication
 import com.duckduckgo.app.pixels.AppPixelName.SEARCH_AND_FAVORITES_WIDGET_ADDED
@@ -81,6 +83,9 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
 
     @Inject
     lateinit var searchWidgetLifecycleDelegate: SearchWidgetLifecycleDelegate
+
+    @Inject
+    lateinit var faviconPersister: FaviconPersister
 
     private var layoutId: Int = R.layout.search_favorites_widget_daynight_auto
 
@@ -143,6 +148,9 @@ class SearchAndFavoritesWidget : AppWidgetProvider() {
     override fun onDisabled(context: Context?) {
         super.onDisabled(context)
         searchWidgetLifecycleDelegate.handleOnWidgetDisabled(SEARCH_AND_FAVORITES_WIDGET_DELETED)
+        appCoroutineScope.launch(dispatchers.io()) {
+            faviconPersister.deleteAll(FAVICON_WIDGET_PLACEHOLDERS_DIR)
+        }
     }
 
     private suspend fun updateWidget(

--- a/app/src/main/java/com/duckduckgo/widget/WidgetFaviconProvider.kt
+++ b/app/src/main/java/com/duckduckgo/widget/WidgetFaviconProvider.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.widget
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.annotation.DimenRes
+import androidx.core.graphics.drawable.toBitmap
+import com.duckduckgo.app.browser.favicon.FaviconPersister
+import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister
+import com.duckduckgo.app.global.view.generateDefaultDrawable
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+class WidgetFaviconProvider @Inject constructor(
+    private val context: Context,
+    private val faviconPersister: FaviconPersister,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    /**
+     * Resolves a favicon file to display in the favorites widget for the given [domain].
+     *
+     * Lookup order:
+     * 1. Existing persisted real favicon.
+     * 2. Previously cached widget placeholder.
+     * 3. Newly generated placeholder (stored on disk).
+     *
+     * Stale widget-sized placeholders previously mis-persisted into the main favicons
+     * directory by older app versions are cleaned up as part of this lookup.
+     */
+    suspend fun getOrGenerateWidgetFavicon(
+        domain: String,
+        placeholderSizePx: Int,
+        @DimenRes placeholderCornerRadius: Int,
+    ): File? = withContext(dispatcherProvider.io()) {
+        // step 1: check if any file (real favicon or placeholder) already exists on disk to avoid fetching/generating it again
+        faviconPersister.faviconFile(
+            FileBasedFaviconPersister.FAVICON_PERSISTED_DIR,
+            FileBasedFaviconPersister.NO_SUBFOLDER,
+            domain,
+        )?.let { file ->
+            // Older app versions mistakenly persisted widget-sized placeholders into the real favicons
+            // directory (https://app.asana.com/1/137249556945/project/414730916066338/task/1214072492090532).
+            // Real favicons virtually never match the widget placeholder size exactly, so this is used
+            // as a heuristic to detect and remove the stale file before falling through to placeholder logic.
+            if (file.isSizedExactly(placeholderSizePx)) {
+                file.delete()
+            } else {
+                return@withContext file
+            }
+        }
+
+        // step 2: check if there is an existing placeholder cached and use it
+        faviconPersister.faviconFile(
+            FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR,
+            FileBasedFaviconPersister.NO_SUBFOLDER,
+            domain,
+        )?.let {
+            return@withContext it
+        }
+
+        // step 3: generate and save placeholder
+        val placeholder = generateDefaultDrawable(
+            context = context,
+            domain = domain,
+            cornerRadius = placeholderCornerRadius,
+        ).toBitmap(placeholderSizePx, placeholderSizePx)
+
+        faviconPersister.store(
+            FileBasedFaviconPersister.FAVICON_WIDGET_PLACEHOLDERS_DIR,
+            FileBasedFaviconPersister.NO_SUBFOLDER,
+            placeholder,
+            domain,
+        )
+    }
+
+    private fun File.isSizedExactly(sizePx: Int): Boolean {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(absolutePath, options)
+        return options.outWidth == sizePx && options.outHeight == sizePx
+    }
+}

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -21,4 +21,5 @@
         path="." />
     <cache-path name="sync" path="sync" />
     <cache-path name="favicons" path="favicons/" />
+    <cache-path name="favicons_widget_placeholders" path="faviconsWidgetPlaceholders/" />
 </paths>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214072492090532?focus=true

### Description
We introduced a bug when fixing the favorites widget for Android 16, causing the generated favicon to be used in most cases instead of the actual favicon. This was due to using the domain instead of base host as the cache key.

Generated placeholder favicons are now stored in a separate folder to avoid overwriting the main browser one. The files are removed when widget is deleted.

### Steps to test this PR

- [ ] Add a few favorites
- [ ] Add favorites and search widget to home screen
- [ ] Favicons should be visible instead of the generated placeholders with letters

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1344" height="2992" alt="Screenshot_20260417_114914" src="https://github.com/user-attachments/assets/be0c4181-e25e-4510-9daa-979a4f0e2c9f" />| <img width="1344" height="2992" alt="Screenshot_20260417_114614" src="https://github.com/user-attachments/assets/af296af2-aa82-432f-8303-11ef7210caad" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes widget favicon resolution and introduces new on-disk caching/cleanup logic; risk is mainly around file persistence/heuristic deletion potentially impacting cached favicons on upgrade.
> 
> **Overview**
> Fixes favorites widget favicon selection by centralizing lookup/generation in a new `WidgetFaviconProvider`, prioritizing persisted real favicons, then cached widget placeholders, and only then generating/storing a new placeholder.
> 
> Widget placeholders are now stored in a dedicated cache directory (`FAVICON_WIDGET_PLACEHOLDERS_DIR`) with a `FileProvider` path entry, cleaned up when the widget is disabled, and the widget now derives the cache key using `baseHost` (instead of `domain`) to avoid mismatches.
> 
> Adds an instrumentation test covering the provider’s lookup/store behavior and includes a heuristic to delete stale widget-sized placeholders that were previously saved into the main `favicons` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26fd1411223c1600f780c65e9f7b1202ee543cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->