### PR TITLE
DuckAi/Voice chat: Allow voice chat to run in background

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4306,6 +4306,7 @@ class BrowserTabViewModel @Inject constructor(
                         method,
                         id,
                         data,
+                        tabId = tabId,
                     )
                     withContext(dispatchers.main()) {
                         response?.let {

--- a/duckchat/duckchat-impl/src/main/AndroidManifest.xml
+++ b/duckchat/duckchat-impl/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <application>
         <activity
             android:name="com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsActivity"
@@ -34,5 +38,10 @@
             android:name=".subscription.DuckAiPaidSettingsActivity"
             android:exported="false"
             android:label="@string/duck_ai_paid_settings_title"/>
+
+        <service
+            android:name=".ui.DuckChatVoiceMicrophoneService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
     </application>
 </manifest>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -228,4 +228,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun digitalAssistantDuckAi(): Toggle
+
+    /**
+     * @return `true` when the Duck.ai voice chat foreground service (microphone) should be started
+     * and stopped during a voice session.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun duckAiVoiceChatService(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -225,7 +225,7 @@ class RealDuckChatJSHelper @Inject constructor(
             }
 
             METHOD_VOICE_SESSION_STARTED -> {
-                voiceSessionStateManager.onVoiceSessionStarted()
+                voiceSessionStateManager.onVoiceSessionStarted(tabId)
                 duckChatPixels.reportVoiceSessionStarted()
                 null
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.di.scopes.ServiceScope
+import com.duckduckgo.duckchat.impl.R
+import dagger.android.AndroidInjection
+import javax.inject.Inject
+
+/**
+ * Foreground service that keeps the process alive and signals to Android that microphone access
+ * is intentionally used while Duck.ai voice mode is active in the background.
+ */
+@InjectWith(scope = ServiceScope::class)
+class DuckChatVoiceMicrophoneService : Service() {
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        AndroidInjection.inject(this)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            buildNotification(),
+            if (appBuildConfig.sdkInt >= 30) {
+                FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                0
+            },
+        )
+        return START_NOT_STICKY
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.duckAiVoiceNotificationTitle))
+            .setContentText(getString(R.string.duckAiVoiceNotificationMessage))
+            .setSmallIcon(R.drawable.ic_duckduckgo_ai_grayscale_color_24)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.duckAiVoiceNotificationChannelName),
+            NotificationManager.IMPORTANCE_LOW,
+        )
+        getSystemService(NotificationManager::class.java)?.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 9100
+        private const val CHANNEL_ID = "duck_ai_voice_microphone"
+
+        fun start(context: Context) {
+            ContextCompat.startForegroundService(context, Intent(context, DuckChatVoiceMicrophoneService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, DuckChatVoiceMicrophoneService::class.java))
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.ui
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -70,14 +71,22 @@ class DuckChatVoiceMicrophoneService : Service() {
         return START_NOT_STICKY
     }
 
-    private fun buildNotification(): Notification =
-        NotificationCompat.Builder(this, CHANNEL_ID)
+    private fun buildNotification(): Notification {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val pendingIntent = launchIntent?.let {
+            PendingIntent.getActivity(this, 0, it, PendingIntent.FLAG_IMMUTABLE)
+        }
+        return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.duckAiVoiceNotificationTitle))
             .setContentText(getString(R.string.duckAiVoiceNotificationMessage))
-            .setSmallIcon(R.drawable.ic_duckduckgo_ai_grayscale_color_24)
+            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setContentIntent(pendingIntent)
             .build()
+    }
 
     private fun createNotificationChannel() {
         val channel = NotificationChannel(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -16,40 +16,82 @@
 
 package com.duckduckgo.duckchat.impl.voice
 
+import android.content.Context
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.ui.DuckChatVoiceMicrophoneService
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 interface VoiceSessionStateManager {
     val isVoiceSessionActive: Boolean
-    fun onVoiceSessionStarted()
+    fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded()
 }
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class, boundType = VoiceSessionStateManager::class)
 @ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
-class RealVoiceSessionStateManager @Inject constructor() : VoiceSessionStateManager, BrowserLifecycleObserver {
+class RealVoiceSessionStateManager @Inject constructor(
+    private val context: Context,
+    private val tabRepository: TabRepository,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : VoiceSessionStateManager, BrowserLifecycleObserver {
+
+    private val listenJob = ConflatedJob()
 
     @Volatile
-    // NOTE: We are unable to detect that voice chat has ended IF the user closes the tab running voice chat.
+    private var activeSessionTabId: String? = null
+
+    @Volatile
     override var isVoiceSessionActive: Boolean = false
         private set
 
-    override fun onVoiceSessionStarted() {
+    override fun onVoiceSessionStarted(tabId: String) {
         isVoiceSessionActive = true
+        activeSessionTabId = tabId.ifBlank { null }
+        DuckChatVoiceMicrophoneService.start(context)
+        if (activeSessionTabId != null) {
+            listenToTabRemoval()
+        }
     }
 
     override fun onVoiceSessionEnded() {
+        listenJob.cancel()
         isVoiceSessionActive = false
+        activeSessionTabId = null
+        DuckChatVoiceMicrophoneService.stop(context)
     }
 
     override fun onOpen(isFreshLaunch: Boolean) {
         if (isFreshLaunch) {
-            isVoiceSessionActive = false
+            if (isVoiceSessionActive) {
+                onVoiceSessionEnded()
+            }
+        }
+    }
+
+    override fun onExit() {
+        if (isVoiceSessionActive) {
+            onVoiceSessionEnded()
+        }
+    }
+
+    private fun listenToTabRemoval() {
+        listenJob += appCoroutineScope.launch {
+            tabRepository.flowTabs.drop(1).collect { tabs ->
+                if (activeSessionTabId != null && tabs.none { it.tabId == activeSessionTabId }) {
+                    onVoiceSessionEnded()
+                }
+            }
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.ui.DuckChatVoiceMicrophoneService
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -45,6 +46,7 @@ class RealVoiceSessionStateManager @Inject constructor(
     private val context: Context,
     private val tabRepository: TabRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val duckChatFeature: DuckChatFeature,
 ) : VoiceSessionStateManager, BrowserLifecycleObserver {
 
     private val listenJob = ConflatedJob()
@@ -59,7 +61,9 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {
         activeSessionTabId = tabId.ifBlank { STANDALONE_SESSION_ID }
-        DuckChatVoiceMicrophoneService.start(context)
+        if (duckChatFeature.duckAiVoiceChatService().isEnabled()) {
+            DuckChatVoiceMicrophoneService.start(context)
+        }
         if (tabId.isNotBlank()) {
             listenToTabRemoval()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 
 interface VoiceSessionStateManager {
     val isVoiceSessionActive: Boolean
+        get() = false
     fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded()
 }
@@ -48,50 +49,51 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     private val listenJob = ConflatedJob()
 
+    // null = no session, STANDALONE_SESSION_ID = session without a browser tab, non-empty = tab session
     @Volatile
     private var activeSessionTabId: String? = null
 
-    @Volatile
-    override var isVoiceSessionActive: Boolean = false
-        private set
+    override val isVoiceSessionActive: Boolean
+        get() = activeSessionTabId != null
 
+    @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {
-        isVoiceSessionActive = true
-        activeSessionTabId = tabId.ifBlank { null }
+        activeSessionTabId = tabId.ifBlank { STANDALONE_SESSION_ID }
         DuckChatVoiceMicrophoneService.start(context)
-        if (activeSessionTabId != null) {
+        if (tabId.isNotBlank()) {
             listenToTabRemoval()
         }
     }
 
+    @Synchronized
     override fun onVoiceSessionEnded() {
         listenJob.cancel()
-        isVoiceSessionActive = false
         activeSessionTabId = null
         DuckChatVoiceMicrophoneService.stop(context)
     }
 
     override fun onOpen(isFreshLaunch: Boolean) {
         if (isFreshLaunch) {
-            if (isVoiceSessionActive) {
-                onVoiceSessionEnded()
-            }
+            onVoiceSessionEnded()
         }
     }
 
     override fun onExit() {
-        if (isVoiceSessionActive) {
-            onVoiceSessionEnded()
-        }
+        onVoiceSessionEnded()
     }
 
     private fun listenToTabRemoval() {
         listenJob += appCoroutineScope.launch {
             tabRepository.flowTabs.drop(1).collect { tabs ->
-                if (activeSessionTabId != null && tabs.none { it.tabId == activeSessionTabId }) {
+                val tabId = activeSessionTabId ?: return@collect
+                if (tabs.none { it.tabId == tabId }) {
                     onVoiceSessionEnded()
                 }
             }
         }
+    }
+
+    companion object {
+        private const val STANDALONE_SESSION_ID = "__duck_ai_standalone__"
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -25,4 +25,9 @@
     <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>
     <string name="duckAiModelPickerBasicModels" translatable="false">Basic Models</string>
     <string name="duckAiModelPickerPremiumModels" translatable="false">Advanced Models \u2014 DuckDuckGo subscription</string>
+
+    <!-- Duck.ai voice microphone foreground service notification -->
+    <string name="duckAiVoiceNotificationTitle">Duck.ai Voice Chat Active</string>
+    <string name="duckAiVoiceNotificationMessage">Microphone is in use by Duck.ai</string>
+    <string name="duckAiVoiceNotificationChannelName">Duck.ai Voice Chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1611,17 +1611,19 @@ class RealDuckChatJSHelperTest {
 
     @Test
     fun whenVoiceSessionStartedThenPixelFiredAndStateUpdated() = runTest {
+        val tabId = "test-tab-id"
         val result = testee.processJsCallbackMessage(
             "aiChat",
             "voiceSessionStarted",
             null,
             null,
             pageContext = viewModel.updatedPageContext,
+            tabId = tabId,
         )
 
         assertNull(result)
         verify(mockDuckChatPixels).reportVoiceSessionStarted()
-        verify(mockVoiceSessionStateManager).onVoiceSessionStarted()
+        verify(mockVoiceSessionStateManager).onVoiceSessionStarted(tabId)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -16,18 +16,53 @@
 
 package com.duckduckgo.duckchat.impl.voice
 
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class RealVoiceSessionStateManagerTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val tabRepository: TabRepository = mock()
+    private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
 
     private lateinit var testee: RealVoiceSessionStateManager
 
+    @After
+    fun teardown() {
+        // Cancels the flowTabs collect coroutine so runTest doesn't fail with UncompletedCoroutinesError
+        testee.onVoiceSessionEnded()
+    }
+
     @Before
     fun setup() {
-        testee = RealVoiceSessionStateManager()
+        whenever(tabRepository.flowTabs).thenReturn(tabsFlow)
+        testee = RealVoiceSessionStateManager(
+            context = context,
+            tabRepository = tabRepository,
+            appCoroutineScope = coroutineTestRule.testScope,
+        )
     }
 
     @Test
@@ -37,14 +72,14 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenVoiceSessionStartedThenIsVoiceSessionActiveIsTrue() {
-        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted(TAB_ID)
 
         assertTrue(testee.isVoiceSessionActive)
     }
 
     @Test
     fun whenVoiceSessionEndedThenIsVoiceSessionActiveIsFalse() {
-        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted(TAB_ID)
         testee.onVoiceSessionEnded()
 
         assertFalse(testee.isVoiceSessionActive)
@@ -59,15 +94,15 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenVoiceSessionStartedMultipleTimesThenIsVoiceSessionActiveIsTrue() {
-        testee.onVoiceSessionStarted()
-        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionStarted(TAB_ID)
 
         assertTrue(testee.isVoiceSessionActive)
     }
 
     @Test
     fun whenFreshLaunchAndVoiceSessionWasActiveThenIsVoiceSessionActiveIsFalse() {
-        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted(TAB_ID)
         testee.onOpen(isFreshLaunch = true)
 
         assertFalse(testee.isVoiceSessionActive)
@@ -75,9 +110,98 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenNotFreshLaunchAndVoiceSessionWasActiveThenIsVoiceSessionActiveRemainsTrue() {
-        testee.onVoiceSessionStarted()
+        testee.onVoiceSessionStarted(TAB_ID)
         testee.onOpen(isFreshLaunch = false)
 
         assertTrue(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenFreshLaunchAndNoActiveSessionThenRemainsInactive() {
+        testee.onOpen(isFreshLaunch = true)
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenExitAndVoiceSessionWasActiveThenIsVoiceSessionActiveIsFalse() {
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onExit()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenExitAndNoActiveSessionThenRemainsInactive() {
+        testee.onExit()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenVoiceSessionStartedWithBlankTabIdThenSessionIsActiveButTabRemovalNotTracked() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID))
+        testee.onVoiceSessionStarted("")
+
+        tabsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        // Session stays active — no tab to track, so tab removal has no effect
+        assertTrue(testee.isVoiceSessionActive)
+        testee.onVoiceSessionEnded()
+    }
+
+    @Test
+    fun whenActiveTabIsClosedThenSessionEnded() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        tabsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenDifferentTabIsClosedThenSessionRemainsActive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        tabsFlow.value = listOf(tabEntity(TAB_ID))
+        advanceUntilIdle()
+
+        assertTrue(testee.isVoiceSessionActive)
+        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+    }
+
+    @Test
+    fun whenNewTabAddedThenSessionRemainsActive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        advanceUntilIdle()
+
+        assertTrue(testee.isVoiceSessionActive)
+        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+    }
+
+    @Test
+    fun whenSessionEndedManuallyAndActiveTabSubsequentlyRemovedThenNoAdditionalEffect() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionEnded()
+
+        tabsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    private fun tabEntity(tabId: String) = TabEntity(tabId = tabId)
+
+    companion object {
+        private const val TAB_ID = "test-tab-id"
+        private const val OTHER_TAB_ID = "other-tab-id"
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -22,6 +22,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -46,6 +48,8 @@ class RealVoiceSessionStateManagerTest {
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     private val tabRepository: TabRepository = mock()
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
+    private val duckChatFeature: DuckChatFeature = mock()
+    private val voiceChatServiceToggle: Toggle = mock()
 
     private lateinit var testee: RealVoiceSessionStateManager
 
@@ -58,10 +62,13 @@ class RealVoiceSessionStateManagerTest {
     @Before
     fun setup() {
         whenever(tabRepository.flowTabs).thenReturn(tabsFlow)
+        whenever(duckChatFeature.duckAiVoiceChatService()).thenReturn(voiceChatServiceToggle)
+        whenever(voiceChatServiceToggle.isEnabled()).thenReturn(true)
         testee = RealVoiceSessionStateManager(
             context = context,
             tabRepository = tabRepository,
             appCoroutineScope = coroutineTestRule.testScope,
+            duckChatFeature = duckChatFeature,
         )
     }
 
@@ -194,6 +201,38 @@ class RealVoiceSessionStateManagerTest {
 
         tabsFlow.value = emptyList()
         advanceUntilIdle()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenVoiceSessionStartedAndServiceFlagDisabledThenSessionIsActive() = coroutineTestRule.testScope.runTest {
+        whenever(voiceChatServiceToggle.isEnabled()).thenReturn(false)
+        testee = RealVoiceSessionStateManager(
+            context = context,
+            tabRepository = tabRepository,
+            appCoroutineScope = coroutineTestRule.testScope,
+            duckChatFeature = duckChatFeature,
+        )
+
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        assertTrue(testee.isVoiceSessionActive)
+        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+    }
+
+    @Test
+    fun whenVoiceSessionEndedAndServiceFlagDisabledThenSessionIsInactive() = coroutineTestRule.testScope.runTest {
+        whenever(voiceChatServiceToggle.isEnabled()).thenReturn(false)
+        testee = RealVoiceSessionStateManager(
+            context = context,
+            tabRepository = tabRepository,
+            appCoroutineScope = coroutineTestRule.testScope,
+            duckChatFeature = duckChatFeature,
+        )
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        testee.onVoiceSessionEnded()
 
         assertFalse(testee.isVoiceSessionActive)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1214087464606240?focus=true 

### Description
Enables Duck.ai voice mode to retain microphone access when the app is backgrounded.                                                                                                                               
   
  Previously, Android would cut off microphone access as soon as the app left the foreground, interrupting any active voice session. This change introduces a foreground service (DuckChatVoiceMicrophoneService)    
  that is started when a voice session begins and stopped when it ends, signalling to Android that microphone use is intentional and keeping the process alive in the background.                                  
                                                                                                                                                                                                                     
  Changes                                                                                                                                                                                                          
  - DuckChatVoiceMicrophoneService — new foreground service that displays a persistent notification while a voice session is active, satisfying Android's background microphone requirements                         
  - VoiceSessionStateManager — new component that tracks the active voice session and its associated tab. Automatically ends the session (and stops the service) when:
    - The Duck.ai tab is closed                                                                                                                                                                                      
    - The app fully exits (swipe from recents)                                                                                                                                                                     
    - The app is fresh-launched after a process kill                                                                                                                                                                 
    - The Duck.ai frontend sends a voiceSessionEnded message                                                                                                                                                         
  - BrowserTabViewModel — passes tabId into processJsCallbackMessage so the session manager can correctly identify which tab owns the voice session and avoid ending the session when an unrelated tab is closed     
  - AndroidManifest — adds FOREGROUND_SERVICE, FOREGROUND_SERVICE_MICROPHONE, and RECORD_AUDIO permissions, and registers the service with foregroundServiceType="microphone"                                        
                                                                                                                                                                                     
NOTE: This does not consider multiple duck.ai voice sessions.

### Steps to test this PR

Prerequisites: Enable Search & Duck.Ai

_Background app — microphone stays active_
- [ ] Open Duck.ai and start a voice session
- [ ] Press the Home button to background the app
- [ ] Expected: A persistent notification appears ("Duck.ai Voice" or similar). Voice continues picking up audio in the background.

_Return from background — session intact_
- [ ] Complete step 1–2 above
- [ ] Re-open the app from the Recent Apps switcher or tap the notification
- [ ] Expected: The notification disappears. The voice session is still active in Duck.ai.

_Swipe app away from recents — session ends_

- [ ] Open Duck.ai and start a voice session
- [ ] Open the Recent Apps switcher and swipe the app away
- [ ] Expected: The notification is dismissed. The foreground service stops.

_Close the Duck.ai tab — session ends_

- [ ] Open Duck.ai and start a voice session
- [ ] Close the Duck.ai tab (via the tab switcher)
- [ ] Expected: The notification disappears immediately. The voice session ends.

_Closing a different tab — session unaffected_
- [ ] Open Duck.ai and start a voice session, plus at least one other tab
- [ ] Close any tab that is NOT the Duck.ai tab
- [ ] Expected: The notification remains. The voice session continues.

_Voice session ended by Duck.ai UI — service stops_

- [ ] Open Duck.ai and start a voice session
- [ ] End the voice session within Duck.ai (e.g. tap stop/end)
- [ ] Expected: The notification disappears.

_Fresh app launch — no stale session_

- [ ] Force-stop the app while a voice session notification is visible
- [ ] Re-launch the app
- [ ] Expected: No notification appears. No stale session is active.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new microphone foreground service and additional permissions, which can impact privacy expectations, battery, and lifecycle correctness if mis-triggered. Risk is moderated by being scoped to voice sessions and gated behind a feature toggle.
> 
> **Overview**
> Enables Duck.ai voice chat to continue while the app is backgrounded by introducing `DuckChatVoiceMicrophoneService`, a microphone foreground service that shows a persistent notification during an active voice session.
> 
> Voice session tracking is expanded to be *tab-aware* (`VoiceSessionStateManager.onVoiceSessionStarted(tabId)`), optionally starts/stops the foreground service behind a new `duckAiVoiceChatService` feature toggle, and automatically ends the session when the owning tab is closed or on app fresh launch/exit. `BrowserTabViewModel` now passes `tabId` through JS callbacks so the voice session can be associated with the correct tab, and the DuckChat manifest adds the required foreground-service/microphone/audio permissions plus registers the new service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80465997193bc45ecb67794f1593d9b5d9367eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->