### PR TITLE
Remove asana release bridge

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,8 +22,6 @@
     releaseNotesLocales= ["en-US", "en-GB", "en-CA"]
     releaseNotesMaxLength = 500
     errorMessageCancelled = "Release cancelled 😢"
-    aarbExecutable = "AndroidAsanaBridge"
-    asanaBridgeInstallationProblem = "Android Asana Release Bridge not installed or configured correctly - see https://app.asana.com/0/0/1203116937958001/f for instructions"
 
 default_platform(:android)
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -87,14 +87,6 @@ Start new hotfix
 
 Finish a hotfix in progress
 
-### android asana_release_prep
-
-```sh
-[bundle exec] fastlane android asana_release_prep
-```
-
-Prepares the Asana release board with a new release task, tags tasks waiting for release etc..
-
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1214119358887958?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only deletes unused Fastlane constants and documentation for the `asana_release_prep` lane, with no impact on build or release lanes.
> 
> **Overview**
> Removes the Asana release bridge integration from Fastlane by deleting the `aarbExecutable`/installation-error constants and dropping the documented `android asana_release_prep` action from the generated `fastlane/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870e01765a23b448ea41d3862dc55b3fde450f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->