### PR TITLE
Fix back history dropped by progressBarUpgrade reorder

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2190,15 +2190,18 @@ class BrowserTabViewModel @Inject constructor(
     ) {
         logcat(VERBOSE) { "Loading in progress $newProgress, url: ${webViewNavigationState.currentUrl}" }
 
+        // Always run navigation-state bookkeeping: this updates webNavigationState (consulted by
+        // onUserPressedBack) and persists the resolved URL. Skipping it leaves canGoBack stale and
+        // back press exits the browser instead of returning to the previous page.
+        if (!currentBrowserViewState().maliciousSiteBlocked) {
+            navigationStateChanged(webViewNavigationState)
+        }
+
         if (!currentBrowserViewState().browserShowing) return
 
         // Once a page load completes, ignore subsequent progress events (iframes, subresources)
         // until a new navigation starts (pageStarted/onPageContentStart resets hasCompletedPageLoad)
         if (progressBarUpgradeFeature.behaviourUpdate().isEnabled() && hasCompletedPageLoad) return
-
-        if (!currentBrowserViewState().maliciousSiteBlocked) {
-            navigationStateChanged(webViewNavigationState)
-        }
 
         val isLoading = newProgress < 100 || isProcessingTrackingLink
         val progress = currentLoadingViewState()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1790,6 +1790,23 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenProgressChangedFiresWhileBrowserNotShowingThenWebNavigationStateStillUpdatedSoBackPressNavigatesBack() {
+        // Regression: the browserShowing early-return in progressChanged once skipped
+        // navigationStateChanged, leaving webNavigationState stale. A subsequent back press
+        // saw canGoBack=false and exited the browser instead of navigating to the previous page.
+        whenever(mockStack.currentIndex).thenReturn(1)
+        setBrowserShowing(false)
+
+        testee.progressChanged(50, WebViewNavigationState(mockStack, 50))
+
+        setBrowserShowing(true)
+        val handled = testee.onUserPressedBack()
+
+        assertTrue(handled)
+        assertCommandIssued<NavigationCommand.NavigateBack>()
+    }
+
+    @Test
     fun whentrackersDetectedThenPrivacyGradeIsUpdated() {
         val grade = privacyShieldState().privacyShield
         loadUrl("https://example.com")


### PR DESCRIPTION
Restore the navigation-state bookkeeping that progressChanged was silently skipping when browserShowing=false. The browserShowing early-return had been moved above navigationStateChanged in #8119, leaving webNavigationState stale; onUserPressedBack then saw canGoBack=false and exited the browser instead of navigating to the previous page. The hasCompletedPageLoad gate stays in place to avoid re-animating the upgraded progress bar from iframe/subresource events.

Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1214172338559653?focus=true

### Steps to test this PR
- open a new tab 
- visit svt.se
- navigate to any page within it
- press back 
- should go back to main page and not to NTP

### UI changes
bugfix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized reorder in `progressChanged` plus a regression test; behavior changes only affect navigation/back-history state updates when the browser UI isn’t showing.
> 
> **Overview**
> Fixes a back-history regression by ensuring `BrowserTabViewModel.progressChanged` always updates navigation bookkeeping (via `navigationStateChanged`) *before* the `browserShowing` early-return, so `onUserPressedBack` sees an up-to-date `canGoBack`/history state.
> 
> Adds a unit test covering the scenario where progress events occur while the browser isn’t showing and verifies a subsequent back press triggers `NavigateBack` instead of exiting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0cf7f1b0c992450de5acf72f597f0ccfdc807e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->