### PR TITLE
Add pixel for system autofill after idle return

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -89,6 +89,21 @@
         "parameters": ["appVersion"]
     },
 
+    // Autofill after idle return pixel
+    "m_ntp_after_idle_autofill_after_idle_return": {
+        "description": "System autofill filled credentials after the idle-return feature navigated the user away from their login page. Only fires when idle threshold is Always (0s) and launch option is NTP or Specific Page.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "appLaunchOption",
+                "description": "The app launch option that was active when idle return triggered (new_tab_page or specific_page)"
+            }
+        ]
+    },
+
     // Timeout selected pixels (one per supported value)
     "m_ntp_after_idle_timeout_selected_always": {
         "description": "User selected Always as the idle timeout threshold",

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
@@ -18,12 +18,15 @@ package com.duckduckgo.app.browser.autofill
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority.VERBOSE
@@ -32,9 +35,12 @@ import javax.inject.Inject
 
 interface SystemAutofillEngagement {
     fun onSystemAutofillEvent()
+    fun setIdleReturnTriggered(appLaunchOption: String)
+    fun clearIdleReturnTriggered()
 }
 
 @ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
 class RealSystemAutofillEngagement @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
@@ -42,9 +48,30 @@ class RealSystemAutofillEngagement @Inject constructor(
     private val pixel: Pixel,
 ) : SystemAutofillEngagement {
 
+    @Volatile
+    private var idleReturnAppLaunchOption: String? = null
+
+    override fun setIdleReturnTriggered(appLaunchOption: String) {
+        idleReturnAppLaunchOption = appLaunchOption
+    }
+
+    override fun clearIdleReturnTriggered() {
+        idleReturnAppLaunchOption = null
+    }
+
     override fun onSystemAutofillEvent() {
         logcat(VERBOSE) { "System autofill event received" }
         appCoroutineScope.launch(dispatchers.io()) {
+            val option = idleReturnAppLaunchOption
+            if (option != null) {
+                pixel.fire(
+                    NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+                    mapOf("appLaunchOption" to option),
+                    type = Count,
+                )
+                idleReturnAppLaunchOption = null
+            }
+
             if (autofillFeature.canDetectSystemAutofillEngagement().isEnabled()) {
                 pixel.fire(AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -65,7 +64,7 @@ class RealSystemAutofillEngagement @Inject constructor(
             val option = idleReturnAppLaunchOption
             if (option != null) {
                 pixel.fire(
-                    NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+                    AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
                     mapOf("appLaunchOption" to option),
                     type = Count,
                 )
@@ -76,5 +75,9 @@ class RealSystemAutofillEngagement @Inject constructor(
                 pixel.fire(AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
             }
         }
+    }
+
+    companion object {
+        const val AUTOFILL_AFTER_IDLE_RETURN_PIXEL = "m_ntp_after_idle_autofill_after_idle_return"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import androidx.core.net.toUri
+import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -46,6 +47,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val duckChat: DuckChat,
     private val tabRepository: TabRepository,
+    private val systemAutofillEngagement: SystemAutofillEngagement,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : BrowserLifecycleObserver {
 
@@ -83,6 +85,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     }
 
     override fun onClose() {
+        systemAutofillEngagement.clearIdleReturnTriggered()
         appCoroutineScope.launch(dispatcherProvider.io()) {
             settingsDataStore.lastSessionBackgroundTimestamp = System.currentTimeMillis()
         }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import android.net.Uri
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
-import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
@@ -78,10 +77,6 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
         val option = showOnAppLaunchOptionDataStore.optionFlow.first()
         logcat { "FirstScreen: showing $option on app launch" }
 
-        if (fromInactivity) {
-            maybeSetAutofillIdleReturnFlag(option)
-        }
-
         when (option) {
             LastOpenedTab -> Unit
             NewTabPage -> {
@@ -89,11 +84,17 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
                 if (selectedTab == null || !selectedTab.url.isNullOrBlank()) {
                     if (fromInactivity) {
                         ntpAfterIdleManager.onIdleReturnTriggered()
+                        notifyAutofillIdleReturn("new_tab_page")
                     }
                     tabRepository.add()
                 }
             }
-            is SpecificPage -> handleSpecificPageOption(option)
+            is SpecificPage -> {
+                if (fromInactivity) {
+                    notifyAutofillIdleReturn("specific_page")
+                }
+                handleSpecificPageOption(option)
+            }
         }
     }
 
@@ -113,16 +114,10 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
         }
     }
 
-    private fun maybeSetAutofillIdleReturnFlag(option: ShowOnAppLaunchOption) {
-        val threshold = settingsDataStore.userSelectedIdleThresholdSeconds
-        if (threshold != 0L) return
-
-        val optionName = when (option) {
-            is NewTabPage -> "new_tab_page"
-            is SpecificPage -> "specific_page"
-            else -> return
+    private fun notifyAutofillIdleReturn(optionName: String) {
+        if (settingsDataStore.userSelectedIdleThresholdSeconds == 0L) {
+            systemAutofillEngagement.setIdleReturnTriggered(optionName)
         }
-        systemAutofillEngagement.setIdleReturnTriggered(optionName)
     }
 
     private suspend fun handleSpecificPageOption(option: SpecificPage) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -18,10 +18,13 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import android.net.Uri
 import androidx.core.net.toUri
+import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -52,6 +55,8 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private val tabRepository: TabRepository,
     private val appBuildConfig: AppBuildConfig,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val settingsDataStore: SettingsDataStore,
+    private val systemAutofillEngagement: SystemAutofillEngagement,
 ) : ShowOnAppLaunchOptionHandler {
 
     override suspend fun handleAfterInactivityOption(wasIdle: Boolean) {
@@ -72,6 +77,11 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private suspend fun applyShowOnAppLaunchOption(fromInactivity: Boolean) {
         val option = showOnAppLaunchOptionDataStore.optionFlow.first()
         logcat { "FirstScreen: showing $option on app launch" }
+
+        if (fromInactivity) {
+            maybeSetAutofillIdleReturnFlag(option)
+        }
+
         when (option) {
             LastOpenedTab -> Unit
             NewTabPage -> {
@@ -101,6 +111,18 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
                 showOnAppLaunchOptionDataStore.setResolvedPageUrl(currentUrl!!)
             }
         }
+    }
+
+    private fun maybeSetAutofillIdleReturnFlag(option: ShowOnAppLaunchOption) {
+        val threshold = settingsDataStore.userSelectedIdleThresholdSeconds
+        if (threshold != 0L) return
+
+        val optionName = when (option) {
+            is NewTabPage -> "new_tab_page"
+            is SpecificPage -> "specific_page"
+            else -> return
+        }
+        systemAutofillEngagement.setIdleReturnTriggered(optionName)
     }
 
     private suspend fun handleSpecificPageOption(option: SpecificPage) {

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.autofill
 
 import android.annotation.SuppressLint
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED
@@ -25,6 +26,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -66,5 +68,61 @@ class RealSystemAutofillEngagementTest {
         feature.canDetectSystemAutofillEngagement().setRawStoredState(State(false))
         testee.onSystemAutofillEvent()
         verify(pixel, never()).fire(AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
+    }
+
+    @Test
+    fun whenIdleReturnFlagSetAndAutofillEventThenAutofillAfterIdlePixelFired() = runTest {
+        testee.setIdleReturnTriggered("new_tab_page")
+        testee.onSystemAutofillEvent()
+        verify(pixel).fire(
+            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            mapOf("appLaunchOption" to "new_tab_page"),
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenIdleReturnFlagSetWithSpecificPageAndAutofillEventThenPixelFiredWithCorrectParam() = runTest {
+        testee.setIdleReturnTriggered("specific_page")
+        testee.onSystemAutofillEvent()
+        verify(pixel).fire(
+            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            mapOf("appLaunchOption" to "specific_page"),
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenNoIdleReturnFlagAndAutofillEventThenAutofillAfterIdlePixelNotFired() = runTest {
+        testee.onSystemAutofillEvent()
+        verify(pixel, never()).fire(
+            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            mapOf("appLaunchOption" to "new_tab_page"),
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenIdleReturnFlagSetAndAutofillEventFiredTwiceThenPixelFiredOnlyOnce() = runTest {
+        testee.setIdleReturnTriggered("new_tab_page")
+        testee.onSystemAutofillEvent()
+        testee.onSystemAutofillEvent()
+        verify(pixel).fire(
+            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            mapOf("appLaunchOption" to "new_tab_page"),
+            type = Count,
+        )
+    }
+
+    @Test
+    fun whenIdleReturnFlagClearedThenAutofillAfterIdlePixelNotFired() = runTest {
+        testee.setIdleReturnTriggered("new_tab_page")
+        testee.clearIdleReturnTriggered()
+        testee.onSystemAutofillEvent()
+        verify(pixel, never()).fire(
+            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            mapOf("appLaunchOption" to "new_tab_page"),
+            type = Count,
+        )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.autofill
 
 import android.annotation.SuppressLint
+import com.duckduckgo.app.browser.autofill.RealSystemAutofillEngagement.Companion.AUTOFILL_AFTER_IDLE_RETURN_PIXEL
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
@@ -26,7 +27,6 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
-import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -75,7 +75,7 @@ class RealSystemAutofillEngagementTest {
         testee.setIdleReturnTriggered("new_tab_page")
         testee.onSystemAutofillEvent()
         verify(pixel).fire(
-            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
             mapOf("appLaunchOption" to "new_tab_page"),
             type = Count,
         )
@@ -86,7 +86,7 @@ class RealSystemAutofillEngagementTest {
         testee.setIdleReturnTriggered("specific_page")
         testee.onSystemAutofillEvent()
         verify(pixel).fire(
-            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
             mapOf("appLaunchOption" to "specific_page"),
             type = Count,
         )
@@ -96,7 +96,7 @@ class RealSystemAutofillEngagementTest {
     fun whenNoIdleReturnFlagAndAutofillEventThenAutofillAfterIdlePixelNotFired() = runTest {
         testee.onSystemAutofillEvent()
         verify(pixel, never()).fire(
-            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
             mapOf("appLaunchOption" to "new_tab_page"),
             type = Count,
         )
@@ -108,7 +108,7 @@ class RealSystemAutofillEngagementTest {
         testee.onSystemAutofillEvent()
         testee.onSystemAutofillEvent()
         verify(pixel).fire(
-            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
             mapOf("appLaunchOption" to "new_tab_page"),
             type = Count,
         )
@@ -120,7 +120,7 @@ class RealSystemAutofillEngagementTest {
         testee.clearIdleReturnTriggered()
         testee.onSystemAutofillEvent()
         verify(pixel, never()).fire(
-            NtpAfterIdlePixelName.AUTOFILL_AFTER_IDLE_RETURN,
+            AUTOFILL_AFTER_IDLE_RETURN_PIXEL,
             mapOf("appLaunchOption" to "new_tab_page"),
             type = Count,
         )

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -48,6 +49,7 @@ class FirstScreenHandlerImplTest {
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler = mock()
     private val duckChat: DuckChat = mock()
     private val tabRepository: TabRepository = mock()
+    private val systemAutofillEngagement: SystemAutofillEngagement = mock()
     private val idleReturnToggle: Toggle = mock()
     private val showOnAppLaunchToggle: Toggle = mock()
     private val testScope = coroutineTestRule.testScope
@@ -68,6 +70,7 @@ class FirstScreenHandlerImplTest {
             showOnAppLaunchOptionHandler = showOnAppLaunchOptionHandler,
             duckChat = duckChat,
             tabRepository = tabRepository,
+            systemAutofillEngagement = systemAutofillEngagement,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
         )
@@ -353,6 +356,13 @@ class FirstScreenHandlerImplTest {
         testee.onClose()
 
         verify(settingsDataStore).lastSessionBackgroundTimestamp = org.mockito.kotlin.any()
+    }
+
+    @Test
+    fun whenOnCloseThenClearsAutofillIdleReturnFlag() {
+        testee.onClose()
+
+        verify(systemAutofillEngagement).clearIdleReturnTriggered()
     }
 
     // --- User preference overrides RC default ---

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -20,11 +20,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData
@@ -61,6 +63,8 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     private lateinit var fakeTabRepository: TabRepository
     private val appBuildConfig: AppBuildConfig = mock()
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val settingsDataStore: SettingsDataStore = mock()
+    private val systemAutofillEngagement: SystemAutofillEngagement = mock()
     private lateinit var testee: ShowOnAppLaunchOptionHandler
 
     @Before
@@ -68,8 +72,16 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         fakeDataStore = FakeShowOnAppLaunchOptionDataStore()
         fakeTabRepository = FakeTabRepository()
         whenever(appBuildConfig.isNewInstall()).thenReturn(false)
-        testee =
-            ShowOnAppLaunchOptionHandlerImpl(dispatcherProvider, fakeDataStore, fakeTabRepository, appBuildConfig, ntpAfterIdleManager)
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
+        testee = ShowOnAppLaunchOptionHandlerImpl(
+            dispatcherProvider,
+            fakeDataStore,
+            fakeTabRepository,
+            appBuildConfig,
+            ntpAfterIdleManager,
+            settingsDataStore,
+            systemAutofillEngagement,
+        )
     }
 
     @Test
@@ -967,6 +979,68 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         testee.handleAppLaunchOption()
 
         verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
+    }
+
+    // autofill idle return flag tests
+
+    @Test
+    fun whenInactivityWithThresholdAlwaysAndNewTabPageThenAutofillFlagSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement).setIdleReturnTriggered("new_tab_page")
+    }
+
+    @Test
+    fun whenInactivityWithThresholdAlwaysAndSpecificPageThenAutofillFlagSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
+        fakeDataStore.setShowOnAppLaunchOption(SpecificPage("https://example.com/"))
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement).setIdleReturnTriggered("specific_page")
+    }
+
+    @Test
+    fun whenInactivityWithThresholdAlwaysAndLastOpenedTabThenAutofillFlagNotSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
+        fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement, never()).setIdleReturnTriggered(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenInactivityWithThresholdNonZeroAndNewTabPageThenAutofillFlagNotSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(300L)
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement, never()).setIdleReturnTriggered(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenInactivityWithThresholdNullAndNewTabPageThenAutofillFlagNotSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement, never()).setIdleReturnTriggered(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenAppLaunchOptionNotFromInactivityThenAutofillFlagNotSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        testee.handleAppLaunchOption()
+
+        verify(systemAutofillEngagement, never()).setIdleReturnTriggered(org.mockito.kotlin.any())
     }
 
     // handleResolvedUrlStorage tests

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -1034,6 +1034,18 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     }
 
     @Test
+    fun whenInactivityWithThresholdAlwaysAndNewTabPageButAlreadyOnNtpThenAutofillFlagNotSet() = runTest {
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
+        fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
+        (fakeTabRepository as FakeTabRepository).selectedTab =
+            TabEntity(tabId = "1", url = "", position = 0)
+
+        testee.handleAfterInactivityOption(wasIdle = true)
+
+        verify(systemAutofillEngagement, never()).setIdleReturnTriggered(org.mockito.kotlin.any())
+    }
+
+    @Test
     fun whenAppLaunchOptionNotFromInactivityThenAutofillFlagNotSet() = runTest {
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(0L)
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NtpAfterIdlePixelName.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NtpAfterIdlePixelName.kt
@@ -37,6 +37,9 @@ enum class NtpAfterIdlePixelName(override val pixelName: String) : Pixel.PixelNa
     BAR_USED_FROM_NTP_USER_INITIATED("m_ntp_after_idle_bar_used_from_ntp_user_initiated"),
     BAR_USED_FROM_NTP_USER_INITIATED_DAILY("m_ntp_after_idle_bar_used_from_ntp_user_initiated_daily"),
 
+    // Autofill after idle return pixel
+    AUTOFILL_AFTER_IDLE_RETURN("m_ntp_after_idle_autofill_after_idle_return"),
+
     // Timeout selected pixels — one enum entry per supported timeout value
     TIMEOUT_SELECTED_ALWAYS("m_ntp_after_idle_timeout_selected_always"),
     TIMEOUT_SELECTED_ALWAYS_DAILY("m_ntp_after_idle_timeout_selected_daily_always"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214050958318612?focus=true

### Description

Adds a new pixel (`m_ntp_after_idle_autofill_after_idle_return`) to measure when an external password manager fills credentials via Android system autofill after the idle-return (Hatch) feature has navigated the user away from their login page.

The pixel fires only when all of the following are true:
- The `showNTPAfterIdleReturn` feature flag is enabled
- The idle threshold is set to "Always" (0 seconds)
- The app launch option is "New Tab Page" or "Specific Page"
- The idle return handler executes and navigates the user
- The system autofill callback fires in the same session

The pixel includes an `appLaunchOption` parameter (`new_tab_page` or `specific_page`).

**Implementation:**
- **ShowOnAppLaunchOptionHandler** sets a flag on `SystemAutofillEngagement` when the idle return conditions are met
- **SystemAutofillEngagement** checks the flag when the autofill callback fires, sends the pixel, and clears it
- **FirstScreenHandlerImpl** clears the flag on `onClose()` to prevent stale flags across sessions

### Steps to test this PR

_Pixel fires when autofill occurs after idle return with "Always" threshold_
- [x] Enable the `showNTPAfterIdleReturn` feature flag
- [x] Set idle threshold to "Always" (0 seconds)
- [x] Set app launch option to "New Tab Page"
- [x] Navigate to a login page and background the app
- [x] Return to the app (idle return triggers, NTP is shown)
- [x] Use an external password manager to fill credentials
- [x] Verify `m_ntp_after_idle_autofill_after_idle_return` pixel fires with `appLaunchOption=new_tab_page`

_Pixel does not fire when threshold is not "Always"_
- [x] Set idle threshold to 60 seconds or higher
- [x] Repeat the steps above
- [x] Verify the pixel does not fire

_Pixel does not fire when option is "Last Opened Tab"_
- [x] Set idle threshold to "Always"
- [x] Set app launch option to "Last Opened Tab"
- [x] Repeat the autofill steps
- [x] Verify the pixel does not fire

### UI changes

No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds analytics/pixel tracking with simple state gating and no user data handling beyond a small string parameter; main risk is misfiring or missed events due to lifecycle/flag clearing.
> 
> **Overview**
> Adds a new `m_ntp_after_idle_autofill_after_idle_return` pixel definition (with `appLaunchOption` param) to track system autofill usage immediately after the NTP idle-return flow navigates users away from a login page.
> 
> Implements a session-scoped “idle return triggered” flag in `SystemAutofillEngagement`: `ShowOnAppLaunchOptionHandler` sets it only for *Always (0s)* threshold and launch options `new_tab_page`/`specific_page`, `RealSystemAutofillEngagement` fires the count pixel on the next system autofill event and clears it, and `FirstScreenHandlerImpl` clears the flag on app close; unit tests were expanded to cover firing/clearing behavior and parameter correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fb309e665ebf0c93a00a9a9328915954d409b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->