### PR TITLE
Add WinBackPromptEvaluator to re-engage users who switched away from the app as their default browser

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserver.kt
@@ -35,7 +35,6 @@ class DefaultBrowserObserver(
             appInstallStore.defaultBrowser = isDefaultBrowser
             when {
                 isDefaultBrowser -> {
-                    appInstallStore.wasEverDefaultBrowser = true
                     val params = mapOf(
                         PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to false.toString(),
                     )

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/AdditionalDefaultBrowserPromptsImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/AdditionalDefaultBrowserPromptsImpl.kt
@@ -109,7 +109,7 @@ class AdditionalDefaultBrowserPromptsImpl @Inject constructor(
     moshi: Moshi,
 ) : AdditionalDefaultBrowserPrompts, ModalEvaluator, PrivacyConfigCallbackPlugin {
 
-    override val priority: Int = 2
+    override val priority: Int = 3
     override val evaluatorId: String = "additional_default_browser_prompts"
 
     private val evaluationMutex = Mutex()

--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -37,8 +37,9 @@ interface AppInstallStore : MainProcessLifecycleObserver {
 
     var widgetInstalled: Boolean
 
+    /** Setting to `true` also flips [wasEverDefaultBrowser] to `true` permanently. */
     var defaultBrowser: Boolean
-    var wasEverDefaultBrowser: Boolean
+    val wasEverDefaultBrowser: Boolean
 
     var defaultBrowserChangedSurveyDone: Boolean
 
@@ -66,11 +67,15 @@ class AppInstallSharedPreferences @Inject constructor(
 
     override var defaultBrowser: Boolean
         get() = preferences.getBoolean(KEY_DEFAULT_BROWSER, false)
-        set(defaultBrowser) = preferences.edit { putBoolean(KEY_DEFAULT_BROWSER, defaultBrowser) }
+        set(defaultBrowser) = preferences.edit {
+            putBoolean(KEY_DEFAULT_BROWSER, defaultBrowser)
+            if (defaultBrowser) {
+                putBoolean(KEY_WAS_EVER_DEFAULT_BROWSER, true)
+            }
+        }
 
-    override var wasEverDefaultBrowser: Boolean
+    override val wasEverDefaultBrowser: Boolean
         get() = preferences.getBoolean(KEY_WAS_EVER_DEFAULT_BROWSER, false)
-        set(value) = preferences.edit { putBoolean(KEY_WAS_EVER_DEFAULT_BROWSER, value) }
 
     override var defaultBrowserChangedSurveyDone: Boolean
         get() = preferences.getBoolean(KEY_DEFAULT_BROWSER_CHANGED_SURVEY_DONE, false)

--- a/app/src/main/java/com/duckduckgo/app/global/store/AndroidUserBrowserProperties.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/store/AndroidUserBrowserProperties.kt
@@ -61,7 +61,7 @@ class AndroidUserBrowserProperties(
         return appInstallStore.defaultBrowser
     }
 
-    override fun wasEverDefaultBrowser(): Boolean {
+    override suspend fun wasEverDefaultBrowser(): Boolean {
         return appInstallStore.wasEverDefaultBrowser
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/store/AndroidUserBrowserProperties.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/store/AndroidUserBrowserProperties.kt
@@ -61,6 +61,10 @@ class AndroidUserBrowserProperties(
         return appInstallStore.defaultBrowser
     }
 
+    override fun wasEverDefaultBrowser(): Boolean {
+        return appInstallStore.wasEverDefaultBrowser
+    }
+
     override fun emailEnabled(): Boolean {
         return emailManager.isSignedIn()
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -298,7 +298,6 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     fun onDefaultBrowserSet() {
         defaultRoleBrowserDialog.dialogShown()
         appInstallStore.defaultBrowser = true
-        appInstallStore.wasEverDefaultBrowser = true
         pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, mapOf(PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()))
         viewModelScope.launch {
             _viewState.update { it.copy(showSplitOption = isSplitOmnibarEnabled()) }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -154,7 +154,6 @@ class DefaultBrowserPageViewModel @Inject constructor(
         timesPressedJustOnce = 0
         if (defaultBrowserDetector.isDefaultBrowser()) {
             installStore.defaultBrowser = true
-            installStore.wasEverDefaultBrowser = true
             val params = mapOf(
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 Pixel.PixelParameter.DEFAULT_BROWSER_SET_ORIGIN to originValue,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -346,7 +346,6 @@ class WelcomePageViewModel @Inject constructor(
     fun onDefaultBrowserSet() {
         defaultRoleBrowserDialog.dialogShown()
         appInstallStore.defaultBrowser = true
-        appInstallStore.wasEverDefaultBrowser = true
         pixel.fire(AppPixelName.DEFAULT_BROWSER_SET, mapOf(PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString()))
 
         viewModelScope.launch {

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
@@ -66,36 +66,6 @@ class DefaultBrowserObserverTest {
     }
 
     @Test
-    fun whenDDGBecomesDefaultBrowserThenWasEverDefaultSetToTrue() {
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppInstallStore.defaultBrowser).thenReturn(false)
-
-        testee.onResume(mockOwner)
-
-        verify(mockAppInstallStore).wasEverDefaultBrowser = true
-    }
-
-    @Test
-    fun whenDDGIsNotDefaultBrowserThenWasEverDefaultNotChanged() {
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
-        whenever(mockAppInstallStore.defaultBrowser).thenReturn(false)
-
-        testee.onResume(mockOwner)
-
-        verify(mockAppInstallStore, never()).wasEverDefaultBrowser = any()
-    }
-
-    @Test
-    fun whenDDGRemainsDefaultBrowserThenWasEverDefaultNotChanged() {
-        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
-        whenever(mockAppInstallStore.defaultBrowser).thenReturn(true)
-
-        testee.onResume(mockOwner)
-
-        verify(mockAppInstallStore, never()).wasEverDefaultBrowser = any()
-    }
-
-    @Test
     fun whenDDGIsNotDefaultBrowserIfItWasNotBeforeThenDoNotFireSetPixel() {
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
         whenever(mockAppInstallStore.defaultBrowser).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/global/install/AppInstallSharedPreferencesTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/install/AppInstallSharedPreferencesTest.kt
@@ -87,4 +87,35 @@ class AppInstallSharedPreferencesTest {
 
         assertEquals(existingTimestamp, testee.installTimestamp)
     }
+
+    @Test
+    fun whenInitializedThenDefaultBrowserAndWasEverDefaultBrowserAreFalse() = runTest {
+        assertFalse(testee.defaultBrowser)
+        assertFalse(testee.wasEverDefaultBrowser)
+    }
+
+    @Test
+    fun whenDefaultBrowserSetToTrueThenWasEverDefaultBrowserIsTrue() = runTest {
+        testee.defaultBrowser = true
+
+        assertTrue(testee.defaultBrowser)
+        assertTrue(testee.wasEverDefaultBrowser)
+    }
+
+    @Test
+    fun whenDefaultBrowserSetToFalseInitiallyThenWasEverDefaultBrowserRemainsFalse() = runTest {
+        testee.defaultBrowser = false
+
+        assertFalse(testee.defaultBrowser)
+        assertFalse(testee.wasEverDefaultBrowser)
+    }
+
+    @Test
+    fun whenDefaultBrowserSetToFalseAfterBeingTrueThenWasEverDefaultBrowserRemainsTrue() = runTest {
+        testee.defaultBrowser = true
+        testee.defaultBrowser = false
+
+        assertFalse(testee.defaultBrowser)
+        assertTrue(testee.wasEverDefaultBrowser)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -2018,6 +2018,10 @@ class TabSwitcherViewModelTest {
             TODO("Not yet implemented")
         }
 
+        override fun wasEverDefaultBrowser(): Boolean {
+            TODO("Not yet implemented")
+        }
+
         override fun emailEnabled(): Boolean {
             TODO("Not yet implemented")
         }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -2018,7 +2018,7 @@ class TabSwitcherViewModelTest {
             TODO("Not yet implemented")
         }
 
-        override fun wasEverDefaultBrowser(): Boolean {
+        override suspend fun wasEverDefaultBrowser(): Boolean {
             TODO("Not yet implemented")
         }
 

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
@@ -31,6 +31,12 @@ interface UserBrowserProperties {
     fun daysSinceInstalled(): Long
     suspend fun daysUsedSince(since: Date): Long
     fun defaultBrowser(): Boolean
+
+    /**
+     * Returns true if this app has ever been set as the user's default browser.
+     * Once true, this value is permanent — it does not revert if the user later
+     * changes their default browser to something else.
+     */
     fun wasEverDefaultBrowser(): Boolean
     fun emailEnabled(): Boolean
     fun searchCount(): Long

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
@@ -37,7 +37,7 @@ interface UserBrowserProperties {
      * Once true, this value is permanent — it does not revert if the user later
      * changes their default browser to something else.
      */
-    fun wasEverDefaultBrowser(): Boolean
+    suspend fun wasEverDefaultBrowser(): Boolean
     fun emailEnabled(): Boolean
     fun searchCount(): Long
     fun widgetAdded(): Boolean

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/UserBrowserProperties.kt
@@ -31,6 +31,7 @@ interface UserBrowserProperties {
     fun daysSinceInstalled(): Long
     suspend fun daysUsedSince(since: Date): Long
     fun defaultBrowser(): Boolean
+    fun wasEverDefaultBrowser(): Boolean
     fun emailEnabled(): Boolean
     fun searchCount(): Long
     fun widgetAdded(): Boolean

--- a/dax-prompts/dax-prompts-impl/build.gradle
+++ b/dax-prompts/dax-prompts-impl/build.gradle
@@ -25,6 +25,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(':dax-prompts-api')
+    implementation project(':modal-coordinator-api')
     implementation project(':browser-api')
     implementation project(':common-utils')
     implementation project(':design-system')

--- a/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
+++ b/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.onboarding.OnboardingFlowChecker
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonNoParams
@@ -56,6 +57,7 @@ class WinBackPromptEvaluatorImpl @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val dispatchers: DispatcherProvider,
     private val reactivateUsersToggles: ReactivateUsersToggles,
+    private val onboardingFlowChecker: OnboardingFlowChecker,
 ) : ModalEvaluator, WinBackPromptEvaluator {
 
     override val priority: Int = 1
@@ -81,7 +83,8 @@ class WinBackPromptEvaluatorImpl @Inject constructor(
 
     private fun isEnabled() = reactivateUsersToggles.self().isEnabled() && reactivateUsersToggles.defaultBrowserWinBackPrompt().isEnabled()
 
-    private suspend fun isEligible() = userBrowserProperties.wasEverDefaultBrowser() &&
+    private suspend fun isEligible() = onboardingFlowChecker.isOnboardingComplete() &&
+        userBrowserProperties.wasEverDefaultBrowser() &&
         !daxPromptsRepository.getDaxPromptsBrowserComparisonShown() &&
         !defaultBrowserDetector.isDefaultBrowser()
 

--- a/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
+++ b/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.daxprompts.impl
+
+import android.content.Context
+import android.content.Intent
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonNoParams
+import com.duckduckgo.daxprompts.impl.repository.DaxPromptsRepository
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface WinBackPromptEvaluator
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ModalEvaluator::class,
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = WinBackPromptEvaluator::class,
+)
+class WinBackPromptEvaluatorImpl @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val applicationContext: Context,
+    private val userBrowserProperties: UserBrowserProperties,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
+    private val daxPromptsRepository: DaxPromptsRepository,
+    private val globalActivityStarter: GlobalActivityStarter,
+    private val dispatchers: DispatcherProvider,
+    private val reactivateUsersToggles: ReactivateUsersToggles,
+) : ModalEvaluator, WinBackPromptEvaluator {
+
+    override val priority: Int = 1
+
+    override val evaluatorId: String = "win_back_prompt"
+
+    override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
+        if (isEnabled() && isEligible()) {
+            val intent = globalActivityStarter
+                .startIntent(applicationContext, DaxPromptBrowserComparisonNoParams) ?: return@withContext ModalEvaluator.EvaluationResult.Skipped
+
+            delay(MODAL_DISPLAY_DELAY)
+            appCoroutineScope.launch(dispatchers.main()) {
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                applicationContext.startActivity(intent)
+            }
+
+            return@withContext ModalEvaluator.EvaluationResult.ModalShown
+        } else {
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+    }
+
+    private fun isEnabled() = reactivateUsersToggles.self().isEnabled() && reactivateUsersToggles.defaultBrowserWinBackPrompt().isEnabled()
+
+    private suspend fun isEligible() = userBrowserProperties.wasEverDefaultBrowser() &&
+        !daxPromptsRepository.getDaxPromptsBrowserComparisonShown() &&
+        !defaultBrowserDetector.isDefaultBrowser()
+
+    companion object {
+        private const val MODAL_DISPLAY_DELAY = 1500L
+    }
+}

--- a/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
+++ b/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluator.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.modalcoordinator.api.ModalEvaluator
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -45,6 +46,7 @@ interface WinBackPromptEvaluator
     scope = AppScope::class,
     boundType = WinBackPromptEvaluator::class,
 )
+@SingleInstanceIn(scope = AppScope::class)
 class WinBackPromptEvaluatorImpl @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val applicationContext: Context,

--- a/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
+++ b/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.onboarding.OnboardingFlowChecker
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonNoParams
@@ -50,6 +51,7 @@ class WinBackPromptEvaluatorImplTest {
     private val mockDaxPromptsRepository: DaxPromptsRepository = mock()
     private val mockGlobalActivityStarter: GlobalActivityStarter = mock()
     private val fakeReactivateUsersToggles = FakeFeatureToggleFactory.create(ReactivateUsersToggles::class.java)
+    private val mockOnboardingFlowChecker: OnboardingFlowChecker = mock()
     private val mockIntent: Intent = mock()
 
     private val testee = WinBackPromptEvaluatorImpl(
@@ -61,6 +63,7 @@ class WinBackPromptEvaluatorImplTest {
         globalActivityStarter = mockGlobalActivityStarter,
         dispatchers = coroutinesTestRule.testDispatcherProvider,
         reactivateUsersToggles = fakeReactivateUsersToggles,
+        onboardingFlowChecker = mockOnboardingFlowChecker,
     )
 
     @Test
@@ -86,8 +89,23 @@ class WinBackPromptEvaluatorImplTest {
     }
 
     @Test
+    fun whenOnboardingIsNotCompleteThenEvaluationIsSkipped() = runTest {
+        givenTogglesEnabled()
+        whenever(mockOnboardingFlowChecker.isOnboardingComplete()).thenReturn(false)
+        whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
+        whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(false)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
     fun whenUserWasNeverDefaultBrowserThenEvaluationIsSkipped() = runTest {
         givenTogglesEnabled()
+        whenever(mockOnboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
         whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(false)
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
 
@@ -100,6 +118,7 @@ class WinBackPromptEvaluatorImplTest {
     @Test
     fun whenUserIsCurrentlyDefaultBrowserThenEvaluationIsSkipped() = runTest {
         givenTogglesEnabled()
+        whenever(mockOnboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
         whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
         whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(false)
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
@@ -166,6 +185,7 @@ class WinBackPromptEvaluatorImplTest {
     }
 
     private suspend fun givenUserIsEligible() {
+        whenever(mockOnboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
         whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
     }

--- a/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
+++ b/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
@@ -165,7 +165,7 @@ class WinBackPromptEvaluatorImplTest {
         fakeReactivateUsersToggles.defaultBrowserWinBackPrompt().setRawStoredState(State(true))
     }
 
-    private fun givenUserIsEligible() {
+    private suspend fun givenUserIsEligible() {
         whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
         whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
     }

--- a/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
+++ b/dax-prompts/dax-prompts-impl/src/test/java/com/duckduckgo/daxprompts/impl/WinBackPromptEvaluatorImplTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.daxprompts.impl
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonNoParams
+import com.duckduckgo.daxprompts.impl.repository.DaxPromptsRepository
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class WinBackPromptEvaluatorImplTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private val mockApplicationContext: Context = mock()
+    private val mockUserBrowserProperties: UserBrowserProperties = mock()
+    private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
+    private val mockDaxPromptsRepository: DaxPromptsRepository = mock()
+    private val mockGlobalActivityStarter: GlobalActivityStarter = mock()
+    private val fakeReactivateUsersToggles = FakeFeatureToggleFactory.create(ReactivateUsersToggles::class.java)
+    private val mockIntent: Intent = mock()
+
+    private val testee = WinBackPromptEvaluatorImpl(
+        appCoroutineScope = coroutinesTestRule.testScope,
+        applicationContext = mockApplicationContext,
+        userBrowserProperties = mockUserBrowserProperties,
+        defaultBrowserDetector = mockDefaultBrowserDetector,
+        daxPromptsRepository = mockDaxPromptsRepository,
+        globalActivityStarter = mockGlobalActivityStarter,
+        dispatchers = coroutinesTestRule.testDispatcherProvider,
+        reactivateUsersToggles = fakeReactivateUsersToggles,
+    )
+
+    @Test
+    fun whenSelfToggleIsDisabledThenEvaluationIsSkipped() = runTest {
+        fakeReactivateUsersToggles.self().setRawStoredState(State(false))
+        fakeReactivateUsersToggles.defaultBrowserWinBackPrompt().setRawStoredState(State(true))
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
+    fun whenWinBackPromptToggleIsDisabledThenEvaluationIsSkipped() = runTest {
+        fakeReactivateUsersToggles.self().setRawStoredState(State(true))
+        fakeReactivateUsersToggles.defaultBrowserWinBackPrompt().setRawStoredState(State(false))
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
+    fun whenUserWasNeverDefaultBrowserThenEvaluationIsSkipped() = runTest {
+        givenTogglesEnabled()
+        whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(false)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
+    fun whenUserIsCurrentlyDefaultBrowserThenEvaluationIsSkipped() = runTest {
+        givenTogglesEnabled()
+        whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
+        whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(false)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
+    fun whenBrowserComparisonAlreadyShownThenEvaluationIsSkipped() = runTest {
+        givenTogglesEnabled()
+        givenUserIsEligible()
+        whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(true)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockGlobalActivityStarter, never()).startIntent(any(), any<GlobalActivityStarter.ActivityParams>())
+    }
+
+    @Test
+    fun whenAllConditionsMetButIntentIsNullThenEvaluationIsSkipped() = runTest {
+        givenTogglesEnabled()
+        givenUserIsEligible()
+        whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(false)
+        whenever(mockGlobalActivityStarter.startIntent(mockApplicationContext, DaxPromptBrowserComparisonNoParams)).thenReturn(null)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, result)
+        verify(mockApplicationContext, never()).startActivity(any())
+    }
+
+    @Test
+    fun whenAllConditionsMetAndIntentAvailableThenModalShownAndActivityLaunched() = runTest {
+        givenTogglesEnabled()
+        givenUserIsEligible()
+        whenever(mockDaxPromptsRepository.getDaxPromptsBrowserComparisonShown()).thenReturn(false)
+        whenever(mockGlobalActivityStarter.startIntent(mockApplicationContext, DaxPromptBrowserComparisonNoParams)).thenReturn(mockIntent)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, result)
+        coroutinesTestRule.testScope.testScheduler.advanceUntilIdle()
+        verify(mockApplicationContext).startActivity(mockIntent)
+        verify(mockIntent).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    }
+
+    @Test
+    fun evaluatorHasCorrectPriority() {
+        assertEquals(1, testee.priority)
+    }
+
+    @Test
+    fun evaluatorHasCorrectId() {
+        assertEquals("win_back_prompt", testee.evaluatorId)
+    }
+
+    private fun givenTogglesEnabled() {
+        fakeReactivateUsersToggles.self().setRawStoredState(State(true))
+        fakeReactivateUsersToggles.defaultBrowserWinBackPrompt().setRawStoredState(State(true))
+    }
+
+    private fun givenUserIsEligible() {
+        whenever(mockUserBrowserProperties.wasEverDefaultBrowser()).thenReturn(true)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(false)
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluator.kt
@@ -61,7 +61,7 @@ class RemoteMessageModalSurfaceEvaluatorImpl @Inject constructor(
     private val onboardingFlowChecker: OnboardingFlowChecker,
 ) : RemoteMessageModalSurfaceEvaluator, ModalEvaluator {
 
-    override val priority: Int = 1
+    override val priority: Int = 2
     override val evaluatorId: String = "remote_message_modal"
 
     override suspend fun evaluate(): ModalEvaluator.EvaluationResult {

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluatorImplTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/modal/evaluator/RemoteMessageModalSurfaceEvaluatorImplTest.kt
@@ -309,7 +309,7 @@ class RemoteMessageModalSurfaceEvaluatorImplTest {
 
     @Test
     fun evaluatorHasCorrectPriority() {
-        assertEquals(1, testee.priority)
+        assertEquals(2, testee.priority)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1211724162604201/task/1213440050991462?focus=true

### Description

Introduces a "win back" prompt for users who previously set DuckDuckGo as their default browser but no longer have it set as default. Key changes include:

- Added a new `WinBackPromptEvaluator` that shows the browser comparison screen to eligible users (those who were once the default browser but no longer are, and haven't seen the browser comparison prompt before). This evaluator is registered as a `ModalEvaluator` with the highest priority (`1`).
- Bumped `RemoteMessageModalSurfaceEvaluator` priority from `1` to `2` and `AdditionalDefaultBrowserPromptsImpl` priority from `2` to `3` to accommodate the new evaluator's priority slot.
- Consolidated `wasEverDefaultBrowser` tracking logic into the `defaultBrowser` setter in `AppInstallSharedPreferences`. Setting `defaultBrowser = true` now automatically and permanently flips `wasEverDefaultBrowser` to `true`, removing the need for callers to set it manually. `wasEverDefaultBrowser` is now a read-only `val`.
- Exposed `wasEverDefaultBrowser` through the `UserBrowserProperties` interface and its Android implementation.

### Steps to test this PR

_Win Back Prompt_

- [x] Clean install the app and enable the `reactivateUsers` and `defaultBrowserWinBackPrompt` feature toggles
- [x] From the settings set the app as default browser and resume the app
- [x] Set another app as default browser and then resume the app
- [x] The re-engagement prompt should be displayed

### UI changes

Show the browser comparison prompt when the user unsets the app as the default browser and then resumes the app:

![Screenshot 2026-04-17 at 19.09.12.png](https://app.graphite.com/user-attachments/assets/97a91081-76d6-4d90-bd98-96ea48bb5812.png)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modal evaluation priority and introduces a new re-engagement flow, which could affect which prompts users see and when. Also alters persistence semantics for default-browser history, so regressions would mainly impact eligibility/analytics rather than security.
> 
> **Overview**
> Adds a new `WinBackPromptEvaluatorImpl` modal (priority `1`) that launches the browser comparison prompt for users who **previously set DDG as default** but are no longer default, gated by feature toggles, onboarding completion, and “not previously shown” state.
> 
> Refactors default-browser history tracking by making `AppInstallStore.wasEverDefaultBrowser` read-only and permanently set via the `defaultBrowser` setter (call sites stop writing it directly); this is surfaced via a new `UserBrowserProperties.wasEverDefaultBrowser()` API.
> 
> Rebalances modal ordering by bumping `RemoteMessageModalSurfaceEvaluator` to priority `2` and `AdditionalDefaultBrowserPromptsImpl` to `3`, and updates/adjusts unit tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f423df49010a417822aeff68dcd7a07d57a74e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->