### PR TITLE
Hatch: disable on Custom Tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
@@ -89,7 +89,8 @@ class IntentDispatcherViewModel @Inject constructor(
 
                 logcat { "Intent $intent received. Has extra session=$hasSession. Intent text=$intentText. Toolbar color=$toolbarColor" }
 
-                customTabDetector.setCustomTab(false)
+                customTabDetector.setCustomTab(customTabRequested)
+
                 _viewState.emit(
                     viewState.value.copy(
                         customTabRequested = customTabRequested,

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -50,11 +51,13 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val duckChat: DuckChat,
     private val tabRepository: TabRepository,
     private val systemAutofillEngagement: SystemAutofillEngagement,
+    private val customTabDetector: CustomTabDetector,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : BrowserLifecycleObserver {
 
     override fun onOpen(isFreshLaunch: Boolean) {
         appCoroutineScope.launch {
+            logcat { "FirstScreen: onOpen isFreshLaunch $isFreshLaunch" }
             handleFirstScreen(isFreshLaunch)
         }
     }
@@ -66,10 +69,7 @@ class FirstScreenHandlerImpl @Inject constructor(
             val elapsed = System.currentTimeMillis() - lastBackgrounded
             val wasIdle = lastBackgrounded != 0L && elapsed >= timeoutMs
             if (lastBackgrounded == 0L || wasIdle) {
-                if (!isVoiceSessionActiveOnCurrentTab()) {
-                    showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle)
-                }
-                if (!isActiveTabCustomTab()){
+                if (!isVoiceSessionActiveOnCurrentTab() && !isActiveTabCustomTab()) {
                     showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle)
                 }
                 return
@@ -90,9 +90,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     }
 
     private suspend fun isActiveTabCustomTab(): Boolean = withContext(dispatcherProvider.io()) {
-        val selectedTab = tabRepository.getSelectedTab()
-        logcat { "Hatch: current tab $selectedTab" }
-        return@withContext selectedTab?.tabId?.startsWith(CUSTOM_TAB_NAME_PREFIX) ?: false
+        return@withContext customTabDetector.isCustomTab()
     }
 
     override fun onClose() {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
+import com.duckduckgo.app.browser.customtabs.CustomTabViewModel.Companion.CUSTOM_TAB_NAME_PREFIX
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -31,6 +32,7 @@ import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.logcat
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -67,6 +69,9 @@ class FirstScreenHandlerImpl @Inject constructor(
                 if (!isVoiceSessionActiveOnCurrentTab()) {
                     showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle)
                 }
+                if (!isActiveTabCustomTab()){
+                    showOnAppLaunchOptionHandler.handleAfterInactivityOption(wasIdle = wasIdle)
+                }
                 return
             }
         } else if (isFreshLaunch && showOnAppLaunchFeature.self().isEnabled()) {
@@ -82,6 +87,12 @@ class FirstScreenHandlerImpl @Inject constructor(
         return@withContext selectedTab?.url?.toUri()?.let {
             duckChat.isDuckChatUrl(it)
         } == true
+    }
+
+    private suspend fun isActiveTabCustomTab(): Boolean = withContext(dispatcherProvider.io()) {
+        val selectedTab = tabRepository.getSelectedTab()
+        logcat { "Hatch: current tab $selectedTab" }
+        return@withContext selectedTab?.tabId?.startsWith(CUSTOM_TAB_NAME_PREFIX) ?: false
     }
 
     override fun onClose() {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
-import com.duckduckgo.app.browser.customtabs.CustomTabViewModel.Companion.CUSTOM_TAB_NAME_PREFIX
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -140,7 +140,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun showNTPAfterIdleReturn(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -140,7 +140,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun showNTPAfterIdleReturn(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)

--- a/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
@@ -43,6 +43,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -268,6 +269,26 @@ class IntentDispatcherViewModelTest {
             val state = awaitItem()
             assertNull(state.activityParams)
         }
+    }
+
+    @Test
+    fun whenCustomTabIntentReceivedThenDetectorIsUpdatedWithTrue() = runTest {
+        configureHasSession(true)
+        whenever(mockIntent.intentText).thenReturn("https://example.com")
+
+        testee.onIntentReceived(mockIntent, isExternal = false)
+
+        verify(mockCustomTabDetector).setCustomTab(true)
+    }
+
+    @Test
+    fun whenNonCustomTabIntentReceivedThenDetectorIsUpdatedWithFalse() = runTest {
+        configureHasSession(false)
+        whenever(mockIntent.intentText).thenReturn("https://example.com")
+
+        testee.onIntentReceived(mockIntent, isExternal = false)
+
+        verify(mockCustomTabDetector).setCustomTab(false)
     }
 
     private fun configureHasSession(returnValue: Boolean) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
@@ -50,6 +51,7 @@ class FirstScreenHandlerImplTest {
     private val duckChat: DuckChat = mock()
     private val tabRepository: TabRepository = mock()
     private val systemAutofillEngagement: SystemAutofillEngagement = mock()
+    private val customTabDetector: CustomTabDetector = mock()
     private val idleReturnToggle: Toggle = mock()
     private val showOnAppLaunchToggle: Toggle = mock()
     private val testScope = coroutineTestRule.testScope
@@ -62,6 +64,7 @@ class FirstScreenHandlerImplTest {
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
         whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+        whenever(customTabDetector.isCustomTab()).thenReturn(false)
 
         testee = FirstScreenHandlerImpl(
             androidBrowserConfigFeature = androidBrowserConfigFeature,
@@ -71,6 +74,7 @@ class FirstScreenHandlerImplTest {
             duckChat = duckChat,
             tabRepository = tabRepository,
             systemAutofillEngagement = systemAutofillEngagement,
+            customTabDetector = customTabDetector,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
         )
@@ -435,5 +439,46 @@ class FirstScreenHandlerImplTest {
         testScope.testScheduler.advanceUntilIdle()
 
         verifyNoInteractions(showOnAppLaunchOptionHandler)
+    }
+
+    @Test
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndIsCustomTabThenDoesNotDelegate() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        whenever(customTabDetector.isCustomTab()).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler, never()).handleAfterInactivityOption(wasIdle = true)
+    }
+
+    @Test
+    fun whenIdleReturnEnabledAndNoTimestampAndIsCustomTabThenDoesNotDelegate() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+        whenever(customTabDetector.isCustomTab()).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler, never()).handleAfterInactivityOption(wasIdle = false)
+    }
+
+    @Test
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndIsNotCustomTabThenDelegates() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        whenever(customTabDetector.isCustomTab()).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).handleAfterInactivityOption(wasIdle = true)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214155101201365?focus=true

### Description

When the app is opened via a Custom Tab intent, the idle-return (Hatch) logic should not redirect the user to the NTP or their configured "show on app launch" screen. This PR makes two changes:

- **IntentDispatcherViewModel**: `customTabDetector.setCustomTab()` now passes the actual `customTabRequested` value instead of always passing `false`, so the detector correctly tracks whether the current session is a Custom Tab.
- **FirstScreenHandlerImpl**: The idle-return path now checks `customTabDetector.isCustomTab()` alongside the existing voice session check. If the active tab is a Custom Tab, `handleAfterInactivityOption` is skipped.

### Steps to test this PR

_Custom Tab does not trigger idle return_
- [x] Enable the `showNTPAfterIdleReturn` feature flag
- [x] Set the idle threshold to a low value (e.g. 0 seconds / "Always")
- [x] Open a Custom Tab from another app (e.g. long-press a link in a messaging app and choose DuckDuckGo)
- [x] Background the app, wait for the idle threshold to elapse, then return
- [x] Verify the Custom Tab content is still displayed (not replaced by NTP)

_Regular tabs still trigger idle return_
- [x] Open DuckDuckGo normally (not via Custom Tab)
- [x] Navigate to any website
- [x] Background the app, wait for the idle threshold to elapse, then return
- [x] Verify the NTP or configured launch screen is shown as expected

_Voice session check still works_
- [x] Start a voice chat session on duck.ai
- [x] Background the app, wait for the idle threshold to elapse, then return
- [x] Verify the voice session is preserved (not replaced by NTP)

### UI changes

No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app launch/idle-return navigation behavior by suppressing redirects when a Custom Tab session is active, which could affect first-screen routing in edge cases. Scope is limited and covered by new unit tests for both custom-tab and non-custom-tab paths.
> 
> **Overview**
> Prevents *idle-return (Hatch)* from redirecting to NTP / configured first screen when the current session was launched as a **Custom Tab**.
> 
> `IntentDispatcherViewModel` now updates `CustomTabDetector` with the computed `customTabRequested` value (instead of always `false`), and `FirstScreenHandlerImpl` gates `handleAfterInactivityOption` on `!customTabDetector.isCustomTab()` (alongside the existing voice-session check). Tests were expanded to assert detector updates and the new custom-tab idle-return suppression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2fa033fce8bb9f584a46ff9d3d4d14bc24dd6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->