### PR TITLE
Update PIR broker bundle - 2026-04-20

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "AdvancedBackgroundChecks",
   "url": "advancedbackgroundchecks.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678060800000,
   "optOutUrl": "https://www.advancedbackgroundchecks.com/removal",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "070b6417-8ccd-4111-b5ae-7ae470b0399a",
-          "url": "https://www.advancedbackgroundchecks.com/names/${firstName}-${lastName}_${city}-${state}"
+          "url": "https://www.advancedbackgroundchecks.com/names/${firstName|hyphenated}-${lastName|hyphenated}_${city|hyphenated}-${state|hyphenated}"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
@@ -1,7 +1,7 @@
 {
   "name": "BeenVerified",
   "url": "beenverified.com",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts",
   "mirrorSites": [
     {
@@ -75,7 +75,7 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.beenverified.com/svc/optout/search/optouts/search_person_result",
+          "url": "https://www.beenverified.com/svc/optout/search/optouts",
           "id": "000df3ca-c08b-4261-9d19-6b6463865677"
         },
         {
@@ -83,47 +83,27 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "#result-filter"
+              "selector": "#optout-form"
             }
           ],
           "id": "888d175a-9c31-46c8-8a37-eab78c3c37e5"
         },
         {
-          "_comment": "Filter menu is hidden on mobile, so we need to click the button to show it",
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "#filters-toggle",
-              "failSilently": true
-            }
-          ],
-          "id": "a1c2e3f4-5678-9abc-def0-123456789abc"
-        },
-        {
           "actionType": "fillForm",
-          "selector": "#result-filter",
+          "selector": "#optout-form",
           "dataSource": "userProfile",
           "elements": [
             {
               "type": "firstName",
-              "selector": "//input[@name='fName']"
-            },
-            {
-              "type": "middleName",
-              "selector": "//input[@name='mName']"
+              "selector": "//input[@name='fname']"
             },
             {
               "type": "lastName",
-              "selector": "//input[@name='lName']"
+              "selector": "//input[@name='ln']"
             },
             {
               "type": "state",
-              "selector": "#stateSelect"
-            },
-            {
-              "type": "city",
-              "selector": "//input[@name='city']"
+              "selector": "//input[@name='state']"
             }
           ],
           "id": "444a01d9-630f-42e4-a8b8-4c87ddab91e3"
@@ -133,10 +113,114 @@
           "elements": [
             {
               "type": "button",
-              "selector": "//button[@name='search' and @type='submit']"
+              "selector": "//button[@aria-label='search-optout-button' and @type='submit']"
             }
           ],
           "id": "111eb5ef-b469-41a6-af92-da9056c00781"
+        },
+        {
+          "_comment": "Wait for either form to appear before branching. The condition below runs once without retries.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//*[@id='comprehensive-form'] | //*[@id='result-filter']"
+            }
+          ],
+          "id": "ba896158-77d6-4769-b373-2b5226c6d870"
+        },
+        {
+          "_comment": "Highly populated states show a different form.",
+          "actionType": "condition",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#comprehensive-form",
+              "failSilently": true
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "dataSource": "userProfile",
+              "elements": [
+                {
+                  "type": "firstName",
+                  "selector": "#fname"
+                },
+                {
+                  "type": "middleName",
+                  "selector": "#mn"
+                },
+                {
+                  "type": "lastName",
+                  "selector": "#ln"
+                },
+                {
+                  "type": "age",
+                  "selector": "#age"
+                },
+                {
+                  "type": "city",
+                  "selector": "#city"
+                }
+              ],
+              "id": "37326759-daef-46e8-9aad-95a3ce26b2c2"
+            },
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "elements": [
+                {
+                  "type": "email",
+                  "selector": "#requestor_email"
+                },
+                {
+                  "type": "$generated_street_address$",
+                  "selector": "#street"
+                },
+                {
+                  "type": "$generated_zip_code$",
+                  "selector": "#zip"
+                }
+              ],
+              "id": "84550c23-55d6-4bd4-9e3f-f588d5635a41"
+            },
+            {
+              "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+              "actionType": "expectation",
+              "expectations": [
+                {
+                  "type": "element",
+                  "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']",
+                  "parent": "//*[@id='comprehensive-form']"
+                }
+              ],
+              "id": "380a8326-fb41-4ba3-8721-f1e437d3ee43"
+            },
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "button[aria-label='continue-button']"
+                }
+              ],
+              "id": "15d01baf-8ef1-4d23-b110-c01ce978069d"
+            }
+          ],
+          "id": "6087c415-005d-4bca-91d9-bcd22b48c6ba"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#result-filter"
+            }
+          ],
+          "id": "e773731e-f9c7-40d6-b996-21c1e6ac617a"
         },
         {
           "actionType": "extract",
@@ -152,10 +236,10 @@
               "afterText": ", "
             },
             "addressCityState": {
-              "selector": ".MuiGrid-item:nth-child(3) .MuiTypography-body1"
+              "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
             }
           },
-          "id": "4285ef9d-aebf-4176-80e6-2959fc9f5c8a"
+          "id": "94f0c65d-cac1-4724-ba3a-4da7fd59ab2c"
         }
       ]
     },
@@ -221,71 +305,109 @@
           "id": "018eb6ef-b469-41a6-af92-da9056c00781"
         },
         {
+          "_comment": "Wait for either form to appear before branching. The condition below runs once without retries.",
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "#comprehensive-form"
+              "selector": "//*[@id='comprehensive-form'] | //*[@id='result-filter']"
             }
           ],
-          "id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+          "id": "d275c4c7-cd31-44c3-93e4-f94ffbea600e"
         },
         {
-          "actionType": "fillForm",
-          "selector": "#comprehensive-form",
-          "elements": [
+          "_comment": "Highly populated states show a different form.",
+          "actionType": "condition",
+          "expectations": [
             {
-              "type": "email",
-              "selector": "#requestor_email"
-            },
-            {
-              "type": "$generated_street_address$",
-              "selector": "#street"
-            },
-            {
-              "type": "$generated_zip_code$",
-              "selector": "#zip"
+              "type": "element",
+              "selector": "#comprehensive-form",
+              "failSilently": true
             }
           ],
-          "id": "b2c34e54-f67a-4bc8-9d0e-1f2a3bc5d6e2"
+          "actions": [
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "dataSource": "userProfile",
+              "elements": [
+                {
+                  "type": "firstName",
+                  "selector": "#fname"
+                },
+                {
+                  "type": "middleName",
+                  "selector": "#mn"
+                },
+                {
+                  "type": "lastName",
+                  "selector": "#ln"
+                },
+                {
+                  "type": "age",
+                  "selector": "#age"
+                },
+                {
+                  "type": "city",
+                  "selector": "#city"
+                }
+              ],
+              "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
+            },
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "elements": [
+                {
+                  "type": "email",
+                  "selector": "#requestor_email"
+                },
+                {
+                  "type": "$generated_street_address$",
+                  "selector": "#street"
+                },
+                {
+                  "type": "$generated_zip_code$",
+                  "selector": "#zip"
+                }
+              ],
+              "id": "b2c34e54-f67a-4bc8-9d0e-1f2a3bc5d6e2"
+            },
+            {
+              "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+              "actionType": "expectation",
+              "expectations": [
+                {
+                  "type": "element",
+                  "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']",
+                  "parent": "//*[@id='comprehensive-form']"
+                }
+              ],
+              "id": "e5d37b9a-d7ae-42aa-80a8-cafc5dd5defd"
+            },
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "button[aria-label='continue-button']"
+                }
+              ],
+              "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
+            }
+          ],
+          "id": "68b1567f-abbe-4fb4-9c4d-3105db8dd709"
         },
         {
-          "actionType": "fillForm",
-          "selector": "#comprehensive-form",
-          "dataSource": "userProfile",
-          "elements": [
+          "_comment": "Results page. Low-pop lands here directly, high-pop after the comprehensive form.",
+          "actionType": "expectation",
+          "expectations": [
             {
-              "type": "firstName",
-              "selector": "#fname"
-            },
-            {
-              "type": "middleName",
-              "selector": "#mn"
-            },
-            {
-              "type": "lastName",
-              "selector": "#ln"
-            },
-            {
-              "type": "age",
-              "selector": "#age"
-            },
-            {
-              "type": "city",
-              "selector": "#city"
+              "type": "element",
+              "selector": "#result-filter"
             }
           ],
-          "id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": "button[aria-label='continue-button']"
-            }
-          ],
-          "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
+          "id": "088d8233-ce87-4a49-bfe2-38d386764f1b"
         },
         {
           "actionType": "click",

--- a/pir/pir-impl/src/main/assets/brokers/clustrmaps.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/clustrmaps.com.json
@@ -1,7 +1,7 @@
 {
   "name": "ClustrMaps",
   "url": "clustrmaps.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "neighbor.report",
   "addedDatetime": 1692594000000,
   "optOutUrl": "https://clustrmaps.com/bl/opt-out",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "c4d4ce8d-0b33-46cb-8e73-a544b362460d",
-          "url": "https://clustrmaps.com/persons/${firstName}-${lastName}/${state|stateFull|capitalize}/${city|hyphenated}"
+          "url": "https://clustrmaps.com/persons/${firstName|hyphenated}-${lastName|hyphenated}/${state|stateFull|capitalize|hyphenated}/${city|hyphenated}"
         },
         {
           "_comment": "Wait for CF challenge interstitial to complete",

--- a/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/cyberbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Cyber Background Checks",
   "url": "cyberbackgroundchecks.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1705644000000,
   "optOutUrl": "https://cyberbackgroundchecks.com/donotsellmyinfo",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "9f5caaf9-5bd7-494e-bfbb-e33c4927cdb3",
-          "url": "https://www.cyberbackgroundchecks.com/people/${firstName}-${lastName}/${state}/${city}"
+          "url": "https://www.cyberbackgroundchecks.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${state|hyphenated}/${city|hyphenated}"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FastBackgroundCheck.com",
   "url": "fastbackgroundcheck.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1706248800000,
   "optOutUrl": "https://www.fastbackgroundcheck.com/opt-out",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "58fdfa90-9b0c-4fda-8961-e73502f68474",
-          "url": "https://www.fastbackgroundcheck.com/people/${firstName}-${lastName}/${city}-${state}"
+          "url": "https://www.fastbackgroundcheck.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${city|hyphenated}-${state|hyphenated}"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FastPeopleSearch",
   "url": "fastpeoplesearch.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1675317600000,
   "optOutUrl": "https://www.fastpeoplesearch.com/removal",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "040e0a0a-095a-490e-8c55-ee7b66732030",
-          "url": "https://www.fastpeoplesearch.com/name/${firstName}-${lastName}_${city}-${state}"
+          "url": "https://www.fastpeoplesearch.com/name/${firstName|hyphenated}-${lastName|hyphenated}_${city|hyphenated}-${state|hyphenated}"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/freepeopledirectory.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/freepeopledirectory.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FreePeopleDirectory",
   "url": "freepeopledirectory.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "spokeo.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://freepeopledirectory.com/contact",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "f1510c8b-f010-4e6f-a748-d34c7777edd7",
-          "url": "https://www.freepeopledirectory.com/name/${firstName}-${lastName}/${state|upcase}/${city|hyphenated}"
+          "url": "https://www.freepeopledirectory.com/name/${firstName|hyphenated}-${lastName|hyphenated}/${state|upcase}/${city|hyphenated}"
         },
         {
           "actionType": "condition",

--- a/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
@@ -1,7 +1,7 @@
 {
   "name": "NeighborWho",
   "url": "neighborwho.com",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.neighborwho.com/svc/optout/search/optouts",
   "mirrorSites": [
@@ -64,6 +64,100 @@
           "id": "777eb5ef-b469-41a6-af92-da9056c00781"
         },
         {
+          "_comment": "Wait for either form to appear before branching. The condition below runs once without retries.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//*[@id='comprehensive-form'] | //*[@id='result-filter']"
+            }
+          ],
+          "id": "26f825f6-eec4-4439-a1f3-6a4464adfd34"
+        },
+        {
+          "_comment": "Highly populated states show a different form.",
+          "actionType": "condition",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#comprehensive-form",
+              "failSilently": true
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "dataSource": "userProfile",
+              "elements": [
+                {
+                  "type": "firstName",
+                  "selector": "#fname"
+                },
+                {
+                  "type": "middleName",
+                  "selector": "#mn"
+                },
+                {
+                  "type": "lastName",
+                  "selector": "#ln"
+                },
+                {
+                  "type": "age",
+                  "selector": "#age"
+                },
+                {
+                  "type": "city",
+                  "selector": "#city"
+                }
+              ],
+              "id": "d61fece1-8300-4dd3-ba27-a043a424f668"
+            },
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "elements": [
+                {
+                  "type": "email",
+                  "selector": "#requestor_email"
+                },
+                {
+                  "type": "$generated_street_address$",
+                  "selector": "#street"
+                },
+                {
+                  "type": "$generated_zip_code$",
+                  "selector": "#zip"
+                }
+              ],
+              "id": "fcda8348-9c1e-4304-9163-6d546b7aa099"
+            },
+            {
+              "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+              "actionType": "expectation",
+              "expectations": [
+                {
+                  "type": "element",
+                  "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']",
+                  "parent": "//*[@id='comprehensive-form']"
+                }
+              ],
+              "id": "86642ccf-0273-4523-ad03-a90260e9f47b"
+            },
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "button[aria-label='continue-button']"
+                }
+              ],
+              "id": "dc412524-0265-4e69-8a97-7f7c1438c8d5"
+            }
+          ],
+          "id": "08170fc2-18d2-4dad-8dce-5341795f3557"
+        },
+        {
           "actionType": "expectation",
           "expectations": [
             {
@@ -87,7 +181,7 @@
               "afterText": ", "
             },
             "addressCityState": {
-              "selector": ".MuiGrid-item:nth-child(3) .MuiTypography-body1"
+              "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
             }
           },
           "id": "7775ef9d-aebf-4176-80e6-2959fc9f5c8a"

--- a/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleLooker",
   "url": "peoplelooker.com",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.peoplelooker.com/svc/optout/search/optouts",
   "steps": [
@@ -55,6 +55,100 @@
           "id": "fffeb5ef-b469-41a6-af92-da9056c00781"
         },
         {
+          "_comment": "Wait for either form to appear before branching. The condition below runs once without retries.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//*[@id='comprehensive-form'] | //*[@id='result-filter']"
+            }
+          ],
+          "id": "09343be2-6454-4d0f-8f23-143b16f26b32"
+        },
+        {
+          "_comment": "Highly populated states show a different form.",
+          "actionType": "condition",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "#comprehensive-form",
+              "failSilently": true
+            }
+          ],
+          "actions": [
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "dataSource": "userProfile",
+              "elements": [
+                {
+                  "type": "firstName",
+                  "selector": "#fname"
+                },
+                {
+                  "type": "middleName",
+                  "selector": "#mn"
+                },
+                {
+                  "type": "lastName",
+                  "selector": "#ln"
+                },
+                {
+                  "type": "age",
+                  "selector": "#age"
+                },
+                {
+                  "type": "city",
+                  "selector": "#city"
+                }
+              ],
+              "id": "a24f99a5-4224-43ae-9f3d-9fa480544526"
+            },
+            {
+              "actionType": "fillForm",
+              "selector": "#comprehensive-form",
+              "elements": [
+                {
+                  "type": "email",
+                  "selector": "#requestor_email"
+                },
+                {
+                  "type": "$generated_street_address$",
+                  "selector": "#street"
+                },
+                {
+                  "type": "$generated_zip_code$",
+                  "selector": "#zip"
+                }
+              ],
+              "id": "31b85f99-c3ae-4d0b-be7a-d12275aea7d2"
+            },
+            {
+              "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+              "actionType": "expectation",
+              "expectations": [
+                {
+                  "type": "element",
+                  "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']",
+                  "parent": "//*[@id='comprehensive-form']"
+                }
+              ],
+              "id": "10fcca38-bd1d-4fd5-a38a-678d4d6aadcd"
+            },
+            {
+              "actionType": "click",
+              "elements": [
+                {
+                  "type": "button",
+                  "selector": "button[aria-label='continue-button']"
+                }
+              ],
+              "id": "236dbcf4-2b7b-4c9a-9684-b5c11c11177d"
+            }
+          ],
+          "id": "9b35d3f7-a1c9-4f92-82f3-ba48edbbda84"
+        },
+        {
           "actionType": "expectation",
           "expectations": [
             {
@@ -78,7 +172,7 @@
               "afterText": ", "
             },
             "addressCityState": {
-              "selector": ".MuiGrid-item:nth-child(3) .MuiTypography-body1"
+              "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
             }
           },
           "id": "4285ef9d-aebf-4176-80e6-2959fc9f5c8a"

--- a/pir/pir-impl/src/main/assets/brokers/peoplewhizr.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplewhizr.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleWhizr.com",
   "url": "peoplewhizr.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplewhiz.com",
   "addedDatetime": 1709445600000,
   "optOutUrl": "https://peoplewhizr.com/optout",
@@ -54,5 +54,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1776436538115
 }

--- a/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Search People FREE",
   "url": "searchpeoplefree.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1703052000000,
   "optOutUrl": "https://www.searchpeoplefree.com/opt-out",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "a85625a6-4607-4fea-9fa4-38294a7de727",
-          "url": "https://searchpeoplefree.com/find/${firstName}-${lastName}/${state}/${city}"
+          "url": "https://searchpeoplefree.com/find/${firstName|hyphenated}-${lastName|hyphenated}/${state|hyphenated}/${city|hyphenated}"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/smartbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "SmartBackgroundChecks",
   "url": "smartbackgroundchecks.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.smartbackgroundchecks.com/optout",
@@ -13,13 +13,13 @@
         {
           "actionType": "navigate",
           "id": "290d3add-c786-4ecf-a528-50b2a240f791",
-          "url": "https://www.smartbackgroundchecks.com/people/${firstName}-${lastName}/${city}/${state}"
+          "url": "https://www.smartbackgroundchecks.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${city|hyphenated}/${state|hyphenated}"
         },
         {
           "actionType": "extract",
           "id": "2e04c4da-5f4b-4ab3-bd9e-4d4300d51f63",
           "selector": "//div[contains(@class, 'card-block') and not(.//text()[contains(., 'Paid Results')])]",
-          "noResultsFound": "//h1[contains(text(), '0 Results')]",
+          "noResultsSelector": "//h1[contains(text(), '0 Results')]",
           "profile": {
             "name": {
               "selector": ".name-list-title"

--- a/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
@@ -1,7 +1,7 @@
 {
   "name": "USA People Search",
   "url": "usa-people-search.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usa-people-search.com/manage",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "3cb9a2ce-6443-4934-9df3-ec63a181d9bb",
-          "url": "https://usa-people-search.com/name/${firstName|downcase}-${lastName|downcase}/${city|downcase}-${state|stateFull|downcase}"
+          "url": "https://usa-people-search.com/name/${firstName|downcase|hyphenated}-${lastName|downcase|hyphenated}/${city|downcase|hyphenated}-${state|stateFull|downcase|hyphenated}"
         },
         {
           "_comment": "Wait for CF challenge interstitial to complete",

--- a/pir/pir-impl/src/main/assets/brokers/usatrace.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usatrace.com.json
@@ -1,7 +1,7 @@
 {
   "name": "USA Trace",
   "url": "usatrace.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://www.usatrace.com/contact-us/",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "06a2d15f-19ba-45b7-b606-fdd9c9cdb751",
-          "url": "https://www.usatrace.com/people-search/${firstName}-${lastName}/${city|hyphenated}-${state|upcase}"
+          "url": "https://www.usatrace.com/people-search/${firstName|replaceWhitespace:_}-${lastName|replaceWhitespace:_}/${city|hyphenated}-${state|upcase}"
         },
         {
           "actionType": "extract",

--- a/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usphonebook.com.json
@@ -1,7 +1,7 @@
 {
   "name": "USPhoneBook",
   "url": "usphonebook.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usphonebook.com/opt-out",
@@ -13,7 +13,7 @@
         {
           "actionType": "navigate",
           "id": "98a804b2-115c-4c2c-8e97-3f3679cd3fbb",
-          "url": "https://www.usphonebook.com/${firstName}-${lastName}/${state|stateFull}/${city}"
+          "url": "https://www.usphonebook.com/${firstName|hyphenated}-${lastName|hyphenated}/${state|upcase}/${city|hyphenated}"
         },
         {
           "actionType": "extract",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1214118114075704/f 

 ----- 
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (15):**
- advancedbackgroundchecks.com.json (0.6.0 → 0.7.0)
- beenverified.com.json (0.8.0 → 0.9.0)
- clustrmaps.com.json (0.6.0 → 0.7.0)
- cyberbackgroundchecks.com.json (0.6.0 → 0.7.0)
- fastbackgroundcheck.com.json (0.6.0 → 0.7.0)
- fastpeoplesearch.com.json (0.6.0 → 0.7.0)
- freepeopledirectory.com.json (0.6.0 → 0.7.0)
- neighborwho.com.json (0.4.0 → 0.5.0)
- peoplelooker.com.json (0.4.0 → 0.5.0)
- peoplewhizr.com.json (0.7.0 → 0.8.0)
- searchpeoplefree.com.json (0.7.0 → 0.8.0)
- smartbackgroundchecks.com.json (0.6.0 → 0.7.0)
- usa-people-search.com.json (0.6.0 → 0.7.0)
- usatrace.com.json (0.6.0 → 0.7.0)
- usphonebook.com.json (0.5.0 → 0.6.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it updates multiple broker automation JSONs (URL templates, selectors, and conditional flows), which can easily break scanning/opt-out execution if any site markup has changed again.
> 
> **Overview**
> **Updates 15 broker definitions** with version bumps and refreshed scan/opt-out automation.
> 
> Most changes normalize scan URL templating (e.g., applying `|hyphenated`, state casing, or whitespace replacement) to better match current broker URL formats.
> 
> The biggest behavioral change is for **BeenVerified and its family sites** (`beenverified.com`, `neighborwho.com`, `peoplelooker.com`): the scan/opt-out flows are updated to use new form selectors/field names, and add a conditional branch for “highly populated states” that requires completing a `#comprehensive-form` (including waiting for a Turnstile token) before proceeding to results and opt-out.
> 
> `peoplewhizr.com` is also marked as removed via `removedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408c6a61cf5fb0b423fb28a6e697a9c8918b2f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->