### PR TITLE
Update native input UI when Duck.ai is disabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -264,9 +264,9 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val widgetContent = card.findViewById<View?>(R.id.inputModeWidget)
         widgetContent?.alpha = 0f
 
-        val fullWidth = (card.parent as View).width
-        val fullHeight = measureUnconstrainedHeight(card, fullWidth)
         val params = card.layoutParams as FrameLayout.LayoutParams
+        val fullWidth = (card.parent as View).width - params.leftMargin - params.rightMargin
+        val fullHeight = measureUnconstrainedHeight(card, fullWidth)
 
         runAnimator(
             cleanup = { omnibarCard.alpha = 1f },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -430,6 +430,10 @@ class RealNativeInputManager @Inject constructor(
     private fun attachWidget(widgetView: View) {
         val omnibarCard = omnibarController.getCardView()
         val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard)
+        if (!duckChat.isEnabled() && !layoutCoordinator.isWidgetBottom()) {
+            matchOmnibarShape(widgetCard)
+        }
+        addTrailingButtonMargin(widgetView)
         val margins = if (!omnibarController.isDuckAiMode() && omnibarCard != null && widgetCard != null) {
             animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, layoutCoordinator.isWidgetBottom())
         } else {
@@ -501,6 +505,30 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
         )
+    }
+
+    private fun matchOmnibarShape(widgetCard: View?) {
+        val card = widgetCard as? MaterialCardView ?: return
+        card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
+        val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
+        val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+        (card.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+            lp.topMargin = targetTopMargin - card.paddingTop
+            lp.marginStart = targetHorizontalMargin - card.paddingLeft
+            lp.marginEnd = targetHorizontalMargin - card.paddingRight
+            card.layoutParams = lp
+        }
+    }
+
+    private fun addTrailingButtonMargin(widgetView: View) {
+        val layout = widgetView.findViewById<View?>(com.duckduckgo.duckchat.impl.R.id.inputModeWidgetLayout) ?: return
+        val targetMarginEnd = layout.resources.getDimensionPixelSize(
+            com.duckduckgo.duckchat.impl.R.dimen.inputScreenOmnibarCardMarginHorizontal,
+        )
+        (layout.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+            lp.marginEnd = targetMarginEnd
+            layout.layoutParams = lp
+        }
     }
 
     private fun createFloatingSubmitContainer(): ViewGroup {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -21,12 +21,14 @@ import android.content.Context
 import android.graphics.Color
 import android.text.InputType
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.Space
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -274,6 +276,24 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         toggle.getTabAt(0)?.select()
         toggle.visibility = GONE
+        matchOmnibarHeight()
+    }
+
+    private fun matchOmnibarHeight() {
+        if (floatingSubmitContainer == null) return
+        findViewById<Space?>(R.id.spacer)?.updateLayoutParams<LayoutParams> { height = 0 }
+        findViewById<Space?>(R.id.bottomSpacer)?.updateLayoutParams<LayoutParams> { height = 0 }
+        findViewById<View?>(R.id.inputModeWidgetLayout)?.updateLayoutParams<MarginLayoutParams> { topMargin = 0 }
+        getActionBarSize()?.let { minimumHeight = it }
+    }
+
+    private fun getActionBarSize(): Int? {
+        val typedValue = TypedValue()
+        return if (context.theme.resolveAttribute(android.R.attr.actionBarSize, typedValue, true)) {
+            TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics)
+        } else {
+            null
+        }
     }
 
     private fun setToggleMatchParent() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1213433888294717?focus=true

### Description

- Updates the input Ui when Duck.ai is disabled

### Steps to test this PR

_With native input enabled_
- [ ] Disable Duck.ai
- [ ] Focus the input
- [ ] Verify that the input is the correct size

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native input sizing/animation and runtime margin adjustments, which can cause visual regressions across device sizes and top/bottom widget configurations.
> 
> **Overview**
> Improves native input UI consistency when Duck.ai is disabled by **matching the widget card’s shape/margins to the omnibar** and adding an explicit trailing margin for the widget layout.
> 
> Adjusts the enter animation sizing to compute the expanded width *excluding* card side margins, and updates the Duck.ai-disabled widget to **collapse extra spacers/top margin and enforce omnibar-like minimum height** when the toggle is hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec2c36abd3b729341df52eecd3ccc45f12213aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->