### PR TITLE
DuckAi/Voice chat: Support voice chat in native unified input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -58,7 +59,13 @@ class NativeInputCallbacks(
 )
 
 interface NativeInputManager {
-    fun init(omnibar: Omnibar, rootView: ViewGroup, lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit = {})
+    fun init(
+        omnibar: Omnibar,
+        rootView: ViewGroup,
+        lifecycleOwner: LifecycleOwner,
+        onDisabled: () -> Unit = {},
+    )
+
     fun isNativeInputEnabled(): Boolean
     fun showNativeInput(
         layoutInflater: LayoutInflater,
@@ -67,6 +74,7 @@ interface NativeInputManager {
         query: String = "",
         callbacks: NativeInputCallbacks,
     )
+
     fun hideNativeInput(animate: Boolean = true): Boolean
     fun handleDuckAiVoiceResult(query: String)
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
@@ -79,6 +87,7 @@ class RealNativeInputManager @Inject constructor(
     private val voiceSearchAvailability: VoiceSearchAvailability,
     private val globalActivityStarter: GlobalActivityStarter,
     private val queryUrlPredictor: QueryUrlPredictor,
+    private val duckAiFeatureState: DuckAiFeatureState,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -92,7 +101,12 @@ class RealNativeInputManager @Inject constructor(
         return widgetView.findViewById<View?>(R.id.inputModeWidget) as? NativeInputWidget
     }
 
-    override fun init(omnibar: Omnibar, rootView: ViewGroup, lifecycleOwner: LifecycleOwner, onDisabled: () -> Unit) {
+    override fun init(
+        omnibar: Omnibar,
+        rootView: ViewGroup,
+        lifecycleOwner: LifecycleOwner,
+        onDisabled: () -> Unit,
+    ) {
         this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView)
         this.rootView = rootView
         this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
@@ -214,7 +228,10 @@ class RealNativeInputManager @Inject constructor(
         widgetRoot?.translationZ = 0f
     }
 
-    private fun onKeyboardHidden(widget: NativeInputWidget, widgetRoot: View?) {
+    private fun onKeyboardHidden(
+        widget: NativeInputWidget,
+        widgetRoot: View?,
+    ) {
         if (widget.isModelMenuVisible()) return
         if (omnibarController.isDuckAiMode()) {
             updateWidgetFocus(widget)
@@ -238,7 +255,10 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun isDescendantOf(ancestor: View, view: View): Boolean {
+    private fun isDescendantOf(
+        ancestor: View,
+        view: View,
+    ): Boolean {
         var current: View? = view
         while (current != null) {
             if (current === ancestor) return true
@@ -392,10 +412,6 @@ class RealNativeInputManager @Inject constructor(
             onStopTapped = callbacks.onStopTapped
             bindTabCount(lifecycleOwner, tabs.map { it.size })
             hideMainButtons()
-            if (voiceSearchAvailability.isVoiceSearchAvailable) {
-                setVoiceButtonVisible(true)
-                onVoiceClick = { callbacks.onVoiceSearchPressed(isChatTabSelected()) }
-            }
             onImageClick = { callbacks.onImageButtonPressed() }
             onPaidTierChanged = { isPaid ->
                 val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
@@ -410,7 +426,43 @@ class RealNativeInputManager @Inject constructor(
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         applyInitialTabSelection(widgetView)
+        bindVoiceButtons(widgetView, callbacks)
         layoutCoordinator.applyBottomCardShape(widgetView)
+    }
+
+    private fun bindVoiceButtons(
+        widgetView: View,
+        callbacks: NativeInputCallbacks,
+    ) {
+        val widget = widgetFrom(widgetView) ?: return
+        updateVoiceButtons(widget)
+        val previousOnSearchSelected = widget.onSearchSelected
+        widget.onSearchSelected = { animate ->
+            updateVoiceButtons(widget)
+            previousOnSearchSelected?.invoke(animate)
+        }
+        val previousOnChatSelected = widget.onChatSelected
+        widget.onChatSelected = { animate ->
+            updateVoiceButtons(widget)
+            previousOnChatSelected?.invoke(animate)
+        }
+        widget.onVoiceSearchClick = {
+            callbacks.onVoiceSearchPressed(widget.isChatTabSelected())
+        }
+        widget.onVoiceChatClick = {
+            hideNativeInput(animate = false)
+            duckChat.openVoiceDuckChat()
+        }
+    }
+
+    private fun updateVoiceButtons(widget: NativeInputWidget) {
+        val isDuckAiTabSelected = widget.isChatTabSelected()
+        val voiceSearchAvailable = voiceSearchAvailability.isVoiceSearchAvailable
+        val voiceSearchDuckAiAvailable = duckAiFeatureState.showVoiceSearchToggle.value
+        val voiceChatEntryAvailable = duckAiFeatureState.showVoiceChatEntry.value
+        val shouldShowVoiceSearchForDuckAi = !voiceChatEntryAvailable && voiceSearchDuckAiAvailable
+        widget.setVoiceSearchAvailable(voiceSearchAvailable && (!isDuckAiTabSelected || shouldShowVoiceSearchForDuckAi))
+        widget.setVoiceChatAvailable(isDuckAiTabSelected && voiceChatEntryAvailable)
     }
 
     private fun bindSearchTabAutocompleteClearing(

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -70,6 +70,12 @@ interface DuckAiFeatureState {
     val showVoiceSearchToggle: StateFlow<Boolean>
 
     /**
+     * Indicates whether the voice chat entry point (e.g. the voice chat button on the chat tab of the input screen)
+     * should be shown.
+     */
+    val showVoiceChatEntry: StateFlow<Boolean>
+
+    /**
      * Indicates whether Duck.ai should be open in FullScreen mode
      */
     val showFullScreenMode: StateFlow<Boolean>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -368,6 +368,7 @@ class RealDuckChat @Inject constructor(
     private val _chatState = MutableStateFlow(ChatState.HIDE)
     private val _showInputScreenOnSystemSearchLaunch = MutableStateFlow(false)
     private val _showVoiceSearchToggle = MutableStateFlow(false)
+    private val _showVoiceChatEntry = MutableStateFlow(false)
     private val _showFullScreenMode = MutableStateFlow(false)
     private val _showFullScreenModeToggle = MutableStateFlow(false)
     private val _showContextualMode = MutableStateFlow(false)
@@ -400,6 +401,7 @@ class RealDuckChat @Inject constructor(
     private var isAutomaticContextAttachmentEnabled: Boolean = false
     private var duckAiNativeStorage: Boolean = false
     private var areMultipleContentAttachmentsEnabled: Boolean = false
+
     init {
         if (isMainProcess) {
             cacheConfig()
@@ -568,6 +570,8 @@ class RealDuckChat @Inject constructor(
     override val showInputScreenOnSystemSearchLaunch: StateFlow<Boolean> = _showInputScreenOnSystemSearchLaunch.asStateFlow()
 
     override val showVoiceSearchToggle: StateFlow<Boolean> = _showVoiceSearchToggle.asStateFlow()
+
+    override val showVoiceChatEntry: StateFlow<Boolean> = _showVoiceChatEntry.asStateFlow()
 
     override val showFullScreenMode: StateFlow<Boolean> = _showFullScreenMode.asStateFlow()
 
@@ -907,6 +911,10 @@ class RealDuckChat @Inject constructor(
                 duckChatFeatureRepository.shouldShowInVoiceSearch() &&
                     isDuckChatFeatureEnabled && isDuckChatUserEnabled && isVoiceSearchEntryPointEnabled
             _showVoiceSearchToggle.emit(showVoiceSearchToggle)
+
+            val showVoiceChatEntry =
+                isDuckChatFeatureEnabled && isDuckChatUserEnabled && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
+            _showVoiceChatEntry.emit(showVoiceChatEntry)
 
             val showFullScreenMode = isDuckChatFeatureEnabled && isDuckChatUserEnabled &&
                 (duckChatFeature.fullscreenMode().isEnabled() || duckChatFeatureRepository.isFullScreenModeUserSettingEnabled())

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -323,12 +323,17 @@ class InputScreenViewModel @AssistedInject constructor(
             voiceInputAllowed,
             isSearchModeFlow,
             chatInputTextState,
-        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText ->
+            duckAiFeatureState.showVoiceSearchToggle,
+        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText, showVoiceSearch ->
             val newEntryPointActive = !isSearchMode && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
             _visibilityState.update {
                 it.copy(
                     voiceSearchButtonVisible = if (!newEntryPointActive) {
-                        serviceAvailable && inputAllowed
+                        if (isSearchMode) {
+                            serviceAvailable && inputAllowed
+                        } else {
+                            serviceAvailable && inputAllowed && showVoiceSearch
+                        }
                     } else {
                         false
                     },

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -69,7 +69,8 @@ interface NativeInputWidget {
     var onChatSelected: ((animate: Boolean) -> Unit)?
     var onClearTextTapped: (() -> Unit)?
     var onStopTapped: (() -> Unit)?
-    var onVoiceClick: (() -> Unit)?
+    var onVoiceSearchClick: (() -> Unit)?
+    var onVoiceChatClick: (() -> Unit)?
     var onImageClick: (() -> Unit)?
     var onPaidTierChanged: ((Boolean) -> Unit)?
 
@@ -82,7 +83,8 @@ interface NativeInputWidget {
     fun selectChatTab()
     fun isChatTabSelected(): Boolean
     fun hideMainButtons()
-    fun setVoiceButtonVisible(visible: Boolean)
+    fun setVoiceSearchAvailable(available: Boolean)
+    fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
     fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
@@ -146,8 +148,21 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
     private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
+    private var voiceSearchAvailable: Boolean = false
+    private var voiceChatAvailable: Boolean = false
     override var onStopTapped: (() -> Unit)? = null
     override var onImageClick: (() -> Unit)? = null
+    override var onVoiceSearchClick: (() -> Unit)? = null
+        set(value) {
+            field = value
+            submitButtons?.onVoiceSearchClick = value
+            onVoiceClick = value
+        }
+    override var onVoiceChatClick: (() -> Unit)? = null
+        set(value) {
+            field = value
+            submitButtons?.onVoiceChatClick = value
+        }
     override var onPaidTierChanged: ((Boolean) -> Unit)? = null
         set(value) {
             field = value
@@ -239,7 +254,31 @@ class NativeInputModeWidget @JvmOverloads constructor(
             if (isChatTabSelected() && !isStreaming) {
                 submitButtons?.setSendButtonEnabled(!text.isNullOrBlank())
             }
+            updateSendButtonVisibility()
+            updateVoiceButtonVisibility()
         }
+    }
+
+    override fun setVoiceSearchAvailable(available: Boolean) {
+        voiceSearchAvailable = available
+        updateVoiceButtonVisibility()
+    }
+
+    override fun setVoiceChatAvailable(available: Boolean) {
+        voiceChatAvailable = available
+        updateVoiceButtonVisibility()
+    }
+
+    private fun updateVoiceButtonVisibility() {
+        val isBlank = inputField.text.isNullOrBlank()
+        setVoiceButtonVisible(voiceSearchAvailable && isBlank)
+        submitButtons?.setVoiceSearchVisible(false)
+        submitButtons?.setVoiceChatVisible(voiceChatAvailable && isBlank)
+    }
+
+    private fun updateSendButtonVisibility() {
+        val visible = isChatTabSelected() && (isStreaming || inputField.text.isNotBlank())
+        submitButtons?.setSendButtonVisible(visible)
     }
 
     private fun applyToggleVisibility() {
@@ -561,6 +600,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             submitButtons?.showSendButton()
             submitButtons?.setSendButtonEnabled(inputField.text.isNotBlank())
         }
+        updateSendButtonVisibility()
     }
 
     private fun updateDuckAiSubmitButton() {
@@ -569,7 +609,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         setImageButtonVisible(isChatTab)
         if (isChatTab) {
             submitButtons?.setSendButtonIcon(R.drawable.ic_arrow_up_24)
-            submitButtons?.setSendButtonVisible(true)
             if (!isStreaming) {
                 submitButtons?.setSendButtonEnabled(inputField.text.isNotBlank())
             }
@@ -577,8 +616,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
             inputField.maxLines = MAX_LINES
         } else {
             submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_find_search_24)
-            submitButtons?.setSendButtonVisible(false)
         }
+        updateSendButtonVisibility()
     }
 
     override fun setImageButtonVisible(visible: Boolean) {
@@ -600,12 +639,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val buttons = InputScreenButtons(context, useTopBar = useTopBar).apply {
             onSendClick = { submitMessage() }
             onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
+            onVoiceSearchClick = this@NativeInputModeWidget.onVoiceSearchClick
+            onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
             setSendButtonVisible(false)
             setNewLineButtonVisible(false)
-            setVoiceButtonVisible(false)
         }
         container.addView(buttons)
         submitButtons = buttons
+        updateVoiceButtonVisibility()
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -376,6 +376,68 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenDuckChatEnabledAndVoiceEntryPointEnabledThenShowVoiceChatEntryIsTrue() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertTrue(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenVoiceEntryPointDisabledThenShowVoiceChatEntryIsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = false))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertFalse(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenDuckChatFeatureDisabledThenShowVoiceChatEntryIsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = false))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertFalse(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenDuckChatUserDisabledThenShowVoiceChatEntryIsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertFalse(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenShouldShowInVoiceSearchSettingFalseThenShowVoiceChatEntryStillTrue() = runTest {
+        // showVoiceChatEntry must be independent of the in-voice-search toggle user setting
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceSearch()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertTrue(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
     fun showInAddressBarReturnsCorrectValueBasedOnUserSettingAndConfig() = runTest {
         duckChatFeature.self().setRawStoredState(
             State(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -127,6 +127,7 @@ class InputScreenViewModelTest {
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
             whenever(omnibarRepository.omnibarType).thenReturn(OmnibarType.SINGLE_TOP)
             whenever(duckAiFeatureState.showFullScreenMode).thenReturn(fullScreenModeDisabledFlow)
+            whenever(duckAiFeatureState.showVoiceSearchToggle).thenReturn(MutableStateFlow(true))
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1213968100249543?focus=true 

### Description
Ensure that the Duck AI voice chat entry points work for the native input field
Figma: https://www.figma.com/design/VY5H9N5GaCupAKjEZLqGSd/Voice-chat-access?node-id=1-954&m=dev

### Steps to test this PR
 ### Preconditions (common to all cases)                                                                                                                                                                            
  - Native input field enabled in Settings → AI Chat                                                                                                                                                                 
  - Build the app and open a tab                                                                                                                                                                                     
  - Each scenario must be repeated on **top omnibar** and **bottom omnibar** (Settings → Address Bar Position)                                                                                                       
  - Each scenario must be repeated with **empty input** and **non-empty input**                                                                                                                                      
                                                                                                                                                                                                                     
  ### Toggles under test                                                                                                                                                                                             
  - **A — Search & Duck.ai toggle** (`Settings → AI Chat → Show Search & Duck.ai input mode`) — controls whether the Search/Chat tab switcher is shown above the input                                               
  - **B — `duckAiVoiceEntryPoint` FF** — gates `showVoiceChatEntry`, i.e. whether the voice **chat** icon is offered on the chat tab                                                                                 
  - **C — Private voice search** (`Settings → General → Private voice search`) — user-facing voice search availability (also requires device speech recognition support)                                             
  - **D — `duckAiVoiceSearch` FF** — gates `showVoiceSearchToggle`, i.e. whether the Search ↔ Duck.ai mode toggle is shown **inside the voice search screen** after the user taps the voice icon                     
                                                                                                                                                                                                                     
  ### Expected behavior reference                                                                                                                                                                                    
  - **Voice search icon** lives **inline inside the input field** (not rendered in the floating button row)                                                                                                          
  - **Voice chat icon** lives in the **submit buttons row** (floating top-right on top bar; inline on bottom bar)                                                                                                    
  - Both icons hide as soon as the user types any text                                                                                                                                                               
  - C gates **voice search icon visibility**. B gates **voice chat icon visibility**. D does **not** affect icon visibility in the native input — it only affects the UI of the voice search screen after launch.    
                                                                                                                                                                                                                     
  ---                                                    
                                                                                                                                                                                                                     
  ### Icon visibility matrix (varies on A, B, C; D irrelevant for this matrix)                                                                                                                                       
  
  #### 1. A=on, B=on, C=on                                                                                                                                                                                           
  | Tab | Text | Voice search icon | Voice chat icon |   
  |---|---|---|---|                                                                                                                                                                                                  
  | Search | empty | Visible | Hidden |                                                                                                                                                                              
  | Search | non-empty | Hidden | Hidden |
  | Chat | empty | Hidden | Visible |                                                                                                                                                                                
  | Chat | non-empty | Hidden | Hidden |                 
                                                                                                                                                                                                                     
  #### 2. A=on, B=off, C=on (voice chat FF off → fallback to voice search on chat tab)                                                                                                                               
  | Tab | Text | Voice search icon | Voice chat icon |                                                                                                                                                               
  |---|---|---|---|                                                                                                                                                                                                  
  | Search | empty | Visible | Hidden |                  
  | Search | non-empty | Hidden | Hidden |
  | Chat | empty | **Visible** | Hidden |                                                                                                                                                                            
  | Chat | non-empty | Hidden | Hidden |
  
  #### 3. A=on, B=off, C=on, D= OFF (duckAiVoiceSearch OFF)                                                                                                                               
  | Tab | Text | Voice search icon | Voice chat icon |                                                                                                                                                               
  |---|---|---|---|                                                                                                                                                                                                  
  | Search | empty | Visible | Hidden |                  
  | Search | non-empty | Hidden | Hidden |
  | Chat | empty | Hidden | Hidden |                                                                                                                                                                            
  | Chat | non-empty | Hidden | Hidden |
                                                                                                                                                                                                                     
  #### 4. A=on, B=on, C=off (private voice search disabled / unsupported)                                                                                                                                            
  | Tab | Text | Voice search icon | Voice chat icon |
  |---|---|---|---|                                                                                                                                                                                                  
  | Search | empty | Hidden | Hidden |                   
  | Chat | empty | Hidden | Visible |                                                                                                                                                                                
  | Chat | non-empty | Hidden | Hidden |                    
                                                                                                                                                                                                                     
  #### 5. A=on, B=off, C=off
  | Tab | Text | Voice search icon | Voice chat icon |                                                                                                                                                               
  |---|---|---|---|                                      
  | Search | empty | Hidden | Hidden |                                                                                                                                                                               
  | Chat | empty | Hidden | Hidden |
                                                                                                                                                                                                                     
  #### 5. A=off                                          
  Only the Search tab is reachable (the Chat tab is hidden along with the input mode toggle). Apply the **Search** row of cases 1–4.
                                                                                                                                                                                                                     
  ---
                                                                                                                                                                                                                     
  ### Click outcomes (varies on B, C, D)                                                                                                                                                                             
  
  For each visible icon, tap it and verify the launched flow:                                                                                                                                                        
                                                         
  - **Voice search icon, Search tab** (any C=on case)                                                                                                                                                                
    - Opens the system voice search screen in `SEARCH` mode
    - **D=on:** the voice search screen shows the Search ↔ Duck.ai mode toggle, default position = Search                                                                                                            
    - **D=off:** the voice search screen shows **no** toggle                                                                                                                                                         
    - Recognized text submits as a search                                                                                                                                                                            
                                                                                                                                                                                                                     
  - **Voice search icon, Chat tab** (case 2 only — B=off, C=on)                                                                                                                                                      
    - Opens the system voice search screen in `DUCK_AI` mode
    - **D=on:** toggle is shown, default position = Duck.ai                                                                                                                                                          
    - **D=off:** no toggle; recognized text submits straight to Duck.ai                                                                                                                                              
                                                                                                                                                                                                                     
  - **Voice chat icon** (B=on cases)                                                                                                                                                                                 
    - Native input is dismissed, then Duck.ai opens in voice mode (web-based voice flow inside the Duck.ai screen)                                                                                                   
    - This path is **independent of C and D** — it must work even if private voice search is disabled and `duckAiVoiceSearch` FF is off                                                                              
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  ### Position-specific checks (top vs bottom omnibar)                                                                                                                                                               
  - **Top omnibar:** voice chat icon appears as a floating circular button near the bottom-right above the keyboard.
  - **Bottom omnibar:** voice chat icon appears inline next to the send button. The voice search slot in the floating row is intentionally never used — voice search must only render inside the input field, never  
  to the right of the send button.                                                                                                                                                                                   
                                                                                                                                                                                                                     
  ### Regression checks                                                                                                                                                                                              
  - Toggling Search/Chat tabs while the input is empty must update the visible icon immediately (no stale state).
  - Typing then clearing the input must restore whichever icon was previously visible.
  - Streaming a Duck.ai response must hide the voice chat icon while the stop button is shown, then restore it when the response completes (input still empty).                                                      
  - Flipping **D** at runtime via remote config / internal toggle must not change icon visibility in the native input — it should only affect the next launch of the voice search screen.                                                                                           


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Duck.ai feature-state plumbing and native input UI logic to conditionally expose voice search vs voice chat entry points, which can affect core input interactions across search/chat tabs.
> 
> **Overview**
> Adds a new `DuckAiFeatureState.showVoiceChatEntry` flag (computed in `RealDuckChat` from `duckAiVoiceEntryPoint`) and corresponding tests to gate when the *voice chat* entry point should be shown.
> 
> Updates the native unified input (`NativeInputManager` + `NativeInputModeWidget`) to split voice actions into separate **voice search** vs **voice chat** callbacks, dynamically toggling which button is visible based on selected tab, text emptiness, voice availability, and the new feature-state flags; tapping voice chat now dismisses native input and calls `duckChat.openVoiceDuckChat()`.
> 
> Aligns input-screen visibility logic (`InputScreenViewModel`) so the chat tab only shows the voice-search button when `showVoiceSearchToggle` permits it, keeping voice chat visibility independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dabf920ff6da7b4d293315874234a7eea854539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->