### PR TITLE
Update PIR broker bundle - 2026-04-27

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/advancedbackgroundchecks.com.json
@@ -1,7 +1,7 @@
 {
   "name": "AdvancedBackgroundChecks",
   "url": "advancedbackgroundchecks.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678060800000,
   "optOutUrl": "https://www.advancedbackgroundchecks.com/removal",
@@ -14,6 +14,17 @@
           "actionType": "navigate",
           "id": "070b6417-8ccd-4111-b5ae-7ae470b0399a",
           "url": "https://www.advancedbackgroundchecks.com/names/${firstName|hyphenated}-${lastName|hyphenated}_${city|hyphenated}-${state|hyphenated}"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-2030df08-d913-4294-9406-c3086fc54ca7"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/backgroundcheckers.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/backgroundcheckers.net.json
@@ -1,7 +1,7 @@
 {
   "name": "BackgroundCheckers",
   "url": "backgroundcheckers.net",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.backgroundcheckers.net/optOut/name/landing",
   "steps": [
@@ -61,6 +61,17 @@
             }
           ],
           "id": "fc993b0d-773a-4279-a634-0ce401da0e20"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-cd37d114-6091-49f9-b682-9b13f221c9e1"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
@@ -1,7 +1,7 @@
 {
   "name": "BeenVerified",
   "url": "beenverified.com",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts",
   "mirrorSites": [
     {
@@ -80,6 +80,17 @@
         },
         {
           "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-31402247-3777-4887-8958-5e5fbe1fa227"
+        },
+        {
+          "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
@@ -107,6 +118,17 @@
             }
           ],
           "id": "444a01d9-630f-42e4-a8b8-4c87ddab91e3"
+        },
+        {
+          "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']"
+            }
+          ],
+          "id": "cft-ede2413a-f55e-417a-a1e0-871b6a37dc61"
         },
         {
           "actionType": "click",
@@ -197,7 +219,7 @@
                   "parent": "//*[@id='comprehensive-form']"
                 }
               ],
-              "id": "380a8326-fb41-4ba3-8721-f1e437d3ee43"
+              "id": "cft-fb884f1a-49d5-4f69-ba48-170347aa3f2d"
             },
             {
               "actionType": "click",

--- a/pir/pir-impl/src/main/assets/brokers/centeda.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/centeda.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Centeda",
   "url": "centeda.com",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "addedDatetime": 1677736800000,
   "optOutUrl": "https://centeda.com/ng/control/privacy",
   "steps": [
@@ -22,6 +22,17 @@
             "71-80",
             "81+"
           ]
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-cb72ba41-7692-44ca-a7f7-646c3f295852"
         },
         {
           "actionType": "expectation",
@@ -80,11 +91,11 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".page-title",
-              "parent": ".search-page"
+              "selector": ".logo",
+              "parent": "header"
             }
           ],
-          "id": "eeeef2aa-1360-4e5e-912b-28b3e067c941"
+          "id": "b8a4d47e-cbe0-43c3-ba3e-86191946f1e9"
         },
         {
           "actionType": "click",

--- a/pir/pir-impl/src/main/assets/brokers/checksecrets.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/checksecrets.com.json
@@ -1,7 +1,7 @@
 {
   "name": "CheckSecrets",
   "url": "checksecrets.com",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.checksecrets.com/optOut/name/landing",
   "steps": [
@@ -57,6 +57,17 @@
             }
           ],
           "id": "42448e4f-2dc5-460a-881a-bafddb2e3ce4"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-f0a8bd6f-21c4-4656-b4e7-9aa3770299d4"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastbackgroundcheck.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FastBackgroundCheck.com",
   "url": "fastbackgroundcheck.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1706248800000,
   "optOutUrl": "https://www.fastbackgroundcheck.com/opt-out",
@@ -16,16 +16,15 @@
           "url": "https://www.fastbackgroundcheck.com/people/${firstName|hyphenated}-${lastName|hyphenated}/${city|hyphenated}-${state|hyphenated}"
         },
         {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
           "actionType": "expectation",
-          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector because CF challenge page has class 'page-manage-challenge' on the html element",
           "expectations": [
             {
               "type": "element",
-              "selector": "//html[not(contains(@class, 'page-manage-challenge'))]",
-              "failSilently": true
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "faa2a63e-1d47-45e9-a1f3-c1780b29cd1f"
+          "id": "cft-a7852fd3-51ee-4a77-85d6-d448ce00516a"
         },
         {
           "actionType": "condition",
@@ -60,6 +59,16 @@
             }
           ],
           "id": "7927f058-9aa9-477b-9671-b3ad06ca9100"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".site-message-header-box"
+            }
+          ],
+          "id": "926af483-bf8a-4bfc-9145-3d4f39373049"
         },
         {
           "actionType": "extract",

--- a/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/fastpeoplesearch.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FastPeopleSearch",
   "url": "fastpeoplesearch.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1675317600000,
   "optOutUrl": "https://www.fastpeoplesearch.com/removal",
@@ -16,15 +16,15 @@
           "url": "https://www.fastpeoplesearch.com/name/${firstName|hyphenated}-${lastName|hyphenated}_${city|hyphenated}-${state|hyphenated}"
         },
         {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
           "actionType": "expectation",
-          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector because CF challenge page has class 'page-manage-challenge' on the html element",
           "expectations": [
             {
               "type": "element",
-              "selector": "//html[not(contains(@class, 'page-manage-challenge'))]"
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "98a2a63e-1d47-45e9-a1f3-c1780b29cd1f"
+          "id": "cft-a59102a9-ec77-4d75-8009-2e604055a11a"
         },
         {
           "actionType": "condition",
@@ -59,6 +59,16 @@
             }
           ],
           "id": "99915607-e720-4e68-b464-5eb2f75ba5a0"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".list-results-header"
+            }
+          ],
+          "id": "51307f20-4cf8-4864-9718-bc2457e745ff"
         },
         {
           "actionType": "extract",

--- a/pir/pir-impl/src/main/assets/brokers/inmatessearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/inmatessearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "InmatesSearcher",
   "url": "inmatessearcher.com",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.inmatessearcher.com/optOut/name/landing",
   "steps": [
@@ -57,6 +57,17 @@
             }
           ],
           "id": "c19c3169-28a6-4b2d-af77-06eddfbf3c6b"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-7ac5dc38-8858-4593-bd42-2638b6ed99bc"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
@@ -1,9 +1,9 @@
 {
   "name": "MugshotLook",
   "url": "mugshotlook.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "privatereports.com",
-  "optOutUrl": "https://www.mugshotlook.com/optOut/name/landingPage",
+  "optOutUrl": "https://www.mugshotlook.com/api/helper/optOutLight/search",
   "steps": [
     {
       "stepType": "scan",
@@ -11,7 +11,7 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.mugshotlook.com/optOut/name/landingPage",
+          "url": "https://www.mugshotlook.com/api/helper/optOutLight/search",
           "id": "88ee28d0-e747-46bd-a4c4-493603935126"
         },
         {
@@ -19,134 +19,75 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".search-wrapper"
+              "selector": "#pageForm"
             }
           ],
-          "id": "df7a2baa-5cd9-4b5d-a4d7-b461d6e8aa00"
+          "id": "e9f535f8-e54e-40f6-a0d2-9f6c385bd0e5"
         },
         {
           "actionType": "fillForm",
           "dataSource": "userProfile",
-          "selector": ".search-wrapper",
+          "selector": "#pageForm",
           "elements": [
             {
               "type": "firstName",
-              "selector": "#firstName"
+              "selector": "input[name='fname']"
             },
             {
               "type": "lastName",
-              "selector": "#lastName"
+              "selector": "input[name='lname']"
+            },
+            {
+              "type": "city",
+              "selector": "input[name='city']"
             },
             {
               "type": "state",
-              "selector": "#state"
+              "selector": "select[name='state']"
             }
           ],
-          "id": "7104601c-7817-4ce0-9ced-290739c65aa4"
+          "id": "178153eb-8fdf-4c22-b3c2-034b70677394"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "4184678b-52b3-46cf-bc21-1f890a06f7f2"
+          "id": "5db69b2f-c141-409f-a975-8507397b3009"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-43f45274-51a4-4ce7-9218-d2550073cc07"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "f2313951-9c50-472f-a61d-2bce70fe4724"
+          "id": "3a1b536b-7d08-4489-a3b0-e35b5c8a3ee6"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.cityState']",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "actions": [
-            {
-              "actionType": "click",
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "button[class~='loader-submit-btn']"
-                }
-              ],
-              "id": "fcf73752-0965-4a4e-add7-4d2a20d7e226"
-            }
-          ],
-          "id": "7a9586a5-26d6-4173-810f-aa8f69d9fe81"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "20b0ea92-803c-4bcd-a542-2c69cb7b15e8"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.moreThanAge']",
-              "failSilently": true
-            }
-          ],
-          "actions": [
-            {
-              "actionType": "click",
-              "choices": [
-                {
-                  "condition": {
-                    "left": "${age}",
-                    "operation": ">=",
-                    "right": "45"
-                  },
-                  "elements": [
-                    {
-                      "type": "button",
-                      "selector": "//div[contains(text(), 'YES')]"
-                    }
-                  ]
-                }
-              ],
-              "default": {
-                "elements": [
-                  {
-                    "type": "button",
-                    "selector": "//div[contains(text(), 'NO')]"
-                  }
-                ]
-              },
-              "id": "86174772-7f79-42df-9b62-bb5317b49dbf"
-            }
-          ],
-          "id": "6096cc3f-ec69-4e35-928e-bf242483b8de"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "add a bit more wait time for the captchas to complete",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "b08aad4c-0e80-4a8b-88a4-b1392b3a8d66"
+          "id": "be11d724-549b-4620-bcdd-2250569b4d86"
         },
         {
           "actionType": "condition",
@@ -154,22 +95,21 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "#svg-captcha-rendering svg",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
           "actions": [
             {
               "actionType": "getCaptchaInfo",
               "captchaType": "image",
-              "selector": "#svg-captcha-rendering svg",
-              "id": "33f06cab-1bc8-41d6-a77e-e89b0b9d68ba"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+              "id": "dd8e0ac7-e54b-4f01-89db-6b1840108119"
             },
             {
               "actionType": "solveCaptcha",
               "captchaType": "image",
-              "selector": "#svgCaptchaInputId",
-              "id": "28e0695b-d3cd-475d-b1bb-4b693124cb9d"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+              "id": "f6c2395d-3df4-4f96-b06a-6eff640e572b"
             },
             {
               "actionType": "click",
@@ -177,61 +117,41 @@
               "elements": [
                 {
                   "type": "button",
-                  "selector": "#svgCaptchaButtonId"
+                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
                 }
               ],
-              "id": "3f577c07-7934-4272-9fe8-65102e6f65ba"
+              "id": "06de7b66-5c0a-4d10-825e-28df89dcbd97"
             }
           ],
-          "id": "e087bcd6-3c92-45bf-92a8-96197252cec6"
+          "id": "acb647eb-ae04-4afa-bac5-4bf2373376ea"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "9c31d292-26b7-4125-9b7a-bca5b1f6a8e9"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": ".result .more",
-              "multiple": true,
-              "failSilently": true
-            }
-          ],
-          "id": "f03efbd4-e0b8-4732-9ba9-e0fdbd1af55e"
+          "id": "116cc890-4471-4e36-ad3f-98894392e6d1"
         },
         {
           "actionType": "extract",
-          "selector": "//li[contains(@class, 'searchedPerson')]",
-          "noResultsSelector": "//div[contains(text(), 'unable to find')]|//h2[contains(text(), 'too many results')]",
+          "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
+          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
           "profile": {
             "name": {
-              "selector": ".//a/div[1]//h3"
+              "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
             },
             "age": {
-              "selector": ".//a/div[1]//h4",
-              "afterText": "Age:"
+              "selector": ".//span[contains(text(), 'Age')]/following-sibling::span[1]"
             },
-            "relativesList": {
-              "selector": ".//strong[contains(text(), 'relative')]/following-sibling::text()",
-              "findElements": true
-            },
-            "addressCityState": {
-              "selector": ".//strong[contains(text(), 'Locations:')]/following-sibling::text()",
-              "findElements": true
-            },
-            "profileUrl": {
-              "identifierType": "hash"
+            "addressCityStateList": {
+              "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
+              "separator": "/(?<=, [A-Z]{2}), /"
             }
           },
-          "id": "1f22c974-afc3-4656-be65-000322243064"
+          "id": "3ecc7abc-8bfc-40db-80b0-e7087b99bcef"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/mylife.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/mylife.com.json
@@ -1,7 +1,7 @@
 {
   "name": "mylife",
   "url": "mylife.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "addedDatetime": 1715797497496,
   "optOutUrl": "https://mylife.jotform.com/260284407610047",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "id": "31285970-27bd-4ec6-a4c1-afc5fb501624",
           "url": "https://www.mylife.com/pub-multisearch.pubview?searchFirstName=${firstName}&searchLastName=${lastName}&searchLocation=${city}%2C+${state|upcase}&whyReg=peoplesearch&whySub=Member+Profile+Sub&pageType=ps"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-f0f516ec-a5eb-4a49-81cf-3ac076d5a06b"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
@@ -1,7 +1,7 @@
 {
   "name": "NeighborWho",
   "url": "neighborwho.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.neighborwho.com/svc/optout/search/optouts",
   "mirrorSites": [
@@ -22,6 +22,17 @@
           "actionType": "navigate",
           "url": "https://www.neighborwho.com/svc/optout/search/optouts",
           "id": "777df3ca-c08b-4261-9d19-6b6463865677"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-b925d36d-ce04-418e-871f-b6787fdc0ffb"
         },
         {
           "actionType": "expectation",
@@ -52,6 +63,17 @@
             }
           ],
           "id": "777a01d9-630f-42e4-a8b8-4c87ddab91e3"
+        },
+        {
+          "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']"
+            }
+          ],
+          "id": "cft-f464162f-bdcb-459f-a348-c832ee8dd49f"
         },
         {
           "actionType": "click",
@@ -142,7 +164,7 @@
                   "parent": "//*[@id='comprehensive-form']"
                 }
               ],
-              "id": "86642ccf-0273-4523-ad03-a90260e9f47b"
+              "id": "cft-86642ccf-0273-4523-ad03-a90260e9f47b"
             },
             {
               "actionType": "click",

--- a/pir/pir-impl/src/main/assets/brokers/peoplefinders.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplefinders.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleFinders",
   "url": "peoplefinders.com",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "addedDatetime": 1677132000000,
   "optOutUrl": "https://www.peoplefinders.com/opt-out",
   "steps": [
@@ -15,15 +15,25 @@
           "url": "https://www.peoplefinders.com/people/${firstName}-${lastName}/${state}/${city}?landing=all"
         },
         {
-          "_comment": "Wait for CF challenge interstitial to complete",
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "body.peoplesearch"
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "aaaab20b-aaaa-45b6-8c53-36e9bed2612b"
+          "id": "cft-9a7d5035-a78e-4fda-93d4-01cbfb46cf74"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".body-content"
+            }
+          ],
+          "id": "e9baf855-5a5a-41e4-93cb-4ab6215c18b1"
         },
         {
           "actionType": "extract",
@@ -68,13 +78,23 @@
           "url": "https://www.peoplefinders.com/opt-out"
         },
         {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-29020501-0911-42c4-be7e-58e3b7ddd75a"
+        },
+        {
           "_comment": "Wait for CF challenge interstitial to complete",
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".opt-out-body",
-              "failSilently": true
+              "selector": ".v-opt-out-wrapper"
             }
           ],
           "id": "623b0022-8c67-4cef-8a11-4481c34229b7"

--- a/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleLooker",
   "url": "peoplelooker.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.peoplelooker.com/svc/optout/search/optouts",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.peoplelooker.com/svc/optout/search/optouts",
           "id": "fffdf3ca-c08b-4261-9d19-6b6463865677"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-5255bb2d-2ff5-485d-8201-2265c2ae2312"
         },
         {
           "actionType": "expectation",
@@ -43,6 +54,17 @@
             }
           ],
           "id": "fffa01d9-630f-42e4-a8b8-4c87ddab91e3"
+        },
+        {
+          "_comment": "Turnstile auto-completes. Wait for the hidden token before submitting.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//input[@name='cf-turnstile-response' and @value and @value != '']"
+            }
+          ],
+          "id": "cft-b895ae57-ba31-4a76-9210-aac2c04e9c7f"
         },
         {
           "actionType": "click",
@@ -133,7 +155,7 @@
                   "parent": "//*[@id='comprehensive-form']"
                 }
               ],
-              "id": "10fcca38-bd1d-4fd5-a38a-678d4d6aadcd"
+              "id": "cft-10fcca38-bd1d-4fd5-a38a-678d4d6aadcd"
             },
             {
               "actionType": "click",

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearch123.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearch123.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearch123",
   "url": "peoplesearch123.com",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearch123.com/optOut/name/landing",
   "steps": [
@@ -61,6 +61,17 @@
             }
           ],
           "id": "5334448e-6ca2-48d1-9a69-75d910dabd7b"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-dddfd8b3-6e36-4cf2-89d4-d43f52985e03"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearchusa.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearchusa.org.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearchUSA",
   "url": "peoplesearchusa.org",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearchusa.org/optOut/name/landing",
   "steps": [
@@ -57,6 +57,17 @@
             }
           ],
           "id": "0349bd42-b9c3-4852-a347-0c986296e44d"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-13a30d0b-6d7f-40e1-8f6d-71a063090463"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/personsearchers.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/personsearchers.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PersonSearchers",
   "url": "personsearchers.com",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.personsearchers.com/optOut/name/landing",
   "steps": [
@@ -61,6 +61,17 @@
             }
           ],
           "id": "91f495d7-2037-42b7-904b-76ae2c2798e0"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-fde7d76b-54c9-48d4-95bd-ef9a58b95992"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/privaterecords.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/privaterecords.net.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateRecords",
   "url": "privaterecords.net",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.privaterecords.net/optOut/name/landing",
   "steps": [
@@ -61,6 +61,17 @@
             }
           ],
           "id": "cdba1374-4bdd-41c3-b1fb-a135c6accd37"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-ed8bd1d5-991c-4ef8-ad3c-6fd8ecd1288c"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateReports",
   "url": "privatereports.com",
-  "version": "0.995.0",
+  "version": "0.996.0",
   "optOutUrl": "https://www.privatereports.com/api/helper/optOutLight/search",
   "steps": [
     {
@@ -56,6 +56,17 @@
             }
           ],
           "id": "e803ba82-782e-4f19-a2ac-f25ef1a654f2"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-6a9ba7e2-2d6b-42f1-85bb-51d132eeba32"
         },
         {
           "actionType": "expectation",
@@ -196,6 +207,17 @@
             }
           ],
           "id": "c91a389d-3079-4537-9d39-f7b8a49ebec4"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-44601f5a-1243-434b-b1ef-974254ccb679"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
@@ -1,9 +1,9 @@
 {
   "name": "PublicSearcher",
   "url": "publicsearcher.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "privatereports.com",
-  "optOutUrl": "https://www.publicsearcher.com/optOut/name/landingPage",
+  "optOutUrl": "https://www.publicsearcher.com/api/helper/optOutLight/search",
   "steps": [
     {
       "stepType": "scan",
@@ -11,7 +11,7 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.publicsearcher.com/optOut/name/landingPage",
+          "url": "https://www.publicsearcher.com/api/helper/optOutLight/search",
           "id": "331b4f4e-5534-43f5-90f8-589c89d59a8d"
         },
         {
@@ -19,134 +19,75 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".search-wrapper"
+              "selector": "#pageForm"
             }
           ],
-          "id": "9a72ae74-eb07-4735-9da7-f5e67018b53a"
+          "id": "7f069b71-df6f-4044-86a5-fe1d13956071"
         },
         {
           "actionType": "fillForm",
           "dataSource": "userProfile",
-          "selector": ".search-wrapper",
+          "selector": "#pageForm",
           "elements": [
             {
               "type": "firstName",
-              "selector": "#firstName"
+              "selector": "input[name='fname']"
             },
             {
               "type": "lastName",
-              "selector": "#lastName"
+              "selector": "input[name='lname']"
+            },
+            {
+              "type": "city",
+              "selector": "input[name='city']"
             },
             {
               "type": "state",
-              "selector": "#state"
+              "selector": "select[name='state']"
             }
           ],
-          "id": "12a78bc7-1dca-423f-8c37-f5d85ccbf7e0"
+          "id": "92ae2b11-0952-4a81-ac0b-2c02a1a9c2d5"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "2489dee9-2b59-40bb-8ec4-88ef15c7c5c3"
+          "id": "f9e9b48c-a0e7-4bab-8344-76a04f0c4cb3"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-48ab0132-8c30-4b1e-a731-7d0a736bb3f6"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "d7ea97a0-ba6f-483a-afd1-af787745fcb8"
+          "id": "5b46e666-e1ae-48e4-ae39-4ffc025e332c"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.cityState']",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "actions": [
-            {
-              "actionType": "click",
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "button[class~='loader-submit-btn']"
-                }
-              ],
-              "id": "6987e048-6062-488a-b9db-924e936f10af"
-            }
-          ],
-          "id": "25abf339-5c1c-4743-a266-7bfcafb82433"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "f4b692c2-2e98-49bb-bce7-f8edbde56e15"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.moreThanAge']",
-              "failSilently": true
-            }
-          ],
-          "actions": [
-            {
-              "actionType": "click",
-              "choices": [
-                {
-                  "condition": {
-                    "left": "${age}",
-                    "operation": ">=",
-                    "right": "45"
-                  },
-                  "elements": [
-                    {
-                      "type": "button",
-                      "selector": "//div[contains(text(), 'YES')]"
-                    }
-                  ]
-                }
-              ],
-              "default": {
-                "elements": [
-                  {
-                    "type": "button",
-                    "selector": "//div[contains(text(), 'NO')]"
-                  }
-                ]
-              },
-              "id": "d0208c1a-605a-4482-904f-34b9bed2c808"
-            }
-          ],
-          "id": "632f5161-71d4-4e0b-ac2d-f6c770ebda48"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "add a bit more wait time for the captchas to complete",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "3a01aae9-612e-4ed8-b36d-54484e62cd7b"
+          "id": "bfa4006f-c1cc-4244-8259-d97470421077"
         },
         {
           "actionType": "condition",
@@ -154,22 +95,21 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "#svg-captcha-rendering svg",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
           "actions": [
             {
               "actionType": "getCaptchaInfo",
               "captchaType": "image",
-              "selector": "#svg-captcha-rendering svg",
-              "id": "3ade98cb-9fcd-4c02-803a-157fcd3c92c9"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+              "id": "c8b53a54-2719-465b-88c3-0eda49c9ce52"
             },
             {
               "actionType": "solveCaptcha",
               "captchaType": "image",
-              "selector": "#svgCaptchaInputId",
-              "id": "244986f1-e765-4f20-b94a-2e2faa3d7a75"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+              "id": "88eb51cd-1af4-4dca-996c-0cafae0533e2"
             },
             {
               "actionType": "click",
@@ -177,61 +117,41 @@
               "elements": [
                 {
                   "type": "button",
-                  "selector": "#svgCaptchaButtonId"
+                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
                 }
               ],
-              "id": "42ba49cf-2b2f-4d77-8756-df800ef5e18d"
+              "id": "47a5210d-7a5f-4336-9eb8-5aa97f6eb9fb"
             }
           ],
-          "id": "0448a534-9040-484d-9e2f-f7faae520ddb"
+          "id": "41c5e3f5-c852-4098-8306-550700e01736"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "0466c021-3689-4151-86db-27e02305d4de"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": ".result .more",
-              "multiple": true,
-              "failSilently": true
-            }
-          ],
-          "id": "539c6e87-95d1-45e2-930b-32a2707a88cc"
+          "id": "eb63bfb5-c3fa-4c4e-a1be-86e9a7b31775"
         },
         {
           "actionType": "extract",
-          "selector": "//li[contains(@class, 'searchedPerson')]",
-          "noResultsSelector": "//div[contains(text(), 'unable to find')]|//h2[contains(text(), 'too many results')]",
+          "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
+          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
           "profile": {
             "name": {
-              "selector": ".//a/div[1]//h3"
+              "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
             },
             "age": {
-              "selector": ".//a/div[1]//h4",
-              "afterText": "Age:"
+              "selector": ".//span[contains(text(), 'Age')]/following-sibling::span[1]"
             },
-            "relativesList": {
-              "selector": ".//strong[contains(text(), 'relative')]/following-sibling::text()",
-              "findElements": true
-            },
-            "addressCityState": {
-              "selector": ".//strong[contains(text(), 'Locations:')]/following-sibling::text()",
-              "findElements": true
-            },
-            "profileUrl": {
-              "identifierType": "hash"
+            "addressCityStateList": {
+              "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
+              "separator": "/(?<=, [A-Z]{2}), /"
             }
           },
-          "id": "0aa28805-62ab-4f8f-814e-56612537b735"
+          "id": "a75cc46f-81dd-4257-b241-964632818184"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/sealedrecords.net.json
+++ b/pir/pir-impl/src/main/assets/brokers/sealedrecords.net.json
@@ -1,7 +1,7 @@
 {
   "name": "SealedRecords",
   "url": "sealedrecords.net",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.sealedrecords.net/optOut/name/landing",
   "steps": [
@@ -57,6 +57,17 @@
             }
           ],
           "id": "5f797133-1947-4b9b-9687-a9780e58f480"
+        },
+        {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-c6a106d9-ee53-48fb-a6b7-21afedf1bbf3"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/searchpeoplefree.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Search People FREE",
   "url": "searchpeoplefree.com",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1703052000000,
   "optOutUrl": "https://www.searchpeoplefree.com/opt-out",
@@ -14,6 +14,17 @@
           "actionType": "navigate",
           "id": "a85625a6-4607-4fea-9fa4-38294a7de727",
           "url": "https://searchpeoplefree.com/find/${firstName|hyphenated}-${lastName|hyphenated}/${state|hyphenated}/${city|hyphenated}"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-d4f5286d-55d8-405b-a3ec-f3e9741a3da5"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
@@ -1,9 +1,9 @@
 {
   "name": "SecretInfo",
   "url": "secretinfo.org",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "parent": "privatereports.com",
-  "optOutUrl": "https://www.secretinfo.org/optOut/name/landing",
+  "optOutUrl": "https://www.secretinfo.org/api/helper/optOutLight/search",
   "steps": [
     {
       "stepType": "scan",
@@ -11,7 +11,7 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.secretinfo.org/optOut/name/landing",
+          "url": "https://www.secretinfo.org/api/helper/optOutLight/search",
           "id": "0834d4a6-6613-4d00-bda0-8031242778b3"
         },
         {
@@ -19,134 +19,75 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".search-wrapper"
+              "selector": "#pageForm"
             }
           ],
-          "id": "720d31b2-4017-43de-bce3-310c0cc897d5"
+          "id": "a2a57479-12e6-48c0-ae45-15b0ac441e9a"
         },
         {
           "actionType": "fillForm",
           "dataSource": "userProfile",
-          "selector": ".search-wrapper",
+          "selector": "#pageForm",
           "elements": [
             {
               "type": "firstName",
-              "selector": "#firstName"
+              "selector": "input[name='fname']"
             },
             {
               "type": "lastName",
-              "selector": "#lastName"
+              "selector": "input[name='lname']"
+            },
+            {
+              "type": "city",
+              "selector": "input[name='city']"
             },
             {
               "type": "state",
-              "selector": "#state"
+              "selector": "select[name='state']"
             }
           ],
-          "id": "083f1eb1-5b06-423e-8672-54ba39678b2f"
+          "id": "091fcc8d-0e7b-4c1e-8bec-9cf1ab7e423b"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "005d70b1-75d8-4574-8b8d-cd7d3d41580b"
+          "id": "99f4b4ad-31cc-4ae0-8f0f-2b04e1e8cfb1"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-fe95410e-a7a7-49ed-ad02-11eadbcb1875"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "9a76f89d-0449-4e08-a16b-8c1f88c48bd1"
+          "id": "50ef537c-a958-4201-8a2a-2235bf2810c4"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.cityState']",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "actions": [
-            {
-              "actionType": "click",
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "button[class~='btn-primary']"
-                }
-              ],
-              "id": "518d57a1-115f-466b-92f2-d08483eab312"
-            }
-          ],
-          "id": "bcaa465c-2e04-493b-b4e6-dadea3d466e1"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "a6f51f14-e9c4-40ce-a80d-c7e60142b753"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.moreThanAge']",
-              "failSilently": true
-            }
-          ],
-          "actions": [
-            {
-              "actionType": "click",
-              "choices": [
-                {
-                  "condition": {
-                    "left": "${age}",
-                    "operation": ">=",
-                    "right": "45"
-                  },
-                  "elements": [
-                    {
-                      "type": "button",
-                      "selector": "//button[contains(text(), 'Yes')]"
-                    }
-                  ]
-                }
-              ],
-              "default": {
-                "elements": [
-                  {
-                    "type": "button",
-                    "selector": "//button[contains(text(), 'No')]"
-                  }
-                ]
-              },
-              "id": "1bee9239-5093-47ad-9adc-8cb0ba819b4d"
-            }
-          ],
-          "id": "0118cd52-25c5-4deb-bf26-a184bac8d7f3"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "add a bit more wait time for the captchas to complete",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "825bf2a5-6995-4616-b316-090a4da9f8fa"
+          "id": "bff38cd3-f87d-4d9d-b405-d8d00bb00f14"
         },
         {
           "actionType": "condition",
@@ -154,22 +95,21 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "#svg-captcha-rendering svg",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
           "actions": [
             {
               "actionType": "getCaptchaInfo",
               "captchaType": "image",
-              "selector": "#svg-captcha-rendering svg",
-              "id": "3bf37fdd-3cee-4023-8fe7-9acb1e82818a"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+              "id": "c68b8c21-fdcb-46cc-b657-6ee3a7bc02b1"
             },
             {
               "actionType": "solveCaptcha",
               "captchaType": "image",
-              "selector": "#svgCaptchaInputId",
-              "id": "489389c0-db60-4b24-93da-e65601639e3e"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+              "id": "29d92fc8-9746-4d1a-883d-7b045eb40b75"
             },
             {
               "actionType": "click",
@@ -177,61 +117,41 @@
               "elements": [
                 {
                   "type": "button",
-                  "selector": "#svgCaptchaButtonId"
+                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
                 }
               ],
-              "id": "941e6f3d-a7d1-46ed-b1d5-ecc92dc646c5"
+              "id": "9bc05a90-f6ae-48fd-b571-537ab510c80d"
             }
           ],
-          "id": "9f55ecc5-1e54-485e-bbda-2f5fb7f0dada"
+          "id": "5266d408-836e-402f-b4b1-1b931b51aa39"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "439928fd-1e9a-492c-a8f3-42ccff095eff"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": ".result .more",
-              "multiple": true,
-              "failSilently": true
-            }
-          ],
-          "id": "4960ef4a-2f92-441f-823c-0355854e6d56"
+          "id": "9d498876-8b9c-491c-a31a-4eec1accf33c"
         },
         {
           "actionType": "extract",
-          "selector": "//li[contains(@class, 'searchedPerson')]",
-          "noResultsSelector": "//div[contains(text(), 'unable to find')]|//h2[contains(text(), 'too many results')]",
+          "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
+          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
           "profile": {
             "name": {
-              "selector": ".//a/div[1]//h3"
+              "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
             },
             "age": {
-              "selector": ".//a/div[1]//h4",
-              "afterText": "Age:"
+              "selector": ".//span[contains(text(), 'Age')]/following-sibling::span[1]"
             },
-            "relativesList": {
-              "selector": ".//strong[contains(text(), 'relative')]/following-sibling::text()",
-              "findElements": true
-            },
-            "addressCityState": {
-              "selector": ".//strong[contains(text(), 'Locations:')]/following-sibling::text()",
-              "findElements": true
-            },
-            "profileUrl": {
-              "identifierType": "hash"
+            "addressCityStateList": {
+              "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
+              "separator": "/(?<=, [A-Z]{2}), /"
             }
           },
-          "id": "08bcba08-61ac-4369-bc21-ac835a1444df"
+          "id": "2edfae8c-bbf5-469f-a052-68f75f0659b3"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
@@ -1,7 +1,7 @@
 {
   "name": "SpyFly",
   "url": "spyfly.com",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "addedDatetime": 1775214750818,
   "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
   "steps": [
@@ -13,6 +13,17 @@
           "actionType": "navigate",
           "url": "https://www.spyfly.com/help-center/privacy-requests",
           "id": "91ea665d-89f1-4f38-942e-d27ea2438ec2"
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-f5bc721e-cc51-4404-9a34-465af869a243"
         },
         {
           "actionType": "expectation",
@@ -67,7 +78,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "c83793ff-9b93-4924-ad9c-008e01356bea"
+          "id": "cft-c83793ff-9b93-4924-ad9c-008e01356bea"
         },
         {
           "actionType": "click",
@@ -89,6 +100,18 @@
             }
           ],
           "id": "619924fc-4ad6-47aa-a5e6-44b2c8013273"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "_comment": "Ensure the Turnstile captcha is solved before proceeding",
+              "selector": ".//input[@name='cf-turnstile-response' and @value and @value != '']",
+              "parent": ".form__captcha"
+            }
+          ],
+          "id": "cft-3e0d35a5-6548-4387-982a-563b05674a70"
         },
         {
           "_comment": "Terminal action. We are on the email page, not results. noResultsSelector matches #email-address so extract returns empty results cleanly.",

--- a/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
@@ -1,7 +1,7 @@
 {
   "name": "TruePeopleSearch",
   "url": "truepeoplesearch.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1703138400000,
   "optOutUrl": "https://www.truepeoplesearch.com/removal",
@@ -17,24 +17,11 @@
         },
         {
           "actionType": "expectation",
-          "_comment": "detect CF managed challenge - the page renders a hidden input named cf-turnstile-response when Cloudflare intercepts with an inline challenge",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]",
-              "failSilently": false
-            }
-          ],
-          "id": "8ae2fd99-5e9d-4f2e-bdb0-8acf9d7237ba"
-        },
-        {
-          "actionType": "expectation",
           "_comment": "detect Datadome bot protection - Datadome injects an iframe from captcha-delivery.com with a slide-to-verify challenge",
           "expectations": [
             {
               "type": "element",
-              "selector": "//body[not(.//iframe[contains(@src,'captcha-delivery.com')])]",
-              "failSilently": false
+              "selector": "//body[not(.//iframe[contains(@src,'captcha-delivery.com')])]"
             }
           ],
           "id": "263f1b6f-674f-46e5-9f0f-97e832c34219"
@@ -45,8 +32,7 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "//body[not(.//form[@id='captchaForm'])]",
-              "failSilently": false
+              "selector": "//body[not(.//form[@id='captchaForm'])]"
             }
           ],
           "id": "9ea1684f-1953-45b7-954e-d1597a0c5063"

--- a/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
@@ -1,9 +1,9 @@
 {
   "name": "TruthRecord",
   "url": "truthrecord.org",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "parent": "privatereports.com",
-  "optOutUrl": "https://www.truthrecord.org/opt_out/name/landing_page",
+  "optOutUrl": "https://www.truthrecord.org/api/helper/optOutLight/search",
   "steps": [
     {
       "stepType": "scan",
@@ -11,7 +11,7 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.truthrecord.org/opt_out/name/landing_page",
+          "url": "https://www.truthrecord.org/api/helper/optOutLight/search",
           "id": "07693f63-db90-42c7-b9aa-5cdaab2f6fff"
         },
         {
@@ -19,134 +19,75 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".search-wrapper"
+              "selector": "#pageForm"
             }
           ],
-          "id": "eb503687-d056-4913-9260-480b9256c999"
+          "id": "3c5dc220-e58b-44ef-a846-576ed358f133"
         },
         {
           "actionType": "fillForm",
           "dataSource": "userProfile",
-          "selector": ".search-wrapper",
+          "selector": "#pageForm",
           "elements": [
             {
               "type": "firstName",
-              "selector": "#firstName"
+              "selector": "input[name='fname']"
             },
             {
               "type": "lastName",
-              "selector": "#lastName"
+              "selector": "input[name='lname']"
+            },
+            {
+              "type": "city",
+              "selector": "input[name='city']"
             },
             {
               "type": "state",
-              "selector": "#state"
+              "selector": "select[name='state']"
             }
           ],
-          "id": "cddf7e50-75be-4374-885f-3a1e310be2c8"
+          "id": "a7f3df7f-7f72-45a8-9136-a253791bb936"
         },
         {
           "actionType": "click",
           "elements": [
             {
               "type": "button",
-              "selector": "button[type='submit']"
+              "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "df6d3ee8-43d9-47ac-96cd-2081140b9acd"
+          "id": "387b7d89-5762-4056-b716-c9ff0d27c775"
+        },
+        {
+          "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-715cb574-a694-43b6-8c27-7afb04b4ad6d"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "06cf7d97-43cc-42a1-956b-a0147921e705"
+          "id": "1c2561d3-d767-401d-aef7-f16e8c9c3bd4"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.cityState']",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "actions": [
-            {
-              "actionType": "click",
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "button[class~='btn-primary']"
-                }
-              ],
-              "id": "5917281e-5b99-4a3b-9845-8020ccb9e19f"
-            }
-          ],
-          "id": "f2da5bce-ccab-42f4-b019-91c985d89299"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "6058cfcc-841c-481a-8fd4-dcf3c1ad4d42"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": "//div[@data-key='comp.name-search.rule.question.reSearch.moreThanAge']",
-              "failSilently": true
-            }
-          ],
-          "actions": [
-            {
-              "actionType": "click",
-              "choices": [
-                {
-                  "condition": {
-                    "left": "${age}",
-                    "operation": ">=",
-                    "right": "45"
-                  },
-                  "elements": [
-                    {
-                      "type": "button",
-                      "selector": "//button[contains(text(), 'Yes')]"
-                    }
-                  ]
-                }
-              ],
-              "default": {
-                "elements": [
-                  {
-                    "type": "button",
-                    "selector": "//button[contains(text(), 'No')]"
-                  }
-                ]
-              },
-              "id": "3a4bb3f4-58ef-4137-9973-2ed45ff3705b"
-            }
-          ],
-          "id": "4b9ffa94-51a9-4fc8-954b-18853b9f6824"
-        },
-        {
-          "actionType": "expectation",
-          "_comment": "add a bit more wait time for the captchas to complete",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".container"
-            }
-          ],
-          "id": "c4e2dd85-36b6-48b6-8226-b58c99bde850"
+          "id": "d3a20ab9-d1bc-40b6-964f-78c77b83f0ce"
         },
         {
           "actionType": "condition",
@@ -154,22 +95,21 @@
           "expectations": [
             {
               "type": "element",
-              "selector": "#svg-captcha-rendering svg",
-              "failSilently": true
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
           "actions": [
             {
               "actionType": "getCaptchaInfo",
               "captchaType": "image",
-              "selector": "#svg-captcha-rendering svg",
-              "id": "1f1fb68f-9bf5-44d5-a3fa-54043d67e780"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+              "id": "fb136c1e-f032-452d-9011-0f7a9b781175"
             },
             {
               "actionType": "solveCaptcha",
               "captchaType": "image",
-              "selector": "#svgCaptchaInputId",
-              "id": "4e0eabf5-f1d0-4102-a60b-9904da93efe9"
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+              "id": "7aa13f78-7caf-499a-a529-451ea4ea2d2e"
             },
             {
               "actionType": "click",
@@ -177,61 +117,41 @@
               "elements": [
                 {
                   "type": "button",
-                  "selector": "#svgCaptchaButtonId"
+                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
                 }
               ],
-              "id": "23cd35e7-29a8-4ad2-9ba5-c936893aeb12"
+              "id": "5893f48f-6f8f-45d3-a0fe-11f32053c6e4"
             }
           ],
-          "id": "5c3b80a2-ee41-4494-b3e5-d92dc88091b0"
+          "id": "2a9e2856-da43-4a22-a80f-68feb7e8d24c"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".container"
+              "selector": ".header"
             }
           ],
-          "id": "cd50b12f-71ad-4b51-911e-011dd696886c"
-        },
-        {
-          "actionType": "click",
-          "elements": [
-            {
-              "type": "button",
-              "selector": ".result .more",
-              "multiple": true,
-              "failSilently": true
-            }
-          ],
-          "id": "10d4eb1c-bc24-4096-9020-8ed5818bf248"
+          "id": "5defbbd7-c6de-4e7b-9ada-81e69f5dbdf1"
         },
         {
           "actionType": "extract",
-          "selector": "//li[contains(@class, 'searchedPerson')]",
-          "noResultsSelector": "//div[contains(text(), 'unable to find')]|//h2[contains(text(), 'too many results')]",
+          "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
+          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
           "profile": {
             "name": {
-              "selector": ".//a/div[1]//h3"
+              "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
             },
             "age": {
-              "selector": ".//a/div[1]//h4",
-              "afterText": "Age:"
+              "selector": ".//span[contains(text(), 'Age')]/following-sibling::span[1]"
             },
-            "relativesList": {
-              "selector": ".//strong[contains(text(), 'relative')]/following-sibling::text()",
-              "findElements": true
-            },
-            "addressCityState": {
-              "selector": ".//strong[contains(text(), 'Locations:')]/following-sibling::text()",
-              "findElements": true
-            },
-            "profileUrl": {
-              "identifierType": "hash"
+            "addressCityStateList": {
+              "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
+              "separator": "/(?<=, [A-Z]{2}), /"
             }
           },
-          "id": "43c02b53-bfce-4df6-9cfa-ff1a3256b3e0"
+          "id": "cd0f0aa3-fba2-4330-b4ab-6d7700aad9cb"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/usa-people-search.com.json
@@ -1,7 +1,7 @@
 {
   "name": "USA People Search",
   "url": "usa-people-search.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1678082400000,
   "optOutUrl": "https://www.usa-people-search.com/manage",
@@ -16,7 +16,17 @@
           "url": "https://usa-people-search.com/name/${firstName|downcase|hyphenated}-${lastName|downcase|hyphenated}/${city|downcase|hyphenated}-${state|stateFull|downcase|hyphenated}"
         },
         {
-          "_comment": "Wait for CF challenge interstitial to complete",
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-29d08bed-8034-40e6-bbb9-6b7a21e91eae"
+        },
+        {
           "actionType": "expectation",
           "expectations": [
             {

--- a/pir/pir-impl/src/main/assets/brokers/veripages.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/veripages.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Veripages",
   "url": "veripages.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "addedDatetime": 1691989200000,
   "optOutUrl": "https://veripages.com/inner/control/privacy",
   "steps": [
@@ -22,6 +22,27 @@
             "71-80",
             "81+"
           ]
+        },
+        {
+          "actionType": "expectation",
+          "_comment": "wait for cloudflare check to pass - we are using a negative xpath selector to ensure the challenge is not being displayed",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src, '/cdn-cgi/challenge-platform/')]) and not(.//script[contains(., '_cf_chl_opt')])]"
+            }
+          ],
+          "id": "cfc-44043ed9-ae63-4dd2-843a-9956bfd820cc"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": ".header-nav"
+            }
+          ],
+          "id": "c03084e4-7973-4684-916c-b25288eff4bb"
         },
         {
           "actionType": "extract",

--- a/pir/pir-impl/src/main/assets/brokers/weinform.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/weinform.org.json
@@ -1,9 +1,9 @@
 {
-  "name": "PeopleSearcher",
-  "url": "peoplesearcher.com",
-  "version": "0.7.0",
+  "name": "WeInform",
+  "url": "weinform.org",
+  "version": "0.1.0",
   "parent": "privatereports.com",
-  "optOutUrl": "https://www.peoplesearcher.com/api/helper/optOutLight/search",
+  "optOutUrl": "https://www.weinform.org/api/helper/optOutLight/search",
   "steps": [
     {
       "stepType": "scan",
@@ -11,8 +11,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.peoplesearcher.com/api/helper/optOutLight/search",
-          "id": "5a163537-6f89-4652-9a87-0b8054e72bbf"
+          "url": "https://www.weinform.org/api/helper/optOutLight/search",
+          "id": "c89890c9-0b0b-49d5-b72a-152afebea3aa"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "6a0060da-1616-40b2-a307-1315490b5b2c"
+          "id": "65c4efa6-5543-4827-85ac-9beda826f3e9"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "5aa3746a-ff05-4c2e-bf33-90b6af8dc9c6"
+          "id": "9c021278-27a7-4711-8a1a-24d39ac88924"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "c21237ee-6988-4278-9c32-350f82424f35"
+          "id": "20c9a47d-c2a0-4e33-a1a0-2bfe6f3efe46"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,7 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-69d7e91e-9c5d-4523-b625-2decd2b697a0"
+          "id": "cft-b371ee5f-8818-44f4-b36d-77b97fc4c69e"
         },
         {
           "actionType": "expectation",
@@ -77,7 +77,7 @@
               "selector": ".header"
             }
           ],
-          "id": "5ae1dce2-5e4e-4b1f-8649-878071d915c4"
+          "id": "840e1115-7bab-4b9c-862c-311ba49a383f"
         },
         {
           "actionType": "expectation",
@@ -87,7 +87,7 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "f39d9b96-09a5-4e3d-a33f-bfaa191aa2c9"
+          "id": "f8751aac-4d41-4aa9-89d2-35c80eaf2a6a"
         },
         {
           "actionType": "condition",
@@ -103,13 +103,13 @@
               "actionType": "getCaptchaInfo",
               "captchaType": "image",
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "21b3db05-32f2-4089-b6f7-83854ea4e6b2"
+              "id": "79a765f3-c1bb-4c2d-af18-071725f0ddee"
             },
             {
               "actionType": "solveCaptcha",
               "captchaType": "image",
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "8b257457-aa7e-4883-9019-13a1eaf72dc6"
+              "id": "4a2a35f3-3526-43fa-a24e-d519b8a000d6"
             },
             {
               "actionType": "click",
@@ -120,10 +120,10 @@
                   "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
                 }
               ],
-              "id": "ec410930-89bd-4f4d-93fa-73276decfa98"
+              "id": "e5b42120-6dcf-4413-9139-523cbc71cc5a"
             }
           ],
-          "id": "3534def6-b37a-45ce-a3e5-5095757952f0"
+          "id": "ebe52f0a-0176-4853-8f9b-447868a05cd4"
         },
         {
           "actionType": "expectation",
@@ -133,7 +133,7 @@
               "selector": ".header"
             }
           ],
-          "id": "a8de391d-c7cb-4d89-9ac2-f47368c6f347"
+          "id": "766ccef8-c27f-4dc7-9691-ba6377fd6fe6"
         },
         {
           "actionType": "extract",
@@ -151,7 +151,7 @@
               "separator": "/(?<=, [A-Z]{2}), /"
             }
           },
-          "id": "b235a497-3ceb-4dee-9704-dcda0349bd3a"
+          "id": "fd69267b-59ce-4b1a-ba94-e1fd3dd99474"
         }
       ]
     },
@@ -167,6 +167,6 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "addedDatetime": 1738341001174,
+  "addedDatetime": 1777063664947,
   "removedAt": null
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1214283450657766/f 

 ----- 
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Added (1):**
- weinform.org.json
**Updated (28):**
- advancedbackgroundchecks.com.json (0.7.0 → 0.8.0)
- backgroundcheckers.net.json (0.2.0 → 0.3.0)
- beenverified.com.json (0.9.0 → 0.10.0)
- centeda.com.json (0.90.0 → 0.91.0)
- checksecrets.com.json (0.2.0 → 0.3.0)
- fastbackgroundcheck.com.json (0.7.0 → 0.8.0)
- fastpeoplesearch.com.json (0.7.0 → 0.8.0)
- inmatessearcher.com.json (0.2.0 → 0.3.0)
- mugshotlook.com.json (0.5.0 → 0.6.0)
- mylife.com.json (0.7.0 → 0.8.0)
- neighborwho.com.json (0.5.0 → 0.6.0)
- peoplefinders.com.json (0.9.0 → 0.10.0)
- peoplelooker.com.json (0.5.0 → 0.6.0)
- peoplesearch123.com.json (0.2.0 → 0.3.0)
- peoplesearcher.com.json (0.6.0 → 0.7.0)
- peoplesearchusa.org.json (0.2.0 → 0.3.0)
- personsearchers.com.json (0.2.0 → 0.3.0)
- privaterecords.net.json (0.2.0 → 0.3.0)
- privatereports.com.json (0.995.0 → 0.996.0)
- publicsearcher.com.json (0.5.0 → 0.6.0)
- sealedrecords.net.json (0.2.0 → 0.3.0)
- searchpeoplefree.com.json (0.8.0 → 0.9.0)
- secretinfo.org.json (0.4.0 → 0.5.0)
- spyfly.com.json (0.4.0 → 0.5.0)
- truepeoplesearch.com.json (0.7.0 → 0.8.0)
- truthrecord.org.json (0.4.0 → 0.5.0)
- usa-people-search.com.json (0.7.0 → 0.8.0)
- veripages.com.json (0.6.0 → 0.7.0)

### Checklist

- [ ] Verify broker changes look correct
- [ ] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes broker scan/opt-out automation steps and selectors across many sites; small selector mistakes or anti-bot flow changes can break matching/extraction at runtime.
> 
> **Overview**
> Updates the PIR bundled broker configurations, adding a new `weinform.org.json` broker and bumping versions across the existing bundle.
> 
> Most updates adjust scan/opt-out flows to better handle anti-bot interstitials (Cloudflare challenge/Turnstile) by adding explicit wait expectations (negative selectors or token-present checks) and updating page-ready selectors. Several `privatereports.com`-family brokers also switch to the `api/helper/optOutLight/search` entrypoint and simplify/retune form, captcha, and extraction selectors (notably `mugshotlook.com`, `peoplesearcher.com`, `publicsearcher.com`, `secretinfo.org`, `truthrecord.org`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b636f962a7b8e33801a5f37a4d16c863261692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->