### PR TITLE
Remove aiChatSuggestion feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -494,7 +494,6 @@ class RealNativeInputManager @Inject constructor(
         onChatSuggestionSelected: (String) -> Unit,
     ) {
         if (omnibarController.isDuckAiMode()) return
-        if (!duckChat.isChatSuggestionsFeatureAvailable()) return
         val widget = widgetFrom(widgetView) ?: return
         val autoCompleteList =
             rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList) ?: return

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -123,8 +123,7 @@ class GeneralSettingsViewModel @Inject constructor(
                     maliciousSiteProtection.isFeatureEnabled() &&
                     !androidBrowserConfigFeature.newThreatProtectionSettings().isEnabled(),
                 showChatSuggestionsToggle = duckChat.isEnabled() &&
-                    duckChat.observeInputScreenUserSettingEnabled().firstOrNull() == true &&
-                    duckChat.isChatSuggestionsFeatureAvailable(),
+                    duckChat.observeInputScreenUserSettingEnabled().firstOrNull() == true,
                 chatSuggestionsEnabled = duckChat.observeChatSuggestionsUserSettingEnabled().firstOrNull() ?: true,
                 showNTPAfterIdleReturn = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled(),
             )

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -112,7 +112,6 @@ internal class GeneralSettingsViewModelTest {
             fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(LastOpenedTab)
 
             whenever(mockDuckChat.isEnabled()).thenReturn(false)
-            whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(false)
             whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false))
             whenever(mockDuckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(true))
         }
@@ -398,9 +397,8 @@ internal class GeneralSettingsViewModelTest {
     }
 
     @Test
-    fun whenDuckChatEnabledAndInputScreenEnabledAndFeatureAvailableThenChatSuggestionsToggleIsVisible() = runTest {
+    fun whenDuckChatEnabledAndInputScreenEnabledThenChatSuggestionsToggleIsVisible() = runTest {
         whenever(mockDuckChat.isEnabled()).thenReturn(true)
-        whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(true)
         whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
 
         initTestee()
@@ -415,7 +413,6 @@ internal class GeneralSettingsViewModelTest {
     @Test
     fun whenDuckChatDisabledThenChatSuggestionsToggleIsHidden() = runTest {
         whenever(mockDuckChat.isEnabled()).thenReturn(false)
-        whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(true)
         whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
 
         initTestee()
@@ -430,23 +427,7 @@ internal class GeneralSettingsViewModelTest {
     @Test
     fun whenInputScreenDisabledThenChatSuggestionsToggleIsHidden() = runTest {
         whenever(mockDuckChat.isEnabled()).thenReturn(true)
-        whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(true)
         whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false))
-
-        initTestee()
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state!!.showChatSuggestionsToggle)
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenChatSuggestionsFeatureNotAvailableThenChatSuggestionsToggleIsHidden() = runTest {
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
-        whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(false)
-        whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
 
         initTestee()
 
@@ -460,7 +441,6 @@ internal class GeneralSettingsViewModelTest {
     @Test
     fun whenChatSuggestionsUserSettingDisabledThenToggleIsOff() = runTest {
         whenever(mockDuckChat.isEnabled()).thenReturn(true)
-        whenever(mockDuckChat.isChatSuggestionsFeatureAvailable()).thenReturn(true)
         whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
         whenever(mockDuckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(false))
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -124,12 +124,6 @@ interface DuckChat {
     fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean>
 
     /**
-     * Returns whether the chat suggestions feature is available (feature flag is enabled).
-     * Does not consider user preference — use for visibility checks.
-     */
-    fun isChatSuggestionsFeatureAvailable(): Boolean
-
-    /**
      * Opens Duck.ai directly in voice mode (duck.ai/?mode=voice-mode).
      */
     fun openVoiceDuckChat()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -787,9 +787,6 @@ class RealDuckChat @Inject constructor(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> =
         duckChatFeatureRepository.observeChatSuggestionsUserSettingEnabled()
 
-    override fun isChatSuggestionsFeatureAvailable(): Boolean =
-        duckChatFeature.aiChatSuggestions().isEnabled()
-
     override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
     override suspend fun isVoiceChatEnabled(): Boolean = withContext(dispatchers.io()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -177,13 +177,6 @@ interface DuckChatFeature {
     fun supportsSyncChatsDeletion(): Toggle
 
     /**
-     * @return `true` when the AI chat suggestions (pinned and recent chats) are enabled
-     * If the remote feature is not present defaults to `internal`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun aiChatSuggestions(): Toggle
-
-    /**
      * @return `true` when the tab attachment feature (@-mention tabs in chat) is enabled
      * If the remote feature is not present defaults to `false`
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -374,11 +374,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 updateLogoVisibility(state)
                 beginRootTransition()
                 updateFavoritesVisibility(state.searchMode, !state.autoCompleteSuggestionsVisible)
-                if (duckChatFeature.aiChatSuggestions().isEnabled()) {
-                    updateOverlaysForModeChange(state)
-                } else {
-                    hideAutoCompleteIfOnChatTab(state)
-                }
+                updateOverlaysForModeChange(state)
                 previousSearchMode = state.searchMode
                 updateButtonVisibility(state)
                 inputScreenButtons.setNewLineButtonVisible(state.newLineButtonVisible)
@@ -760,14 +756,6 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         binding.ddgLogoContainer.isVisible = shouldBeVisible
     }
 
-    private fun hideAutoCompleteIfOnChatTab(state: InputScreenVisibilityState) {
-        if (!state.searchMode && autoCompleteTargetVisibility) {
-            autoCompleteTargetVisibility = false
-            binding.autoCompleteOverlay.animate().cancel()
-            hideOverlay(binding.autoCompleteOverlay, ::invalidateAutoCompleteBlurView)
-        }
-    }
-
     private fun updateOverlaysForModeChange(state: InputScreenVisibilityState) {
         if (state.searchMode) {
             if (chatSuggestionsTargetVisibility) {
@@ -885,11 +873,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                 overlay.isVisible = false
                 overlay.alpha = 1f
                 overlay.elevation = 0f
-                if (duckChatFeature.aiChatSuggestions().isEnabled()) {
-                    enableViewPagerInputIfNoOverlays()
-                } else {
-                    enableViewPagerInputIfNoFavorites()
-                }
+                enableViewPagerInputIfNoOverlays()
             }
             .start()
     }
@@ -993,12 +977,6 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             !autoCompleteTargetVisibility &&
             !chatSuggestionsTargetVisibility
         ) {
-            enableViewPagerInput()
-        }
-    }
-
-    private fun enableViewPagerInputIfNoFavorites() {
-        if (!binding.newTabContainerScrollView.isVisible) {
             enableViewPagerInput()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -82,7 +82,6 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        if (!duckChatFeature.aiChatSuggestions().isEnabled()) return
         configureChatSuggestions()
         if (duckChatFeature.rememberTogglePosition().isEnabled()) {
             configureChatUrlSuggestions()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -393,28 +393,26 @@ class InputScreenViewModel @AssistedInject constructor(
             }
         }.launchIn(viewModelScope)
 
-        if (duckChatFeature.aiChatSuggestions().isEnabled()) {
-            duckChat.observeChatSuggestionsUserSettingEnabled()
-                .onEach { enabled ->
-                    chatSuggestionsUserEnabled.value = enabled
-                    if (!enabled) {
-                        chatSuggestionsFetchJob?.cancel()
-                        _chatSuggestions.value = emptyList()
-                    }
+        duckChat.observeChatSuggestionsUserSettingEnabled()
+            .onEach { enabled ->
+                chatSuggestionsUserEnabled.value = enabled
+                if (!enabled) {
+                    chatSuggestionsFetchJob?.cancel()
+                    _chatSuggestions.value = emptyList()
                 }
-                .launchIn(viewModelScope)
+            }
+            .launchIn(viewModelScope)
 
-            @OptIn(FlowPreview::class)
-            chatInputTextState
-                .drop(1)
-                .debounce(CHAT_SUGGESTIONS_DEBOUNCE_MS)
-                .onEach { query ->
-                    if (!_visibilityState.value.searchMode && chatSuggestionsUserEnabled.value) {
-                        fetchChatSuggestionsWithQuery(query)
-                    }
+        @OptIn(FlowPreview::class)
+        chatInputTextState
+            .drop(1)
+            .debounce(CHAT_SUGGESTIONS_DEBOUNCE_MS)
+            .onEach { query ->
+                if (!_visibilityState.value.searchMode && chatSuggestionsUserEnabled.value) {
+                    fetchChatSuggestionsWithQuery(query)
                 }
-                .launchIn(viewModelScope)
-        }
+            }
+            .launchIn(viewModelScope)
     }
 
     fun onActivityResume() {
@@ -625,8 +623,7 @@ class InputScreenViewModel @AssistedInject constructor(
 
         // Fetch if the query hasn't changed since the last fetch. The observer
         // on chatInputTextState will handle the case where the query changed.
-        if (duckChatFeature.aiChatSuggestions().isEnabled() &&
-            chatSuggestionsUserEnabled.value &&
+        if (chatSuggestionsUserEnabled.value &&
             chatInputTextState.value == searchInputTextState.value
         ) {
             fetchChatSuggestionsWithQuery(chatInputTextState.value)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -306,20 +306,6 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenAiChatSuggestionsFeatureEnabledThenIsChatSuggestionsFeatureAvailableReturnsTrue() {
-        duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
-
-        assertTrue(testee.isChatSuggestionsFeatureAvailable())
-    }
-
-    @Test
-    fun whenAiChatSuggestionsFeatureDisabledThenIsChatSuggestionsFeatureAvailableReturnsFalse() {
-        duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = false))
-
-        assertFalse(testee.isChatSuggestionsFeatureAvailable())
-    }
-
-    @Test
     fun whenFeatureEnabledThenShowPopupMenuShortcutReturnsValueFromRepository() {
         assertTrue(testee.showPopupMenuShortcut.value)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1435,7 +1435,6 @@ class DuckChatContextualViewModelTest {
         override fun observeNativeInputFieldUserSettingEnabled(): Flow<Boolean> = nativeInputFieldSettingEnabled
         override suspend fun isStandaloneMigrationCompleted(): Boolean = true
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
-        override fun isChatSuggestionsFeatureAvailable(): Boolean = true
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(): Boolean = false

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -111,8 +111,6 @@ class FakeDuckChat(
         chatSuggestionsUserSettingEnabled.value = enabled
     }
 
-    override fun isChatSuggestionsFeatureAvailable(): Boolean = true
-
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -170,8 +170,6 @@ class FakeDuckChatInternal(
         chatSuggestionsUserSettingEnabled.value = enabled
     }
 
-    override fun isChatSuggestionsFeatureAvailable(): Boolean = true
-
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -123,6 +123,7 @@ class InputScreenViewModelTest {
             whenever(duckChat.wasOpenedBefore()).thenReturn(false)
             whenever(duckChat.getDuckChatUrl(any(), any(), any())).thenReturn(duckChatURL)
             whenever(duckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(inputScreenConfigResolver.useTopBar()).thenReturn(true)
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
             whenever(omnibarRepository.omnibarType).thenReturn(OmnibarType.SINGLE_TOP)
@@ -2247,13 +2248,12 @@ class InputScreenViewModelTest {
 
     @SuppressLint("DenyListedApi")
     @Test
-    fun `when onChatSelected and feature flag enabled and suggestions empty then suggestions are fetched`() =
+    fun `when onChatSelected and suggestions empty then suggestions are fetched`() =
         runTest {
             val suggestions = listOf(
                 ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false),
             )
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2261,16 +2261,6 @@ class InputScreenViewModelTest {
 
             verify(chatSuggestionsReader).fetchSuggestions(eq(""))
             assertEquals(suggestions, viewModel.chatSuggestions.value)
-        }
-
-    @Test
-    fun `when onChatSelected and feature flag disabled then suggestions are not fetched`() =
-        runTest {
-            val viewModel = createViewModel()
-            viewModel.onChatSelected()
-            advanceUntilIdle()
-
-            verify(chatSuggestionsReader, never()).fetchSuggestions(any())
         }
 
     @SuppressLint("DenyListedApi")
@@ -2281,7 +2271,6 @@ class InputScreenViewModelTest {
                 ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false),
             )
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2305,7 +2294,6 @@ class InputScreenViewModelTest {
                 ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false),
             )
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2320,7 +2308,6 @@ class InputScreenViewModelTest {
     fun `when chat suggestions are empty then showChatLogo is true and chatSuggestionsVisible is false`() =
         runTest {
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2342,7 +2329,6 @@ class InputScreenViewModelTest {
             )
             whenever(chatSuggestionsReader.fetchSuggestions(eq(""))).thenReturn(initialSuggestions)
             whenever(chatSuggestionsReader.fetchSuggestions(eq("hello"))).thenReturn(filteredSuggestions)
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2360,8 +2346,6 @@ class InputScreenViewModelTest {
     @Test
     fun `when chat input text changes and in search mode then suggestions are not re-fetched`() =
         runTest {
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
-
             val viewModel = createViewModel()
 
             // Stay in search mode (default)
@@ -2377,7 +2361,6 @@ class InputScreenViewModelTest {
     fun `when onChatSelected and user setting disabled then suggestions are not fetched`() =
         runTest {
             whenever(duckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(false))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2391,7 +2374,6 @@ class InputScreenViewModelTest {
     fun `when chat input text changes and user setting disabled then suggestions are not fetched`() =
         runTest {
             whenever(duckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(false))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2412,7 +2394,6 @@ class InputScreenViewModelTest {
                 ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false),
             )
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -2430,7 +2411,6 @@ class InputScreenViewModelTest {
     fun `when fetchSuggestions throws exception then chatSuggestions remains empty`() =
         runTest {
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenThrow(RuntimeException("error"))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
 
             val viewModel = createViewModel()
             viewModel.onChatSelected()
@@ -3018,7 +2998,6 @@ class InputScreenViewModelTest {
     fun `chatUrlSuggestions filters out non-URL suggestions when feature flag is on`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val bookmarkSuggestion = AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion(
@@ -3057,7 +3036,6 @@ class InputScreenViewModelTest {
     fun `chatUrlSuggestions is empty when chat input is empty`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
@@ -3076,7 +3054,6 @@ class InputScreenViewModelTest {
     fun `chatUrlSuggestions shows alongside chat suggestions when both exist`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(
                 listOf(ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false)),
             )
@@ -3097,7 +3074,6 @@ class InputScreenViewModelTest {
     fun `chatUrlSuggestions is limited to max configured count`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoComplete.autoComplete(any())).thenReturn(
                 flowOf(
@@ -3127,7 +3103,6 @@ class InputScreenViewModelTest {
     fun `chatUrlSuggestions is empty when autocomplete suggestions disabled`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
 
@@ -3144,7 +3119,6 @@ class InputScreenViewModelTest {
     fun `chatSuggestionsVisible is true when only URL suggestions exist`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoComplete.autoComplete(any())).thenReturn(
                 flowOf(
@@ -3170,7 +3144,6 @@ class InputScreenViewModelTest {
     fun `chatSuggestionsVisible is true and logo hidden when typing with no results`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val viewModel = createViewModel()
@@ -3187,7 +3160,6 @@ class InputScreenViewModelTest {
     fun `chatInputText exposes current chat input`() =
         runTest {
             duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            duckChatFeature.aiChatSuggestions().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val viewModel = createViewModel()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1213381906205784?focus=true 

### Description

- Remove the aiChatSuggestions feature flag and treat the AI chat suggestions feature (pinned and recent chats) as always enabled.
- Remove DuckChat.isChatSuggestionsFeatureAvailable() API and inline the always-true branches at every call site (InputScreenFragment, ChatTabFragment, InputScreenViewModel, NativeInputManager, GeneralSettingsViewModel).
- Remove dead helpers (hideAutoCompleteIfOnChatTab, enableViewPagerInputIfNoFavorites) and feature flag related tests.

### Steps to test this PR
- Open the input screen, type in chat mode, confirm pinned/recent chats and chat URL suggestions still render
- General Settings shows the chat suggestions toggle when Duck.ai + input screen are enabled. Setting should work as expected when turned on/off.             
- Switching between Search and Chat tabs hides/shows overlays as expected
- Enable native input and confirm pinned/recent chat suggestions render under the input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a remote-config gate around chat suggestions, so pinned/recent chat suggestions will now activate wherever the input screen/native input supports them; this is user-visible and could affect overlay/focus behavior and suggestion fetching frequency.
> 
> **Overview**
> Chat suggestions (pinned/recent chats and related overlays) are now treated as *always available* by removing the `aiChatSuggestions` feature flag and the `DuckChat.isChatSuggestionsFeatureAvailable()` API.
> 
> Call sites in the input screen and native input (`InputScreenFragment`, `ChatTabFragment`, `InputScreenViewModel`, `NativeInputManager`, `GeneralSettingsViewModel`) were simplified to always run the chat-suggestions code paths, and related dead helper methods/branches were deleted.
> 
> Tests were updated accordingly by removing feature-flag expectations and dropping coverage for the “feature not available” scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3e99b5358b7b020d5aa7e1100727d0695b6f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->