### PR TITLE
bugfix: Allow enableSwipeRefresh updates 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -41,6 +41,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewCompat.WebMessageListener
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
+import com.duckduckgo.app.browser.uilock.BrowserUiLockFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import dagger.android.support.AndroidSupportInjection
@@ -82,6 +83,9 @@ class DuckDuckGoWebView :
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    lateinit var browserUiLockFeature: BrowserUiLockFeature
 
     constructor(context: Context) : this(context, null)
     constructor(
@@ -444,8 +448,8 @@ class DuckDuckGoWebView :
 
     internal fun setContentAllowsSwipeToRefresh(allowed: Boolean) {
         contentAllowsSwipeToRefresh = allowed
-        if (!allowed) {
-            enableSwipeRefresh(false)
+        if (!allowed || browserUiLockFeature.self().isEnabled()) {
+            enableSwipeRefresh(allowed)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1214187547786011?focus=true

### Description
When browserUiLock feature is enabled, it's possible for the swipeRefresh to be enabled/disabled based as the site updates it's content, not only on user input, the previous behaviour relied on an assumption that the state will only change due to user input, which is problematic for browserUiLock, where an update in the swipeRefresh state could not be reflected until a user input takes place, resulting in pull-to-refresh feeling buggy.

### Steps to test this PR
- No change in behavior if browserUiLock feature is disabled. 
- if browserUiLock is enabled, pull-to-refresh should work as expected if the site is unlocked (e.g. bbc.com, google searches).
- if site is locked (e.g. windy.com, maps.google.com, https://wafflegame.net/daily) pull-to-refresh should be disabled.
- SERP should always have pull-to-refresh working.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, feature-flagged change limited to pull-to-refresh enablement logic in the WebView; main risk is minor regressions in swipe-to-refresh state updates.
> 
> **Overview**
> Adjusts `DuckDuckGoWebView.setContentAllowsSwipeToRefresh` so swipe-to-refresh state is pushed to the UI not only when content *disallows* refresh, but also whenever the `browserUiLock` feature is enabled.
> 
> This wires in `BrowserUiLockFeature` via DI and uses it to force `enableSwipeRefresh(allowed)` updates, fixing cases where pull-to-refresh could feel stale/buggy until the next user gesture under UI-lock mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e194c9669cb9611b897494848102eb701d9189c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->