### PR TITLE
Add native input state and view model

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -27,23 +27,21 @@ class NativeInputLayoutCoordinator(
     private val rootView: ViewGroup,
     private val omnibarState: OmnibarState,
 ) {
-    fun isWidgetBottom(): Boolean = omnibarState.isDuckAiMode() || omnibarState.isOmnibarBottom()
-
     private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
 
     private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
 
-    fun buildWidgetLayoutParams(): ViewGroup.LayoutParams {
+    fun buildWidgetLayoutParams(isBottom: Boolean): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
         ).apply {
-            gravity = if (isWidgetBottom()) Gravity.BOTTOM else Gravity.TOP
+            gravity = if (isBottom) Gravity.BOTTOM else Gravity.TOP
         }
     }
 
-    fun applyBottomCardCorners(widgetView: View) {
-        if (!isWidgetBottom()) return
+    fun applyBottomCardCorners(widgetView: View, isBottom: Boolean) {
+        if (!isBottom) return
         val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
         val radius = card.resources.getDimension(R.dimen.extraLargeShapeCornerRadius)
         card.shapeAppearanceModel =
@@ -56,9 +54,9 @@ class NativeInputLayoutCoordinator(
                 .build()
     }
 
-    fun applyBottomCardShape(widgetView: View) {
-        if (!isWidgetBottom()) return
-        applyBottomCardCorners(widgetView)
+    fun applyBottomCardShape(widgetView: View, isBottom: Boolean) {
+        if (!isBottom) return
+        applyBottomCardCorners(widgetView, isBottom)
         val card = widgetView.findViewById<MaterialCardView?>(R.id.inputModeWidgetCard) ?: return
         val params = card.layoutParams as? ViewGroup.MarginLayoutParams ?: return
         params.width = ViewGroup.LayoutParams.MATCH_PARENT
@@ -68,7 +66,7 @@ class NativeInputLayoutCoordinator(
         card.layoutParams = params
     }
 
-    fun configureAutocompleteLayout(widgetView: View) {
+    fun configureAutocompleteLayout(widgetView: View, isBottom: Boolean) {
         val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
         val focusedView = rootView.findViewById<View?>(R.id.focusedView)
         val baseElevation = maxOf(autoCompleteList.elevation, focusedView?.elevation ?: 0f)
@@ -93,7 +91,6 @@ class NativeInputLayoutCoordinator(
         }
 
         fun applyForWidgetPosition() {
-            val isBottom = isWidgetBottom()
             val topOffset = if (isBottom) 0 else maxOf(0, widgetView.bottom - autoCompleteList.top)
             val bottomOffset = if (isBottom) maxOf(0, autoCompleteList.bottom - widgetView.top) else 0
             applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
@@ -122,7 +119,7 @@ class NativeInputLayoutCoordinator(
         )
     }
 
-    fun configureContentOffset(widgetView: View) {
+    fun configureContentOffset(widgetView: View, isBottom: Boolean) {
         data class Target(val view: View, val basePadding: Padding)
         val newTabContent =
             rootView.findViewById<View?>(R.id.newTabPage)
@@ -151,13 +148,13 @@ class NativeInputLayoutCoordinator(
                 rootView.findViewById<View?>(R.id.ddgLogo)?.visibility == View.VISIBLE
         }
 
-        fun computeDeltaTop(view: View, isBottom: Boolean, anchorBottomInWindow: Int): Int {
+        fun computeDeltaTop(view: View, anchorBottomInWindow: Int): Int {
             if (isBottom || isLogoVisible(view)) return 0
             val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
             return maxOf(0, anchorBottomInWindow - viewLocation[1])
         }
 
-        fun computeDeltaBottom(isBottom: Boolean): Int {
+        fun computeDeltaBottom(): Int {
             if (!isBottom) return 0
             return if (omnibarState.isOmnibarBottom()) {
                 maxOf(0, overlap)
@@ -171,12 +168,11 @@ class NativeInputLayoutCoordinator(
                 targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
                 return
             }
-            val isBottom = isWidgetBottom()
             val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
             val anchorBottomInWindow = anchorLocation[1] + anchor.height
-            val deltaBottom = computeDeltaBottom(isBottom)
+            val deltaBottom = computeDeltaBottom()
             targets.forEach { target ->
-                val deltaTop = computeDeltaTop(target.view, isBottom, anchorBottomInWindow)
+                val deltaTop = computeDeltaTop(target.view, anchorBottomInWindow)
                 applyPadding(target.view, target.basePadding, deltaTop, deltaBottom)
             }
         }
@@ -204,8 +200,8 @@ class NativeInputLayoutCoordinator(
         )
     }
 
-    fun applyForcedBottomTranslation(widgetView: View) {
-        val shouldForce = isWidgetBottom() && !omnibarState.isOmnibarBottom()
+    fun applyForcedBottomTranslation(widgetView: View, isBottom: Boolean) {
+        val shouldForce = isBottom && !omnibarState.isOmnibarBottom()
         if (!shouldForce) {
             widgetView.translationY = 0f
             return

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -161,9 +161,10 @@ class RealNativeInputManager @Inject constructor(
         val card = widgetView.findViewById<View?>(R.id.inputModeWidgetCard)
         val omnibarCard = omnibarController.getCardView()
 
+        val isBottom = widgetFrom(widgetView)?.isWidgetBottom() ?: false
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
-            animator.animateExit(card, widgetView, omnibarCard, layoutCoordinator.isWidgetBottom()) {
+            animator.animateExit(card, widgetView, omnibarCard, isBottom) {
                 isExiting = false
                 onHide()
             }
@@ -284,9 +285,10 @@ class RealNativeInputManager @Inject constructor(
             omnibarController.show()
             omnibarController.hideBackground()
         }
-        val widgetView = createWidgetView(layoutInflater)
+        val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
+        val widgetView = createWidgetView(layoutInflater, isBottom)
         val prefillText = query.ifEmpty { omnibarController.getText() }
-        bindWidget(widgetView, lifecycleOwner, tabs, callbacks)
+        bindWidget(widgetView, lifecycleOwner, tabs, callbacks, isBottom)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             callbacks.onClearAutocomplete()
             widgetFrom(widgetView)?.apply {
@@ -294,7 +296,7 @@ class RealNativeInputManager @Inject constructor(
                 selectAllText()
             }
         }
-        attachWidget(widgetView)
+        attachWidget(widgetView, isBottom)
         if (omnibarController.isDuckAiMode()) {
             widgetFrom(widgetView)?.setToggleVisible(false)
         } else {
@@ -386,9 +388,9 @@ class RealNativeInputManager @Inject constructor(
         return removed
     }
 
-    private fun createWidgetView(layoutInflater: LayoutInflater): View {
+    private fun createWidgetView(layoutInflater: LayoutInflater, isBottom: Boolean): View {
         val layoutRes =
-            if (layoutCoordinator.isWidgetBottom()) {
+            if (isBottom) {
                 R.layout.input_mode_widget_card_view_bottom
             } else {
                 R.layout.input_mode_widget_card_view
@@ -401,6 +403,7 @@ class RealNativeInputManager @Inject constructor(
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
         callbacks: NativeInputCallbacks,
+        isBottom: Boolean,
     ) {
         widgetFrom(widgetView)?.apply {
             onStopTapped = callbacks.onStopTapped
@@ -411,7 +414,7 @@ class RealNativeInputManager @Inject constructor(
                 val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
                 omnibarController.updateTierTitle(tier) { launchUpgrade() }
             }
-            if (!layoutCoordinator.isWidgetBottom()) {
+            if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())
             }
         }
@@ -420,7 +423,7 @@ class RealNativeInputManager @Inject constructor(
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         bindVoiceButtons(widgetView, callbacks)
-        layoutCoordinator.applyBottomCardShape(widgetView)
+        layoutCoordinator.applyBottomCardShape(widgetView, isBottom)
     }
 
     private fun bindVoiceButtons(
@@ -489,46 +492,47 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun attachWidget(widgetView: View) {
+    private fun attachWidget(widgetView: View, isBottom: Boolean) {
         widgetFrom(widgetView)?.setNativeInputState(
             toggleVisible = duckChat.isEnabled() && isInputScreenUserSettingEnabled,
         )
 
-        rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams())
+        rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom))
         widgetRoot = widgetView
 
         widgetFrom(widgetView)?.apply {
             setWidgetRootView(widgetView)
             setDuckAiMode(omnibarController.isDuckAiMode())
-            applyOmnibarShape(layoutCoordinator.isWidgetBottom())
+            setWidgetPosition(isBottom)
+            applyOmnibarShape()
         }
 
-        applyWindowChrome(widgetView)
+        applyWindowChrome(widgetView, isBottom)
 
-        if (!startEnterAnimation(widgetView)) {
-            animator.applyLayoutTransitions(widgetView, layoutCoordinator.isWidgetBottom())
+        if (!startEnterAnimation(widgetView, isBottom)) {
+            animator.applyLayoutTransitions(widgetView, isBottom)
             onEnterComplete(widgetView)
         }
     }
 
-    private fun applyWindowChrome(widgetView: View) {
+    private fun applyWindowChrome(widgetView: View, isBottom: Boolean) {
         widgetView.translationZ = WIDGET_ELEVATION_DP.toPx()
-        if (layoutCoordinator.isWidgetBottom()) {
+        if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
             rootView.findViewById<View?>(R.id.browserLayout)?.let {
                 it.setPadding(it.paddingLeft, it.paddingTop, it.paddingRight, 0)
             }
         }
-        layoutCoordinator.configureAutocompleteLayout(widgetView)
-        layoutCoordinator.configureContentOffset(widgetView)
-        widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView) }
+        layoutCoordinator.configureAutocompleteLayout(widgetView, isBottom)
+        layoutCoordinator.configureContentOffset(widgetView, isBottom)
+        widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView, isBottom) }
     }
 
-    private fun startEnterAnimation(widgetView: View): Boolean {
+    private fun startEnterAnimation(widgetView: View, isBottom: Boolean): Boolean {
         if (omnibarController.isDuckAiMode()) return false
         val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return false
         val omnibarCard = omnibarController.getCardView() ?: return false
-        val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, layoutCoordinator.isWidgetBottom())
+        val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 
         animator.animateEnter(widgetCard, omnibarCard, widgetView, margins) { onEnterComplete(widgetView) }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -494,9 +494,7 @@ class RealNativeInputManager @Inject constructor(
 
         widgetFrom(widgetView)?.apply {
             setWidgetRootView(widgetView)
-            setDuckAiMode(omnibarController.isDuckAiMode())
-            setWidgetPosition(isBottom)
-            applyOmnibarShape()
+            configure(isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
         applyWindowChrome(widgetView, isBottom)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -93,7 +93,6 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var rootView: ViewGroup
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
-    private var isInputScreenUserSettingEnabled: Boolean = false
     private var isExiting: Boolean = false
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
@@ -116,9 +115,6 @@ class RealNativeInputManager @Inject constructor(
                 if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
                 isNativeInputFieldEnabled = isEnabled
             }
-            .launchIn(lifecycleOwner.lifecycleScope)
-        duckChat.observeInputScreenUserSettingEnabled()
-            .onEach { isInputScreenUserSettingEnabled = it }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 
@@ -493,10 +489,6 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun attachWidget(widgetView: View, isBottom: Boolean) {
-        widgetFrom(widgetView)?.setNativeInputState(
-            toggleVisible = duckChat.isEnabled() && isInputScreenUserSettingEnabled,
-        )
-
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom))
         widgetRoot = widgetView
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -419,7 +419,6 @@ class RealNativeInputManager @Inject constructor(
         bindAutocompleteVisibility(widgetView)
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
-        applyInitialTabSelection(widgetView)
         bindVoiceButtons(widgetView, callbacks)
         layoutCoordinator.applyBottomCardShape(widgetView)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -96,6 +96,7 @@ class RealNativeInputManager @Inject constructor(
     private var isInputScreenUserSettingEnabled: Boolean = false
     private var isExiting: Boolean = false
     private var floatingSubmitContainer: View? = null
+    private var widgetRoot: View? = null
 
     private fun widgetFrom(widgetView: View): NativeInputWidget? {
         return widgetView.findViewById<View?>(R.id.inputModeWidget) as? NativeInputWidget
@@ -117,12 +118,7 @@ class RealNativeInputManager @Inject constructor(
             }
             .launchIn(lifecycleOwner.lifecycleScope)
         duckChat.observeInputScreenUserSettingEnabled()
-            .onEach { enabled ->
-                isInputScreenUserSettingEnabled = enabled
-                if (omnibarController.isDuckAiMode()) {
-                    rootView.post { widgetFrom(rootView)?.selectChatTab() }
-                }
-            }
+            .onEach { isInputScreenUserSettingEnabled = it }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 
@@ -209,7 +205,7 @@ class RealNativeInputManager @Inject constructor(
         if (!isNativeInputFieldEnabled) return
         if (isExiting) return
         val widget = widgetFrom(rootView) ?: return
-        val widgetRoot = widget.asView().parent?.parent as? View
+        val widgetRoot = widgetRoot
 
         if (omnibarController.isDuckAiMode()) {
             widget.setToggleVisible(isVisible)
@@ -300,10 +296,7 @@ class RealNativeInputManager @Inject constructor(
         }
         attachWidget(widgetView)
         if (omnibarController.isDuckAiMode()) {
-            widgetFrom(widgetView)?.apply {
-                setToggleVisible(false)
-                selectChatTab()
-            }
+            widgetFrom(widgetView)?.setToggleVisible(false)
         } else {
             showNtp()
         }
@@ -389,6 +382,7 @@ class RealNativeInputManager @Inject constructor(
             (it.parent as? ViewGroup)?.removeView(it)
             floatingSubmitContainer = null
         }
+        if (removed) widgetRoot = null
         return removed
     }
 
@@ -482,11 +476,6 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyInitialTabSelection(widgetView: View) {
-        if (!omnibarController.isDuckAiMode()) return
-        widgetFrom(widgetView)?.selectChatTab()
-    }
-
     private fun bindAutocompleteVisibility(widgetView: View) {
         if (!omnibarController.isDuckAiMode()) return
         val widget = widgetFrom(widgetView) ?: return
@@ -502,19 +491,28 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun attachWidget(widgetView: View) {
-        val omnibarCard = omnibarController.getCardView()
-        val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard)
-        if (shouldMatchOmnibarShape() && !layoutCoordinator.isWidgetBottom()) {
-            matchOmnibarShape(widgetCard)
-        }
-        addTrailingButtonMargin(widgetView)
-        val margins = if (!omnibarController.isDuckAiMode() && omnibarCard != null && widgetCard != null) {
-            animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, layoutCoordinator.isWidgetBottom())
-        } else {
-            null
-        }
+        widgetFrom(widgetView)?.setNativeInputState(
+            toggleVisible = duckChat.isEnabled() && isInputScreenUserSettingEnabled,
+        )
 
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams())
+        widgetRoot = widgetView
+
+        widgetFrom(widgetView)?.apply {
+            setWidgetRootView(widgetView)
+            setDuckAiMode(omnibarController.isDuckAiMode())
+            applyOmnibarShape(layoutCoordinator.isWidgetBottom())
+        }
+
+        applyWindowChrome(widgetView)
+
+        if (!startEnterAnimation(widgetView)) {
+            animator.applyLayoutTransitions(widgetView, layoutCoordinator.isWidgetBottom())
+            onEnterComplete(widgetView)
+        }
+    }
+
+    private fun applyWindowChrome(widgetView: View) {
         widgetView.translationZ = WIDGET_ELEVATION_DP.toPx()
         if (layoutCoordinator.isWidgetBottom()) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
@@ -525,21 +523,23 @@ class RealNativeInputManager @Inject constructor(
         layoutCoordinator.configureAutocompleteLayout(widgetView)
         layoutCoordinator.configureContentOffset(widgetView)
         widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView) }
+    }
 
-        if (widgetCard != null && omnibarCard != null && margins != null) {
-            animator.animateEnter(widgetCard, omnibarCard, widgetView, margins) {
-                if (!omnibarController.isDuckAiMode()) {
-                    omnibarController.hide()
-                    widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
-                }
-            }
-        } else {
-            animator.applyLayoutTransitions(widgetView, layoutCoordinator.isWidgetBottom())
-            if (!omnibarController.isDuckAiMode()) {
-                omnibarController.hide()
-                widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
-            }
-        }
+    private fun startEnterAnimation(widgetView: View): Boolean {
+        if (omnibarController.isDuckAiMode()) return false
+        val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return false
+        val omnibarCard = omnibarController.getCardView() ?: return false
+        val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, layoutCoordinator.isWidgetBottom())
+            ?: return false
+
+        animator.animateEnter(widgetCard, omnibarCard, widgetView, margins) { onEnterComplete(widgetView) }
+        return true
+    }
+
+    private fun onEnterComplete(widgetView: View) {
+        if (omnibarController.isDuckAiMode()) return
+        omnibarController.hide()
+        widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
     }
 
     private fun bindChatSuggestions(
@@ -578,32 +578,6 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
         )
-    }
-
-    private fun shouldMatchOmnibarShape(): Boolean = !duckChat.isEnabled() || !isInputScreenUserSettingEnabled
-
-    private fun matchOmnibarShape(widgetCard: View?) {
-        val card = widgetCard as? MaterialCardView ?: return
-        card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
-        val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
-        val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
-        (card.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
-            lp.topMargin = targetTopMargin - card.paddingTop
-            lp.marginStart = targetHorizontalMargin - card.paddingLeft
-            lp.marginEnd = targetHorizontalMargin - card.paddingRight
-            card.layoutParams = lp
-        }
-    }
-
-    private fun addTrailingButtonMargin(widgetView: View) {
-        val layout = widgetView.findViewById<View?>(com.duckduckgo.duckchat.impl.R.id.inputModeWidgetLayout) ?: return
-        val targetMarginEnd = layout.resources.getDimensionPixelSize(
-            com.duckduckgo.duckchat.impl.R.dimen.inputScreenOmnibarCardMarginHorizontal,
-        )
-        (layout.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
-            lp.marginEnd = targetMarginEnd
-            layout.layoutParams = lp
-        }
     }
 
     private fun createFloatingSubmitContainer(): ViewGroup {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -29,30 +29,26 @@ import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Space
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.ChatState
-import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
-import com.duckduckgo.subscriptions.api.Product
-import com.duckduckgo.subscriptions.api.Subscriptions
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.Job
@@ -93,6 +89,10 @@ interface NativeInputWidget {
     fun getSelectedModelId(): String?
     fun isModelMenuVisible(): Boolean
     fun storePendingPrompt(query: String)
+    fun setDuckAiMode(isDuckAiMode: Boolean)
+    fun setNativeInputState(toggleVisible: Boolean)
+    fun applyOmnibarShape(isBottom: Boolean)
+    fun setWidgetRootView(view: View)
 
     fun bindInputEvents(
         onSearchTextChanged: (String) -> Unit,
@@ -123,16 +123,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
 ) : InputModeWidget(context, attrs, defStyle), NativeInputWidget {
 
     @Inject
-    lateinit var duckChatInternal: DuckChatInternal
+    lateinit var viewModelFactory: ViewViewModelFactory
 
-    @Inject
-    lateinit var chatSuggestionsReader: ChatSuggestionsReader
-
-    @Inject
-    lateinit var subscriptions: Subscriptions
-
-    @Inject
-    lateinit var pendingNativePromptStore: PendingNativePromptStore
+    private val viewModel: NativeInputModeWidgetViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[NativeInputModeWidgetViewModel::class.java]
+    }
 
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
@@ -142,15 +137,19 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var chatSuggestionsSettingJob: Job? = null
     private var chatSuggestionsJob: Job? = null
     private var tierJob: Job? = null
-    private var inputScreenSettingJob: Job? = null
+    private var nativeInputStateJob: Job? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
-    private var isInputScreenUserSettingEnabled: Boolean = false
+    private var nativeInputState: NativeInputState = NativeInputState(
+        inputMode = NativeInputState.InputMode.SEARCH_ONLY,
+        inputContext = NativeInputState.InputContext.BROWSER,
+    )
     private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
     private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     private var voiceSearchAvailable: Boolean = false
     private var voiceChatAvailable: Boolean = false
+    private var widgetRoot: View? = null
     override var onStopTapped: (() -> Unit)? = null
     override var onImageClick: (() -> Unit)? = null
     override var onVoiceSearchClick: (() -> Unit)? = null
@@ -185,7 +184,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
-        observeInputScreenUserSetting()
+        observeNativeInputState()
         if (onPaidTierChanged != null) observeTier()
     }
 
@@ -197,16 +196,21 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsSettingJob = null
         tierJob?.cancel()
         tierJob = null
-        inputScreenSettingJob?.cancel()
-        inputScreenSettingJob = null
+        nativeInputStateJob?.cancel()
+        nativeInputStateJob = null
+        widgetRoot = null
         tearDownChatSuggestions()
+    }
+
+    override fun setWidgetRootView(view: View) {
+        widgetRoot = view
     }
 
     private fun observeChatState() {
         var isFocussed = false
 
         chatStateJob?.cancel()
-        chatStateJob = duckChatInternal.chatState
+        chatStateJob = viewModel.chatState
             .drop(1)
             .onEach { state ->
                 setChatStreaming(state == ChatState.STREAMING || state == ChatState.LOADING)
@@ -233,22 +237,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 
-    private val widgetRoot: View?
-        get() {
-            var v: View? = this
-            while (v != null) {
-                val p = v.parent
-                if (p is androidx.coordinatorlayout.widget.CoordinatorLayout) return v
-                v = p as? View
-            }
-            return null
-        }
-
     private fun applyNativeStyling() {
         setBackgroundColor(Color.TRANSPARENT)
         hideBackArrow()
         hideInputFieldBackground()
         removeMargins()
+        applyTrailingButtonMargin()
         prepareSubmitButtons()
         configureMainButtonsVisibility()
         inputField.doOnTextChanged { text, _, _, _ ->
@@ -282,26 +276,53 @@ class NativeInputModeWidget @JvmOverloads constructor(
         submitButtons?.setSendButtonVisible(visible)
     }
 
-    private fun applyToggleVisibility() {
+    private fun applyState(state: NativeInputState) {
+        val previousState = nativeInputState
+        nativeInputState = state
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        when {
-            !duckChatInternal.isEnabled() -> {
-                hideToggle()
-                matchOmnibarHeight()
-            }
-            !isInputScreenUserSettingEnabled -> {
-                setToggleMatchParent()
-                hideToggle()
-                matchOmnibarHeight()
-            }
-            else -> {
-                setToggleMatchParent()
-                toggle.visibility = VISIBLE
-            }
+        setToggleMatchParent()
+        if (state.toggleVisible != previousState.toggleVisible) {
+            updateToggleVisibility(toggle, state)
+        }
+        if (!state.toggleVisible) {
+            minimize()
         }
     }
 
-    private fun shouldShowToggle(): Boolean = duckChatInternal.isEnabled() && isInputScreenUserSettingEnabled
+    override fun setNativeInputState(toggleVisible: Boolean) {
+        val initialMode = if (toggleVisible) {
+            NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        } else {
+            NativeInputState.InputMode.SEARCH_ONLY
+        }
+        nativeInputState = nativeInputState.copy(inputMode = initialMode)
+        findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { updateToggleVisibility(it, nativeInputState) }
+        if (!toggleVisible) {
+            minimize()
+        }
+    }
+
+    private fun updateSelectedTab(toggle: TabLayout, state: NativeInputState) {
+        val targetIndex = if (state.defaultToggleSelection == NativeInputState.ToggleSelection.DUCK_AI) 1 else 0
+        if (toggle.selectedTabPosition != targetIndex) {
+            toggle.getTabAt(targetIndex)?.select()
+        }
+    }
+
+    private fun updateToggleVisibility(toggle: TabLayout, state: NativeInputState) {
+        if (!state.toggleVisible) {
+            updateSelectedTab(toggle, state)
+        }
+        toggle.visibility = if (state.toggleVisible) VISIBLE else GONE
+    }
+
+    private fun minimize() {
+        if (floatingSubmitContainer == null) return
+        findViewById<Space?>(R.id.spacer)?.updateLayoutParams<LayoutParams> { height = 0 }
+        findViewById<Space?>(R.id.bottomSpacer)?.updateLayoutParams<LayoutParams> { height = 0 }
+        findViewById<View?>(R.id.inputModeWidgetLayout)?.updateLayoutParams<MarginLayoutParams> { topMargin = 0 }
+        getActionBarSize()?.let { minimumHeight = it }
+    }
 
     private fun removeMargins() {
         findViewById<EditText?>(R.id.inputField)?.updateLayoutParams<MarginLayoutParams> {
@@ -309,6 +330,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer)?.updateLayoutParams<MarginLayoutParams> {
             marginEnd = 0
+        }
+    }
+
+    private fun applyTrailingButtonMargin() {
+        findViewById<View?>(R.id.inputModeWidgetLayout)?.updateLayoutParams<MarginLayoutParams> {
+            marginEnd = resources.getDimensionPixelSize(R.dimen.inputScreenOmnibarCardMarginHorizontal)
         }
     }
 
@@ -331,20 +358,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             elevation = 0f
             outlineProvider = null
         }
-    }
-
-    private fun hideToggle() {
-        val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        toggle.getTabAt(0)?.select()
-        toggle.visibility = GONE
-    }
-
-    private fun matchOmnibarHeight() {
-        if (floatingSubmitContainer == null) return
-        findViewById<Space?>(R.id.spacer)?.updateLayoutParams<LayoutParams> { height = 0 }
-        findViewById<Space?>(R.id.bottomSpacer)?.updateLayoutParams<LayoutParams> { height = 0 }
-        findViewById<View?>(R.id.inputModeWidgetLayout)?.updateLayoutParams<MarginLayoutParams> { topMargin = 0 }
-        getActionBarSize()?.let { minimumHeight = it }
     }
 
     private fun getActionBarSize(): Int? {
@@ -426,7 +439,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun setToggleVisible(visible: Boolean) {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
-        val isVisible = visible && shouldShowToggle()
+        val isVisible = visible && nativeInputState.toggleVisible
         suspendLayoutTransitions {
             toggle.visibility = if (isVisible) VISIBLE else GONE
         }
@@ -448,7 +461,27 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun storePendingPrompt(query: String) {
         // TODO: This should not be the widget's responsibility
-        pendingNativePromptStore.store(query, getSelectedModelId())
+        viewModel.storePendingPrompt(query, getSelectedModelId())
+    }
+
+    override fun setDuckAiMode(isDuckAiMode: Boolean) {
+        viewModel.setDuckAiMode(isDuckAiMode)
+        if (isDuckAiMode) selectChatTab()
+    }
+
+    override fun applyOmnibarShape(isBottom: Boolean) {
+        if (isBottom) return
+        if (nativeInputState.toggleVisible) return
+        val card = parent as? MaterialCardView ?: return
+        card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
+        val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
+        val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+        (card.layoutParams as? MarginLayoutParams)?.let { lp ->
+            lp.topMargin = targetTopMargin - card.paddingTop
+            lp.marginStart = targetHorizontalMargin - card.paddingLeft
+            lp.marginEnd = targetHorizontalMargin - card.paddingRight
+            card.layoutParams = lp
+        }
     }
 
     override fun bindInputEvents(
@@ -490,7 +523,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         this.onClearSuggestions = onClearSuggestions
 
         val adapter = ChatSuggestionsAdapter { suggestion ->
-            onChatSuggestionSelected(buildChatUrl(suggestion))
+            onChatSuggestionSelected(viewModel.buildChatSuggestionUrl(suggestion))
         }.also { chatSuggestionsAdapter = it }
 
         fun showSuggestions(query: String) {
@@ -533,28 +566,23 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun observeChatSuggestionsEnabled() {
         chatSuggestionsSettingJob?.cancel()
-        chatSuggestionsSettingJob = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
+        chatSuggestionsSettingJob = viewModel.chatSuggestionsUserEnabled
             .onEach { enabled -> chatSuggestionsUserEnabled = enabled }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 
-    private fun observeInputScreenUserSetting() {
-        inputScreenSettingJob?.cancel()
-        inputScreenSettingJob = duckChatInternal.observeInputScreenUserSettingEnabled()
-            .onEach { enabled ->
-                isInputScreenUserSettingEnabled = enabled
-                applyToggleVisibility()
-            }
-            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    private fun observeNativeInputState() {
+        nativeInputStateJob?.cancel()
+        val lifecycleOwner = findViewTreeLifecycleOwner() ?: return
+        nativeInputStateJob = viewModel.state
+            .onEach(::applyState)
+            .launchIn(lifecycleOwner.lifecycleScope)
     }
 
     private fun observeTier() {
         tierJob?.cancel()
-        tierJob = subscriptions.getEntitlementStatus()
-            .onEach { entitlements ->
-                val hasDuckAiPlus = entitlements.any { it == Product.DuckAiPlus }
-                onPaidTierChanged?.invoke(hasDuckAiPlus)
-            }
+        tierJob = viewModel.isPaidTier
+            .onEach { hasDuckAiPlus -> onPaidTierChanged?.invoke(hasDuckAiPlus) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 
@@ -565,7 +593,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     ) {
         chatSuggestionsJob?.cancel()
         chatSuggestionsJob = lifecycleOwner.lifecycleScope.launch {
-            val suggestions = runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+            val suggestions = viewModel.fetchChatSuggestions(query)
             if (suggestions.isNotEmpty()) {
                 onShowSuggestions?.invoke(adapter)
             }
@@ -579,17 +607,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun hideChatSuggestions(hideList: Boolean) {
         chatSuggestionsJob?.cancel()
         chatSuggestionsAdapter?.submitList(emptyList())
-        chatSuggestionsReader.tearDown()
+        viewModel.cancelChatSuggestions()
         onClearSuggestions?.invoke(hideList)
-    }
-
-    private fun buildChatUrl(suggestion: ChatSuggestion): String {
-        return duckChatInternal.getDuckChatUrl("", false)
-            .toUri()
-            .buildUpon()
-            .appendQueryParameter(CHAT_ID_PARAM, suggestion.chatId)
-            .build()
-            .toString()
     }
 
     private fun setChatStreaming(streaming: Boolean) {
@@ -651,7 +670,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     companion object {
-        private const val CHAT_ID_PARAM = "chatID"
         private const val MAX_LINES = 5
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -91,7 +91,6 @@ interface NativeInputWidget {
     fun setDuckAiMode(isDuckAiMode: Boolean)
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
-    fun setNativeInputState(toggleVisible: Boolean)
     fun applyOmnibarShape()
     fun setWidgetRootView(view: View)
 
@@ -278,27 +277,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyState(state: NativeInputState) {
-        val previousState = nativeInputState
         nativeInputState = state
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         setToggleMatchParent()
-        if (state.toggleVisible != previousState.toggleVisible) {
-            updateToggleVisibility(toggle, state)
-        }
+        updateToggleVisibility(toggle, state)
         if (!state.toggleVisible) {
-            minimize()
-        }
-    }
-
-    override fun setNativeInputState(toggleVisible: Boolean) {
-        val initialMode = if (toggleVisible) {
-            NativeInputState.InputMode.SEARCH_AND_DUCK_AI
-        } else {
-            NativeInputState.InputMode.SEARCH_ONLY
-        }
-        nativeInputState = nativeInputState.copy(inputMode = initialMode)
-        findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { updateToggleVisibility(it, nativeInputState) }
-        if (!toggleVisible) {
             minimize()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -84,14 +84,15 @@ interface NativeInputWidget {
     fun submitMessage(message: String?)
     fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
-    fun setBrowserMenuHighlightVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
     fun isModelMenuVisible(): Boolean
     fun storePendingPrompt(query: String)
     fun setDuckAiMode(isDuckAiMode: Boolean)
+    fun isWidgetBottom(): Boolean
+    fun setWidgetPosition(isBottom: Boolean)
     fun setNativeInputState(toggleVisible: Boolean)
-    fun applyOmnibarShape(isBottom: Boolean)
+    fun applyOmnibarShape()
     fun setWidgetRootView(view: View)
 
     fun bindInputEvents(
@@ -469,8 +470,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         if (isDuckAiMode) selectChatTab()
     }
 
-    override fun applyOmnibarShape(isBottom: Boolean) {
-        if (isBottom) return
+    override fun isWidgetBottom(): Boolean = nativeInputState.isBottom
+
+    override fun setWidgetPosition(isBottom: Boolean) {
+        val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
+        nativeInputState = nativeInputState.copy(inputPosition = position)
+        viewModel.setWidgetPosition(isBottom)
+    }
+
+    override fun applyOmnibarShape() {
+        if (nativeInputState.isBottom) return
         if (nativeInputState.toggleVisible) return
         val card = parent as? MaterialCardView ?: return
         card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -450,6 +450,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun setDuckAiMode(isDuckAiMode: Boolean) {
         viewModel.setDuckAiMode(isDuckAiMode)
+        viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
         if (isDuckAiMode) selectChatTab()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -88,10 +88,9 @@ interface NativeInputWidget {
     fun getSelectedModelId(): String?
     fun isModelMenuVisible(): Boolean
     fun storePendingPrompt(query: String)
-    fun setDuckAiMode(isDuckAiMode: Boolean)
+    fun configure(isDuckAiMode: Boolean, isBottom: Boolean)
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
-    fun applyOmnibarShape()
     fun setWidgetRootView(view: View)
 
     fun bindInputEvents(
@@ -448,22 +447,21 @@ class NativeInputModeWidget @JvmOverloads constructor(
         viewModel.storePendingPrompt(query, getSelectedModelId())
     }
 
-    override fun setDuckAiMode(isDuckAiMode: Boolean) {
-        viewModel.setDuckAiMode(isDuckAiMode)
+    override fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {
+        viewModel.configure(isDuckAiMode, isBottom)
         viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
         if (isDuckAiMode) selectChatTab()
+        applyOmnibarShape(isBottom)
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState.isBottom
 
     override fun setWidgetPosition(isBottom: Boolean) {
-        val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
-        nativeInputState = nativeInputState.copy(inputPosition = position)
         viewModel.setWidgetPosition(isBottom)
     }
 
-    override fun applyOmnibarShape() {
-        if (nativeInputState.isBottom) return
+    private fun applyOmnibarShape(isBottom: Boolean) {
+        if (isBottom) return
         if (nativeInputState.toggleVisible) return
         val card = parent as? MaterialCardView ?: return
         card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -49,16 +49,19 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val inputContext = MutableStateFlow(NativeInputState.InputContext.BROWSER)
+    private val inputPosition = MutableStateFlow(NativeInputState.InputPosition.TOP)
 
     val state: SharedFlow<NativeInputState> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
         inputContext,
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, context ->
+        inputPosition,
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, context, position ->
         NativeInputState(
             inputMode = getInputMode(isFeatureEnabled && isUserEnabled, isInputScreenUserSettingEnabled),
             inputContext = context,
+            inputPosition = position,
         )
     }.shareIn(
         scope = viewModelScope,
@@ -75,6 +78,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun setDuckAiMode(isDuckAiMode: Boolean) {
         inputContext.value = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
+    }
+
+    fun setWidgetPosition(isBottom: Boolean) {
+        inputPosition.value = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
     }
 
     fun storePendingPrompt(query: String, modelId: String?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import androidx.core.net.toUri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.impl.ChatState
+import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class NativeInputModeWidgetViewModel @Inject constructor(
+    private val duckChatInternal: DuckChatInternal,
+    duckAiFeatureState: DuckAiFeatureState,
+    subscriptions: Subscriptions,
+    private val pendingNativePromptStore: PendingNativePromptStore,
+    private val chatSuggestionsReader: ChatSuggestionsReader,
+) : ViewModel() {
+
+    private val inputContext = MutableStateFlow(NativeInputState.InputContext.BROWSER)
+
+    val state: SharedFlow<NativeInputState> = combine(
+        duckAiFeatureState.showSettings,
+        duckChatInternal.observeEnableDuckChatUserSetting(),
+        duckChatInternal.observeInputScreenUserSettingEnabled(),
+        inputContext,
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, context ->
+        NativeInputState(
+            inputMode = getInputMode(isFeatureEnabled && isUserEnabled, isInputScreenUserSettingEnabled),
+            inputContext = context,
+        )
+    }.shareIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        replay = 1,
+    )
+
+    val chatState: Flow<ChatState> = duckChatInternal.chatState
+
+    val isPaidTier: Flow<Boolean> = subscriptions.getEntitlementStatus()
+        .map { entitlements -> entitlements.any { it == Product.DuckAiPlus } }
+
+    val chatSuggestionsUserEnabled: Flow<Boolean> = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
+
+    fun setDuckAiMode(isDuckAiMode: Boolean) {
+        inputContext.value = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
+    }
+
+    fun storePendingPrompt(query: String, modelId: String?) {
+        pendingNativePromptStore.store(query, modelId)
+    }
+
+    suspend fun fetchChatSuggestions(query: String): List<ChatSuggestion> =
+        runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+
+    fun cancelChatSuggestions() {
+        chatSuggestionsReader.tearDown()
+    }
+
+    fun buildChatSuggestionUrl(suggestion: ChatSuggestion): String =
+        duckChatInternal.getDuckChatUrl("", false)
+            .toUri()
+            .buildUpon()
+            .appendQueryParameter(CHAT_ID_PARAM, suggestion.chatId)
+            .build()
+            .toString()
+
+    private fun getInputMode(
+        isEnabled: Boolean,
+        isInputScreenUserSettingEnabled: Boolean,
+    ): NativeInputState.InputMode =
+        if (isEnabled && isInputScreenUserSettingEnabled) {
+            NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        } else {
+            NativeInputState.InputMode.SEARCH_ONLY
+        }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @ContributesViewModel(ViewScope::class)
@@ -48,20 +49,23 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val chatSuggestionsReader: ChatSuggestionsReader,
 ) : ViewModel() {
 
-    private val inputContext = MutableStateFlow(NativeInputState.InputContext.BROWSER)
-    private val inputPosition = MutableStateFlow(NativeInputState.InputPosition.TOP)
+    private data class WidgetConfig(
+        val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
+        val inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP,
+    )
+
+    private val widgetConfig = MutableStateFlow(WidgetConfig())
 
     val state: SharedFlow<NativeInputState> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
-        inputContext,
-        inputPosition,
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, context, position ->
+        widgetConfig,
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, config ->
         NativeInputState(
             inputMode = getInputMode(isFeatureEnabled && isUserEnabled, isInputScreenUserSettingEnabled),
-            inputContext = context,
-            inputPosition = position,
+            inputContext = config.inputContext,
+            inputPosition = config.inputPosition,
         )
     }.shareIn(
         scope = viewModelScope,
@@ -77,11 +81,19 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     val chatSuggestionsUserEnabled: Flow<Boolean> = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
 
     fun setDuckAiMode(isDuckAiMode: Boolean) {
-        inputContext.value = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
+        val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
+        widgetConfig.update { it.copy(inputContext = context) }
     }
 
     fun setWidgetPosition(isBottom: Boolean) {
-        inputPosition.value = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
+        val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
+        widgetConfig.update { it.copy(inputPosition = position) }
+    }
+
+    fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {
+        val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
+        val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
+        widgetConfig.value = WidgetConfig(inputContext = context, inputPosition = position)
     }
 
     fun storePendingPrompt(query: String, modelId: String?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+data class NativeInputState(
+    val inputMode: InputMode,
+    val inputContext: InputContext,
+) {
+    enum class InputMode {
+        SEARCH_AND_DUCK_AI,
+        SEARCH_ONLY,
+    }
+
+    enum class InputContext { BROWSER, DUCK_AI }
+
+    enum class ToggleSelection { SEARCH, DUCK_AI }
+
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI
+
+    val defaultToggleSelection: ToggleSelection get() =
+        if (inputContext == InputContext.DUCK_AI) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.ui
 data class NativeInputState(
     val inputMode: InputMode,
     val inputContext: InputContext,
+    val inputPosition: InputPosition = InputPosition.TOP,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,
@@ -29,7 +30,11 @@ data class NativeInputState(
 
     enum class ToggleSelection { SEARCH, DUCK_AI }
 
+    enum class InputPosition { TOP, BOTTOM }
+
     val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI
+
+    val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
     val defaultToggleSelection: ToggleSelection get() =
         if (inputContext == InputContext.DUCK_AI) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -204,6 +204,49 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenInitialPositionThenTop() = runTest {
+        assertEquals(NativeInputState.InputPosition.TOP, testee.state.firstOrNull()!!.inputPosition)
+    }
+
+    @Test
+    fun whenSetInputPositionBottomThenPositionIsBottom() = runTest {
+        testee.setWidgetPosition(isBottom = true)
+
+        assertEquals(NativeInputState.InputPosition.BOTTOM, testee.state.firstOrNull()!!.inputPosition)
+    }
+
+    @Test
+    fun whenSetInputPositionTopThenPositionIsTop() = runTest {
+        testee.setWidgetPosition(isBottom = true)
+        testee.setWidgetPosition(isBottom = false)
+
+        assertEquals(NativeInputState.InputPosition.TOP, testee.state.firstOrNull()!!.inputPosition)
+    }
+
+    @Test
+    fun whenPositionIsBottomThenIsBottomTrue() = runTest {
+        testee.setWidgetPosition(isBottom = true)
+
+        assertTrue(testee.state.firstOrNull()!!.isBottom)
+    }
+
+    @Test
+    fun whenPositionIsTopThenIsBottomFalse() = runTest {
+        assertFalse(testee.state.firstOrNull()!!.isBottom)
+    }
+
+    @Test
+    fun whenSetInputPositionThenInputModeUnchanged() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        val initialMode = testee.state.firstOrNull()!!.inputMode
+
+        testee.setWidgetPosition(isBottom = true)
+
+        assertEquals(initialMode, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
     fun whenStorePendingPromptThenDelegatesToStore() {
         testee.storePendingPrompt("hello", "model-1")
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.impl.ChatState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.time.LocalDateTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class NativeInputModeWidgetViewModelTest {
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val duckChatInternal: DuckChatInternal = mock()
+    private val duckAiFeatureState: DuckAiFeatureState = mock()
+    private val subscriptions: Subscriptions = mock()
+    private val pendingNativePromptStore: PendingNativePromptStore = mock()
+    private val chatSuggestionsReader: ChatSuggestionsReader = mock()
+
+    private val showSettingsFlow = MutableStateFlow(false)
+    private val duckChatUserEnabledFlow = MutableStateFlow(false)
+    private val inputScreenUserSettingFlow = MutableStateFlow(false)
+    private val chatStateFlow = MutableStateFlow(ChatState.READY)
+    private val chatSuggestionsUserEnabledFlow = MutableStateFlow(true)
+    private val entitlementsFlow = MutableStateFlow<List<Product>>(emptyList())
+
+    private lateinit var testee: NativeInputModeWidgetViewModel
+
+    @Before
+    fun setUp() {
+        whenever(duckAiFeatureState.showSettings).thenReturn(showSettingsFlow)
+        whenever(duckChatInternal.observeEnableDuckChatUserSetting()).thenReturn(duckChatUserEnabledFlow)
+        whenever(duckChatInternal.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
+        whenever(duckChatInternal.observeChatSuggestionsUserSettingEnabled()).thenReturn(chatSuggestionsUserEnabledFlow)
+        whenever(duckChatInternal.chatState).thenReturn(chatStateFlow)
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementsFlow)
+
+        testee = NativeInputModeWidgetViewModel(
+            duckChatInternal = duckChatInternal,
+            duckAiFeatureState = duckAiFeatureState,
+            subscriptions = subscriptions,
+            pendingNativePromptStore = pendingNativePromptStore,
+            chatSuggestionsReader = chatSuggestionsReader,
+        )
+    }
+
+    private fun setIsEnabled(enabled: Boolean) {
+        showSettingsFlow.value = enabled
+        duckChatUserEnabledFlow.value = enabled
+    }
+
+    @Test
+    fun whenInitialStateThenInputModeReflectsObservedSources() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+
+        val freshTestee = NativeInputModeWidgetViewModel(
+            duckChatInternal = duckChatInternal,
+            duckAiFeatureState = duckAiFeatureState,
+            subscriptions = subscriptions,
+            pendingNativePromptStore = pendingNativePromptStore,
+            chatSuggestionsReader = chatSuggestionsReader,
+        )
+
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, freshTestee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenInitialContextThenBrowser() = runTest {
+        assertEquals(NativeInputState.InputContext.BROWSER, testee.state.firstOrNull()!!.inputContext)
+    }
+
+    @Test
+    fun whenIsEnabledFlowEmitsTrueAndInputScreenSettingTrueThenSearchAndDuckAi() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenIsEnabledFlowFlipsToFalseThenSearchOnly() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.state.firstOrNull()!!.inputMode)
+
+        setIsEnabled(false)
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenInputScreenUserSettingFlipsToFalseThenSearchOnly() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.state.firstOrNull()!!.inputMode)
+
+        inputScreenUserSettingFlow.value = false
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenIsEnabledTrueButInputScreenSettingFalseThenSearchOnly() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = false
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenSearchAndDuckAiThenToggleVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+
+        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenSearchOnlyThenToggleNotVisible() = runTest {
+        setIsEnabled(false)
+        inputScreenUserSettingFlow.value = false
+
+        assertFalse(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenSetDuckAiModeTrueThenContextIsDuckAi() = runTest {
+        testee.setDuckAiMode(true)
+
+        assertEquals(NativeInputState.InputContext.DUCK_AI, testee.state.firstOrNull()!!.inputContext)
+    }
+
+    @Test
+    fun whenSetDuckAiModeFalseThenContextIsBrowser() = runTest {
+        testee.setDuckAiMode(true)
+        testee.setDuckAiMode(false)
+
+        assertEquals(NativeInputState.InputContext.BROWSER, testee.state.firstOrNull()!!.inputContext)
+    }
+
+    @Test
+    fun whenContextIsDuckAiThenDefaultToggleSelectionIsDuckAi() = runTest {
+        testee.setDuckAiMode(true)
+
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
+    }
+
+    @Test
+    fun whenContextIsBrowserThenDefaultToggleSelectionIsSearch() = runTest {
+        assertEquals(NativeInputState.ToggleSelection.SEARCH, testee.state.firstOrNull()!!.defaultToggleSelection)
+    }
+
+    @Test
+    fun whenSetDuckAiModeThenInputModeUnchanged() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        val initialMode = testee.state.firstOrNull()!!.inputMode
+
+        testee.setDuckAiMode(true)
+
+        assertEquals(initialMode, testee.state.firstOrNull()!!.inputMode)
+    }
+
+    @Test
+    fun whenStorePendingPromptThenDelegatesToStore() {
+        testee.storePendingPrompt("hello", "model-1")
+
+        verify(pendingNativePromptStore).store("hello", "model-1")
+    }
+
+    @Test
+    fun whenCancelChatSuggestionsThenDelegatesToReader() {
+        testee.cancelChatSuggestions()
+
+        verify(chatSuggestionsReader).tearDown()
+    }
+
+    @Test
+    fun whenFetchChatSuggestionsThenReturnsReaderSuggestions() = runTest {
+        val suggestions = listOf(
+            ChatSuggestion(chatId = "id-1", title = "Title", lastEdit = LocalDateTime.now(), pinned = false),
+        )
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
+
+        val result = testee.fetchChatSuggestions("query")
+
+        assertEquals(suggestions, result)
+    }
+
+    @Test
+    fun whenFetchChatSuggestionsFailsThenReturnsEmptyList() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenAnswer { throw IOException("boom") }
+
+        val result = testee.fetchChatSuggestions("query")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenBuildChatSuggestionUrlThenAppendsChatIdParam() {
+        whenever(duckChatInternal.getDuckChatUrl("", false)).thenReturn("https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
+        val suggestion = ChatSuggestion(
+            chatId = "abc-123",
+            title = "Title",
+            lastEdit = LocalDateTime.now(),
+            pinned = false,
+        )
+
+        val url = testee.buildChatSuggestionUrl(suggestion)
+
+        assertTrue(url.contains("chatID=abc-123"))
+    }
+
+    @Test
+    fun whenChatStateFlowEmitsThenViewModelChatStateMirrorsIt() = runTest {
+        chatStateFlow.value = ChatState.STREAMING
+
+        assertEquals(ChatState.STREAMING, testee.chatState.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenChatStateFlowFlipsThenSubsequentValueObserved() = runTest {
+        chatStateFlow.value = ChatState.LOADING
+        assertEquals(ChatState.LOADING, testee.chatState.firstOrNull()!!)
+
+        chatStateFlow.value = ChatState.HIDE
+
+        assertEquals(ChatState.HIDE, testee.chatState.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenEntitlementsContainDuckAiPlusThenIsPaidTierTrue() = runTest {
+        entitlementsFlow.value = listOf(Product.DuckAiPlus)
+
+        assertTrue(testee.isPaidTier.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenEntitlementsAreEmptyThenIsPaidTierFalse() = runTest {
+        entitlementsFlow.value = emptyList()
+
+        assertFalse(testee.isPaidTier.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenEntitlementsContainOnlyOtherProductsThenIsPaidTierFalse() = runTest {
+        entitlementsFlow.value = listOf(Product.NetP, Product.ITR, Product.PIR)
+
+        assertFalse(testee.isPaidTier.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenEntitlementsContainDuckAiPlusAlongsideOthersThenIsPaidTierTrue() = runTest {
+        entitlementsFlow.value = listOf(Product.NetP, Product.DuckAiPlus, Product.PIR)
+
+        assertTrue(testee.isPaidTier.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenChatSuggestionsUserEnabledFlowEmitsTrueThenObservedTrue() = runTest {
+        chatSuggestionsUserEnabledFlow.value = true
+
+        assertTrue(testee.chatSuggestionsUserEnabled.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenChatSuggestionsUserEnabledFlowEmitsFalseThenObservedFalse() = runTest {
+        chatSuggestionsUserEnabledFlow.value = false
+
+        assertFalse(testee.chatSuggestionsUserEnabled.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenFetchChatSuggestionsThenDelegatesQueryToReader() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions("hello world")).thenReturn(emptyList())
+
+        testee.fetchChatSuggestions("hello world")
+
+        verify(chatSuggestionsReader).fetchSuggestions("hello world")
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -247,6 +247,15 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenConfigureThenBothContextAndPositionSetAtomically() = runTest {
+        testee.configure(isDuckAiMode = true, isBottom = true)
+
+        val state = testee.state.firstOrNull()!!
+        assertEquals(NativeInputState.InputContext.DUCK_AI, state.inputContext)
+        assertEquals(NativeInputState.InputPosition.BOTTOM, state.inputPosition)
+    }
+
+    @Test
     fun whenStorePendingPromptThenDelegatesToStore() {
         testee.storePendingPrompt("hello", "model-1")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214299040324666?focus=true

### Description

- Adds a state and view model to `NativeInputModeWidget`

### Steps to test this PR

- [ ] Smoke test


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core native input UI behavior (toggle visibility, default selection, bottom/top layout, and enter/exit animation plumbing), so regressions could affect omnibar/widget layout and focus/keyboard interactions across modes.
> 
> **Overview**
> **Native input widget state is now driven by a ViewModel.** This adds `NativeInputState` plus `NativeInputModeWidgetViewModel`, and refactors `NativeInputModeWidget` to consume a shared state flow (toggle visibility/default tab, bottom/top position, paid tier, chat suggestions, chat state) instead of directly wiring multiple injected dependencies.
> 
> **Layout/animation positioning is made explicit.** `NativeInputLayoutCoordinator` no longer queries omnibar/widget position internally; callers pass `isBottom` into layout params, padding/offset adjustments, card shaping, and forced translation. `RealNativeInputManager` computes `isBottom` once when showing the widget, passes it through creation/binding/attach + enter/exit animations, tracks `widgetRoot` directly, and removes the prior omnibar-shape/margin hacks and the separate “input screen setting” observer.
> 
> Adds comprehensive unit tests for `NativeInputModeWidgetViewModel` state derivation, configuration, and delegation behavior (suggestions, pending prompt storage, entitlements).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef87e3b012b58a17ccac73eb380b6b00cd14c7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->