### PR TITLE
use the data-clearing API to delete all chats upon fire button

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -279,6 +279,8 @@ dependencies {
 	implementation project(":duckchat-api")
 	implementation project(":duckchat-impl")
 	implementation project(":duckchat-store")
+	implementation project(":data-clearing-api")
+	implementation project(":data-clearing-impl")
 	internalImplementation project(":duckchat-internal")
 	implementation project(":malicious-site-protection-impl")
 	implementation project(":malicious-site-protection-api")

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -32,6 +32,8 @@ import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabAtomicOperations
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.dataclearing.api.plugin.ClearableData
+import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
@@ -71,6 +73,7 @@ class DataClearing @Inject constructor(
     private val duckChat: DuckChat,
     private val contextualDataStore: DuckChatContextualDataStore,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val dataClearingTrigger: DataClearingTrigger,
 ) : ManualDataClearing, AutomaticDataClearing {
 
     override suspend fun clearSingleTabData(tabId: String): ClearDataResult {
@@ -130,7 +133,7 @@ class DataClearing @Inject constructor(
     private suspend fun clearDuckAiChatIfNeeded(tabUrl: String?) {
         logcat { "clearDuckAiChatIfNeeded url=$tabUrl" }
         if (tabUrl == null) return
-        duckChat.deleteChat(tabUrl)
+        dataClearingTrigger.clearData(setOf(ClearableData.DuckChats.Single(tabUrl)))
     }
 
     override suspend fun clearDataUsingManualFireOptions(shouldRestartIfRequired: Boolean, wasAppUsedSinceLastClear: Boolean) {
@@ -251,6 +254,7 @@ class DataClearing @Inject constructor(
 
         if (shouldClearDuckAiChats) {
             clearDataAction.clearDuckAiChatsOnly()
+            dataClearingTrigger.clearData(setOf(ClearableData.DuckChats.All))
         }
 
         logcat { "Granular clear completed" }

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -223,8 +223,10 @@ class ClearPersonalDataAction(
                 shouldClearDuckAiData = true,
             )
 
-            logcat(INFO) { "Finished clearing chats" }
+            logcat(INFO) { "Finished clearing chats (web storage)" }
         }
+
+        logcat(INFO) { "Finished clearing chats" }
     }
 
     override suspend fun clearDataForSpecificDomains(

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.app.tabs.model.TabAtomicOperations
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.dataclearing.api.plugin.ClearableData
+import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
@@ -105,6 +107,9 @@ class DataClearingTest {
     @Mock
     private lateinit var mockShowOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore
 
+    @Mock
+    private lateinit var mockDataClearingTrigger: DataClearingTrigger
+
     private val showClearDuckAIChatHistoryFlow = MutableStateFlow(true)
     private val showOnAppLaunchOptionFlow = MutableStateFlow<ShowOnAppLaunchOption>(ShowOnAppLaunchOption.LastOpenedTab)
 
@@ -133,6 +138,7 @@ class DataClearingTest {
             duckChat = mockDuckChat,
             contextualDataStore = mockContextualDataStore,
             showOnAppLaunchOptionDataStore = mockShowOnAppLaunchOptionDataStore,
+            dataClearingTrigger = mockDataClearingTrigger,
         )
     }
 
@@ -779,7 +785,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=abc-123")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
     }
 
     @Test
@@ -789,7 +795,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://example.com")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://example.com")))
     }
 
     @Test
@@ -800,7 +806,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=abc-123")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
     }
 
     @Test
@@ -811,7 +817,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=abc-123")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
     }
 
     @Test
@@ -821,7 +827,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat, never()).deleteChat(any())
+        verify(mockDataClearingTrigger, never()).clearData(any())
     }
 
     // --- clearContextualChatDataIfNeeded tests ---
@@ -835,7 +841,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=contextual-123")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=contextual-123")))
         verify(mockContextualDataStore).clearTabChatUrl("tab1")
     }
 
@@ -872,8 +878,8 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=tab-chat")
-        verify(mockDuckChat).deleteChat("https://duck.ai/chat?chatID=contextual-456")
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=tab-chat")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=contextual-456")))
     }
 
     // --- getNewTabUrl tests (via clearSingleTabData) ---

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -38,14 +38,6 @@ interface DuckChat {
     fun openDuckChat()
 
     /**
-     * Deletes the local storage data for a specific chat conversation.
-     *
-     * @param url the URL associated with the chat to delete
-     * @return true if the chat was successfully deleted from all domains, false otherwise
-     */
-    suspend fun deleteChat(url: String): Boolean
-
-    /**
      * Auto-prompts the DuckChat WebView with the provided [String] query.
      */
     fun openDuckChatWithAutoPrompt(query: String)

--- a/duckchat/duckchat-impl/build.gradle
+++ b/duckchat/duckchat-impl/build.gradle
@@ -25,6 +25,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
 	implementation project(":duckchat-api")
+    implementation project(':data-clearing-api')
     implementation project(':settings-api')
     implementation project(':navigation-api')
     implementation project(':design-system')

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -38,8 +38,6 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
-import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
-import com.duckduckgo.duckchat.impl.clearing.DuckChatDeleter
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
@@ -53,12 +51,10 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRES
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BAR_SELECTION
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
-import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.sync.api.DeviceSyncState
-import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
@@ -344,9 +340,6 @@ class RealDuckChat @Inject constructor(
     private val newAddressBarOptionBottomSheetDialogFactory: NewAddressBarOptionBottomSheetDialogFactory,
     private val deviceSyncState: DeviceSyncState,
     private val cookiesManager: CookieManagerProvider,
-    private val duckChatDeleter: DuckChatDeleter,
-    private val duckChatSyncRepository: DuckChatSyncRepository,
-    private val syncEngine: SyncEngine,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val appBuildConfig: AppBuildConfig,
     private val voiceSessionStateManager: VoiceSessionStateManager,
@@ -508,17 +501,6 @@ class RealDuckChat @Inject constructor(
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             context.startActivity(this)
         }
-    }
-
-    override suspend fun deleteChat(url: String): Boolean {
-        logcat { "DuckAI: RealDuckChat.deleteChat url=$url" }
-        val chatId = extractChatId(url) ?: return false
-        val deleted = duckChatDeleter.deleteChat(chatId)
-        if (deleted) {
-            duckChatSyncRepository.recordSingleChatDeletion(chatId)
-            syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
-        }
-        return deleted
     }
 
     override fun observeCloseEvent(
@@ -728,12 +710,6 @@ class RealDuckChat @Inject constructor(
             val queryParameters = uri.queryParameterNames
             queryParameters.contains(CHAT_QUERY_NAME) && uri.getQueryParameter(CHAT_QUERY_NAME) == CHAT_QUERY_VALUE
         }.getOrDefault(false)
-    }
-
-    private fun extractChatId(url: String): String? {
-        val uri = url.toUri()
-        if (!isDuckChatUrl(uri)) return null
-        return uri.getQueryParameter(CHAT_ID_PARAM)?.takeIf { it.isNotBlank() }
     }
 
     private fun isDuckChatBang(uri: Uri): Boolean = bangRegex?.containsMatchIn(uri.toString()) == true

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DelegatingDuckChatDeleter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DelegatingDuckChatDeleter.kt
@@ -54,4 +54,15 @@ class DelegatingDuckChatDeleter @Inject constructor(
         }
         return@withContext deleter.deleteChat(chatId)
     }
+
+    override suspend fun deleteAllChats(): Boolean = withContext(dispatchers.io()) {
+        val hasMigrated = store.hasMigrated()
+        val deleter = if (hasMigrated && feature.useNativeStorageChatData().isEnabled()) nativeDeleter else webViewDeleter
+        logcat { "DuckAI delete all chats: using ${if (deleter === nativeDeleter) "native store" else "WebView"} deleter" }
+        pixels.get().reportNativeStorageDeletionUsed(native = deleter === nativeDeleter)
+        if (hasMigrated && deleter != nativeDeleter) {
+            nativeDeleter.deleteAllChats()
+        }
+        return@withContext deleter.deleteAllChats()
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.clearing
+
+import androidx.core.net.toUri
+import com.duckduckgo.dataclearing.api.plugin.ClearableData
+import com.duckduckgo.dataclearing.api.plugin.DataClearingPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
+import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
+import com.duckduckgo.sync.api.engine.SyncEngine
+import com.squareup.anvil.annotations.ContributesMultibinding
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class DuckChatDataClearingPlugin @Inject constructor(
+    private val duckChatDeleter: DuckChatDeleter,
+    private val duckChatSyncRepository: DuckChatSyncRepository,
+    private val syncEngine: SyncEngine,
+    private val duckChat: DuckChat,
+) : DataClearingPlugin {
+
+    override suspend fun onClearData(types: Set<ClearableData>) {
+        types.forEach { type ->
+            when (type) {
+                is ClearableData.DuckChats.All -> deleteAllChats()
+                is ClearableData.DuckChats.Single -> deleteChat(type.chatUrl)
+                else -> { /* not handled by this plugin */ }
+            }
+        }
+    }
+
+    private suspend fun deleteAllChats() {
+        logcat { "DuckChatDataClearingPlugin: deleting all chats" }
+        val deleted = duckChatDeleter.deleteAllChats()
+        if (deleted) {
+            duckChatSyncRepository.recordDuckAiChatsDeleted(System.currentTimeMillis())
+            duckChatSyncRepository.clearPendingChatDeletions()
+            syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+        }
+    }
+
+    private suspend fun deleteChat(chatUrl: String) {
+        logcat { "DuckChatDataClearingPlugin: deleting chat url=$chatUrl" }
+        val chatId = extractChatId(chatUrl) ?: return
+        val deleted = duckChatDeleter.deleteChat(chatId)
+        if (deleted) {
+            duckChatSyncRepository.recordSingleChatDeletion(chatId)
+            syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+        }
+    }
+
+    private fun extractChatId(url: String): String? {
+        val uri = url.toUri()
+        if (!duckChat.isDuckChatUrl(uri)) return null
+        return uri.getQueryParameter(CHAT_ID_PARAM)?.takeIf { it.isNotBlank() }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
@@ -17,11 +17,13 @@
 package com.duckduckgo.duckchat.impl.clearing
 
 import androidx.core.net.toUri
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -34,6 +36,8 @@ class DuckChatDataClearingPlugin @Inject constructor(
     private val duckChatSyncRepository: DuckChatSyncRepository,
     private val syncEngine: SyncEngine,
     private val duckChat: DuckChat,
+    private val currentTimeProvider: CurrentTimeProvider,
+    private val duckChatFeatureRepository: DuckChatFeatureRepository,
 ) : DataClearingPlugin {
 
     override suspend fun onClearData(types: Set<ClearableData>) {
@@ -50,7 +54,16 @@ class DuckChatDataClearingPlugin @Inject constructor(
         logcat { "DuckChatDataClearingPlugin: deleting all chats" }
         val deleted = duckChatDeleter.deleteAllChats()
         if (deleted) {
-            duckChatSyncRepository.recordDuckAiChatsDeleted(System.currentTimeMillis())
+            // FIXME: This duplicates the background-aware timestamp logic from DuckAiChatDeletionListenerImpl.
+            //  When the fire button triggers an automatic clear (e.g. clear-on-exit via DataClearingWorker), the
+            //  sync timestamp should reflect when the user backgrounded the app, not when the clearing actually
+            //  executed (which could be significantly later). The background timestamp is persisted to disk by
+            //  DuckAiChatDeletionListenerImpl.onStop() and survives process restarts.
+            //  Ideally, the timestamp recording should live in a single place, but clearDuckAiChatsOnly() in
+            //  ClearPersonalDataAction already records via the DuckAiChatDeletionListener, so this plugin must
+            //  also be background-aware to avoid overwriting the correct timestamp with a stale one.
+            val timestamp = duckChatFeatureRepository.getAppBackgroundTimestamp() ?: currentTimeProvider.currentTimeMillis()
+            duckChatSyncRepository.recordDuckAiChatsDeleted(timestamp)
             duckChatSyncRepository.clearPendingChatDeletions()
             syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/NativeDuckChatDeleter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/NativeDuckChatDeleter.kt
@@ -24,4 +24,9 @@ class NativeDuckChatDeleter @Inject constructor(
 ) : DuckChatDeleter {
 
     override suspend fun deleteChat(chatId: String): Boolean = store.deleteChat(chatId)
+
+    override suspend fun deleteAllChats(): Boolean {
+        store.deleteAllChats()
+        return true
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/RealDuckChatDeleter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/RealDuckChatDeleter.kt
@@ -50,6 +50,7 @@ import javax.inject.Inject
 
 interface DuckChatDeleter {
     suspend fun deleteChat(chatId: String): Boolean
+    suspend fun deleteAllChats(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -102,6 +103,11 @@ class RealDuckChatDeleter @Inject constructor(
                 }
             }
         }
+    }
+
+    override suspend fun deleteAllChats(): Boolean {
+        logcat { "deleteAllChats is no-op for the webview legacy implementation" }
+        return true // no-op as we don't clear IDB data from here
     }
 
     private fun tearDown() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
-import com.duckduckgo.duckchat.impl.clearing.DuckChatDeleter
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
@@ -48,14 +47,12 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRES
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BAR_SELECTION
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
-import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.sync.api.DeviceSyncState
-import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -106,9 +103,6 @@ class RealDuckChatTest {
     private val mockNewAddressBarOptionBottomSheetDialog: NewAddressBarOptionBottomSheetDialog = mock()
     private val mockDeviceSyncState: DeviceSyncState = mock()
     private val cookiesManager: CookieManagerProvider = mock()
-    private val mockDuckChatDeleter: DuckChatDeleter = mock()
-    private val mockDuckChatSyncRepository: DuckChatSyncRepository = mock()
-    private val mockSyncEngine: SyncEngine = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
@@ -149,9 +143,6 @@ class RealDuckChatTest {
                 mockNewAddressBarOptionBottomSheetDialogFactory,
                 mockDeviceSyncState,
                 cookiesManager,
-                mockDuckChatDeleter,
-                mockDuckChatSyncRepository,
-                mockSyncEngine,
                 mockDuckAiHostProvider,
                 mockAppBuildConfig,
                 mockVoiceSessionStateManager,
@@ -1501,64 +1492,6 @@ class RealDuckChatTest {
         whenever(cookiesManager.get()).thenReturn(null)
 
         assertFalse(testee.isStandaloneMigrationCompleted())
-    }
-
-    @Test
-    fun `when duck ai url with chatID then deleteChat delegates to deleter`() = runTest {
-        whenever(mockDuckChatDeleter.deleteChat("abc-123")).thenReturn(true)
-
-        val result = testee.deleteChat("https://duck.ai/chat?chatID=abc-123")
-
-        assertTrue(result)
-        verify(mockDuckChatDeleter).deleteChat("abc-123")
-        verify(mockDuckChatSyncRepository).recordSingleChatDeletion("abc-123")
-        verify(mockSyncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
-    }
-
-    @Test
-    fun `when duck ai url without chatID then deleteChat returns false`() = runTest {
-        val result = testee.deleteChat("https://duck.ai/chat")
-
-        assertFalse(result)
-        verify(mockDuckChatDeleter, never()).deleteChat(any())
-    }
-
-    @Test
-    fun `when non duck ai url with chatID param then deleteChat returns false`() = runTest {
-        val result = testee.deleteChat("https://example.com/?chatID=abc-123")
-
-        assertFalse(result)
-        verify(mockDuckChatDeleter, never()).deleteChat(any())
-    }
-
-    @Test
-    fun `when duck ai url with blank chatID then deleteChat returns false`() = runTest {
-        val result = testee.deleteChat("https://duck.ai/chat?chatID=")
-
-        assertFalse(result)
-        verify(mockDuckChatDeleter, never()).deleteChat(any())
-    }
-
-    @Test
-    fun `when legacy duckduckgo duck ai url with chatID then deleteChat delegates to deleter`() = runTest {
-        whenever(mockDuckChatDeleter.deleteChat("abc-123")).thenReturn(true)
-
-        val result = testee.deleteChat("https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5&chatID=abc-123")
-
-        assertTrue(result)
-        verify(mockDuckChatDeleter).deleteChat("abc-123")
-    }
-
-    @Test
-    fun `when deleteChat and deleter returns false then deleteChat returns false`() = runTest {
-        whenever(mockDuckChatDeleter.deleteChat("abc-123")).thenReturn(false)
-
-        val result = testee.deleteChat("https://duck.ai/chat?chatID=abc-123")
-
-        assertFalse(result)
-        verify(mockDuckChatDeleter).deleteChat("abc-123")
-        verify(mockDuckChatSyncRepository, never()).recordSingleChatDeletion(any())
-        verify(mockSyncEngine, never()).triggerSync(any())
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DelegatingDuckChatDeleterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DelegatingDuckChatDeleterTest.kt
@@ -147,4 +147,49 @@ class DelegatingDuckChatDeleterTest {
 
         assertFalse(deleter.deleteChat("chat-1"))
     }
+
+    // --- deleteAllChats ---
+
+    @Test
+    fun `deleteAllChats uses native deleter when migrated and FF enabled`() = runTest {
+        whenever(store.hasMigrated()).thenReturn(true)
+        whenever(nativeStorageToggle.isEnabled()).thenReturn(true)
+        whenever(nativeDeleter.deleteAllChats()).thenReturn(true)
+
+        assertTrue(deleter.deleteAllChats())
+        verify(nativeDeleter).deleteAllChats()
+        verify(webViewDeleter, never()).deleteAllChats()
+    }
+
+    @Test
+    fun `deleteAllChats uses WebView deleter when not migrated`() = runTest {
+        whenever(store.hasMigrated()).thenReturn(false)
+        whenever(nativeStorageToggle.isEnabled()).thenReturn(true)
+        whenever(webViewDeleter.deleteAllChats()).thenReturn(true)
+
+        assertTrue(deleter.deleteAllChats())
+        verify(webViewDeleter).deleteAllChats()
+        verify(nativeDeleter, never()).deleteAllChats()
+    }
+
+    @Test
+    fun `deleteAllChats also clears native store when migrated but FF disabled`() = runTest {
+        whenever(store.hasMigrated()).thenReturn(true)
+        whenever(nativeStorageToggle.isEnabled()).thenReturn(false)
+        whenever(webViewDeleter.deleteAllChats()).thenReturn(true)
+
+        deleter.deleteAllChats()
+
+        verify(nativeDeleter).deleteAllChats()
+        verify(webViewDeleter).deleteAllChats()
+    }
+
+    @Test
+    fun `deleteAllChats returns false when deleter fails`() = runTest {
+        whenever(store.hasMigrated()).thenReturn(true)
+        whenever(nativeStorageToggle.isEnabled()).thenReturn(true)
+        whenever(nativeDeleter.deleteAllChats()).thenReturn(false)
+
+        assertFalse(deleter.deleteAllChats())
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
@@ -19,8 +19,10 @@ package com.duckduckgo.duckchat.impl.clearing
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.sync.api.engine.SyncEngine
 import kotlinx.coroutines.test.runTest
@@ -44,11 +46,16 @@ class DuckChatDataClearingPluginTest {
     private val duckChatSyncRepository: DuckChatSyncRepository = mock()
     private val syncEngine: SyncEngine = mock()
     private val duckChat: DuckChat = mock()
+    private val currentTimeProvider: CurrentTimeProvider = mock()
+    private val duckChatFeatureRepository: DuckChatFeatureRepository = mock()
     private lateinit var plugin: DuckChatDataClearingPlugin
 
     @Before
     fun setup() {
-        plugin = DuckChatDataClearingPlugin(duckChatDeleter, duckChatSyncRepository, syncEngine, duckChat)
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1234567890L)
+        plugin = DuckChatDataClearingPlugin(
+            duckChatDeleter, duckChatSyncRepository, syncEngine, duckChat, currentTimeProvider, duckChatFeatureRepository,
+        )
     }
 
     @Test
@@ -61,6 +68,27 @@ class DuckChatDataClearingPluginTest {
         verify(duckChatSyncRepository).recordDuckAiChatsDeleted(any())
         verify(duckChatSyncRepository).clearPendingChatDeletions()
         verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
+    @Test
+    fun `deleteAllChats uses background timestamp when available`() = runTest {
+        val backgroundTimestamp = 9999999999L
+        whenever(duckChatDeleter.deleteAllChats()).thenReturn(true)
+        whenever(duckChatFeatureRepository.getAppBackgroundTimestamp()).thenReturn(backgroundTimestamp)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.All))
+
+        verify(duckChatSyncRepository).recordDuckAiChatsDeleted(backgroundTimestamp)
+    }
+
+    @Test
+    fun `deleteAllChats falls back to current time when no background timestamp`() = runTest {
+        whenever(duckChatDeleter.deleteAllChats()).thenReturn(true)
+        whenever(duckChatFeatureRepository.getAppBackgroundTimestamp()).thenReturn(null)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.All))
+
+        verify(duckChatSyncRepository).recordDuckAiChatsDeleted(1234567890L)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.clearing
 
 import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.duckchat.api.DuckChat
@@ -32,9 +33,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class DuckChatDataClearingPluginTest {
 
     @get:Rule

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.clearing
+
+import android.net.Uri
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.dataclearing.api.plugin.ClearableData
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
+import com.duckduckgo.sync.api.engine.SyncEngine
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DuckChatDataClearingPluginTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val duckChatDeleter: DuckChatDeleter = mock()
+    private val duckChatSyncRepository: DuckChatSyncRepository = mock()
+    private val syncEngine: SyncEngine = mock()
+    private val duckChat: DuckChat = mock()
+    private lateinit var plugin: DuckChatDataClearingPlugin
+
+    @Before
+    fun setup() {
+        plugin = DuckChatDataClearingPlugin(duckChatDeleter, duckChatSyncRepository, syncEngine, duckChat)
+    }
+
+    @Test
+    fun `deleteAllChats deletes all chats and records sync`() = runTest {
+        whenever(duckChatDeleter.deleteAllChats()).thenReturn(true)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.All))
+
+        verify(duckChatDeleter).deleteAllChats()
+        verify(duckChatSyncRepository).recordDuckAiChatsDeleted(any())
+        verify(duckChatSyncRepository).clearPendingChatDeletions()
+        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
+    @Test
+    fun `deleteAllChats does not record sync when deletion fails`() = runTest {
+        whenever(duckChatDeleter.deleteAllChats()).thenReturn(false)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.All))
+
+        verify(duckChatDeleter).deleteAllChats()
+        verify(duckChatSyncRepository, never()).recordDuckAiChatsDeleted(any())
+        verify(duckChatSyncRepository, never()).clearPendingChatDeletions()
+        verify(syncEngine, never()).triggerSync(any())
+    }
+
+    @Test
+    fun `deleteSingleChat extracts chatId and deletes`() = runTest {
+        val chatUrl = "https://duckduckgo.com/?ia=chat&chatID=abc-123"
+        whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
+        whenever(duckChatDeleter.deleteChat("abc-123")).thenReturn(true)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+
+        verify(duckChatDeleter).deleteChat("abc-123")
+        verify(duckChatSyncRepository).recordSingleChatDeletion("abc-123")
+        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
+    @Test
+    fun `deleteSingleChat does nothing when url is not a duck chat url`() = runTest {
+        val chatUrl = "https://example.com/?chatID=abc-123"
+        whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(false)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+
+        verify(duckChatDeleter, never()).deleteChat(any())
+        verify(syncEngine, never()).triggerSync(any())
+    }
+
+    @Test
+    fun `deleteSingleChat does nothing when chatId is missing`() = runTest {
+        val chatUrl = "https://duckduckgo.com/?ia=chat"
+        whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+
+        verify(duckChatDeleter, never()).deleteChat(any())
+        verify(syncEngine, never()).triggerSync(any())
+    }
+
+    @Test
+    fun `deleteSingleChat does not record sync when deletion fails`() = runTest {
+        val chatUrl = "https://duckduckgo.com/?ia=chat&chatID=abc-123"
+        whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
+        whenever(duckChatDeleter.deleteChat("abc-123")).thenReturn(false)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+
+        verify(duckChatDeleter).deleteChat("abc-123")
+        verify(duckChatSyncRepository, never()).recordSingleChatDeletion(any())
+        verify(syncEngine, never()).triggerSync(any())
+    }
+
+    @Test
+    fun `ignores unrelated clearable data types`() = runTest {
+        plugin.onClearData(setOf(ClearableData.Tabs.All, ClearableData.BrowserData.All))
+
+        verify(duckChatDeleter, never()).deleteAllChats()
+        verify(duckChatDeleter, never()).deleteChat(any())
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/NativeDuckChatDeleterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/NativeDuckChatDeleterTest.kt
@@ -59,4 +59,10 @@ class NativeDuckChatDeleterTest {
         deleter.deleteChat("chat-1")
         verify(store).deleteChat("chat-1")
     }
+
+    @Test
+    fun `deleteAllChats delegates to store and returns true`() = runTest {
+        assertTrue(deleter.deleteAllChats())
+        verify(store).deleteAllChats()
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1420,7 +1420,6 @@ class DuckChatContextualViewModelTest {
         ): String = nextUrl
 
         override fun isDuckChatUrl(uri: android.net.Uri): Boolean = false
-        override suspend fun deleteChat(url: String): Boolean = false
         override suspend fun wasOpenedBefore(): Boolean = false
         override fun showNewAddressBarOptionChoiceScreen(
             context: android.content.Context,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -66,8 +66,6 @@ class FakeDuckChat(
         return uri.toString().contains("duckchat")
     }
 
-    override suspend fun deleteChat(url: String): Boolean = false
-
     override suspend fun wasOpenedBefore(): Boolean {
         return wasOpenedBeforeValue
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -64,8 +64,6 @@ class FakeDuckChatInternal(
 
     override fun isDuckChatUrl(uri: Uri): Boolean = false
 
-    override suspend fun deleteChat(url: String): Boolean = false
-
     override suspend fun wasOpenedBefore(): Boolean = false
 
     override fun showNewAddressBarOptionChoiceScreen(context: Context, isDarkThemeEnabled: Boolean) { }

--- a/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/store/DuckAiDebugServer.kt
+++ b/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/store/DuckAiDebugServer.kt
@@ -17,6 +17,13 @@
 package com.duckduckgo.duckchat.internal.store
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.store.impl.DuckAiMigrationPrefs
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatEntity
@@ -25,8 +32,12 @@ import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingEntity
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingsDao
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import fi.iki.elonen.NanoHTTPD
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONArray
 import org.json.JSONObject
@@ -48,22 +59,44 @@ class RealDuckAiDebugServer @Inject constructor(
     private val fileMetaDao: DuckAiBridgeFileMetaDao,
     private val context: Context,
     private val migrationPrefs: DuckAiMigrationPrefs,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : DuckAiDebugServer {
 
     override val port = 8765
     private var server: InternalNanoServer? = null
     override val isRunning get() = server?.isAlive == true
 
+    private val preferences: SharedPreferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = false, migrate = false)
+    }
+
     override fun start() {
         if (isRunning) return
         server = InternalNanoServer().also { it.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false) }
+        appCoroutineScope.launch(dispatchers.io()) {
+            preferences.edit { putBoolean(KEY_SERVER_ENABLED, true) }
+        }
         logcat { "DuckAiDebugServer started on port $port" }
     }
 
     override fun stop() {
         server?.stop()
         server = null
+        appCoroutineScope.launch(dispatchers.io()) {
+            preferences.edit { putBoolean(KEY_SERVER_ENABLED, false) }
+        }
         logcat { "DuckAiDebugServer stopped" }
+    }
+
+    internal suspend fun startIfPreviouslyEnabled() {
+        val enabled = withContext(dispatchers.io()) {
+            preferences.getBoolean(KEY_SERVER_ENABLED, false)
+        }
+        if (enabled) {
+            withContext(dispatchers.main()) { start() }
+        }
     }
 
     private val filesDir: File get() = File(context.filesDir, "duck_ai_bridge_files")
@@ -233,6 +266,9 @@ class RealDuckAiDebugServer @Inject constructor(
     }
 
     companion object {
+        private const val PREFS_FILENAME = "com.duckduckgo.duckchat.debug.server"
+        private const val KEY_SERVER_ENABLED = "server_enabled"
+
         @Suppress("LongMethod")
         private val DEBUG_HTML = """
             <!DOCTYPE html>
@@ -792,5 +828,21 @@ class RealDuckAiDebugServer @Inject constructor(
             </body>
             </html>
         """.trimIndent()
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class DuckAiDebugServerLifecycleObserver @Inject constructor(
+    private val server: RealDuckAiDebugServer,
+    @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appCoroutineScope.launch {
+            server.startIfPreviouslyEnabled()
+        }
     }
 }

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -55,6 +55,9 @@ interface DuckAiChatStore {
 
     /** Deletes the chat with [chatId] and its associated files. Returns true if the chat existed, false if not found. */
     suspend fun deleteChat(chatId: String): Boolean
+
+    /** Deletes all chats and their associated files. */
+    suspend fun deleteAllChats()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -101,6 +104,22 @@ class RealDuckAiChatStore @Inject constructor(
 
             true
         }
+
+    override suspend fun deleteAllChats() {
+        withContext(dispatchers.io()) {
+            logcat { "DuckAI: RealDuckAiChatStore.deleteAllChats()...deleting all chats" }
+            chatsDao.deleteAll()
+            val filesDir = filesDirLazy.get()
+            fileMetaDao.getAll().forEach { meta ->
+                val file = File(filesDir, meta.uuid)
+                if (file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {
+                    logcat { "DuckAI: deleting chat file $file" }
+                    file.delete()
+                }
+            }
+            fileMetaDao.deleteAll()
+        }
+    }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatEntity
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
+import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaEntity
 import dagger.Lazy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -195,5 +196,48 @@ class RealDuckAiChatStoreTest {
 
         assertTrue(store.deleteChat("abc"))
         verify(chatsDao).delete("abc")
+    }
+
+    // --- deleteAllChats ---
+
+    @Test
+    fun `deleteAllChats clears all chats and file metadata`() = runTest {
+        whenever(fileMetaDao.getAll()).thenReturn(emptyList())
+
+        store.deleteAllChats()
+
+        verify(chatsDao).deleteAll()
+        verify(fileMetaDao).deleteAll()
+    }
+
+    @Test
+    fun `deleteAllChats deletes files from disk`() = runTest {
+        val file = File(filesDir, "uuid1").also { it.writeText("data") }
+        whenever(fileMetaDao.getAll()).thenReturn(
+            listOf(DuckAiBridgeFileMetaEntity("uuid1", "chat1", "file.png", "image/png")),
+        )
+
+        store.deleteAllChats()
+
+        assertFalse(file.exists())
+        verify(fileMetaDao).deleteAll()
+        verify(chatsDao).deleteAll()
+    }
+
+    @Test
+    fun `deleteAllChats ignores path traversal fileRefs`() = runTest {
+        val safeFile = File(filesDir, "uuid1").also { it.writeText("data") }
+        whenever(fileMetaDao.getAll()).thenReturn(
+            listOf(
+                DuckAiBridgeFileMetaEntity("uuid1", "chat1", "file.png", "image/png"),
+                DuckAiBridgeFileMetaEntity("../../etc/passwd", "chat2", "bad.txt", "text/plain"),
+            ),
+        )
+
+        store.deleteAllChats()
+
+        assertFalse(safeFile.exists())
+        // traversal file should not be deleted — it's outside filesDir
+        verify(chatsDao).deleteAll()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1198194956794324/task/1214355719902342?focus=true

### Description
Use the `DataClearingPlugin` plugin to delete chats upon fire button instead of manually wiring delete calls.
This fix a bug where "delete all" fire action was not clearing the chats when "delete chats" setting was enabled.

Incidentally I have also refactor the calls to delete single chats to use the plugin as well.
Also incidentally, I have improved the duck.ai native storage server to re-start automatically if not previously stopped

### Steps to test this PR

_Test_
- [x] install assemble debug, enable duck.ai and duck.ai toggle
- [x] start the duck.ai debug server from settings -> duck.ai (dev settings) -> Native storage debug
- [x] launch the app and create some regular chats, images, voice etc.
- [x] go to duck.ai toggle, duck.ai mode and select one chat suggestion
- [x] in duck.ai screen, use the fire button to delete the chat
- [x] Expected: `DuckChatDataClearingPlugin: deleting chat url=https://duck.ai/chat...` appears in the logcat
- [x] Expected: chat is removed
- [x] Expected: The chat is removed from the debug server 
- [x] go to tab switcher and press the fire button, delete all
- [x] Expected: all remaining chats are also removed
- [x] Expected: `DuckChatDataClearingPlugin: deleting all chats` appears in logcat

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user data-deletion paths and Duck.ai chat sync signaling; mistakes could cause incomplete clears or unintended sync state despite being well-covered by unit tests.
> 
> **Overview**
> **Routes Duck.ai chat deletion through the new `data-clearing` plugin system.** Fire-button clearing now calls `DataClearingTrigger.clearData` for `ClearableData.DuckChats` (single-tab and “delete all”), fixing the gap where “delete all” wasn’t actually removing chats.
> 
> DuckChat’s public API drops `deleteChat`, and deletion/sync side-effects move into a new `DuckChatDataClearingPlugin`, with deleters extended to support `deleteAllChats` (native store implementation added; legacy WebView path is effectively a no-op for all-chats). Separately, the Duck.ai native storage debug server now persists its enabled state and auto-restarts on app launch via a `MainProcessLifecycleObserver`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89dbe46e0c4d02235b937971da192e469275367e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->