### PR TITLE
Hide toggle for Search Only (Native Input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -101,6 +101,13 @@ class RealNativeInputManager @Inject constructor(
                 isNativeInputFieldEnabled = isEnabled
             }
             .launchIn(lifecycleOwner.lifecycleScope)
+        duckChat.observeInputScreenUserSettingEnabled()
+            .onEach {
+                if (omnibarController.isDuckAiMode()) {
+                    rootView.post { widgetFrom(rootView)?.selectChatTab() }
+                }
+            }
+            .launchIn(lifecycleOwner.lifecycleScope)
     }
 
     override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
@@ -271,7 +278,10 @@ class RealNativeInputManager @Inject constructor(
         }
         attachWidget(widgetView)
         if (omnibarController.isDuckAiMode()) {
-            widgetFrom(widgetView)?.setToggleVisible(false)
+            widgetFrom(widgetView)?.apply {
+                setToggleVisible(false)
+                selectChatTab()
+            }
         } else {
             showNtp()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -137,8 +137,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var chatSuggestionsSettingJob: Job? = null
     private var chatSuggestionsJob: Job? = null
     private var tierJob: Job? = null
+    private var inputScreenSettingJob: Job? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
+    private var isInputScreenUserSettingEnabled: Boolean = false
     private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
     private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
@@ -165,6 +167,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
+        observeInputScreenUserSetting()
         if (onPaidTierChanged != null) observeTier()
     }
 
@@ -176,6 +179,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsSettingJob = null
         tierJob?.cancel()
         tierJob = null
+        inputScreenSettingJob?.cancel()
+        inputScreenSettingJob = null
         tearDownChatSuggestions()
     }
 
@@ -226,11 +231,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         hideBackArrow()
         hideInputFieldBackground()
         removeMargins()
-        if (duckChatInternal.isEnabled()) {
-            setToggleMatchParent()
-        } else {
-            hideToggle()
-        }
+        applyToggleVisibility()
         prepareSubmitButtons()
         configureMainButtonsVisibility()
         inputField.doOnTextChanged { text, _, _, _ ->
@@ -239,6 +240,25 @@ class NativeInputModeWidget @JvmOverloads constructor(
             }
         }
     }
+
+    private fun applyToggleVisibility() {
+        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        when {
+            !duckChatInternal.isEnabled() -> {
+                hideToggle()
+            }
+            !isInputScreenUserSettingEnabled -> {
+                setToggleMatchParent()
+                hideToggle()
+            }
+            else -> {
+                setToggleMatchParent()
+                toggle.visibility = VISIBLE
+            }
+        }
+    }
+
+    private fun shouldShowToggle(): Boolean = duckChatInternal.isEnabled() && isInputScreenUserSettingEnabled
 
     private fun removeMargins() {
         findViewById<EditText?>(R.id.inputField)?.updateLayoutParams<MarginLayoutParams> {
@@ -346,8 +366,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun setToggleVisible(visible: Boolean) {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
+        val isVisible = visible && shouldShowToggle()
         suspendLayoutTransitions {
-            toggle.visibility = if (visible) VISIBLE else GONE
+            toggle.visibility = if (isVisible) VISIBLE else GONE
         }
     }
 
@@ -454,6 +475,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsSettingJob?.cancel()
         chatSuggestionsSettingJob = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
             .onEach { enabled -> chatSuggestionsUserEnabled = enabled }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    private fun observeInputScreenUserSetting() {
+        inputScreenSettingJob?.cancel()
+        inputScreenSettingJob = duckChatInternal.observeInputScreenUserSettingEnabled()
+            .onEach { enabled ->
+                isInputScreenUserSettingEnabled = enabled
+                applyToggleVisibility()
+            }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213890328647790?focus=true

### Description

- Hides the toggle when AI Features are set to “Search Only"

### Steps to test this PR

_With native input enabled_
- [ ] Go to AI Features
- [ ] Set to "Search Only"
- [ ] Verify that the toggle is hidden


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state wiring change limited to toggle visibility and initial tab selection based on an existing user setting.
> 
> **Overview**
> **Native input now reacts to the “Input Screen” (AI features) user setting to hide the Search/Chat toggle in “Search Only” mode.** `NativeInputModeWidget` observes the setting, centralizes toggle visibility logic (`applyToggleVisibility`/`shouldShowToggle`), and gates `setToggleVisible` so the toggle can’t reappear during keyboard transitions when disabled.
> 
> In Duck AI mode, `RealNativeInputManager` also listens for that setting and re-selects the Chat tab (and on initial show) to keep the UI in the expected state when the toggle is suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d6ccc0d04f396eaafeaa3d03dab5d3ce518f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->