### PR TITLE
Move Duck Player E2E failures to AOR

### DIFF
--- a/.github/workflows/e2e-duckplayer.yml
+++ b/.github/workflows/e2e-duckplayer.yml
@@ -51,8 +51,8 @@ jobs:
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
           maestro_include_tags: duckplayer
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana_project_id: ${{ secrets.DUCK_PLAYER_AOR_PROJECT_ID }}
+          asana_section_id: ${{ secrets.DUCK_PLAYER_AOR_INCOMING_ID }}
           test_suite_name: Duck Player
 
       - name: Create Asana task when workflow failed
@@ -60,8 +60,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.DUCK_PLAYER_AOR_PROJECT_ID }}
-          asana-section: ${{ vars.DUCK_PLAYER_AOR_INCOMING_ID }}
+          asana-project: ${{ secrets.DUCK_PLAYER_AOR_PROJECT_ID }}
+          asana-section: ${{ secrets.DUCK_PLAYER_AOR_INCOMING_ID }}
           asana-task-name: GH Workflow Failure - Duck Player End to End Tests
           asana-task-description: The Duck Player workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/e2e-duckplayer.yml
+++ b/.github/workflows/e2e-duckplayer.yml
@@ -60,8 +60,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-project: ${{ vars.DUCK_PLAYER_AOR_PROJECT_ID }}
+          asana-section: ${{ vars.DUCK_PLAYER_AOR_INCOMING_ID }}
           asana-task-name: GH Workflow Failure - Duck Player End to End Tests
           asana-task-description: The Duck Player workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210626814037951/task/1214348337654034?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; the main impact is where E2E failures create/report Asana tasks, which could misroute notifications if the new secrets are misconfigured.
> 
> **Overview**
> Updates the `e2e-duckplayer.yml` GitHub Actions workflow to send Duck Player E2E Maestro/Asana reporting and failure task creation to the AOR Asana project/section, switching from repo `vars` IDs to `secrets` (`DUCK_PLAYER_AOR_PROJECT_ID`, `DUCK_PLAYER_AOR_INCOMING_ID`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e863a3cd5bcbb86ac20a50273b010320f90be457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->