### PR TITLE
Apply toggle default settings to the Native Input field

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -992,7 +992,7 @@ class BrowserTabFragment :
                 is VoiceSearchLauncher.Event.VoiceRecognitionSuccess -> {
                     when (val result = it.result) {
                         is VoiceSearchLauncher.VoiceRecognitionResult.SearchResult -> {
-                            nativeInputManager.hideNativeInput(animate = false)
+                            nativeInputManager.hideNativeInput(animate = false, isNavigation = true)
                             omnibar.setText(result.query)
                             userEnteredQuery(result.query)
                         }
@@ -2418,6 +2418,7 @@ class BrowserTabFragment :
     }
 
     fun submitQuery(query: String) {
+        nativeInputManager.hideNativeInput(animate = false, isNavigation = true)
         viewModel.onUserSubmittedQuery(query)
     }
 
@@ -3557,7 +3558,7 @@ class BrowserTabFragment :
         autoCompleteSuggestionsAdapter =
             BrowserAutoCompleteSuggestionsAdapter(
                 immediateSearchClickListener = {
-                    nativeInputManager.hideNativeInput(animate = false)
+                    nativeInputManager.hideNativeInput(animate = false, isNavigation = true)
                     viewModel.userSelectedAutocomplete(it)
                 },
                 editableSearchClickListener = {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -81,12 +81,14 @@ class NativeInputLayoutCoordinator(
             }
         fun applyPadding(deltaTop: Int, deltaBottom: Int) {
             targets.forEach { (view, padding) ->
-                view.setPadding(
-                    padding.left,
-                    padding.top + deltaTop,
-                    padding.right,
-                    padding.bottom + deltaBottom,
-                )
+                val newTop = padding.top + deltaTop
+                val newBottom = padding.bottom + deltaBottom
+                // Only post requestLayout when padding actually changed to avoid extra layout passes in steady state
+                if (view.paddingTop != newTop || view.paddingBottom != newBottom) {
+                    view.setPadding(padding.left, newTop, padding.right, newBottom)
+                    // Force RecyclerView to reposition items after padding changes during widget enter animation
+                    view.post { view.requestLayout() }
+                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -293,6 +293,8 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, isBottom)
+        val isNewTab = query.isEmpty() && omnibarController.getText().isEmpty()
+        applyInitialTabSelection(widgetView, isNewTab)
         if (omnibarController.isDuckAiMode()) {
             widgetFrom(widgetView)?.setToggleVisible(false)
         } else {
@@ -315,10 +317,12 @@ class RealNativeInputManager @Inject constructor(
         widget.bindInputEvents(
             onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
+                widget.saveLastUsedTogglePosition(isChat = false)
                 hideNativeInput()
                 callbacks.onSearchSubmitted(query)
             },
             onChatSubmitted = { query ->
+                widget.saveLastUsedTogglePosition(isChat = true)
                 if (queryUrlPredictor.isUrl(query)) {
                     hideNativeInput()
                     callbacks.onSearchSubmitted(query)
@@ -474,6 +478,15 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
+    private fun applyInitialTabSelection(widgetView: View, isNewTab: Boolean) {
+        val widget = widgetFrom(widgetView) ?: return
+        if (omnibarController.isDuckAiMode()) {
+            widget.selectChatTab()
+        } else if (isNewTab) {
+            widget.applyDefaultTogglePosition()
+        }
+    }
+
     private fun bindAutocompleteVisibility(widgetView: View) {
         if (!omnibarController.isDuckAiMode()) return
         val widget = widgetFrom(widgetView) ?: return
@@ -549,6 +562,7 @@ class RealNativeInputManager @Inject constructor(
         widget.bindChatSuggestions(
             lifecycleOwner = lifecycleOwner,
             onChatSuggestionSelected = { query ->
+                widget.saveLastUsedTogglePosition(isChat = true)
                 hideNativeInput(animate = false)
                 onChatSuggestionSelected(query)
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -74,8 +74,7 @@ interface NativeInputManager {
         query: String = "",
         callbacks: NativeInputCallbacks,
     )
-
-    fun hideNativeInput(animate: Boolean = true): Boolean
+    fun hideNativeInput(animate: Boolean = true, isNavigation: Boolean = false): Boolean
     fun handleDuckAiVoiceResult(query: String)
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
 }
@@ -132,12 +131,18 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    override fun hideNativeInput(animate: Boolean): Boolean {
+    override fun hideNativeInput(animate: Boolean, isNavigation: Boolean): Boolean {
         if (!isNativeInputFieldEnabled) return false
 
         val widgetView = rootView.findViewById<View?>(R.id.inputModeTopRoot)
             ?: rootView.findViewById(R.id.inputModeBottomRoot)
             ?: return false
+
+        if (isNavigation) {
+            widgetFrom(widgetView)?.let { widget ->
+                widget.saveLastUsedTogglePosition(isChat = widget.isChatTabSelected())
+            }
+        }
 
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
@@ -317,20 +322,20 @@ class RealNativeInputManager @Inject constructor(
         widget.bindInputEvents(
             onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
-                widget.saveLastUsedTogglePosition(isChat = false)
-                hideNativeInput()
+                hideNativeInput(isNavigation = true)
                 callbacks.onSearchSubmitted(query)
             },
             onChatSubmitted = { query ->
-                widget.saveLastUsedTogglePosition(isChat = true)
                 if (queryUrlPredictor.isUrl(query)) {
-                    hideNativeInput()
+                    hideNativeInput(isNavigation = true)
                     callbacks.onSearchSubmitted(query)
                 } else if (omnibarController.isDuckAiMode()) {
+                    widget.saveLastUsedTogglePosition(isChat = true)
                     widget.text = ""
                     widget.hideKeyboard()
                     callbacks.onDuckAiChatSubmitted(query, widget.getSelectedModelId())
                 } else {
+                    widget.saveLastUsedTogglePosition(isChat = true)
                     widget.storePendingPrompt(query)
                     animator.cancelAnimation()
                     rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
@@ -562,8 +567,7 @@ class RealNativeInputManager @Inject constructor(
         widget.bindChatSuggestions(
             lifecycleOwner = lifecycleOwner,
             onChatSuggestionSelected = { query ->
-                widget.saveLastUsedTogglePosition(isChat = true)
-                hideNativeInput(animate = false)
+                hideNativeInput(animate = false, isNavigation = true)
                 onChatSuggestionSelected(query)
             },
             onShowSuggestions = { chatAdapter ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -48,14 +48,10 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
-import com.duckduckgo.subscriptions.api.Product
-import com.duckduckgo.subscriptions.api.Subscriptions
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.Job
@@ -435,9 +431,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun applyDefaultTogglePosition() {
         if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
         findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-            val position = duckChatInternal.observeDefaultTogglePosition().firstOrNull() ?: return@launch
+            val position = viewModel.defaultTogglePosition.firstOrNull() ?: return@launch
             val resolved = if (position == DefaultTogglePosition.LAST_USED) {
-                DefaultTogglePosition.fromName(duckChatInternal.observeLastUsedTogglePosition().firstOrNull())
+                DefaultTogglePosition.fromName(viewModel.lastUsedTogglePosition.firstOrNull())
             } else {
                 position
             }
@@ -451,7 +447,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
         val position = if (isChat) DefaultTogglePosition.DUCK_AI else DefaultTogglePosition.SEARCH
         findViewTreeLifecycleOwner()?.lifecycleScope?.launch(dispatchers.io()) {
-            duckChatInternal.saveLastUsedTogglePosition(position.name)
+            viewModel.saveLastUsedTogglePosition(position.name)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -40,19 +40,27 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -77,6 +85,8 @@ interface NativeInputWidget {
     fun selectAllText()
     fun hideKeyboard()
     fun selectChatTab()
+    fun applyDefaultTogglePosition()
+    fun saveLastUsedTogglePosition(isChat: Boolean)
     fun isChatTabSelected(): Boolean
     fun hideMainButtons()
     fun setVoiceSearchAvailable(available: Boolean)
@@ -127,6 +137,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private val viewModel: NativeInputModeWidgetViewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[NativeInputModeWidgetViewModel::class.java]
     }
+
+    @Inject
+    lateinit var duckChatFeature: DuckChatFeature
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
@@ -413,6 +429,29 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         if (toggle.selectedTabPosition != 1) {
             toggle.getTabAt(1)?.select()
+        }
+    }
+
+    override fun applyDefaultTogglePosition() {
+        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+            val position = duckChatInternal.observeDefaultTogglePosition().first()
+            val resolved = if (position == DefaultTogglePosition.LAST_USED) {
+                DefaultTogglePosition.fromName(duckChatInternal.observeLastUsedTogglePosition().first())
+            } else {
+                position
+            }
+            if (resolved == DefaultTogglePosition.DUCK_AI) {
+                selectChatTab()
+            }
+        }
+    }
+
+    override fun saveLastUsedTogglePosition(isChat: Boolean) {
+        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
+        val position = if (isChat) DefaultTogglePosition.DUCK_AI else DefaultTogglePosition.SEARCH
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch(dispatchers.io()) {
+            duckChatInternal.saveLastUsedTogglePosition(position.name)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -60,7 +60,7 @@ import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -435,9 +435,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun applyDefaultTogglePosition() {
         if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
         findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-            val position = duckChatInternal.observeDefaultTogglePosition().first()
+            val position = duckChatInternal.observeDefaultTogglePosition().firstOrNull() ?: return@launch
             val resolved = if (position == DefaultTogglePosition.LAST_USED) {
-                DefaultTogglePosition.fromName(duckChatInternal.observeLastUsedTogglePosition().first())
+                DefaultTogglePosition.fromName(duckChatInternal.observeLastUsedTogglePosition().firstOrNull())
             } else {
                 position
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.flow.Flow
@@ -79,6 +80,14 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         .map { entitlements -> entitlements.any { it == Product.DuckAiPlus } }
 
     val chatSuggestionsUserEnabled: Flow<Boolean> = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
+
+    val defaultTogglePosition: Flow<DefaultTogglePosition> = duckChatInternal.observeDefaultTogglePosition()
+
+    val lastUsedTogglePosition: Flow<String?> = duckChatInternal.observeLastUsedTogglePosition()
+
+    suspend fun saveLastUsedTogglePosition(position: String) {
+        duckChatInternal.saveLastUsedTogglePosition(position)
+    }
 
     fun setDuckAiMode(isDuckAiMode: Boolean) {
         val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214292512522699?focus=true 

### Description

- Wire the "remember toggle position" setting to the native input field: new tabs respect the user's preferred default (Search, Duck.ai, or Last Used), matching existing input screen behaviour
- Fix chat suggestions rendering behind the native input widget during the enter animation by forcing a layout pass after padding settles                                                                                                 
- Fix NTP favourite taps not dismissing the native input widget when native input is showing
- Add isNavigation parameter to hideNativeInput to distinguish user navigations from non-navigation dismissals (back press, keyboard hide), ensuring the toggle position is only saved on intentional navigations

### Steps to test this PR

Toggle position on new tabs

- [x] Set default toggle position to Search in settings → open new tab → native input shows on Search tab
- [x] Set default toggle position to Duck.ai in settings → open new tab → native input shows on Duck.ai tab
- [x] Set default toggle position to Last Used → submit a search → open new tab → native input shows on Search tab
- [x] Set default toggle position to Last Used → submit a chat → open new tab → native input shows on Duck.ai tab
- [x] Tap omnibar on an existing page (not new tab) → native input always defaults to Search tab regardless of setting

Last used position saving

- [x] On Search tab, type a query and press enter → last used saved as Search
- [x] On Search tab, type and tap an autocomplete suggestion → last used saved as Search
- [x] On Duck.ai tab, send a chat message → last used saved as Duck.ai
- [x] On Duck.ai tab, tap a chat suggestion → last used saved as Duck.ai
- [x] On Search tab, tap a NTP favourite → last used saved as Search
- [x] Type text then press back without submitting → last used is not updated
- [x] On Search tab, use voice search → last used saved as Search

Chat suggestions layout during animation

- [x] Set default to Duck.ai → open new tab → chat suggestions appear below the widget (not hidden behind it)
- [x] Chat suggestions animate smoothly downward as the widget expands during enter animation

Feature flag gating                                                                                                   
                                                                                                                        
- [x] Disable rememberTogglePosition feature flag → new tabs always default to Search tab

Regression

- [x] Search autocomplete works normally on Search tab
- [x] Switching tabs manually (Search ↔ Duck.ai) works as before
- [x] DuckAI fullscreen mode unaffected
- [x] Old input screen (native input disabled) behaviour unchanged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core omnibar/native-input UX flow and adds persistence of toggle state, so regressions could affect navigation behavior and input-mode selection, though the changes are localized and feature-flag gated.
> 
> **Overview**
> Native input now applies the user’s configured default toggle (Search, Duck.ai, or Last Used) *when opening a new tab*, and records the last-used toggle only on intentional navigations (query submit, autocomplete tap, voice search, etc.) via a new `hideNativeInput(..., isNavigation)` parameter.
> 
> Chat suggestion/autocomplete layout during the native input enter animation is stabilized by only re-applying padding when it actually changes and forcing a layout pass after padding updates, and some navigation paths (e.g., `submitQuery`/NTP interactions) now dismiss native input consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6860f3b711bc41e8e13cd7d0237bd5832a712d85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->