### PR TITLE
Show correct menu icon on app startup

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -63,6 +63,7 @@ import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBinding
 import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBottomBinding
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog.EventListener
+import com.duckduckgo.app.browser.menu.BrowserMenuDisplayRepository
 import com.duckduckgo.app.browser.newaddressbaroption.NewAddressBarOptionManager
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.OmnibarType
@@ -151,6 +152,9 @@ import javax.inject.Inject
 open class BrowserActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var settingsDataStore: SettingsDataStore
+
+    @Inject
+    lateinit var browserMenuDisplayRepository: BrowserMenuDisplayRepository
 
     @Inject
     lateinit var clearDataAction: ClearDataAction
@@ -1647,6 +1651,15 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun bindMockupToolbars() {
+        val mockupBrowserMenuIcon = if (browserMenuDisplayRepository.isBottomSheetMenuEnabled()) {
+            com.duckduckgo.mobile.android.R.drawable.ic_menu_hamburger_24
+        } else {
+            com.duckduckgo.mobile.android.R.drawable.ic_menu_vertical_24
+        }
+        binding.topMockupToolbar.browserMenuImageView.setImageResource(mockupBrowserMenuIcon)
+        binding.bottomMockupToolbar.browserMenuImageView.setImageResource(mockupBrowserMenuIcon)
+        binding.navigationBarMockup.browserMenuImageView.setImageResource(mockupBrowserMenuIcon)
+
         when (settingsDataStore.omnibarType) {
             OmnibarType.SINGLE_TOP, OmnibarType.SPLIT -> {
                 if (Build.VERSION.SDK_INT < 28) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -649,7 +649,7 @@ class BrowserTabViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = BrowserMenuDisplayState(hasOption = false, isEnabled = false),
+            initialValue = BrowserMenuDisplayState(hasOption = false, isEnabled = browserMenuDisplayRepository.isBottomSheetMenuEnabled()),
         )
 
     private val fireproofWebsitesObserver =
@@ -3079,7 +3079,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun initializeDefaultViewStates() {
         globalLayoutState.value = Browser()
-        browserViewState.value = BrowserViewState()
+        browserViewState.value = BrowserViewState(useBottomSheetMenu = browserMenuState.value.isEnabled)
         loadingViewState.value = LoadingViewState()
         autoCompleteViewState.value = AutoCompleteViewState()
         omnibarViewState.value = OmnibarViewState()

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuDisplayRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuDisplayRepository.kt
@@ -43,6 +43,11 @@ interface BrowserMenuDisplayRepository {
     val browserMenuState: Flow<BrowserMenuDisplayState>
 
     /**
+     * Synchronously checks whether the bottom sheet browser menu is enabled.
+     */
+    fun isBottomSheetMenuEnabled(): Boolean
+
+    /**
      * Sets the experimental menu enabled state.
      *
      * @param enabled true to enable the experimental menu, false to disable it
@@ -90,6 +95,12 @@ class RealBrowserMenuDisplayRepository @Inject constructor(
             replay = 1,
             started = SharingStarted.WhileSubscribed(),
         )
+
+    override fun isBottomSheetMenuEnabled(): Boolean {
+        val isEnabled = browserConfigFeature.experimentalBrowsingMenu().isEnabled()
+        val isRolloutEnabled = browserConfigFeature.rolloutBrowsingMenu().isEnabled()
+        return isRolloutEnabled || (isEnabled && browserMenuStore.useBottomSheetMenu)
+    }
 
     override suspend fun setExperimentalMenuEnabled(enabled: Boolean) {
         browserMenuStore.useBottomSheetMenu = enabled

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuDisplayRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuDisplayRepositoryTest.kt
@@ -331,4 +331,49 @@ class RealBrowserMenuDisplayRepositoryTest {
             cancel()
         }
     }
+
+    @Test
+    fun `isBottomSheetMenuEnabled returns true when rollout flag enabled`() {
+        browserConfigFeature.experimentalBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        browserConfigFeature.rolloutBrowsingMenu().setRawStoredState(Toggle.State(enable = true))
+        whenever(settingsDataStore.useBottomSheetMenu).thenReturn(false)
+
+        assertTrue(testee.isBottomSheetMenuEnabled())
+    }
+
+    @Test
+    fun `isBottomSheetMenuEnabled returns true when experimental flag enabled and user pref enabled`() {
+        browserConfigFeature.experimentalBrowsingMenu().setRawStoredState(Toggle.State(enable = true))
+        browserConfigFeature.rolloutBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        whenever(settingsDataStore.useBottomSheetMenu).thenReturn(true)
+
+        assertTrue(testee.isBottomSheetMenuEnabled())
+    }
+
+    @Test
+    fun `isBottomSheetMenuEnabled returns false when experimental flag enabled but user pref disabled`() {
+        browserConfigFeature.experimentalBrowsingMenu().setRawStoredState(Toggle.State(enable = true))
+        browserConfigFeature.rolloutBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        whenever(settingsDataStore.useBottomSheetMenu).thenReturn(false)
+
+        assertFalse(testee.isBottomSheetMenuEnabled())
+    }
+
+    @Test
+    fun `isBottomSheetMenuEnabled returns false when both flags disabled even if user pref enabled`() {
+        browserConfigFeature.experimentalBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        browserConfigFeature.rolloutBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        whenever(settingsDataStore.useBottomSheetMenu).thenReturn(true)
+
+        assertFalse(testee.isBottomSheetMenuEnabled())
+    }
+
+    @Test
+    fun `isBottomSheetMenuEnabled returns false when both flags disabled and user pref disabled`() {
+        browserConfigFeature.experimentalBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        browserConfigFeature.rolloutBrowsingMenu().setRawStoredState(Toggle.State(enable = false))
+        whenever(settingsDataStore.useBottomSheetMenu).thenReturn(false)
+
+        assertFalse(testee.isBottomSheetMenuEnabled())
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214187547786023?focus=true

### Description

- The menu icon was recently updated but the mock omnibar/layout XML still use the old icon, which means it shows briefly on startup.

**Solution**

- When we `bindMockupToolbars` then the icon should be set based on the menu feature flag.

- The initial `BrowserMenuDisplayState` should be the actual state based on the feature flag instead of false.

### Steps to test this PR

- [ ] Kill the app and reopen
- [ ] Verify that the correct menu icon is shown on startup

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2340" alt="Screenshot_20260422_215028" src="https://github.com/user-attachments/assets/942940c0-289c-46e4-a010-c2023a88dc94" />|<img width="1080" height="2340" alt="Screenshot_20260422_214713" src="https://github.com/user-attachments/assets/1d68ce3f-8862-4641-9bb2-c393e73581f9" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change: adds a synchronous check for the bottom-sheet menu flag to avoid incorrect initial state before flows emit, with unit tests covering the new logic.
> 
> **Overview**
> Ensures the browser menu icon is correct immediately on startup by introducing `BrowserMenuDisplayRepository.isBottomSheetMenuEnabled()` and using it to set initial `useBottomSheetMenu`/menu icon state before reactive flows emit.
> 
> `BrowserActivity` now picks the mock toolbar menu icon (hamburger vs vertical) based on this synchronous check, and `BrowserTabViewModel` initializes `browserMenuState`/`BrowserViewState` with the same derived value. Adds unit tests for the new enablement computation across rollout/experimental flags and user preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61521184a47ecb2725a01018767a4141e8a21bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->