### PR TITLE
Subscription promo modal

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3349,6 +3349,8 @@ class BrowserTabViewModel @Inject constructor(
 
     private suspend fun checkSubscriptionPromoOnForeground(): Boolean {
         if (currentGlobalLayoutState() !is Browser) return false
+        val currentUrl = url
+        if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) return false
         val cta = withContext(dispatchers.io()) { ctaViewModel.getPromoCtaOnForeground() }
         if (cta != null) {
             ctaViewState.value = currentCtaViewState().copy(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3394,8 +3394,7 @@ class BrowserTabViewModel @Inject constructor(
                 }
                 is SubscriptionPromoModalCta -> {
                     viewModelScope.launch {
-                        val origin = "funnel_skippedonboarding_android"
-                        command.value = LaunchSubscription("https://duckduckgo.com/pro?origin=$origin".toUri())
+                        command.value = LaunchSubscription("https://duckduckgo.com/pro?origin=${cta.origin}".toUri())
                     }
                     null
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1158,11 +1158,15 @@ class BrowserTabViewModel @Inject constructor(
         // we expect refreshCta to be called when a site is fully loaded if browsingShowing -trackers data available-.
         if (!currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteBlocked) {
             viewModelScope.launch {
+                if (checkSubscriptionPromoOnForeground()) return@launch
                 val cta = refreshCta()
                 showOrHideKeyboard(cta)
             }
         } else {
             command.value = HideKeyboard
+            if (currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteBlocked) {
+                viewModelScope.launch { checkSubscriptionPromoOnForeground() }
+            }
         }
 
         browserViewState.value =
@@ -3341,6 +3345,21 @@ class BrowserTabViewModel @Inject constructor(
             return cta
         }
         return null
+    }
+
+    private suspend fun checkSubscriptionPromoOnForeground(): Boolean {
+        if (currentGlobalLayoutState() !is Browser) return false
+        val cta = withContext(dispatchers.io()) { ctaViewModel.getPromoCtaOnForeground() }
+        if (cta != null) {
+            ctaViewState.value = currentCtaViewState().copy(
+                cta = cta,
+                isBrowserShowing = currentBrowserViewState().browserShowing,
+                isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
+            )
+            ctaChangedTicker.emit(System.currentTimeMillis().toString())
+            return true
+        }
+        return false
     }
 
     private fun showOrHideKeyboard(cta: Cta?) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1230,6 +1230,7 @@ class BrokenSitePromptDialogCta : Cta {
 
 class SubscriptionPromoModalCta(
     val isFreeTrialCopy: Boolean,
+    val origin: String,
 ) : Cta {
     override val ctaId: CtaId = CtaId.DAX_INTRO_PRIVACY_PRO
     override val shownPixel: Pixel.PixelName = AppPixelName.ONBOARDING_DAX_CTA_SHOWN

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -231,8 +231,14 @@ class CtaViewModel @Inject constructor(
     suspend fun getPromoCtaOnForeground(): Cta? {
         return withContext(dispatchers.io()) {
             when {
-                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
-                canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
+                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
+                    isFreeTrialCopy = freeTrialCopyAvailable(),
+                    origin = "funnel_browsermodal_android",
+                )
+                canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(
+                    isFreeTrialCopy = freeTrialCopyAvailable(),
+                    origin = "funnel_skippedonboarding_android",
+                )
                 else -> null
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -165,6 +165,9 @@ class CtaViewModel @Inject constructor(
             if (cta is DaxBubbleCta.DaxSubscriptionCta || cta is DaxSubscriptionBrandDesignUpdateBubbleCta || cta is SubscriptionPromoModalCta) {
                 subscriptionPromoCtaShownPlugins.getPlugins().forEach { it.onSubscriptionPromoCtaShown() }
             }
+            if (cta is SubscriptionPromoModalCta) {
+                dismissedCtaDao.insert(DismissedCta(cta.ctaId))
+            }
         }
     }
 
@@ -304,7 +307,7 @@ class CtaViewModel @Inject constructor(
                 }
             }
 
-            // Subscription onboarding for returning users who skipped onboarding
+            // Subscription promo for skipped-onboarding users
             canShowSubscriptionCtaForSkippedOnboarding() -> {
                 SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
             }
@@ -346,6 +349,13 @@ class CtaViewModel @Inject constructor(
             isSubscriptionCtaAvailable()
 
     @WorkerThread
+    private suspend fun canShowSubscriptionPromoCta(): Boolean =
+        extendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers().isEnabled() &&
+            appInstallStore.daysInstalled() >= SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS &&
+            !daxDialogSubscriptionShown() &&
+            isSubscriptionCtaAvailable()
+
+    @WorkerThread
     private fun canShowWidgetCta(): Boolean {
         return !widgetCapabilities.hasInstalledWidgets && !dismissedCtaDao.exists(CtaId.ADD_WIDGET)
     }
@@ -367,9 +377,12 @@ class CtaViewModel @Inject constructor(
                 return null
             }
 
+            if (canShowSubscriptionPromoCta()) {
+                return SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
+            }
+
             if (areInContextDaxDialogsCompleted()) {
-                return if (brokenSitePrompt.shouldShowBrokenSitePrompt(nonNullSite.url, detectedRefreshPatterns)
-                ) {
+                return if (brokenSitePrompt.shouldShowBrokenSitePrompt(nonNullSite.url, detectedRefreshPatterns)) {
                     BrokenSitePromptDialogCta()
                 } else {
                     null
@@ -528,7 +541,7 @@ class CtaViewModel @Inject constructor(
 
     suspend fun isPromoOnboardingDialogShowing(): Boolean =
         withContext(dispatchers.io()) {
-            canShowSubscriptionCtaForSkippedOnboarding()
+            canShowSubscriptionCtaForSkippedOnboarding() || canShowSubscriptionPromoCta()
         }
 
     private suspend fun hasNoSubscription(): Boolean = subscriptions.getSubscriptionStatus() == SubscriptionStatus.UNKNOWN

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -231,13 +231,13 @@ class CtaViewModel @Inject constructor(
     suspend fun getPromoCtaOnForeground(): Cta? {
         return withContext(dispatchers.io()) {
             when {
-                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
-                    isFreeTrialCopy = freeTrialCopyAvailable(),
-                    origin = "funnel_browsermodal_android",
-                )
                 canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(
                     isFreeTrialCopy = freeTrialCopyAvailable(),
                     origin = "funnel_skippedonboarding_android",
+                )
+                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
+                    isFreeTrialCopy = freeTrialCopyAvailable(),
+                    origin = "funnel_browsermodal_android",
                 )
                 else -> null
             }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -228,6 +228,16 @@ class CtaViewModel @Inject constructor(
         }
     }
 
+    suspend fun getPromoCtaOnForeground(): Cta? {
+        return withContext(dispatchers.io()) {
+            when {
+                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
+                canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
+                else -> null
+            }
+        }
+    }
+
     suspend fun getFireDialogCta(): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() || daxDialogFireEducationShown()) return@withContext null
@@ -307,11 +317,6 @@ class CtaViewModel @Inject constructor(
                 }
             }
 
-            // Subscription promo for skipped-onboarding users
-            canShowSubscriptionCtaForSkippedOnboarding() -> {
-                SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
-            }
-
             // Add Widget
             canShowWidgetCta() -> {
                 if (widgetCapabilities.supportsAutomaticWidgetAdd) {
@@ -375,10 +380,6 @@ class CtaViewModel @Inject constructor(
         nonNullSite.let {
             if (duckDuckGoUrlDetector.isDuckDuckGoEmailUrl(it.url)) {
                 return null
-            }
-
-            if (canShowSubscriptionPromoCta()) {
-                return SubscriptionPromoModalCta(isFreeTrialCopy = freeTrialCopyAvailable())
             }
 
             if (areInContextDaxDialogsCompleted()) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -237,7 +237,7 @@ class CtaViewModel @Inject constructor(
                 )
                 canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
                     isFreeTrialCopy = freeTrialCopyAvailable(),
-                    origin = "funnel_browsermodal_android",
+                    origin = "funnel_newusermodal_android",
                 )
                 else -> null
             }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
@@ -43,6 +43,9 @@ interface ExtendedOnboardingFeatureToggles {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun subscriptionPromoModalCta(): Toggle
 
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun subscriptionPromoModalCtaExistingUsers(): Toggle
+
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     @Experiment
     fun freeTrialCopy(): Toggle

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3397,13 +3397,48 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserClickedBrowserModalSubscriptionPromoCtaThenLaunchSubscriptionWithBrowserModalOrigin() {
-        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android")
+    fun whenUserClickedPromoModalSubscriptionPromoCtaThenLaunchSubscriptionWithPromoModalOrigin() {
+        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android")
         setCta(cta)
         testee.onUserClickCtaOkButton(cta)
         assertCommandIssued<LaunchSubscription> {
-            assertEquals("funnel_browsermodal_android", uri.getQueryParameter("origin"))
+            assertEquals("funnel_newusermodal_android", uri.getQueryParameter("origin"))
         }
+    }
+
+    @Test
+    fun whenOnViewVisibleAndOnDuckAiUrlThenSubscriptionPromoModalNotShown() =
+        runTest {
+            givenSubscriptionPromoModalCtaEligible()
+            whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+            loadUrl("https://duck.ai/", isBrowserShowing = true)
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+
+            testee.onViewVisible()
+
+            assertFalse(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
+
+    @Test
+    fun whenOnViewVisibleAndOnNonDuckAiUrlThenSubscriptionPromoModalShown() =
+        runTest {
+            givenSubscriptionPromoModalCtaEligible()
+            whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
+            loadUrl(exampleUrl, isBrowserShowing = true)
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+
+            testee.onViewVisible()
+
+            assertTrue(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
+
+    private suspend fun givenSubscriptionPromoModalCtaEligible() {
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
+        whenever(mockDismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
+        whenever(subscriptions.isEligible()).thenReturn(true)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3388,11 +3388,21 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedSubscriptionPromoModalCtaThenLaunchSubscriptionWithReinstallModalOrigin() {
-        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false)
+        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_skippedonboarding_android")
         setCta(cta)
         testee.onUserClickCtaOkButton(cta)
         assertCommandIssued<LaunchSubscription> {
             assertEquals("funnel_skippedonboarding_android", uri.getQueryParameter("origin"))
+        }
+    }
+
+    @Test
+    fun whenUserClickedBrowserModalSubscriptionPromoCtaThenLaunchSubscriptionWithBrowserModalOrigin() {
+        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android")
+        setCta(cta)
+        testee.onUserClickCtaOkButton(cta)
+        assertCommandIssued<LaunchSubscription> {
+            assertEquals("funnel_browsermodal_android", uri.getQueryParameter("origin"))
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -748,6 +748,7 @@ class BrowserTabViewModelTest {
             whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
             whenever(subscriptions.isEligible()).thenReturn(false)
             whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
+            whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
             whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
             whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
             whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -161,6 +161,7 @@ class CtaViewModelTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
@@ -1150,5 +1151,149 @@ class CtaViewModelTest {
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertTrue(value is DaxBubbleCta.DaxSubscriptionCta)
+    }
+
+    @Test
+    fun whenSubscriptionPromoModalCtaIsShownThenDismissedCtaIsInserted() = runTest {
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+        verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
+    }
+
+    private suspend fun givenSubscriptionPromoEligible() {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+    }
+
+    @Test
+    fun givenBrowsingAndEligibleWhenRefreshCtaThenReturnSubscriptionPromoModalCta() = runTest {
+        givenSubscriptionPromoEligible()
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertTrue(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingWithOnboardingActiveAndEligibleWhenRefreshCtaThenReturnSubscriptionPromoModalCta() = runTest {
+        givenDaxOnboardingActive()
+        givenSubscriptionPromoEligible()
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertTrue(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingButExistingUsersToggleDisabledWhenRefreshCtaThenDontReturnSubscriptionPromoModalCta() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingAndInstalledLessThan7DaysWhenRefreshCtaThenDontReturnSubscriptionPromoModalCta() = runTest {
+        // installTimestamp defaults to 1 day ago in @Before
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingAndSubscriptionModalAlreadyShownWhenRefreshCtaThenDontReturnSubscriptionPromoModalCta() = runTest {
+        givenSubscriptionPromoEligible()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingAndNotEligibleWhenRefreshCtaThenDontReturnSubscriptionPromoModalCta() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        // mockSubscriptions.isEligible() returns false by default from @Before
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenBrowsingWithFreeTrialCopyWhenRefreshCtaThenReturnSubscriptionPromoModalCtaWithFreeTrialCopy() = runTest {
+        givenSubscriptionPromoEligible()
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
+        val site = site(url = "https://example.com")
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertTrue(value is SubscriptionPromoModalCta)
+        assertTrue((value as SubscriptionPromoModalCta).isFreeTrialCopy)
+    }
+
+    @Test
+    fun givenSubscriptionPromoModalCtaShownWhenOnboardingActiveAndEligibleThenBubbleCtaNotShown() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+
+        // After modal is shown, DAX_INTRO_PRIVACY_PRO is in dismissed_cta, so bubble must not show
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertFalse(value is DaxBubbleCta.DaxSubscriptionCta)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1169,7 +1169,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun givenBrowsingAndEligibleWhenRefreshCtaThenReturnSubscriptionPromoModalCta() = runTest {
+    fun givenBrowsingAndEligibleWhenRefreshCtaThenDontReturnSubscriptionPromoModalCta() = runTest {
         givenSubscriptionPromoEligible()
         val site = site(url = "https://example.com")
 
@@ -1179,22 +1179,7 @@ class CtaViewModelTest {
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
         )
-        assertTrue(value is SubscriptionPromoModalCta)
-    }
-
-    @Test
-    fun givenBrowsingWithOnboardingActiveAndEligibleWhenRefreshCtaThenReturnSubscriptionPromoModalCta() = runTest {
-        givenDaxOnboardingActive()
-        givenSubscriptionPromoEligible()
-        val site = site(url = "https://example.com")
-
-        val value = testee.refreshCta(
-            coroutineRule.testDispatcher,
-            isBrowserShowing = true,
-            site = site,
-            detectedRefreshPatterns = detectedRefreshPatterns,
-        )
-        assertTrue(value is SubscriptionPromoModalCta)
+        assertFalse(value is SubscriptionPromoModalCta)
     }
 
     @Test
@@ -1266,18 +1251,35 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun givenBrowsingWithFreeTrialCopyWhenRefreshCtaThenReturnSubscriptionPromoModalCtaWithFreeTrialCopy() = runTest {
+    fun givenForegroundAndEligibleWhenGetPromoCtaOnForegroundThenReturnSubscriptionPromoModalCta() = runTest {
+        givenSubscriptionPromoEligible()
+        val value = testee.getPromoCtaOnForeground()
+        assertTrue(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenForegroundButToggleDisabledWhenGetPromoCtaOnForegroundThenDontReturnSubscriptionPromoModalCta() = runTest {
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        val value = testee.getPromoCtaOnForeground()
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenForegroundAndSubscriptionModalAlreadyShownWhenGetPromoCtaOnForegroundThenDontReturnSubscriptionPromoModalCta() = runTest {
+        givenSubscriptionPromoEligible()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+        val value = testee.getPromoCtaOnForeground()
+        assertFalse(value is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun givenForegroundWithFreeTrialCopyWhenGetPromoCtaOnForegroundThenReturnSubscriptionPromoModalCtaWithFreeTrialCopy() = runTest {
         givenSubscriptionPromoEligible()
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockEnabledToggle)
         whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
-        val site = site(url = "https://example.com")
-
-        val value = testee.refreshCta(
-            coroutineRule.testDispatcher,
-            isBrowserShowing = true,
-            site = site,
-            detectedRefreshPatterns = detectedRefreshPatterns,
-        )
+        val value = testee.getPromoCtaOnForeground()
         assertTrue(value is SubscriptionPromoModalCta)
         assertTrue((value as SubscriptionPromoModalCta).isFreeTrialCopy)
     }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1015,7 +1015,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenOnUserClickCtaOkButtonWithSubscriptionPromoModalCtaThenDismissedCtaIsInserted() = runTest {
-        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1027,7 +1027,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenSubscriptionPromoPluginsAreCalled() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
         verify(mockSubscriptionPromoCtaShownPlugin).onSubscriptionPromoCtaShown()
     }
 
@@ -1155,7 +1155,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenDismissedCtaIsInserted() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1291,7 +1291,7 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
 
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
 
         // After modal is shown, DAX_INTRO_PRIVACY_PRO is in dismissed_cta, so bubble must not show
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1015,7 +1015,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenOnUserClickCtaOkButtonWithSubscriptionPromoModalCtaThenDismissedCtaIsInserted() = runTest {
-        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
+        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1027,7 +1027,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenSubscriptionPromoPluginsAreCalled() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
         verify(mockSubscriptionPromoCtaShownPlugin).onSubscriptionPromoCtaShown()
     }
 
@@ -1155,7 +1155,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenDismissedCtaIsInserted() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1291,7 +1291,7 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
 
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_browsermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
 
         // After modal is shown, DAX_INTRO_PRIVACY_PRO is in dismissed_cta, so bubble must not show
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -269,7 +269,7 @@ class OnboardingDaxDialogTests {
     }
 
     @Test
-    fun whenHideTipsAndSevenDaysSinceInstallAndSubscriptionNotShownThenRefreshCtaReturnsSubscriptionCta() = runTest {
+    fun whenHideTipsAndSevenDaysSinceInstallAndSubscriptionNotShownThenGetPromoCtaOnForegroundReturnsSubscriptionCta() = runTest {
         whenever(settingsDataStore.hideTips).thenReturn(true)
         whenever(appInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
         whenever(dismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
@@ -280,12 +280,7 @@ class OnboardingDaxDialogTests {
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
         whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
 
-        val result = testee.refreshCta(
-            coroutineRule.testDispatcherProvider.io(),
-            isBrowserShowing = false,
-            site = null,
-            detectedRefreshPatterns = emptySet(),
-        )
+        val result = testee.getPromoCtaOnForeground()
 
         assertNotNull(result)
         assertTrue(result is SubscriptionPromoModalCta)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -97,6 +97,7 @@ class OnboardingDaxDialogTests {
         whenever(extendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(extendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockDisabledToggle)
         whenever(extendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
+        whenever(extendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
         whenever(mockSubscriptions.isEligible()).thenReturn(false)
         whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211002275136765?focus=true

### Description
Add subscription promo half-sheet modal for all existing users who have had the app installed for 7+ days, haven't seen any subscription offer before, and are eligible for a subscription. 

### Steps to test this PR

- [x] Apply patch pinned on https://app.asana.com/1/137249556945/project/72649045549333/task/1211002275136765?focus=true

_New half-sheet promo dialog - open closed_
- [x]  Fresh install
- [x]  Start onboarding but do not complete it so the subscription onboarding dialog doesn't show
- [x]  Close the app and wait 1 minute
- [x]  Open app and confirm half-sheet promo dialog shows immediately on launch (before any navigation)
- [x]  Tap Learn more and confirm the URL contains `origin=funnel_browsermodal_android`
- [x]  Go back to browser and confirm dialog does not show again
- [x]  Reopen app and confirm dialog does not show again
- [x]  Navigate to a website and confirm dialog does NOT appear during navigation

_New half-sheet promo dialog - resume from background while on a website_
- [x]  Fresh install
- [x]  Start onboarding but do not complete it so the subscription onboarding dialog doesn't show
- [x]  After 1 minute, navigate to a website, then background the app
- [x]  Reopen the app and confirm half-sheet promo dialog appears
- [x]  Tap Learn more and confirm the URL contains `origin=funnel_browsermodal_android`
- [x]  Dismiss modal
- [x] Background , reopen and confirm it does NOT show again

_Not shown if subscription dialog already seen during onboarding_
- [x]  Fresh install
- [x]  Complete onboarding including the subscription bubble CTA (last step in new tab page)
- [x]  Wait 1 minute
- [x]  Close/Open app
- [x]  Confirm half-sheet promo dialog is NOT shown

_FF disabled_
- [x]  Fresh install
- [x]  Disable `subscriptionPromoModalCtaExistingUsers` in FeatureFlag Inventory
- [x]  Start onboarding but do not complete it
- [x]  Wait 1 minute
- [x]  Close/Open app
- [x]  Confirm half-sheet promo dialog is NOT shown

### No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/where subscription promo CTAs are evaluated and shown (on app foreground and browser visibility), which can affect onboarding/CTA suppression and user experience. Gated by new feature toggle but touches core `BrowserTabViewModel` CTA flow.
> 
> **Overview**
> Shows the subscription promo half-sheet modal when the app is foregrounded (including while already browsing), before running the normal `refreshCta` flow, and suppresses it on Duck.ai URLs.
> 
> Introduces a new existing-users eligibility path (`subscriptionPromoModalCtaExistingUsers`) with install-age/subscription eligibility checks, centralizes origin handling by adding an `origin` field to `SubscriptionPromoModalCta`, and ensures the modal is marked dismissed when shown/clicked so it won’t reappear. Updates and expands unit tests to cover the new foreground promo logic and origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59cddf39c41873aa0c5bae3d0b997c926d344cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->