### PR TITLE
Enable daily Agentic maintenance worker

### DIFF
--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -272,9 +272,11 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
-          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
+          {
+            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
+            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
+            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
+          } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/android-maintenance-worker.lock.yml
+++ b/.github/workflows/android-maintenance-worker.lock.yml
@@ -24,10 +24,12 @@
 # task from the Android Agentic Maintenance Backlog in Asana, implements it on a
 # feature branch, and opens a draft PR targeting develop.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5a7bb651e791cb46e7337ff931b11c4a8227e813482c52387ffc94f405159ccc","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d8d49c6f5ebfa8f34c7951978087d50ab6f4730ba4c7466fa86692a3aeddc5f8","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
 name: "Android Maintenance Worker"
 "on":
+  schedule:
+  - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -39,7 +41,8 @@ name: "Android Maintenance Worker"
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}"
+  cancel-in-progress: false
+  group: android-maintenance-worker
 
 run-name: "Android Maintenance Worker"
 
@@ -125,19 +128,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
+          cat << 'GH_AW_PROMPT_9f2b79f44f6616bc_EOF'
           <system>
-          GH_AW_PROMPT_afec543437c1b42e_EOF
+          GH_AW_PROMPT_9f2b79f44f6616bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
+          cat << 'GH_AW_PROMPT_9f2b79f44f6616bc_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_afec543437c1b42e_EOF
+          GH_AW_PROMPT_9f2b79f44f6616bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
+          cat << 'GH_AW_PROMPT_9f2b79f44f6616bc_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -167,14 +170,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_afec543437c1b42e_EOF
+          GH_AW_PROMPT_9f2b79f44f6616bc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
+          cat << 'GH_AW_PROMPT_9f2b79f44f6616bc_EOF'
           </system>
-          GH_AW_PROMPT_afec543437c1b42e_EOF
-          cat << 'GH_AW_PROMPT_afec543437c1b42e_EOF'
+          GH_AW_PROMPT_9f2b79f44f6616bc_EOF
+          cat << 'GH_AW_PROMPT_9f2b79f44f6616bc_EOF'
           {{#runtime-import .github/workflows/android-maintenance-worker.md}}
-          GH_AW_PROMPT_afec543437c1b42e_EOF
+          GH_AW_PROMPT_9f2b79f44f6616bc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -246,6 +249,8 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+    concurrency:
+      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -267,11 +272,9 @@ jobs:
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
-          {
-            echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
-            echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
-            echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
-          } >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS=${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" >> "$GITHUB_OUTPUT"
+          echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -334,12 +337,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_876e01d037e1f83a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0065f271169c55bc_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","labels":["agentic-maintenance"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Android Maintenance] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_876e01d037e1f83a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0065f271169c55bc_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_726465ae7b1cd2e5_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_4fc405823a1e36a0_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Android Maintenance] \". Labels [\"agentic-maintenance\"] will be automatically added. PRs will be created as drafts."
@@ -347,8 +350,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_726465ae7b1cd2e5_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_123dce1ba763f353_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_4fc405823a1e36a0_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_401f4d49e8442f92_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -444,7 +447,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_123dce1ba763f353_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_401f4d49e8442f92_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -487,7 +490,7 @@ jobs:
       - name: Setup MCP Scripts Config
         run: |
           mkdir -p ${RUNNER_TEMP}/gh-aw/mcp-scripts/logs
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/tools.json << 'GH_AW_MCP_SCRIPTS_TOOLS_6ac70dc439f1c7ce_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/tools.json << 'GH_AW_MCP_SCRIPTS_TOOLS_a664b047f59de46b_EOF'
           {
             "serverName": "mcpscripts",
             "version": "1.0.0",
@@ -537,8 +540,8 @@ jobs:
               }
             ]
           }
-          GH_AW_MCP_SCRIPTS_TOOLS_6ac70dc439f1c7ce_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs << 'GH_AW_MCP_SCRIPTS_SERVER_a8f553e77d0c0043_EOF'
+          GH_AW_MCP_SCRIPTS_TOOLS_a664b047f59de46b_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs << 'GH_AW_MCP_SCRIPTS_SERVER_aff0ae7c11502f5d_EOF'
             const path = require("path");
             const { startHttpServer } = require("./mcp_scripts_mcp_server_http.cjs");
             const configPath = path.join(__dirname, "tools.json");
@@ -552,12 +555,12 @@ jobs:
               console.error("Failed to start mcp-scripts HTTP server:", error);
               process.exit(1);
             });
-          GH_AW_MCP_SCRIPTS_SERVER_a8f553e77d0c0043_EOF
+          GH_AW_MCP_SCRIPTS_SERVER_aff0ae7c11502f5d_EOF
           chmod +x ${RUNNER_TEMP}/gh-aw/mcp-scripts/mcp-server.cjs
           
       - name: Setup MCP Scripts Tool Files
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_section_tasks.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_4235e5ec5c32c200_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_section_tasks.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_0983252e4fc58b60_EOF'
             async function execute(inputs) {
               const { section_gid } = inputs || {};
               const token = process.env.ASANA_ACCESS_TOKEN;
@@ -572,8 +575,8 @@ jobs:
             if (require.main === module) {
               require("./mcp-scripts-runner.cjs")(execute);
             }
-          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_4235e5ec5c32c200_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_task.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_6e08296a0bed75f2_EOF'
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_SECTION_TASKS_0983252e4fc58b60_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/mcp-scripts/asana_get_task.cjs << 'GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_7adcc18b209843bb_EOF'
             async function execute(inputs) {
               const { task_gid } = inputs || {};
               const token = process.env.ASANA_ACCESS_TOKEN;
@@ -588,7 +591,7 @@ jobs:
             if (require.main === module) {
               require("./mcp-scripts-runner.cjs")(execute);
             }
-          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_6e08296a0bed75f2_EOF
+          GH_AW_MCP_SCRIPTS_JS_ASANA_GET_TASK_7adcc18b209843bb_EOF
           
       - name: Generate MCP Scripts Server Config
         id: mcp-scripts-config
@@ -653,7 +656,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_MCP_SCRIPTS_PORT -e GH_AW_MCP_SCRIPTS_API_KEY -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e ASANA_ACCESS_TOKEN -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_f91eb0717a15e5df_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_366caf6541fbe2c6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -707,7 +710,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_f91eb0717a15e5df_EOF
+          GH_AW_MCP_CONFIG_366caf6541fbe2c6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -6,6 +6,12 @@ description: |
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+concurrency:
+  group: android-maintenance-worker
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -86,23 +92,12 @@ Always be:
 - Transparent: always identify yourself as Android Maintenance Worker (🤖) in all comments and PRs
 - Restrained: when in doubt, stop and ask; it is always better to comment and wait than to make a risky change
 
-## Memory
-
-Use persistent repo memory to track:
-- in_progress_task: GID and Asana URL of the task currently being worked
-- in_progress_pr: PR number and branch name of the current in-progress PR (if any)
-- last_run: timestamp and outcome of the last run
-
-Read memory at the start of every run; update it at the end.
-
-Important: memory may be stale. Always verify the current state of any in-progress task and
-PR against live data before acting on memory.
-
 ## Workflow
 
-### Step 1: Check for in-progress work
+State is derived from live data on every run. Do not maintain any persistent state file —
+the Asana "In Progress" section and open `[Android Maintenance]` PRs are the source of truth.
 
-**Before doing anything else, check live state — do not rely on memory alone.**
+### Step 1: Check for in-progress work
 
 1. Use the `asana_get_section_tasks` tool to list tasks in the "In Progress" section
    (section GID: `1213746476312672`).
@@ -116,8 +111,6 @@ PR against live data before acting on memory.
    - Otherwise (PR is open and healthy, or no PR exists yet) → **stop**. Do not start a new task.
 
 **Never proceed to Step 2 when step 3 applies.**
-Use memory (`in_progress_task`, `in_progress_pr`) only as a hint to locate the task and PR
-faster — it is not the source of truth.
 
 ### Step 2: Select a task
 
@@ -125,7 +118,6 @@ faster — it is not the source of truth.
    - "Ready" section GID: `1213746476312669`
 2. Pick the first task listed
 3. Use the `asana_get_task` tool to fetch the full task details (name, notes, URL)
-4. Save the task GID and URL to memory as in_progress_task
 
 ### Step 3: Read project conventions
 
@@ -151,6 +143,7 @@ Run the commands listed in the task's Validation section.
 Also always run:
 ./gradlew spotlessApply
 ./gradlew spotlessCheck
+./gradlew lint_check
 ./gradlew :<affected-module>:testDebugUnitTest   (for each modified module)
 
 If any check fails due to your changes:
@@ -179,7 +172,7 @@ Body (follow the template exactly — replace the placeholder sections):
     ### Steps to test this PR
 
     _Lint / formatting_
-    - [ ] <module-specific lint command from the task's Validation section>
+    - [ ] ./gradlew lint_check
     - [ ] ./gradlew spotlessCheck
 
     ### UI changes

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -180,16 +180,12 @@ Body (follow the template exactly — replace the placeholder sections):
     | ------ | ----- |
     | No UI changes | No UI changes |
 
-After opening the PR:
-- Update memory: in_progress_pr → PR number and branch
-
 ### Step 7: If stuck
 
 If at any point you cannot proceed (the task is ambiguous, the approach does not work,
 verification fails in a way you cannot resolve):
 1. Do NOT open a partial PR
-2. Update memory: clear in_progress_task and in_progress_pr
-3. Stop and explain what blocked you in the workflow output
+2. Stop and explain what blocked you in the workflow output
 
 ## Guidelines
 

--- a/.github/workflows/android-maintenance-worker.md
+++ b/.github/workflows/android-maintenance-worker.md
@@ -94,8 +94,7 @@ Always be:
 
 ## Workflow
 
-State is derived from live data on every run. Do not maintain any persistent state file —
-the Asana "In Progress" section and open `[Android Maintenance]` PRs are the source of truth.
+State is derived from live data on every run — the Asana "In Progress" section and open `[Android Maintenance]` PRs are the source of truth.
 
 ### Step 1: Check for in-progress work
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214290314562786?focus=true

### Description

Schedules the Android Maintenance Worker to run daily and tightens the agent's instructions:

- Adds a daily `schedule` trigger at 05:00 UTC alongside the existing `workflow_dispatch`.
- Adds a `concurrency` guard (`group: android-maintenance-worker`, `cancel-in-progress: false`) so an overlapping manual run queues instead of killing an in-flight run mid-commit.
- Adds `./gradlew lint_check` to the Step 5 baseline verification commands and to the PR template's Lint / formatting checklist, so lint always runs even if a task author forgets to include it in the Validation section.
- Removes the Memory section and the references to memory in Steps 1, 2, 6, and 7. State is now derived purely from live data — the Asana "In Progress" section and open `[Android Maintenance]` PRs are the source of truth, which is what Step 1 already does. This removes a footgun (memory diverging from live state) for no real benefit.

### Steps to test this PR

_Lint / formatting_
- [ ] ./gradlew spotlessCheck

_Workflow_
- [ ] Trigger the workflow manually via Actions → Android Maintenance Worker → Run workflow, and confirm it runs end-to-end.
- [ ] After merge, confirm the workflow appears in the scheduled runs list and fires at the next 05:00 UTC.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that affect scheduling and execution concurrency; main risk is unintended run frequency/queuing behavior, not product code.
> 
> **Overview**
> Enables **daily scheduled runs** for the Android Maintenance Worker workflow (05:00 UTC) in addition to manual `workflow_dispatch`.
> 
> Adds/adjusts **concurrency controls** (`group: android-maintenance-worker`, `cancel-in-progress: false`, plus an `agent` job concurrency group) to prevent overlapping executions from canceling in-flight runs.
> 
> Tightens the agent prompt in `android-maintenance-worker.md` by removing the memory-based state tracking in favor of live Asana/PR state, and by making `./gradlew lint_check` part of the always-run verification and PR checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7181ac0616a2b458c941952ffec17aaa81b7dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->