### PR TITLE
Duck.Ai/Voice chat: Add duck.ai shortcut setting for voice chat 

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -99,6 +99,11 @@ interface DuckChatInternal : DuckChat {
     suspend fun setShowInVoiceSearchUserSetting(showToggle: Boolean)
 
     /**
+     * Set user setting to determine whether the voice chat entry point should be shown.
+     */
+    suspend fun setShowInVoiceChatUserSetting(showToggle: Boolean)
+
+    /**
      * Set user setting to determine whether DuckChat should automatically update the page context in Contextual Mode
      */
     suspend fun setAutomaticPageContextUserSetting(isEnabled: Boolean)
@@ -149,6 +154,11 @@ interface DuckChatInternal : DuckChat {
     fun observeShowInVoiceSearchUserSetting(): Flow<Boolean>
 
     /**
+     * Observes whether the voice chat entry point should be shown based on user settings only.
+     */
+    fun observeShowInVoiceChatUserSetting(): Flow<Boolean>
+
+    /**
      * Opens DuckChat settings.
      */
     fun openDuckChatSettings()
@@ -180,6 +190,11 @@ interface DuckChatInternal : DuckChat {
      * Returns whether voice search entry point is enabled or not.
      */
     fun isVoiceSearchEntryPointEnabled(): Boolean
+
+    /**
+     * Returns whether voice chat entry point is enabled or not.
+     */
+    fun isVoiceChatEntryPointEnabled(): Boolean
 
     /**
      * Returns whether DuckChat is user enabled or not.
@@ -390,6 +405,7 @@ class RealDuckChat @Inject constructor(
     private var bangRegex: Regex? = null
     private var isAddressBarEntryPointEnabled: Boolean = false
     private var isVoiceSearchEntryPointEnabled: Boolean = false
+    private var isVoiceChatEntryPointEnabled: Boolean = false
     private var isImageUploadEnabled: Boolean = false
     private var isStandaloneMigrationEnabled: Boolean = false
     private var keepSessionAliveInMinutes: Int = DEFAULT_SESSION_ALIVE
@@ -444,6 +460,12 @@ class RealDuckChat @Inject constructor(
             cacheUserSettings()
         }
 
+    override suspend fun setShowInVoiceChatUserSetting(showToggle: Boolean) =
+        withContext(dispatchers.io()) {
+            duckChatFeatureRepository.setShowInVoiceChat(showToggle)
+            cacheUserSettings()
+        }
+
     override suspend fun setAutomaticPageContextUserSetting(isEnabled: Boolean) {
         withContext(dispatchers.io()) {
             duckChatFeatureRepository.setAutomaticPageContextAttachment(isEnabled)
@@ -494,6 +516,8 @@ class RealDuckChat @Inject constructor(
 
     override fun observeShowInVoiceSearchUserSetting(): Flow<Boolean> = duckChatFeatureRepository.observeShowInVoiceSearch()
 
+    override fun observeShowInVoiceChatUserSetting(): Flow<Boolean> = duckChatFeatureRepository.observeShowInVoiceChat()
+
     override fun openDuckChatSettings() {
         val intent = globalActivityStarter.startIntent(context, DuckChatSettingsNoParams)
         intent?.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -540,6 +564,7 @@ class RealDuckChat @Inject constructor(
 
     override fun isAddressBarEntryPointEnabled(): Boolean = isAddressBarEntryPointEnabled
     override fun isVoiceSearchEntryPointEnabled(): Boolean = isVoiceSearchEntryPointEnabled
+    override fun isVoiceChatEntryPointEnabled(): Boolean = isVoiceChatEntryPointEnabled
 
     override fun isDuckChatUserEnabled(): Boolean = isDuckChatUserEnabled
 
@@ -856,6 +881,7 @@ class RealDuckChat @Inject constructor(
                 }
             isAddressBarEntryPointEnabled = settingsJson?.addressBarEntryPoint ?: false
             isVoiceSearchEntryPointEnabled = duckChatFeature.duckAiVoiceSearch().isEnabled()
+            isVoiceChatEntryPointEnabled = duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
             _allowDuckAiAsDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
             isImageUploadEnabled = imageUploadFeature.self().isEnabled()
             isStandaloneMigrationEnabled = duckChatFeature.standaloneMigration().isEnabled()
@@ -906,7 +932,8 @@ class RealDuckChat @Inject constructor(
             _showVoiceSearchToggle.emit(showVoiceSearchToggle)
 
             val showVoiceChatEntry =
-                isDuckChatFeatureEnabled && isDuckChatUserEnabled && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
+                duckChatFeatureRepository.shouldShowInVoiceChat() &&
+                    isDuckChatFeatureEnabled && isDuckChatUserEnabled && isVoiceChatEntryPointEnabled
             _showVoiceChatEntry.emit(showVoiceChatEntry)
 
             val showFullScreenMode = isDuckChatFeatureEnabled && isDuckChatUserEnabled &&

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.common.utils.keyboardVisibilityFlow
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
@@ -131,6 +132,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
     @Inject
     lateinit var duckChatFeature: DuckChatFeature
+
+    @Inject
+    lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
     lateinit var faviconManager: FaviconManager
@@ -513,7 +517,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             }
             onVoiceClick = {
                 val isChatTab = inputModeWidget.isChatTabSelected()
-                if (isChatTab && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()) {
+                if (isChatTab && duckAiFeatureState.showVoiceChatEntry.value) {
                     viewModel.onVoiceEntryTapped()
                 } else {
                     voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.fromValue(inputModeWidget.getSelectedTabPosition()))
@@ -648,7 +652,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         }
         inputScreenButtons.onVoiceSearchClick = {
             val isChatTab = inputModeWidget.isChatTabSelected()
-            if (isChatTab && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()) {
+            if (isChatTab && duckAiFeatureState.showVoiceChatEntry.value) {
                 viewModel.onVoiceEntryTapped()
             } else {
                 voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.fromValue(inputModeWidget.getSelectedTabPosition()))
@@ -656,7 +660,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         }
         inputScreenButtons.onVoiceChatClick = {
             val isChatTab = inputModeWidget.isChatTabSelected()
-            if (isChatTab && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()) {
+            if (isChatTab && duckAiFeatureState.showVoiceChatEntry.value) {
                 viewModel.onVoiceEntryTapped()
             } else {
                 voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.fromValue(inputModeWidget.getSelectedTabPosition()))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -324,8 +324,15 @@ class InputScreenViewModel @AssistedInject constructor(
             isSearchModeFlow,
             chatInputTextState,
             duckAiFeatureState.showVoiceSearchToggle,
-        ) { serviceAvailable, inputAllowed, isSearchMode, chatInputText, showVoiceSearch ->
-            val newEntryPointActive = !isSearchMode && duckChatFeature.duckAiVoiceEntryPoint().isEnabled()
+            duckAiFeatureState.showVoiceChatEntry,
+        ) { values ->
+            val serviceAvailable = values[0] as Boolean
+            val inputAllowed = values[1] as Boolean
+            val isSearchMode = values[2] as Boolean
+            val chatInputText = values[3] as String
+            val showVoiceSearch = values[4] as Boolean
+            val showVoiceChatEntry = values[5] as Boolean
+            val newEntryPointActive = !isSearchMode && showVoiceChatEntry
             _visibilityState.update {
                 it.copy(
                     voiceSearchButtonVisible = if (!newEntryPointActive) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -39,6 +39,8 @@ interface DuckChatFeatureRepository {
 
     suspend fun setShowInVoiceSearch(showToggle: Boolean)
 
+    suspend fun setShowInVoiceChat(showToggle: Boolean)
+
     suspend fun setAutomaticPageContextAttachment(isEnabled: Boolean)
 
     suspend fun setNativeInputFieldUserSetting(enabled: Boolean)
@@ -59,6 +61,8 @@ interface DuckChatFeatureRepository {
 
     fun observeShowInVoiceSearch(): Flow<Boolean>
 
+    fun observeShowInVoiceChat(): Flow<Boolean>
+
     fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean>
 
     suspend fun isDuckChatUserEnabled(): Boolean
@@ -78,6 +82,8 @@ interface DuckChatFeatureRepository {
     suspend fun shouldShowInAddressBar(): Boolean
 
     suspend fun shouldShowInVoiceSearch(): Boolean
+
+    suspend fun shouldShowInVoiceChat(): Boolean
 
     suspend fun registerOpened()
 
@@ -138,6 +144,10 @@ class RealDuckChatFeatureRepository @Inject constructor(
         duckChatDataStore.setShowInVoiceSearch(showToggle)
     }
 
+    override suspend fun setShowInVoiceChat(showToggle: Boolean) {
+        duckChatDataStore.setShowInVoiceChat(showToggle)
+    }
+
     override suspend fun setAutomaticPageContextAttachment(isEnabled: Boolean) {
         duckChatDataStore.setAutomaticPageContextAttachment(isEnabled)
     }
@@ -164,6 +174,8 @@ class RealDuckChatFeatureRepository @Inject constructor(
 
     override fun observeShowInVoiceSearch(): Flow<Boolean> = duckChatDataStore.observeShowInVoiceSearch()
 
+    override fun observeShowInVoiceChat(): Flow<Boolean> = duckChatDataStore.observeShowInVoiceChat()
+
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> =
         duckChatDataStore.observeChatSuggestionsUserSettingEnabled()
 
@@ -184,6 +196,8 @@ class RealDuckChatFeatureRepository @Inject constructor(
     override suspend fun shouldShowInAddressBar(): Boolean = duckChatDataStore.getShowInAddressBar()
 
     override suspend fun shouldShowInVoiceSearch(): Boolean = duckChatDataStore.getShowInVoiceSearch()
+
+    override suspend fun shouldShowInVoiceChat(): Boolean = duckChatDataStore.getShowInVoiceChat()
 
     override suspend fun registerOpened() {
         if (!duckChatDataStore.wasOpenedBefore()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Key
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SESSION_DELTA_TIMESTAMP
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SHOW_IN_ADDRESS_BAR
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SHOW_IN_MENU
+import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SHOW_IN_VOICE_CHAT
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SHOW_IN_VOICE_SEARCH
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_USER_ENABLED
 import com.duckduckgo.duckchat.impl.store.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_USER_PREFERENCES
@@ -77,6 +78,8 @@ interface DuckChatDataStore {
 
     suspend fun setShowInVoiceSearch(showToggle: Boolean)
 
+    suspend fun setShowInVoiceChat(showToggle: Boolean)
+
     suspend fun setAutomaticPageContextAttachment(enabled: Boolean)
 
     suspend fun setNativeInputFieldUserSetting(enabled: Boolean)
@@ -99,6 +102,8 @@ interface DuckChatDataStore {
 
     fun observeShowInVoiceSearch(): Flow<Boolean>
 
+    fun observeShowInVoiceChat(): Flow<Boolean>
+
     fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean>
 
     suspend fun isDuckChatUserEnabled(): Boolean
@@ -114,6 +119,8 @@ interface DuckChatDataStore {
     suspend fun getShowInAddressBar(): Boolean
 
     suspend fun getShowInVoiceSearch(): Boolean
+
+    suspend fun getShowInVoiceChat(): Boolean
 
     suspend fun fetchAndClearUserPreferences(): String?
 
@@ -181,6 +188,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         val DUCK_CHAT_SHOW_IN_MENU = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_MENU")
         val DUCK_CHAT_SHOW_IN_ADDRESS_BAR = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_ADDRESS_BAR")
         val DUCK_CHAT_SHOW_IN_VOICE_SEARCH = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_VOICE_SEARCH")
+        val DUCK_CHAT_SHOW_IN_VOICE_CHAT = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_VOICE_CHAT")
         val DUCK_CHAT_OPENED = booleanPreferencesKey(name = "DUCK_CHAT_OPENED")
         val DUCK_CHAT_USER_PREFERENCES = stringPreferencesKey("DUCK_CHAT_USER_PREFERENCES")
         val DUCK_CHAT_LAST_SESSION_TIMESTAMP = longPreferencesKey(name = "DUCK_CHAT_LAST_SESSION_TIMESTAMP")
@@ -267,6 +275,12 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
             .distinctUntilChanged()
             .stateIn(appCoroutineScope, SharingStarted.Eagerly, true)
 
+    private val duckChatShowInVoiceChat: StateFlow<Boolean> =
+        store.data
+            .map { prefs -> prefs[DUCK_CHAT_SHOW_IN_VOICE_CHAT] ?: true }
+            .distinctUntilChanged()
+            .stateIn(appCoroutineScope, SharingStarted.Eagerly, true)
+
     private val defaultTogglePositionFlow: StateFlow<String?> =
         store.data
             .map { prefs -> prefs[DUCK_AI_DEFAULT_TOGGLE_POSITION] }
@@ -319,6 +333,10 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         store.edit { prefs -> prefs[DUCK_CHAT_SHOW_IN_VOICE_SEARCH] = showToggle }
     }
 
+    override suspend fun setShowInVoiceChat(showToggle: Boolean) {
+        store.edit { prefs -> prefs[DUCK_CHAT_SHOW_IN_VOICE_CHAT] = showToggle }
+    }
+
     override suspend fun setAutomaticPageContextAttachment(enabled: Boolean) {
         store.edit { prefs -> prefs[DUCK_AI_AUTOMATIC_CONTEXT_ATTACHMENT] = enabled }
     }
@@ -342,6 +360,8 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
     override fun observeShowInAddressBar(): Flow<Boolean> = duckChatShowInAddressBar
 
     override fun observeShowInVoiceSearch(): Flow<Boolean> = duckChatShowInVoiceSearch
+
+    override fun observeShowInVoiceChat(): Flow<Boolean> = duckChatShowInVoiceChat
 
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
@@ -377,6 +397,8 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
     override suspend fun getShowInAddressBar(): Boolean = store.data.firstOrNull()?.defaultShowInAddressBar() ?: true
 
     override suspend fun getShowInVoiceSearch(): Boolean = store.data.firstOrNull()?.let { it[DUCK_CHAT_SHOW_IN_VOICE_SEARCH] } ?: true
+
+    override suspend fun getShowInVoiceChat(): Boolean = store.data.firstOrNull()?.let { it[DUCK_CHAT_SHOW_IN_VOICE_CHAT] } ?: true
 
     override suspend fun fetchAndClearUserPreferences(): String? {
         val userPreferences = store.data.map { it[DUCK_CHAT_USER_PREFERENCES] }.firstOrNull()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsActivity.kt
@@ -52,6 +52,11 @@ class DuckAiShortcutSettingsActivity : DuckDuckGoActivity() {
             viewModel.onShowDuckChatInVoiceSearchToggled(isChecked)
         }
 
+    private val voiceChatToggleListener =
+        CompoundButton.OnCheckedChangeListener { _, isChecked ->
+            viewModel.onShowDuckChatInVoiceChatToggled(isChecked)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -80,6 +85,10 @@ class DuckAiShortcutSettingsActivity : DuckDuckGoActivity() {
         binding.showDuckAiInVoiceSearchToggle.apply {
             isVisible = viewState.shouldShowVoiceSearchToggle
             quietlySetIsChecked(viewState.showInVoiceSearch, voiceSearchToggleListener)
+        }
+        binding.showDuckAiInVoiceChatToggle.apply {
+            isVisible = viewState.shouldShowVoiceChatToggle
+            quietlySetIsChecked(viewState.showInVoiceChat, voiceChatToggleListener)
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModel.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -31,29 +30,32 @@ import javax.inject.Inject
 @ContributesViewModel(ActivityScope::class)
 class DuckAiShortcutSettingsViewModel @Inject constructor(
     private val duckChat: DuckChatInternal,
-    duckAiFeatureState: DuckAiFeatureState,
 ) : ViewModel() {
 
     data class ViewState(
         val showInBrowserMenu: Boolean = false,
         val showInAddressBar: Boolean = false,
         val showInVoiceSearch: Boolean = false,
+        val showInVoiceChat: Boolean = false,
         val shouldShowAddressBarToggle: Boolean = false,
         val shouldShowVoiceSearchToggle: Boolean = false,
+        val shouldShowVoiceChatToggle: Boolean = false,
     )
 
     val viewState = combine(
         duckChat.observeShowInBrowserMenuUserSetting(),
         duckChat.observeShowInAddressBarUserSetting(),
         duckChat.observeShowInVoiceSearchUserSetting(),
-        duckAiFeatureState.showVoiceSearchToggle,
-    ) { showInBrowserMenu, showInAddressBar, showInVoiceSearch, showVoiceSearchToggle ->
+        duckChat.observeShowInVoiceChatUserSetting(),
+    ) { showInBrowserMenu, showInAddressBar, showInVoiceSearch, showInVoiceChat ->
         ViewState(
             showInBrowserMenu = showInBrowserMenu,
             showInAddressBar = showInAddressBar,
             showInVoiceSearch = showInVoiceSearch,
+            showInVoiceChat = showInVoiceChat,
             shouldShowAddressBarToggle = duckChat.isAddressBarEntryPointEnabled(),
             shouldShowVoiceSearchToggle = duckChat.isVoiceSearchEntryPointEnabled(),
+            shouldShowVoiceChatToggle = duckChat.isVoiceChatEntryPointEnabled(),
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 
@@ -72,6 +74,12 @@ class DuckAiShortcutSettingsViewModel @Inject constructor(
     fun onShowDuckChatInVoiceSearchToggled(checked: Boolean) {
         viewModelScope.launch {
             duckChat.setShowInVoiceSearchUserSetting(checked)
+        }
+    }
+
+    fun onShowDuckChatInVoiceChatToggled(checked: Boolean) {
+        viewModelScope.launch {
+            duckChat.setShowInVoiceChatUserSetting(checked)
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/layout/activity_duck_ai_shortcut_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/activity_duck_ai_shortcut_settings.xml
@@ -58,6 +58,13 @@
                 app:primaryText="@string/duckAiVoiceSearchVisibilitySetting"
                 app:showSwitch="true" />
 
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/show_duck_ai_in_voice_chat_toggle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/duckAiVoiceChatVisibilitySetting"
+                app:showSwitch="true" />
+
         </LinearLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -24,4 +24,7 @@
     <!-- Model Picker -->
     <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>
     <string name="duckAiModelPickerBasicModels" translatable="false">Basic Models</string>
+
+    <!-- Duck AI Voice Chat Shortcut Setting -->
+    <string name="duckAiVoiceChatVisibilitySetting" translatable="false">Voice Chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -120,6 +120,7 @@ class RealDuckChatTest {
         whenever(mockDuckChatFeatureRepository.shouldShowInBrowserMenu()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(false)
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceSearch()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isNativeInputFieldUserSettingEnabled()).thenReturn(false)
@@ -131,6 +132,7 @@ class RealDuckChatTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiInputScreen().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceSearch().setRawStoredState(State(enable = false))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
         imageUploadFeature.self().setRawStoredState(State(enable = true))
 
         testee = spy(
@@ -365,6 +367,7 @@ class RealDuckChatTest {
     fun whenDuckChatEnabledAndVoiceEntryPointEnabledThenShowVoiceChatEntryIsTrue() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
         testee.onPrivacyConfigDownloaded()
@@ -377,6 +380,7 @@ class RealDuckChatTest {
     fun whenVoiceEntryPointDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = false))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
         testee.onPrivacyConfigDownloaded()
@@ -389,6 +393,7 @@ class RealDuckChatTest {
     fun whenDuckChatFeatureDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = false))
         duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
         testee.onPrivacyConfigDownloaded()
@@ -401,6 +406,7 @@ class RealDuckChatTest {
     fun whenDuckChatUserDisabledThenShowVoiceChatEntryIsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
 
         testee.onPrivacyConfigDownloaded()
@@ -414,6 +420,7 @@ class RealDuckChatTest {
         // showVoiceChatEntry must be independent of the in-voice-search toggle user setting
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.shouldShowInVoiceSearch()).thenReturn(false)
 
@@ -421,6 +428,42 @@ class RealDuckChatTest {
         coroutineRule.testScope.advanceUntilIdle()
 
         assertTrue(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenShouldShowInVoiceChatSettingFalseThenShowVoiceChatEntryIsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertFalse(testee.showVoiceChatEntry.value)
+    }
+
+    @Test
+    fun whenSetShowInVoiceChatUserSettingThenRepositorySetCalled() = runTest {
+        testee.setShowInVoiceChatUserSetting(true)
+        verify(mockDuckChatFeatureRepository).setShowInVoiceChat(true)
+    }
+
+    @Test
+    fun whenSetShowInVoiceChatUserSettingThenShowVoiceChatEntryReflectsChange() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true))
+        duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        testee.onPrivacyConfigDownloaded()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(true)
+        testee.setShowInVoiceChatUserSetting(true)
+        assertTrue(testee.showVoiceChatEntry.value)
+
+        whenever(mockDuckChatFeatureRepository.shouldShowInVoiceChat()).thenReturn(false)
+        testee.setShowInVoiceChatUserSetting(false)
+        assertFalse(testee.showVoiceChatEntry.value)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -38,6 +38,7 @@ class FakeDuckChatInternal(
     private val showInBrowserMenuUserSetting = MutableStateFlow(false)
     private val showInAddressBarUserSetting = MutableStateFlow(false)
     private val showInVoiceSearchUserSetting = MutableStateFlow(false)
+    private val showInVoiceChatUserSetting = MutableStateFlow(false)
     private val _chatState = MutableStateFlow(ChatState.READY)
     private val _inputScreenBottomBarEnabled = MutableStateFlow(false)
     private val _showMainButtonsInInputScreen = MutableStateFlow(false)
@@ -107,6 +108,10 @@ class FakeDuckChatInternal(
         showInVoiceSearchUserSetting.value = showToggle
     }
 
+    override suspend fun setShowInVoiceChatUserSetting(showToggle: Boolean) {
+        showInVoiceChatUserSetting.value = showToggle
+    }
+
     override suspend fun setAutomaticPageContextUserSetting(isEnabled: Boolean) {
         automaticContextAttachmentUserSettingEnabled.value = isEnabled
     }
@@ -123,6 +128,8 @@ class FakeDuckChatInternal(
 
     override fun observeShowInVoiceSearchUserSetting(): Flow<Boolean> = showInVoiceSearchUserSetting
 
+    override fun observeShowInVoiceChatUserSetting(): Flow<Boolean> = showInVoiceChatUserSetting
+
     override fun openDuckChatSettings() { }
 
     override fun closeDuckChat() { }
@@ -134,6 +141,8 @@ class FakeDuckChatInternal(
     override fun isAddressBarEntryPointEnabled(): Boolean = true
 
     override fun isVoiceSearchEntryPointEnabled(): Boolean = false
+
+    override fun isVoiceChatEntryPointEnabled(): Boolean = false
 
     override fun isDuckChatUserEnabled(): Boolean = enableDuckChatUserSetting.value
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
@@ -69,6 +69,13 @@ class DuckChatFeatureRepositoryTest {
     }
 
     @Test
+    fun whenSetShowInVoiceChatThenSetInDataStore() = runTest {
+        testee.setShowInVoiceChat(false)
+
+        verify(mockDataStore).setShowInVoiceChat(false)
+    }
+
+    @Test
     fun `when setInputScreenUserSetting then set in data store`() = runTest {
         testee.setInputScreenUserSetting(false)
 
@@ -140,6 +147,15 @@ class DuckChatFeatureRepositoryTest {
     }
 
     @Test
+    fun whenObserveShowInVoiceChatThenObserveDataStore() = runTest {
+        whenever(mockDataStore.observeShowInVoiceChat()).thenReturn(flowOf(true, false))
+
+        val results = testee.observeShowInVoiceChat().take(2).toList()
+        assertTrue(results[0])
+        assertFalse(results[1])
+    }
+
+    @Test
     fun `when observeInputScreenUserSettingEnabled then observe data store`() = runTest {
         whenever(mockDataStore.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false, true))
 
@@ -199,6 +215,12 @@ class DuckChatFeatureRepositoryTest {
     fun whenShouldShowInVoiceSearchThenGetFromDataStore() = runTest {
         whenever(mockDataStore.getShowInVoiceSearch()).thenReturn(true)
         assertTrue(testee.shouldShowInVoiceSearch())
+    }
+
+    @Test
+    fun whenShouldShowInVoiceChatThenGetFromDataStore() = runTest {
+        whenever(mockDataStore.getShowInVoiceChat()).thenReturn(true)
+        assertTrue(testee.shouldShowInVoiceChat())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -124,6 +124,11 @@ class SharedPreferencesDuckChatDataStoreTest {
     }
 
     @Test
+    fun whenGetShowInVoiceChatDefaultThenReturnTrue() = runTest {
+        assertTrue(testee.getShowInVoiceChat())
+    }
+
+    @Test
     fun `when isNativeInputFieldUserSettingEnabled then return default value`() = runTest {
         assertFalse(testee.isNativeInputFieldUserSettingEnabled())
     }
@@ -166,6 +171,12 @@ class SharedPreferencesDuckChatDataStoreTest {
     fun whenSetShowInVoiceSearchThenGetShowInVoiceSearchThenReturnValue() = runTest {
         testee.setShowInVoiceSearch(false)
         assertFalse(testee.getShowInVoiceSearch())
+    }
+
+    @Test
+    fun whenSetShowInVoiceChatThenGetShowInVoiceChatThenReturnValue() = runTest {
+        testee.setShowInVoiceChat(false)
+        assertFalse(testee.getShowInVoiceChat())
     }
 
     @Test
@@ -281,6 +292,20 @@ class SharedPreferencesDuckChatDataStoreTest {
                 .toList(results)
         }
         testee.setShowInVoiceSearch(false)
+        job.join()
+
+        assertEquals(listOf(true, false), results)
+    }
+
+    @Test
+    fun whenObserveShowInVoiceChatThenReceiveUpdates() = runTest {
+        val results = mutableListOf<Boolean>()
+        val job = launch {
+            testee.observeShowInVoiceChat()
+                .take(2)
+                .toList(results)
+        }
+        testee.setShowInVoiceChat(false)
         job.join()
 
         assertEquals(listOf(true, false), results)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -129,6 +129,7 @@ class InputScreenViewModelTest {
             whenever(omnibarRepository.omnibarType).thenReturn(OmnibarType.SINGLE_TOP)
             whenever(duckAiFeatureState.showFullScreenMode).thenReturn(fullScreenModeDisabledFlow)
             whenever(duckAiFeatureState.showVoiceSearchToggle).thenReturn(MutableStateFlow(true))
+            whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(false))
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)
@@ -2679,11 +2680,10 @@ class InputScreenViewModelTest {
 
     // region voice entry point
 
-    @SuppressLint("DenyListedApi")
     @Test
-    fun `when search mode and voice available and flag on then voice search button visible`() =
+    fun `when search mode and voice available and voice chat entry shown then voice search button visible`() =
         runTest {
-            duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+            whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(true))
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
             val viewModel = createViewModel()
             viewModel.onSearchSelected()
@@ -2692,11 +2692,10 @@ class InputScreenViewModelTest {
             assertFalse(viewModel.visibilityState.value.voiceChatButtonVisible)
         }
 
-    @SuppressLint("DenyListedApi")
     @Test
-    fun `when search mode and voice unavailable and flag on then voice search and voice chat button hidden`() =
+    fun `when search mode and voice unavailable and voice chat entry shown then voice search and voice chat button hidden`() =
         runTest {
-            duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+            whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(true))
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(false)
             val viewModel = createViewModel()
             viewModel.onActivityResume()
@@ -2706,11 +2705,10 @@ class InputScreenViewModelTest {
             assertFalse(viewModel.visibilityState.value.voiceChatButtonVisible)
         }
 
-    @SuppressLint("DenyListedApi")
     @Test
-    fun `when duck ai mode and flag on and no text entered then voice chat button visible regardless of voice service`() =
+    fun `when duck ai mode and voice chat entry shown and no text entered then voice chat button visible regardless of voice service`() =
         runTest {
-            duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+            whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(true))
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(false)
             val viewModel = createViewModel()
             viewModel.onActivityResume()
@@ -2721,11 +2719,10 @@ class InputScreenViewModelTest {
             assertFalse(viewModel.visibilityState.value.voiceSearchButtonVisible)
         }
 
-    @SuppressLint("DenyListedApi")
     @Test
-    fun `when duck ai mode and flag on and text entered then voice chat and search button hidden`() =
+    fun `when duck ai mode and voice chat entry shown and text entered then voice chat and search button hidden`() =
         runTest {
-            duckChatFeature.duckAiVoiceEntryPoint().setRawStoredState(State(enable = true))
+            whenever(duckAiFeatureState.showVoiceChatEntry).thenReturn(MutableStateFlow(true))
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(false)
             val viewModel = createViewModel()
             viewModel.onActivityResume()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckAiShortcutSettingsViewModelTest.kt
@@ -18,9 +18,7 @@ package com.duckduckgo.duckchat.impl.ui.settings
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -41,22 +39,20 @@ class DuckAiShortcutSettingsViewModelTest {
     private lateinit var testee: DuckAiShortcutSettingsViewModel
 
     private val duckChat: DuckChatInternal = mock()
-    private val duckAiFeatureState: DuckAiFeatureState = mock()
-    private val showVoiceSearchToggleFlow = MutableStateFlow(false)
 
     @Before
     fun setUp() = runTest {
         whenever(duckChat.observeShowInBrowserMenuUserSetting()).thenReturn(flowOf(false))
         whenever(duckChat.observeShowInAddressBarUserSetting()).thenReturn(flowOf(false))
         whenever(duckChat.observeShowInVoiceSearchUserSetting()).thenReturn(flowOf(false))
-        whenever(duckAiFeatureState.showVoiceSearchToggle).thenReturn(showVoiceSearchToggleFlow)
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        whenever(duckChat.observeShowInVoiceChatUserSetting()).thenReturn(flowOf(false))
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
     }
 
     @Test
     fun whenViewModelIsCreatedAndShowInBrowserIsEnabledThenEmitEnabled() = runTest {
         whenever(duckChat.observeShowInBrowserMenuUserSetting()).thenReturn(flowOf(true))
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertTrue(awaitItem().showInBrowserMenu)
@@ -66,7 +62,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndShowInBrowserIsDisabledThenEmitDisabled() = runTest {
         whenever(duckChat.observeShowInBrowserMenuUserSetting()).thenReturn(flowOf(false))
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertFalse(awaitItem().showInBrowserMenu)
@@ -76,7 +72,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndShowInAddressBarIsEnabledThenEmitEnabled() = runTest {
         whenever(duckChat.observeShowInAddressBarUserSetting()).thenReturn(flowOf(true))
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertTrue(awaitItem().showInAddressBar)
@@ -85,7 +81,7 @@ class DuckAiShortcutSettingsViewModelTest {
 
     @Test
     fun whenViewModelIsCreatedAndShowInAddressBarIsDisabledThenEmitDisabled() = runTest {
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertFalse(awaitItem().showInAddressBar)
@@ -95,7 +91,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndShowInVoiceSearchIsEnabledThenEmitEnabled() = runTest {
         whenever(duckChat.observeShowInVoiceSearchUserSetting()).thenReturn(flowOf(true))
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertTrue(awaitItem().showInVoiceSearch)
@@ -104,7 +100,7 @@ class DuckAiShortcutSettingsViewModelTest {
 
     @Test
     fun whenViewModelIsCreatedAndShowInVoiceSearchIsDisabledThenEmitDisabled() = runTest {
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             assertFalse(awaitItem().showInVoiceSearch)
@@ -114,7 +110,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenAddressBarEntryPointEnabledTogglesShown() = runTest {
         whenever(duckChat.isAddressBarEntryPointEnabled()).thenReturn(true)
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             val state = awaitItem()
@@ -126,7 +122,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenAddressBarEntryPointDisabledThenToggleHidden() = runTest {
         whenever(duckChat.isAddressBarEntryPointEnabled()).thenReturn(false)
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             val state = awaitItem()
@@ -137,7 +133,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenVoiceSearchEntryPointEnabledThenToggleShown() = runTest {
         whenever(duckChat.isVoiceSearchEntryPointEnabled()).thenReturn(true)
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             val state = awaitItem()
@@ -149,7 +145,7 @@ class DuckAiShortcutSettingsViewModelTest {
     @Test
     fun whenVoiceSearchEntryPointDisabledThenToggleHidden() = runTest {
         whenever(duckChat.isVoiceSearchEntryPointEnabled()).thenReturn(false)
-        testee = DuckAiShortcutSettingsViewModel(duckChat, duckAiFeatureState)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
 
         testee.viewState.test {
             val state = awaitItem()
@@ -162,5 +158,54 @@ class DuckAiShortcutSettingsViewModelTest {
         testee.onShowDuckChatInVoiceSearchToggled(true)
 
         verify(duckChat).setShowInVoiceSearchUserSetting(true)
+    }
+
+    @Test
+    fun whenViewModelIsCreatedAndShowInVoiceChatIsEnabledThenEmitEnabled() = runTest {
+        whenever(duckChat.observeShowInVoiceChatUserSetting()).thenReturn(flowOf(true))
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
+
+        testee.viewState.test {
+            assertTrue(awaitItem().showInVoiceChat)
+        }
+    }
+
+    @Test
+    fun whenViewModelIsCreatedAndShowInVoiceChatIsDisabledThenEmitDisabled() = runTest {
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
+
+        testee.viewState.test {
+            assertFalse(awaitItem().showInVoiceChat)
+        }
+    }
+
+    @Test
+    fun whenVoiceChatEntryEnabledThenToggleShown() = runTest {
+        whenever(duckChat.isVoiceChatEntryPointEnabled()).thenReturn(true)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertTrue(state.shouldShowVoiceChatToggle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenVoiceChatEntryDisabledThenToggleHidden() = runTest {
+        whenever(duckChat.isVoiceChatEntryPointEnabled()).thenReturn(false)
+        testee = DuckAiShortcutSettingsViewModel(duckChat)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertFalse(state.shouldShowVoiceChatToggle)
+        }
+    }
+
+    @Test
+    fun whenOnShowDuckChatInVoiceChatToggledThenCallDuckChatSetShowInVoiceChat() = runTest {
+        testee.onShowDuckChatInVoiceChatToggled(true)
+
+        verify(duckChat).setShowInVoiceChatUserSetting(true)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214290274396484?focus=true

### Description
Adds a “Voice Chat” entry into the Duck.ai Shortcuts Ai Features setttings. Behavior is outlined in the linked task.

### Steps to test this PR
Verifies the new **Voice Chat** shortcut toggle in Duck.ai settings, and that toggling it correctly drives the voice-chat entry point live (no app restart) on both input field modes — the dedicated **Input      
  Screen** and the **Native Input Field** in the omnibar. Inputs varied: the `duckAiVoiceEntryPoint` remote feature flag, the **Voice Chat** shortcut toggle, and the **Native Input Field** setting.                
                                                                                                                                                                                                                     
  ### Setup                                                                                                                                                                                                          
  - [x] Duck.ai is enabled (Settings → Duck.ai → master toggle ON)                                                                                                                                                   
  - [x] Search & Duck.ai mode enabled (Via Settings)
  - [x] Enable the `nativeInputField` FF (ONLY)
  - [x] Restart app every time a FF is updated    
  - [x] Enable Private Voice Search                                                                                                                                                                                     
                                                                                                                                                                                                                     
  ### 1. `duckAiVoiceEntryPoint` disabled                                                                                                                                                                            
  - [x] Settings → Duck.ai shortcuts: the **Voice Chat** row is **NOT** visible                                                                                                                                      
  - [x] With **Native Input Field = OFF** : on the Duck.Ai tab ,the voice **chat** FAB is **NOT** shown; the voice **search** button is shown and opens voice search                                              
  - [x] With **Native Input Field = ON**: on the Duck.Ai tab, the voice **chat** button is **NOT** shown; the voice **search** button is shown and opens voice search                                    
                                                                                                                                                                                                                     
  ### 2. `duckAiVoiceEntryPoint` enabled, **Voice Chat** toggle = ON (default initial state)
  - [x] Settings → Duck.ai shortcuts: the **Voice Chat** row **IS** visible and shows ON by default (first install / fresh state)
  - [x] With **Native Input Field = OFF**: on the Duck.Ai tab , the voice chat FAB is visible and opens **Duck.ai voice mode**
  - [x] With **Native Input Field = ON**: on the native omnibar Duck.Ai tab, tthe voice chat FAB is visible and opens **Duck.ai voice mode**
  - [x] On the **Search** tab in either mode, the voice icon tap opens voice search                                                                                                                     
               
                                                                                                                                                                                                                     
  ### 3. Live update with Input Screen — `duckAiVoiceEntryPoint` enabled, **Native Input Field = OFF**                                                                                                               
  - [x] Toggling **Voice Chat** ON → OFF in settings                                                                                                                                                                 
  - [x] **Without restarting the app**, navigate to the input screen and switch to the **DuckAi** tab                                                                                                                  
  - [x] on the Duck.Ai tab ,the voice **chat** FAB is **NOT** shown; the voice **search** button is shown and opens voice search                                                                                          
  - [x] Toggle **Voice Chat** back to ON; **without restarting**, return to the DuckAi tab — the voice chat FAB is visible and opens **Duck.ai voice mode**
  - [x] On the **Search** tab, the voice icon tap still opens voice search (unchanged) regardless of toggle state                                                                                                    
                                                                                                                                                                                                                     
  ### 4. Live update with Native Input Field — `duckAiVoiceEntryPoint` enabled, **Native Input Field = ON**                                                                                                          
  - [x] Toggling **Voice Chat** ON → OFF in settings                                                                                                                                                                 
  - [x] **Without restarting the app**, navigate to the input screen and switch to the **DuckAi** tab                                                                                                                  
  - [x] on the Duck.Ai tab ,the voice **chat** FAB is **NOT** shown; the voice **search** button is shown and opens voice search                                                                                          
  - [x] Toggle **Voice Chat** back to ON; **without restarting**, return to the DuckAi tab — the voice chat FAB is visible and opens **Duck.ai voice mode**
  - [x] On the **Search** tab, the voice icon tap still opens voice search (unchanged) regardless of toggle state                                                                                                                                                                                                                 
                                                                                                                                                                                                                     
  ### 5. Duck.ai master toggle OFF                                                                                                                                                                                   
  - [x] Disable Duck.ai (Settings → Duck.ai → master toggle OFF)                                                                                                                                                     
  - [x] The **Duck.ai shortcuts** screen is unreachable / hidden — voice-chat toggle state is irrelevant                                                                                                             
  - [x] No Duck.ai chat tab is presented; voice-chat entry path doesn't apply in either input field mode                                                                                                             
                                                                                                                                                                                                                     
  ### Regression checks                                                                                                                                                                                              
  - [x] Test bottom bar configuration
  - [x] **Voice Search** shortcut row continues to behave correctly (independent of the new toggle): toggling ON/OFF reflects on the voice-search screen without restart                                             
  - [x] **Show in browser menu** and **Show in address bar** shortcut toggles are unaffected                                                                                                                         
  - [x] Search-tab voice icon: in both input field modes, always launches voice search regardless of the **Voice Chat** toggle and `duckAiVoiceEntryPoint` flag                                                      
  - [x] String "Voice Chat" displays correctly (only English copy is shipped — `translatable="false"` in `donottranslate.xml`)                                                                                       
                                                                                                                                                                                

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted user preference and threads it through feature-state and UI logic to gate the voice chat entry point; risk is mainly regressions in visibility/launch behavior across input screen and settings.
> 
> **Overview**
> Adds a new **user-facing shortcut setting** to control whether the Duck.ai *voice chat* entry point is shown, including a new toggle in `DuckAiShortcutSettingsActivity`.
> 
> Plumbs the new preference end-to-end: `RealDuckChat` exposes `set/observeShowInVoiceChatUserSetting`, caches an `isVoiceChatEntryPointEnabled` flag from remote config, and updates `showVoiceChatEntry` to require *both* remote enablement and the new user setting, with persistence added in `DuckChatFeatureRepository`/`DuckChatDataStore`.
> 
> Updates input-screen voice button behavior (`InputScreenFragment`/`InputScreenViewModel`) to rely on `DuckAiFeatureState.showVoiceChatEntry` (instead of directly checking the feature flag), and expands unit tests to cover the new toggle and datastore plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d8b397662c1704be94390a42f649551f143e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->