### PR TITLE
DuckAi/Voice chat: Remove incorrect isVoiceChatEnabled()

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -66,7 +66,6 @@ import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchAssis
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchBrowser
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchBrowserAndSwitchToTab
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDeviceApplication
-import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckAi
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckAiVoiceChat
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchEditDialog
@@ -579,11 +578,6 @@ class SystemSearchActivity : DuckDuckGoActivity() {
 
             LaunchDuckAiVoiceChat -> {
                 duckChat.openVoiceDuckChat()
-                finish()
-            }
-
-            LaunchDuckAi -> {
-                duckChat.openDuckChat()
                 finish()
             }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -170,8 +170,6 @@ class SystemSearchViewModel @Inject constructor(
 
         data object LaunchDuckAiVoiceChat : Command()
 
-        data object LaunchDuckAi : Command()
-
         data class LaunchAssistSearch(val intent: Intent) : Command()
     }
 
@@ -318,8 +316,7 @@ class SystemSearchViewModel @Inject constructor(
     fun onDigitalAssistOpened(intent: Intent) {
         viewModelScope.launch {
             command.value = when {
-                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isVoiceChatEnabled() -> Command.LaunchDuckAiVoiceChat
-                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isEnabled() -> Command.LaunchDuckAi
+                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isEnabled() -> Command.LaunchDuckAiVoiceChat
                 else -> Command.LaunchAssistSearch(intent)
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -852,9 +852,9 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun `when onDigitalAssistOpened and digital assist and voice search enabled then LaunchDuckAiVoiceChat command sent`() = runTest {
+    fun `when onDigitalAssistOpened and digital assist enabled and duck chat enabled then LaunchDuckAiVoiceChat command sent`() = runTest {
         whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
-        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
 
         testee.onDigitalAssistOpened(mock())
 
@@ -862,20 +862,8 @@ class SystemSearchViewModelTest {
     }
 
     @Test
-    fun `when onDigitalAssistOpened and digital assist enabled and voice search disabled then LaunchDuckAi command sent`() = runTest {
-        whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
-        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(false)
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
-
-        testee.onDigitalAssistOpened(mock())
-
-        verify(commandObserver).onChanged(Command.LaunchDuckAi)
-    }
-
-    @Test
     fun `when onDigitalAssistOpened and duck chat disabled then LaunchAssistSearch command sent`() = runTest {
         whenever(mockDuckAiFeatureState.allowDuckAiAsDigitalAssistant).thenReturn(MutableStateFlow(true))
-        whenever(mockDuckChat.isVoiceChatEnabled()).thenReturn(false)
         whenever(mockDuckChat.isEnabled()).thenReturn(false)
         val intent = mock<Intent>()
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -138,11 +138,4 @@ interface DuckChat {
      * Returns `true` if a voice session is currently active.
      */
     fun isVoiceSessionActive(): Boolean
-
-    /**
-     * Checks whether DuckChat Voice chat is enabled based on remote config flag
-     *
-     * @return true if DuckChat AI voice chat is enabled, false otherwise.
-     */
-    suspend fun isVoiceChatEnabled(): Boolean
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -792,10 +792,6 @@ class RealDuckChat @Inject constructor(
 
     override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
-    override suspend fun isVoiceChatEnabled(): Boolean = withContext(dispatchers.io()) {
-        isEnabled() && duckChatFeature.duckAiVoiceSearch().isEnabled()
-    }
-
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1653,36 +1653,6 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when duck chat enabled and duckAiVoiceSearch enabled then isVoiceChatEnabled returns true`() = runTest {
-        duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = true))
-        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
-        testee.onPrivacyConfigDownloaded()
-
-        assertTrue(testee.isVoiceChatEnabled())
-    }
-
-    @Test
-    fun `when duck chat enabled and duckAiVoiceSearch disabled then isVoiceChatEnabled returns false`() = runTest {
-        duckChatFeature.self().setRawStoredState(State(enable = true))
-        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = false))
-        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
-        testee.onPrivacyConfigDownloaded()
-
-        assertFalse(testee.isVoiceChatEnabled())
-    }
-
-    @Test
-    fun `when duck chat disabled and duckAiVoiceSearch enabled then isVoiceChatEnabled returns false`() = runTest {
-        duckChatFeature.self().setRawStoredState(State(enable = false))
-        duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = true))
-        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
-        testee.onPrivacyConfigDownloaded()
-
-        assertFalse(testee.isVoiceChatEnabled())
-    }
-
-    @Test
     fun `when global feature flag and digitalAssistantDuckAiVoiceChat both enabled then allowDuckAiAsDigitalAssistant emits true`() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.digitalAssistantDuckAi().setRawStoredState(State(enable = true))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1439,7 +1439,6 @@ class DuckChatContextualViewModelTest {
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(): Boolean = false
-        override suspend fun isVoiceChatEnabled(): Boolean = true
     }
 
     private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 class FakeDuckChat(
     private var enabled: Boolean = true,
-    private var voiceChatEnabled: Boolean = false,
 ) : DuckChat {
 
     private val openDuckChatCalls = mutableListOf<Unit>()
@@ -42,8 +41,6 @@ class FakeDuckChat(
     var standaloneMigrationCompleted: Boolean = false
 
     override fun isEnabled(): Boolean = enabled
-
-    override suspend fun isVoiceChatEnabled(): Boolean = voiceChatEnabled
 
     override fun openDuckChat() {
         openDuckChatCalls.add(Unit)
@@ -120,9 +117,5 @@ class FakeDuckChat(
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled
-    }
-
-    fun setVoiceChatEnabled(enabled: Boolean) {
-        this.voiceChatEnabled = enabled
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -193,6 +193,4 @@ class FakeDuckChatInternal(
     fun setDuckChatUserEnabled(enabled: Boolean) {
         enableDuckChatUserSetting.value = enabled
     }
-
-    override suspend fun isVoiceChatEnabled(): Boolean = true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214290355497175?focus=true

### Description
See attached task description

### Steps to test this PR

                                                                                                                                                                                                                     
  ### Test Cases                                                                                                                                                                                                   
NOTE: You might need to reset the assistant to force changes to apply

  #### TC1 — All enabled → Duck.ai Voice Chat launches                                                                                                                                                               
  > `digitalAssistantDuckAiVoiceChat` = enabled · Duck.ai = on
  - [ ] Set both feature flags to enabled via internal settings                                                                                                                                                      
  - [ ] Trigger the digital assistant intent                                                                                                                                                                       
  - [ ] Duck.ai voice chat screen opens                                                                                                                                                                              
                                                                                                                                                                                                                   
  #### TC2 — Voice search disabled → Duck.ai Voice Chat launches (NO EFFECT)                                                                                                                                                     
  > `digitalAssistantDuckAiVoiceChat` = enabled · `duckAiVoiceSearch` = **disabled** · Duck.ai = on
  - [ ] Set `duckAiVoiceSearch` to disabled via internal settings                                                                                                                                                    
  - [ ] Trigger the digital assistant intent                                                                                                                                                                         
  - [ ] Duck.ai voice chat screen opens   
                                                                                                                                                                                                                     
  #### TC3 — Duck.ai off → Old system search opens                                                                                                                                                                           
  > `digitalAssistantDuckAiVoiceChat` = enabled · Duck.ai = **off**
  - [ ] Disable Duck.ai in Settings                                                                                                                                                                                  
  - [ ] Trigger the digital assistant intent
  - [ ] System search opens                                                                                                                                                                                    
                                                                                                                                                                                                                   
  #### TC4 — Kill switch → Input tab opens in Search
  > `digitalAssistantDuckAiVoiceChat` = **disabled** · Duck.ai = on
  - [ ] Set `digitalAssistantDuckAiVoiceChat` to disabled via internal settings                                                                                                                                      
  - [ ] Trigger the digital assistant intent
  - [ ] System search opens                     
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the digital-assistant launch decision and removes a public API method from `DuckChat`, which may affect any callers and alters user-facing assistant behavior.
> 
> **Overview**
> Updates digital-assistant handling to **always launch Duck.ai Voice Chat** when `allowDuckAiAsDigitalAssistant` is enabled and Duck.ai is enabled, removing the previous branch that could launch non-voice Duck.ai.
> 
> Removes the `DuckChat.isVoiceChatEnabled()` API (and its `RealDuckChat` implementation), deletes the unused `LaunchDuckAi` command path from system search, and updates fakes/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef618c8f7bee9eae8187d5b7003621fe31b1d01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->