### PR TITLE
Onboarding Brand Design Update: Fix in-context dialog click handling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -825,6 +825,14 @@ sealed class DaxBubbleCta(
 
         abstract fun configureContentViews(view: View)
 
+        private var cardContainer: TouchInterceptingLinearLayout? = null
+
+        private var isAnimating: Boolean = false
+            set(value) {
+                field = value
+                cardContainer?.interceptChildTouches = value
+            }
+
         protected fun resolveOnboardingContext(context: Context): Context {
             val themeRes = if (isLightTheme) {
                 DesignSystemR.style.Theme_DuckDuckGo_Light_Onboarding
@@ -872,7 +880,6 @@ sealed class DaxBubbleCta(
 
             // Assumes one active showCta at a time — the intercept flag gates user advances until settled.
             // Overlapping calls would let stale closure callbacks clobber shared view state.
-            var animationsSettled = false
             var contentFadeInAnimator: AnimatorSet? = null
             var fadeOutAnimator: AnimatorSet? = null
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA
@@ -886,8 +893,8 @@ sealed class DaxBubbleCta(
             val dismissButton = container.findViewById<ImageView>(R.id.brandDesignDismissButton)
             val headerImage = container.findViewById<ImageView>(R.id.brandDesignHeaderImage)
             styleDismissButton(dismissButton)
-            val cardContainer = container.findViewById<TouchInterceptingLinearLayout>(R.id.brandDesignCardContainer)
-            cardContainer.interceptChildTouches = true
+            cardContainer = container.findViewById<TouchInterceptingLinearLayout>(R.id.brandDesignCardContainer)
+            isAnimating = true
 
             // The active content include for THIS CTA
             val activeInclude = container.findViewById<View>(activeIncludeId)
@@ -923,9 +930,8 @@ sealed class DaxBubbleCta(
                             playTogether(animators.toList())
                             addListener(object : AnimatorListenerAdapter() {
                                 override fun onAnimationEnd(animation: Animator) {
-                                    if (!animationsSettled) {
-                                        animationsSettled = true
-                                        cardContainer.interceptChildTouches = false
+                                    if (isAnimating) {
+                                        isAnimating = false
                                         onTypingAnimationFinished()
                                     }
                                 }
@@ -942,7 +948,7 @@ sealed class DaxBubbleCta(
                         .withEndAction {
                             // cancel() invokes withEndAction; skip typing when snapToFinished has
                             // already set the final state.
-                            if (!animationsSettled) {
+                            if (isAnimating) {
                                 startTyping()
                             }
                         }
@@ -994,7 +1000,7 @@ sealed class DaxBubbleCta(
                             configureContentViews(container)
                             // Blank the title so typing (or snapped settled state) shows new text, not stale.
                             titleView.text = ""
-                            if (animationsSettled) {
+                            if (!isAnimating) {
                                 applySettledState()
                             } else {
                                 typeAndFadeIn()
@@ -1013,7 +1019,7 @@ sealed class DaxBubbleCta(
                 container.show()
                 container.animate().alpha(1f).setDuration(DIALOG_FADE_IN_DURATION).setStartDelay(200L)
                     .withEndAction {
-                        if (!animationsSettled) {
+                        if (isAnimating) {
                             typeAndFadeIn()
                         }
                     }
@@ -1023,9 +1029,8 @@ sealed class DaxBubbleCta(
             fun snapToFinished() {
                 // Set the flag before cancelling animators; cancel() fires end callbacks
                 // (fadeOutAnimator.onAnimationEnd / headerImage withEndAction) which read it.
-                val alreadySettled = animationsSettled
-                animationsSettled = true
-                cardContainer.interceptChildTouches = false
+                val wasAnimating = isAnimating
+                isAnimating = false
                 titleView.finishAnimation()
                 headerImage?.animate()?.cancel()
                 if (fadeOutAnimator?.isRunning == true) {
@@ -1035,11 +1040,11 @@ sealed class DaxBubbleCta(
                     applySettledState()
                 }
                 contentFadeInAnimator?.let { if (it.isRunning) it.end() }
-                if (!alreadySettled) {
+                if (wasAnimating) {
                     onTypingAnimationFinished()
                 }
             }
-            cardContainer.setOnClickListener { snapToFinished() }
+            cardContainer?.setOnClickListener { snapToFinished() }
         }
 
         override fun clearDialog() {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -878,8 +878,6 @@ sealed class DaxBubbleCta(
         ) {
             ctaView = container
 
-            // Assumes one active showCta at a time — the intercept flag gates user advances until settled.
-            // Overlapping calls would let stale closure callbacks clobber shared view state.
             var contentFadeInAnimator: AnimatorSet? = null
             var fadeOutAnimator: AnimatorSet? = null
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.view.DaxTypeAnimationTextView
+import com.duckduckgo.app.onboarding.ui.view.TouchInterceptingLinearLayout
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.SITE_NOT_WORKING_SHOWN
 import com.duckduckgo.app.pixels.AppPixelName.SITE_NOT_WORKING_WEBSITE_BROKEN
@@ -882,7 +883,8 @@ sealed class DaxBubbleCta(
             val dismissButton = container.findViewById<ImageView>(R.id.brandDesignDismissButton)
             val headerImage = container.findViewById<ImageView>(R.id.brandDesignHeaderImage)
             styleDismissButton(dismissButton)
-            val cardContainer = container.findViewById<View>(R.id.brandDesignCardContainer)
+            val cardContainer = container.findViewById<TouchInterceptingLinearLayout>(R.id.brandDesignCardContainer)
+            cardContainer.interceptChildTouches = true
 
             // The active content include for THIS CTA
             val activeInclude = container.findViewById<View>(activeIncludeId)
@@ -920,6 +922,7 @@ sealed class DaxBubbleCta(
                                 override fun onAnimationEnd(animation: Animator) {
                                     if (!animationsSettled) {
                                         animationsSettled = true
+                                        cardContainer.interceptChildTouches = false
                                         onTypingAnimationFinished()
                                     }
                                 }
@@ -996,6 +999,7 @@ sealed class DaxBubbleCta(
                 // cancel() fires the pending withEndAction, which respects animationsSettled.
                 val alreadySettled = animationsSettled
                 animationsSettled = true
+                cardContainer.interceptChildTouches = false
                 titleView.finishAnimation()
                 // If typing hasn't started yet (tap during initial fade-in), set title directly
                 if (!titleView.hasAnimationStarted()) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -949,9 +949,11 @@ sealed class DaxBubbleCta(
             }
 
             if (isContentTransition) {
-                // Content transition: fade out old description + any visible content include, then swap and animate new
+                // Content transition: fade out title + description + visible includes, then swap and animate new
                 val allContentIncludes = getAllContentIncludes(container)
                 val fadeOutAnimators = mutableListOf<Animator>(
+                    ObjectAnimator.ofFloat(titleView, View.ALPHA, 0f)
+                        .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                     ObjectAnimator.ofFloat(descriptionView, View.ALPHA, 0f)
                         .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                 )
@@ -972,6 +974,8 @@ sealed class DaxBubbleCta(
                             resetAllIncludesExcept(container, activeInclude)
                             resetHeaderState()
                             configureContentViews(container)
+                            // Blank the title so typing shows new text, not stale.
+                            titleView.text = ""
                             typeAndFadeIn()
                         }
                     })

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -870,8 +870,11 @@ sealed class DaxBubbleCta(
         ) {
             ctaView = container
 
+            // Assumes one active showCta at a time — the intercept flag gates user advances until settled.
+            // Overlapping calls would let stale closure callbacks clobber shared view state.
             var animationsSettled = false
             var contentFadeInAnimator: AnimatorSet? = null
+            var fadeOutAnimator: AnimatorSet? = null
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA
 
             val daxTitle = container.context.getString(title)
@@ -948,6 +951,21 @@ sealed class DaxBubbleCta(
                 }
             }
 
+            val applySettledState = {
+                hiddenTitle.text = daxTitle.html(container.context)
+                descriptionView.text = daxDescription.html(container.context)
+                if (!titleView.hasAnimationStarted()) {
+                    titleView.text = daxTitle.html(container.context)
+                }
+                titleView.alpha = 1f
+                descriptionView.alpha = 1f
+                dismissButton.alpha = 1f
+                activeInclude.alpha = 1f
+                if (headerImage?.isVisible == true) {
+                    headerImage.alpha = 1f
+                }
+            }
+
             if (isContentTransition) {
                 // Content transition: fade out title + description + visible includes, then swap and animate new
                 val allContentIncludes = getAllContentIncludes(container)
@@ -964,19 +982,23 @@ sealed class DaxBubbleCta(
                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION)
                     }
                 }
-                AnimatorSet().apply {
+                fadeOutAnimator = AnimatorSet().apply {
                     playTogether(fadeOutAnimators.toList())
                     addListener(object : AnimatorListenerAdapter() {
                         override fun onAnimationEnd(animation: Animator) {
-                            // After fade-out: hide old includes, show new one, type and fade in
+                            // After fade-out: hide old includes, show new one.
                             // Note: do NOT call clearDialog() here — it would re-zero the dismiss
                             // button alpha causing a flicker. Instead, selectively reset content only.
                             resetAllIncludesExcept(container, activeInclude)
                             resetHeaderState()
                             configureContentViews(container)
-                            // Blank the title so typing shows new text, not stale.
+                            // Blank the title so typing (or snapped settled state) shows new text, not stale.
                             titleView.text = ""
-                            typeAndFadeIn()
+                            if (animationsSettled) {
+                                applySettledState()
+                            } else {
+                                typeAndFadeIn()
+                            }
                         }
                     })
                     start()
@@ -999,22 +1021,18 @@ sealed class DaxBubbleCta(
 
             // Tap-to-skip: end running animations and snap all content visible
             fun snapToFinished() {
-                // Set the flag before cancelling the header animator;
-                // cancel() fires the pending withEndAction, which respects animationsSettled.
+                // Set the flag before cancelling animators; cancel() fires end callbacks
+                // (fadeOutAnimator.onAnimationEnd / headerImage withEndAction) which read it.
                 val alreadySettled = animationsSettled
                 animationsSettled = true
                 cardContainer.interceptChildTouches = false
                 titleView.finishAnimation()
-                // If typing hasn't started yet (tap during initial fade-in), set title directly
-                if (!titleView.hasAnimationStarted()) {
-                    titleView.text = daxTitle.html(container.context)
-                }
-                descriptionView.alpha = 1f
-                dismissButton.alpha = 1f
-                activeInclude.alpha = 1f
-                if (headerImage?.isVisible == true) {
-                    headerImage.animate().cancel()
-                    headerImage.alpha = 1f
+                headerImage?.animate()?.cancel()
+                if (fadeOutAnimator?.isRunning == true) {
+                    // cancel() fires onAnimationEnd synchronously, which applies settled state via the branch above.
+                    fadeOutAnimator.cancel()
+                } else {
+                    applySettledState()
                 }
                 contentFadeInAnimator?.let { if (it.isRunning) it.end() }
                 if (!alreadySettled) {

--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
@@ -23,7 +23,7 @@
         app:layout_constraintWidth_max="600dp"
         app:showArrow="false">
 
-        <LinearLayout
+        <com.duckduckgo.app.onboarding.ui.view.TouchInterceptingLinearLayout
             android:id="@+id/brandDesignCardContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -105,7 +105,7 @@
                 tools:text="High Five!"
                 tools:visibility="gone" />
 
-        </LinearLayout>
+        </com.duckduckgo.app.onboarding.ui.view.TouchInterceptingLinearLayout>
 
     </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214123398861719

### Description

Fixes several touch and click handling issues in the brand design update onboarding dialogs that occurred during or immediately after animations.

- Replaced the `LinearLayout` card container with `TouchInterceptingLinearLayout` so the layout can block child touch events while an animation is running — prevents accidental button taps mid-transition.
- Intercept child touches during in-context CTA dialog animations to stop buttons being pressed before the new card has finished animating in.
- Title now fades out alongside the description and content during in-context CTA transitions instead of staying visible independently.
- Cancel any in-progress fade-out animation when tap-to-skip is detected, preventing the Dax typing animation from restarting in a loop.

### Steps to test this PR

_In-context click handling_
- [x] Enable `brandDesignUpdate` and `self` toggles; go through onboarding to a card with in-context CTAs (e.g. visit-site-options or end-CTA).
- [x] Tap a CTA button immediately as the card is animating in — verify no action fires during the transition.
- [x] On a card with typing animation, tap to skip mid-way through, then tap again immediately — verify the typing does not restart in a loop.
- [x] Trigger an in-context CTA transition and confirm the title fades out cleanly with the rest of the card contents.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core onboarding CTA animation/click handling; regressions could block CTA buttons or cause dialogs to get stuck if animation state is mishandled, but there are no security or data risks.
> 
> **Overview**
> Improves the Brand Design Update onboarding CTA dialog animation flow to prevent user interactions from firing while the card is transitioning/typing.
> 
> Replaces the dialog card container with `TouchInterceptingLinearLayout` and toggles child-touch interception via a new shared `isAnimating` state, ensuring taps during animations only trigger the tap-to-skip behavior.
> 
> Refines transition logic by fading out the title with other content, adding an `applySettledState` snap path, and cancelling any in-progress fade-out animator on tap-to-skip to avoid re-triggering typing/animation loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3138cebba8b31f8ab5e5bc6b933b227ad5aa114b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->