### PR TITLE
Fix native input sizing issue

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -84,6 +84,7 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var rootView: ViewGroup
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
+    private var isInputScreenUserSettingEnabled: Boolean = false
     private var isExiting: Boolean = false
     private var floatingSubmitContainer: View? = null
 
@@ -102,7 +103,8 @@ class RealNativeInputManager @Inject constructor(
             }
             .launchIn(lifecycleOwner.lifecycleScope)
         duckChat.observeInputScreenUserSettingEnabled()
-            .onEach {
+            .onEach { enabled ->
+                isInputScreenUserSettingEnabled = enabled
                 if (omnibarController.isDuckAiMode()) {
                     rootView.post { widgetFrom(rootView)?.selectChatTab() }
                 }
@@ -450,7 +452,7 @@ class RealNativeInputManager @Inject constructor(
     private fun attachWidget(widgetView: View) {
         val omnibarCard = omnibarController.getCardView()
         val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard)
-        if (!duckChat.isEnabled() && !layoutCoordinator.isWidgetBottom()) {
+        if (shouldMatchOmnibarShape() && !layoutCoordinator.isWidgetBottom()) {
             matchOmnibarShape(widgetCard)
         }
         addTrailingButtonMargin(widgetView)
@@ -526,6 +528,8 @@ class RealNativeInputManager @Inject constructor(
             },
         )
     }
+
+    private fun shouldMatchOmnibarShape(): Boolean = !duckChat.isEnabled() || !isInputScreenUserSettingEnabled
 
     private fun matchOmnibarShape(widgetCard: View?) {
         val card = widgetCard as? MaterialCardView ?: return

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -233,7 +233,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         hideBackArrow()
         hideInputFieldBackground()
         removeMargins()
-        applyToggleVisibility()
         prepareSubmitButtons()
         configureMainButtonsVisibility()
         inputField.doOnTextChanged { text, _, _, _ ->
@@ -248,10 +247,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         when {
             !duckChatInternal.isEnabled() -> {
                 hideToggle()
+                matchOmnibarHeight()
             }
             !isInputScreenUserSettingEnabled -> {
                 setToggleMatchParent()
                 hideToggle()
+                matchOmnibarHeight()
             }
             else -> {
                 setToggleMatchParent()
@@ -296,7 +297,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         toggle.getTabAt(0)?.select()
         toggle.visibility = GONE
-        matchOmnibarHeight()
     }
 
     private fun matchOmnibarHeight() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214271710998174?focus=true

### Description

- Fixes a regression where the native input is the wrong height

### Steps to test this PR

_With native input enabled_
- [ ] Focus the native input
- [ ] Verify that the input is the correct height
- [ ] In AI Features select “Search Only"
- [ ] Verify that the input resizes correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout-only changes that adjust native input widget sizing/shape based on DuckChat and input-screen user settings; main risk is minor visual regressions across mode/layout combinations.
> 
> **Overview**
> Fixes native input sizing/shape inconsistencies when the input-screen toggle is disabled.
> 
> `RealNativeInputManager` now tracks `observeInputScreenUserSettingEnabled()` and uses it (via `shouldMatchOmnibarShape`) to decide when to match the omnibar card shape. `NativeInputModeWidget` now explicitly applies `matchOmnibarHeight()` whenever the toggle is hidden (DuckChat disabled or user setting off), ensuring the widget height stays aligned with the omnibar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0037e943d5e734231124a12b492be8595ed86593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->