### PR TITLE
Fix fire dialog IllegalStateException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -384,6 +384,7 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
             ?.alpha(0f)
             ?.setDuration(300)
             ?.withEndAction {
+                if (!isAdded) return@withEndAction
                 isCancelable = true
                 dismissAllowingStateLoss()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214131674335761?focus=true

### Description

- Adds an `isAdded` check to prevent an `IllegalStateException` when the animation ends

### Steps to test this PR

- [ ] Burn a single tab
- [ ] Verify that it works as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line lifecycle guard to avoid dismissing a detached fragment; minimal behavioral impact beyond preventing a crash.
> 
> **Overview**
> Prevents a crash in `SingleTabFireDialog` by guarding the fade-out animation end callback in `dismissSingleTabClear()` with `isAdded` before toggling cancelability and calling `dismissAllowingStateLoss()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c392c099b32da22ecdabcdabf879603473926b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->