### PR TITLE
Remove favorites from Duck.ai tab (Native Input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -282,8 +282,15 @@ class RealNativeInputManager @Inject constructor(
         callbacks: NativeInputCallbacks,
     ) {
         val widget = widgetFrom(widgetView) ?: return
+        val onSearchTextChanged: (String) -> Unit = { text ->
+            if (omnibarController.isDuckAiMode() && text.isBlank()) {
+                callbacks.onClearAutocomplete()
+            } else {
+                callbacks.onSearchTextChanged(text)
+            }
+        }
         widget.bindInputEvents(
-            onSearchTextChanged = callbacks.onSearchTextChanged,
+            onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
                 hideNativeInput()
                 callbacks.onSearchSubmitted(query)
@@ -400,9 +407,12 @@ class RealNativeInputManager @Inject constructor(
     ) {
         val widget = widgetFrom(widgetView) ?: return
         val previousOnSearchSelected = widget.onSearchSelected
-        widget.onSearchSelected = { animate ->
+        widget.onSearchSelected = handler@{ animate ->
             if (widget.text.isBlank()) {
                 onClearAutocomplete()
+                if (omnibarController.isDuckAiMode()) {
+                    return@handler
+                }
             }
             previousOnSearchSelected?.invoke(animate)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213821485629415?focus=true

### Description

- Hides favorites when toggling to search on a Duck.ai tab

### Steps to test this PR

_With native input enabled_
- [x] Add a favorite
- [x] Go to Duck.ai
- [x] Toggle to search
- [x] Verify that the favorite does not show
- [x] Type something
- [x] Clear it
- [x] Verify that the favorite does not show

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized callback changes in `NativeInputManager` affecting autocomplete clearing behavior, with minimal impact outside Duck.ai mode.
> 
> **Overview**
> Adjusts native input callback handling so that in **Duck.ai mode** clearing the search field triggers `onClearAutocomplete` (instead of propagating an empty `onSearchTextChanged`).
> 
> Also updates search-tab selection handling to clear autocomplete and **short-circuit further selection behavior** when the text is blank in Duck.ai mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a14205814b6f206372d24180608862562d944e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->