### PR TITLE
Duck.AI/Voice chat: Fix handling for duckAiVoiceSearch / voice search shortcut disabled in input screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -323,12 +323,17 @@ class InputScreenViewModel @AssistedInject constructor(
             voiceInputAllowed,
             isSearchModeFlow,
             chatInputTextState,
-        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText ->
+            duckAiFeatureState.showVoiceSearchToggle,
+        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText, showVoiceSearch ->
             val newEntryPointActive = !isSearchMode && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
             _visibilityState.update {
                 it.copy(
                     voiceSearchButtonVisible = if (!newEntryPointActive) {
-                        serviceAvailable && inputAllowed
+                        if (isSearchMode) {
+                            serviceAvailable && inputAllowed
+                        } else {
+                            serviceAvailable && inputAllowed && showVoiceSearch
+                        }
                     } else {
                         false
                     },

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -127,6 +127,7 @@ class InputScreenViewModelTest {
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
             whenever(omnibarRepository.omnibarType).thenReturn(OmnibarType.SINGLE_TOP)
             whenever(duckAiFeatureState.showFullScreenMode).thenReturn(fullScreenModeDisabledFlow)
+            whenever(duckAiFeatureState.showVoiceSearchToggle).thenReturn(MutableStateFlow(true))
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214290274396473?focus=true 

### Description
This PR fixes the handling for the duckAiVoiceSearch feature flag and Duck.AI Shortcut for voice search. See spec in the attached task.

### Steps to test this PR

Tests visibility and behavior of the voice icons in the Duck.ai tab of the input screen across combinations of the `duckAiVoiceSearch` and `duckAiVoiceEntryPoint` feature flags and the user-facing **AI shortcut:
   Voice search** toggle.              
                                                                                                                                                                                                                     
  ### Setup                                                                                                                                                                                                          
  - [x] Enable Duck.ai (Settings → Duck.ai is on)                                                                                                                                                                    
  - [x] Open the input screen and switch to the **Duck.ai** tab                                                                                                                                                      
  - [x] Note: the input field must be **empty** to evaluate the "no input" cases below                                                                                                                               
                                                                                                                                                                                                                     
  ### 1. `duckAiVoiceSearch` disabled, `duckAiVoiceEntryPoint` enabled                                                                                                                                               
  - [x] Voice **search** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                  
  - [x] Voice **chat** entry icon **IS** visible (input empty)                                                                                                                                                       
  - [x] Tapping the voice chat icon opens the voice chat full-screen flow                                                                                                                                            
                                                                                                                                                                                                                     
  ### 2. `duckAiVoiceSearch` disabled, `duckAiVoiceEntryPoint` disabled                                                                                                                                              
  - [x] Voice **search** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                  
  - [x] Voice **chat** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                    
                                                                                                                                                                                                                     
  ### 3. `duckAiVoiceSearch` enabled, `duckAiVoiceEntryPoint` enabled                                                                                                                                                
  - [x] Voice **search** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                  
  - [x] Voice **chat** entry icon **IS** visible (input empty)                                                                                                                                                       
  - [x] Tapping the voice chat icon opens the voice chat full-screen flow                                                                                                                                            
   
  ### 4. `duckAiVoiceSearch` enabled, `duckAiVoiceEntryPoint` disabled, **AI shortcut: Voice search** = OFF                                                                                                          
  - [x] Settings → Duck.ai shortcut → "Voice search" toggle is OFF
  - [x] Voice **search** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                  
  - [x] Voice **chat** icon is **NOT** visible in the Duck.ai tab                                                                                                                                                    
                                                                                                                                                                                                                     
  ### 5. `duckAiVoiceSearch` enabled, `duckAiVoiceEntryPoint` disabled, **AI shortcut: Voice search** = ON                                                                                                           
  - [x] Settings → Duck.ai shortcut → "Voice search" toggle is ON
  - [x] Voice **search** icon **IS** visible in the Duck.ai tab                                                                                                                                                      
  - [x] Tapping the voice search icon opens **Private voice search** with **Duck.ai mode** selected
  - [x] After speaking, the captured query is **submitted to Duck.ai** (not as a search) and a chat response begins                                                                                                  
                                                                                                                                                                                                                     
  ### Regression checks (Search tab)                                                                                                                                                                                 
  - [x] Voice search icon visibility in the **Search** tab is unchanged across all flag combinations above                                                                                                           
  - [x] Tapping the voice search icon in the Search tab opens Private voice search in **search** mode and submits as a search     

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-state change that only affects visibility logic for voice entry controls; minimal risk beyond potential regression in when the voice search shortcut appears.
> 
> **Overview**
> Adjusts `InputScreenViewModel` voice-entry visibility so the **voice search button in Duck.AI (non-search) mode** is only shown when voice service is available/allowed *and* `duckAiFeatureState.showVoiceSearchToggle` is enabled (search mode behavior is unchanged).
> 
> Updates `InputScreenViewModelTest` setup to mock the new `showVoiceSearchToggle` flow dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9635a19ff1bab8d6ea1bb0e9bdb4818c09c79912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->