### PR TITLE
Remove intermediate focus state (Native Input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -34,18 +34,10 @@ import javax.inject.Inject
 
 data class Margins(val top: Int, val bottom: Int)
 
-data class CardWidthTarget(
-    val width: Int,
-    val marginStart: Int,
-    val marginEnd: Int,
-    val bottomMargin: Int,
-)
-
 interface NativeInputAnimator {
     fun init(widgetCard: View, omnibarCard: View, omnibarWidth: Int, omnibarHeight: Int, isBottom: Boolean): Margins?
     fun animateEnter(widgetCard: View, omnibarCard: View, widgetView: View, margins: Margins, onComplete: () -> Unit = {})
     fun animateExit(widgetCard: View, widgetView: View, omnibarCard: View, isBottom: Boolean, onComplete: () -> Unit)
-    fun animateCardWidth(card: View, widgetView: View, target: CardWidthTarget, onComplete: () -> Unit = {})
     fun cancelAnimation()
     fun applyLayoutTransitions(widgetView: View)
     fun applyLayoutTransitions(widgetView: View, isBottom: Boolean)
@@ -56,7 +48,6 @@ interface NativeInputAnimator {
 class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
     private var transitionAnimator: ValueAnimator? = null
-    private var cardWidthAnimator: ValueAnimator? = null
     private var animationCleanup: (() -> Unit)? = null
     private var pendingPreDraw: Pair<View, ViewTreeObserver.OnPreDrawListener>? = null
 
@@ -198,81 +189,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         )
     }
 
-    override fun animateCardWidth(
-        card: View,
-        widgetView: View,
-        target: CardWidthTarget,
-        onComplete: () -> Unit,
-    ) {
-        cardWidthAnimator?.cancel()
-        cardWidthAnimator = null
-        clearLayoutTransitions(widgetView)
-
-        val params = card.layoutParams as? ViewGroup.MarginLayoutParams ?: return
-        val oldWidth = card.width
-
-        applyTargetMargins(params, card, target)
-
-        if (oldWidth <= 0 || oldWidth == target.width) {
-            onCardWidthAnimated(params, card, widgetView, onComplete)
-            return
-        }
-
-        params.width = oldWidth
-        card.layoutParams = params
-
-        startCardWidthAnimation(params, card, widgetView, oldWidth, target.width, onComplete)
-    }
-
-    private fun applyTargetMargins(params: ViewGroup.MarginLayoutParams, card: View, target: CardWidthTarget) {
-        params.marginStart = target.marginStart
-        params.marginEnd = target.marginEnd
-        params.bottomMargin = target.bottomMargin
-        card.layoutParams = params
-    }
-
-    private fun onCardWidthAnimated(
-        params: ViewGroup.MarginLayoutParams,
-        card: View,
-        widgetView: View,
-        onComplete: () -> Unit,
-    ) {
-        params.width = ViewGroup.LayoutParams.MATCH_PARENT
-        card.layoutParams = params
-        applyLayoutTransitions(widgetView)
-        onComplete()
-    }
-
-    private fun startCardWidthAnimation(
-        params: ViewGroup.MarginLayoutParams,
-        card: View,
-        widgetView: View,
-        fromWidth: Int,
-        toWidth: Int,
-        onComplete: () -> Unit,
-    ) {
-        cardWidthAnimator = ValueAnimator.ofInt(fromWidth, toWidth).apply {
-            duration = ANIMATION_DURATION_MS
-            interpolator = FastOutSlowInInterpolator()
-            addUpdateListener { anim ->
-                params.width = anim.animatedValue as Int
-                card.layoutParams = params
-            }
-            addListener(object : AnimatorListenerAdapter() {
-                private var cancelled = false
-                override fun onAnimationCancel(animation: Animator) { cancelled = true }
-                override fun onAnimationEnd(animation: Animator) {
-                    cardWidthAnimator = null
-                    if (!cancelled) onCardWidthAnimated(params, card, widgetView, onComplete)
-                }
-            })
-            start()
-        }
-    }
-
     override fun cancelAnimation() {
-        cardWidthAnimator?.cancel()
-        cardWidthAnimator = null
         pendingPreDraw?.let { (view, listener) -> view.viewTreeObserver.removeOnPreDrawListener(listener) }
         pendingPreDraw = null
         animationCleanup?.invoke()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -68,24 +68,6 @@ class NativeInputLayoutCoordinator(
         card.layoutParams = params
     }
 
-    fun applyRoundedCardShape(widgetView: View) {
-        if (!isWidgetBottom()) return
-        val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
-        val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
-        card.shapeAppearanceModel =
-            card.shapeAppearanceModel
-                .toBuilder()
-                .setAllCornerSizes(radius)
-                .build()
-        val horizontalInset = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2)
-        val bottomInset = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2)
-        val params = card.layoutParams as? ViewGroup.MarginLayoutParams ?: return
-        params.marginStart = horizontalInset
-        params.marginEnd = horizontalInset
-        params.bottomMargin = bottomInset
-        card.layoutParams = params
-    }
-
     fun configureAutocompleteLayout(widgetView: View) {
         val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
         val focusedView = rootView.findViewById<View?>(R.id.focusedView)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -201,31 +201,19 @@ class RealNativeInputManager @Inject constructor(
         if (omnibarController.isDuckAiMode() || omnibarController.isSplitMode()) return
         omnibarController.hide()
         widgetRoot?.translationZ = 0f
-        if (layoutCoordinator.isWidgetBottom() && widgetRoot != null) {
-            expandBottomCardToFull(widgetRoot)
-        } else {
-            setWidgetCardEndMargin(0)
-        }
-    }
-
-    private fun expandBottomCardToFull(widgetRoot: View) {
-        val card = widgetRoot.findViewById<View?>(R.id.inputModeWidgetCard) ?: return
-        val parentWidth = (card.parent as? View)?.width ?: return
-
-        layoutCoordinator.applyBottomCardCorners(widgetRoot)
-
-        animator.animateCardWidth(
-            card = card,
-            widgetView = widgetRoot,
-            target = CardWidthTarget(width = parentWidth, marginStart = 0, marginEnd = 0, bottomMargin = 0),
-        )
     }
 
     private fun onKeyboardHidden(widget: NativeInputWidget, widgetRoot: View?) {
         if (widget.isModelMenuVisible()) return
-        updateWidgetFocus(widget)
-        if (!omnibarController.isDuckAiMode() && !omnibarController.isSplitMode()) {
-            showTabsAndMenuButtons(widgetRoot)
+        if (omnibarController.isDuckAiMode()) {
+            updateWidgetFocus(widget)
+        } else {
+            omnibarController.showTransparentOmnibar()
+            widgetRoot?.let {
+                it.bringToFront()
+                it.translationZ = WIDGET_ELEVATION_DP.toPx()
+            }
+            rootView.post { hideNativeInput() }
         }
     }
 
@@ -239,22 +227,6 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun showTabsAndMenuButtons(widgetRoot: View?) {
-        omnibarController.showTransparentOmnibar()
-        widgetRoot?.let {
-            it.bringToFront()
-            it.translationZ = 8f.toPx()
-        }
-        if (widgetRoot != null) {
-            layoutCoordinator.applyRoundedCardShape(widgetRoot)
-        }
-        rootView.post {
-            if (widgetRoot != null && widgetRoot.translationZ != 0f) {
-                setWidgetCardEndMargin(omnibarController.getButtonsWidth())
-            }
-        }
-    }
-
     private fun isDescendantOf(ancestor: View, view: View): Boolean {
         var current: View? = view
         while (current != null) {
@@ -262,28 +234,6 @@ class RealNativeInputManager @Inject constructor(
             current = current.parent as? View
         }
         return false
-    }
-
-    private fun setWidgetCardEndMargin(endInset: Int) {
-        val card = rootView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return
-        val widgetView = rootView.findViewById(R.id.inputModeTopRoot)
-            ?: rootView.findViewById<View?>(R.id.inputModeBottomRoot)
-            ?: return
-        val params = card.layoutParams as? ViewGroup.MarginLayoutParams ?: return
-        val targetMarginEnd = params.marginStart + endInset
-        if (params.marginEnd == targetMarginEnd) return
-        val parentWidth = (card.parent as? View)?.width ?: return
-
-        animator.animateCardWidth(
-            card = card,
-            widgetView = widgetView,
-            target = CardWidthTarget(
-                width = parentWidth - params.marginStart - targetMarginEnd,
-                marginStart = params.marginStart,
-                marginEnd = targetMarginEnd,
-                bottomMargin = params.bottomMargin,
-            ),
-        )
     }
 
     override fun showNativeInput(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -62,7 +62,6 @@ interface NativeInputOmnibarController : OmnibarState {
     fun getText(): String
     fun hideBackground()
     fun showTransparentOmnibar()
-    fun getButtonsWidth(): Int
     fun getCardView(): View?
     fun restore()
     fun forceToTop()
@@ -225,13 +224,6 @@ class RealNativeInputOmnibarController(
     override fun getCardView(): View? {
         val omnibarView = omnibar.omnibarView as? View ?: return null
         return omnibarView.findViewById(R.id.omniBarContainerShadow)
-    }
-
-    override fun getButtonsWidth(): Int {
-        val omnibarView = omnibar.omnibarView as? View ?: return 0
-        val tabsMenu = omnibarView.findViewById<View?>(R.id.tabsMenu)
-        val browserMenu = omnibarView.findViewById<View?>(R.id.browserMenu)
-        return (tabsMenu?.width ?: 0) + (browserMenu?.width ?: 0)
     }
 
     override fun restore() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213890328647785?focus=true

### Description

- Removes the intermediate unfocussed state of the native input

### Steps to test this PR

_With native input enabled_
- [ ] Focus the omnibar
- [ ] Verify that the native input is shown
- [ ] Go back or hide the keyboard
- [ ] Verify that the unfocussed omnibar is shown

Repeat for top, bottom and split configurations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior and animation changes in keyboard hide/show flows can cause regressions in native-input layout, focus, and visual transitions across top/bottom omnibar modes.
> 
> **Overview**
> Removes the “intermediate” native-input UI state by deleting card width/margin animations and related layout tweaking.
> 
> `NativeInputManager` now skips bottom-card expansion and end-margin adjustments on keyboard visibility changes; on keyboard hide (non-DuckAI) it shows a transparent omnibar and then schedules `hideNativeInput()` instead of keeping a rounded/inset widget card visible. Related API surface is simplified by removing `animateCardWidth`, `applyRoundedCardShape`, and `getButtonsWidth`, and `cancelAnimation()` no longer manages a separate card-width animator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c2172ccda4f5ee164f212e16bbd4b2beb021ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->