### PR TITLE
Add new subfeature for autofillService so we can have rollouts

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
@@ -34,7 +34,7 @@ interface AutofillServiceFeature {
     fun self(): Toggle
 
     /**
-     * Whether autofill service can be enabled. Allows us to hae a staged rollout
+     * Whether autofill service can be enabled. Allows us to have a staged rollout
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
@@ -28,9 +28,17 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 )
 interface AutofillServiceFeature {
 
+    @Deprecated("Use [canEnableAutofillService] instead")
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun self(): Toggle
+
+    /**
+     * Whether autofill service can be enabled. Allows us to hae a staged rollout
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @InternalAlwaysEnabled
+    fun canEnableAutofillService(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceLifecycleObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceLifecycleObserver.kt
@@ -53,7 +53,7 @@ class AutofillServiceLifecycleObserver @Inject constructor(
             runCatching {
                 val currentState = getAutofillServiceState(context).toBoolean() ?: return@launch
 
-                autofillServiceFeature.self().isEnabled().let { remoteState ->
+                autofillServiceFeature.canEnableAutofillService().isEnabled().let { remoteState ->
                     if (currentState != remoteState) {
                         logcat { "DDGAutofillService: Updating state to $remoteState" }
                         newState(context, remoteState)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
@@ -171,7 +171,7 @@ class RealAutofillService : AutofillService() {
     }
 
     private fun isAutofillServiceEnabled(): Boolean {
-        return autofillServiceFeature.self().isEnabled() && autofillServiceFeature.canProcessSystemFillRequests().isEnabled()
+        return autofillServiceFeature.canEnableAutofillService().isEnabled() && autofillServiceFeature.canProcessSystemFillRequests().isEnabled()
     }
 
     companion object {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceFeatureRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceFeatureRepository.kt
@@ -67,11 +67,12 @@ class RealAutofillServiceFeatureRepository @Inject constructor(
         loadToMemory()
     }
 
+    @Suppress("DEPRECATION")
     private fun loadToMemory() {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (isMainProcess || processName == ":autofill") {
                 exceptions.clear()
-                exceptions.addAll(autofillServiceFeature.canEnableAutofillService().getExceptions().map { it.domain })
+                exceptions.addAll(autofillServiceFeature.self().getExceptions().map { it.domain })
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceFeatureRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceFeatureRepository.kt
@@ -71,7 +71,7 @@ class RealAutofillServiceFeatureRepository @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (isMainProcess || processName == ":autofill") {
                 exceptions.clear()
-                exceptions.addAll(autofillServiceFeature.self().getExceptions().map { it.domain })
+                exceptions.addAll(autofillServiceFeature.canEnableAutofillService().getExceptions().map { it.domain })
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -110,7 +110,7 @@ class RealSecureStorageKeyStore(
 
     private suspend fun harmonyFlags(): HarmonyFlags {
         return withContext(dispatcherProvider.io()) {
-            val autofillServiceFlag = autofillServiceFeature.self().isEnabled()
+            val autofillServiceFlag = autofillServiceFeature.canEnableAutofillService().isEnabled()
             val useHarmonyFlag = autofillFeature.useHarmony().isEnabled()
 
             // Latch: once multiProcess is true, it stays true for this session to prevent

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/mapper/RealAppCredentialProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/mapper/RealAppCredentialProviderTest.kt
@@ -47,7 +47,7 @@ class RealAppCredentialProviderTest {
 
     @Before
     fun setUp() {
-        autofillServiceFeature.self().setRawStoredState(State(enable = true))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = true))
         autofillServiceFeature.canMapAppToDomain().setRawStoredState(State(enable = true))
         MockitoAnnotations.openMocks(this)
         toTest = RealAppCredentialProvider(

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/mapper/RemoteDomainTargetAppDataDownloaderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/mapper/RemoteDomainTargetAppDataDownloaderTest.kt
@@ -85,7 +85,7 @@ class RemoteDomainTargetAppDataDownloaderTest {
     fun setUp() {
         MockitoAnnotations.openMocks(this)
 
-        autofillServiceFeature.self().setRawStoredState(State(enable = true))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = true))
         autofillServiceFeature.canUpdateAppToDomainDataset().setRawStoredState(State(enable = true))
 
         toTest = RemoteDomainTargetAppDataDownloader(

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
@@ -38,7 +38,7 @@ class RealAutofillServiceFeatureRepositoryTest {
 
     @Before
     fun setup() {
-        autofillServiceFeature.self().setRawStoredState(Toggle.State(exceptions = listOf(exception)))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(Toggle.State(exceptions = listOf(exception)))
     }
 
     @Test
@@ -65,7 +65,7 @@ class RealAutofillServiceFeatureRepositoryTest {
         )
 
         assertEquals(listOf(exception.domain), repository.exceptions)
-        autofillServiceFeature.self().setRawStoredState(Toggle.State(exceptions = emptyList()))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(Toggle.State(exceptions = emptyList()))
         repository.onPrivacyConfigDownloaded()
         assertEquals(emptyList<FeatureException>(), repository.exceptions)
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
@@ -36,9 +36,10 @@ class RealAutofillServiceFeatureRepositoryTest {
 
     private val autofillServiceFeature = FakeFeatureToggleFactory.create(AutofillServiceFeature::class.java)
 
+    @Suppress("DEPRECATION")
     @Before
     fun setup() {
-        autofillServiceFeature.canEnableAutofillService().setRawStoredState(Toggle.State(exceptions = listOf(exception)))
+        autofillServiceFeature.self().setRawStoredState(Toggle.State(exceptions = listOf(exception)))
     }
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/keys/RealSecureStorageKeyStoreTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/store/keys/RealSecureStorageKeyStoreTest.kt
@@ -895,13 +895,13 @@ class RealSecureStorageKeyStoreTest {
     private fun configureHarmonyDisabled() {
         autofillFeature.useHarmony().setRawStoredState(State(enable = false))
         autofillFeature.readFromHarmony().setRawStoredState(State(enable = false))
-        autofillServiceFeature.self().setRawStoredState(State(enable = false))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = false))
     }
 
     private fun configureHarmonyEnabled(harmonyPrefsReturnsNull: Boolean = false) {
         autofillFeature.useHarmony().setRawStoredState(State(enable = true))
         autofillFeature.readFromHarmony().setRawStoredState(State(enable = false))
-        autofillServiceFeature.self().setRawStoredState(State(enable = false))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = false))
         sharedPreferencesProvider.stub {
             onBlocking { getMigratedEncryptedSharedPreferences(any(), any()) } doReturn if (harmonyPrefsReturnsNull) null else harmonyPrefs
         }
@@ -910,14 +910,14 @@ class RealSecureStorageKeyStoreTest {
     private fun configureReadFromHarmonyEnabled(harmonyPrefsReturnsNull: Boolean = false) {
         autofillFeature.useHarmony().setRawStoredState(State(enable = true))
         autofillFeature.readFromHarmony().setRawStoredState(State(enable = true))
-        autofillServiceFeature.self().setRawStoredState(State(enable = false))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = false))
         sharedPreferencesProvider.stub {
             onBlocking { getMigratedEncryptedSharedPreferences(any(), any()) } doReturn if (harmonyPrefsReturnsNull) null else harmonyPrefs
         }
     }
 
     private fun configureMultiProcessMode(harmonyPrefsReturnsNull: Boolean = false) {
-        autofillServiceFeature.self().setRawStoredState(State(enable = true))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = true))
         sharedPreferencesProvider.stub {
             onBlocking { getMigratedEncryptedSharedPreferences(any(), any()) } doReturn if (harmonyPrefsReturnsNull) null else harmonyPrefs
         }
@@ -934,7 +934,7 @@ class RealSecureStorageKeyStoreTest {
         testee.updateKey(Pair(KEY_NAME, TEST_VALUE))
 
         // Disable the flag mid-session
-        autofillServiceFeature.self().setRawStoredState(State(enable = false))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = false))
 
         // Key now exists in harmony
         whenever(harmonyPrefs.getString(eq(KEY_NAME), anyOrNull())).thenReturn(TEST_VALUE.toByteString().base64())
@@ -962,7 +962,7 @@ class RealSecureStorageKeyStoreTest {
         assertArrayEquals(TEST_VALUE, firstRead)
 
         // Disable the flag mid-session
-        autofillServiceFeature.self().setRawStoredState(State(enable = false))
+        autofillServiceFeature.canEnableAutofillService().setRawStoredState(State(enable = false))
 
         // Legacy has different/no value (simulating stale cache from another process writing)
         whenever(legacyPrefs.getString(eq(KEY_NAME), anyOrNull())).thenReturn(null)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214293442705565

### Description
Add new subfeature for autofillService so we can have rollouts

### Steps to test this PR

_Feature 1_
- [ ] Verify `AutofillServiceFeature#self()` is never used, other than when getting exceptions 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the feature-gating used to enable/disable the AutofillService component and influences secure-storage multi-process behavior; misconfiguration could unexpectedly disable autofill or change storage paths.
> 
> **Overview**
> Adds a new `AutofillServiceFeature.canEnableAutofillService()` toggle (default off) to support staged rollouts, and deprecates the previous `AutofillServiceFeature.self()` toggle for enablement decisions.
> 
> Updates Autofill Service enablement checks in `AutofillServiceLifecycleObserver`, `RealAutofillService`, and `RealSecureStorageKeyStore` to use `canEnableAutofillService()` instead of `self()`, and adjusts related tests; `self()` is retained only for reading remote-config exceptions in `RealAutofillServiceFeatureRepository` (with deprecation suppressions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc48edadb5146cff9b76cd7c6075b877d9fb987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->