### PR TITLE
Show omnibar buttons in Duck.ai split mode (Native Input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -98,7 +98,22 @@ class RealNativeInputOmnibarController(
             makeOmnibarTransparent(omnibarView)
             hideOmnibarContent(omnibarView)
             showDuckAiTitle(omnibarView)
+            if (isSplitMode()) {
+                showOmnibarButtons(omnibarView)
+            }
         }
+    }
+
+    private fun showOmnibarButtons(omnibarView: View) {
+        omnibarView.findViewById<View?>(R.id.fireIconMenu)?.show()
+        omnibarView.findViewById<View?>(R.id.tabsMenu)?.show()
+        omnibarView.findViewById<View?>(R.id.browserMenu)?.show()
+    }
+
+    private fun hideOmnibarButtons(omnibarView: View) {
+        omnibarView.findViewById<View?>(R.id.fireIconMenu)?.gone()
+        omnibarView.findViewById<View?>(R.id.tabsMenu)?.gone()
+        omnibarView.findViewById<View?>(R.id.browserMenu)?.gone()
     }
 
     override fun showTransparentOmnibar() {
@@ -253,6 +268,9 @@ class RealNativeInputOmnibarController(
         omnibarView.findViewById<View?>(R.id.omnibarIconContainer)?.show()
         omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.show()
         omnibarView.findViewById<View?>(R.id.duckAIHeader)?.gone()
+        if (isSplitMode()) {
+            hideOmnibarButtons(omnibarView)
+        }
     }
 
     private fun restoreOmnibarColors() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214047603542125?focus=true

### Description

- Fixes a bug where the omnibar buttons weren’t shown in Duck.ai split mode

### Steps to test this PR

_With native input enabled_
- [ ] Enable split mode
- [ ] Got to Duck.ai
- [ ] Verify that the omnibar buttons are visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, view-visibility-only change scoped to split-mode Duck.ai omnibar transitions; low likelihood of impacting data or security.
> 
> **Overview**
> When entering Duck.ai *native input* with the omnibar background hidden, the split-omnibar toolbar buttons (`fireIconMenu`, `tabsMenu`, `browserMenu`) are now explicitly shown so the top bar retains its controls.
> 
> On `restore`, those buttons are hidden again in split mode to return the omnibar to its normal state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3751726a2357317a567adc38b1c7570ec89e8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->