### PR TITLE
PIR: Add additional parameters to initial scan pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1179,12 +1179,12 @@
             {
                 "key": "power_saving",
                 "description": "Whether the device is in power saving mode",
-                "type": "string"
+                "type": "boolean"
             },
             {
                 "key": "battery-optimizations",
                 "description": "Whether battery optimizations are enabled for the app",
-                "type": "string"
+                "type": "boolean"
             },
             {
                 "key": "broker_count",
@@ -1222,7 +1222,7 @@
             {
                 "key": "power_saving",
                 "description": "Whether the device is in power saving mode",
-                "type": "string"
+                "type": "boolean"
             },
             {
                 "key": "profile_queries",
@@ -1256,12 +1256,12 @@
             {
                 "key": "power_saving",
                 "description": "Whether the device is in power saving mode",
-                "type": "string"
+                "type": "boolean"
             },
             {
                 "key": "battery-optimizations",
                 "description": "Whether battery optimizations are enabled for the app",
-                "type": "string"
+                "type": "boolean"
             },
             {
                 "key": "total_scan",

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1170,6 +1170,26 @@
                 "description": "Whether tracker blocking was enabled or disabled during the operation",
                 "type": "string",
                 "enum": ["enabled", "disabled"]
+            },
+            {
+                "key": "manufacturer",
+                "description": "Manufacturer of the device",
+                "type": "string"
+            },
+            {
+                "key": "power_saving",
+                "description": "Whether the device is in power saving mode",
+                "type": "string"
+            },
+            {
+                "key": "battery-optimizations",
+                "description": "Whether battery optimizations are enabled for the app",
+                "type": "string"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },
@@ -1234,6 +1254,11 @@
                 "type": "string"
             },
             {
+                "key": "power_saving",
+                "description": "Whether the device is in power saving mode",
+                "type": "string"
+            },
+            {
                 "key": "battery-optimizations",
                 "description": "Whether battery optimizations are enabled for the app",
                 "type": "string"
@@ -1246,6 +1271,16 @@
             {
                 "key": "total_optout",
                 "description": "The number of opt-out jobs executed during the run",
+                "type": "integer"
+            },
+            {
+                "key": "profile_queries",
+                "description": "The number of profile queries used in the scan",
+                "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
             }
         ]

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1174,7 +1174,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             },
             {
                 "key": "power_saving",
@@ -1203,7 +1221,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1217,7 +1253,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             },
             {
                 "key": "power_saving",
@@ -1251,7 +1305,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             },
             {
                 "key": "power_saving",
@@ -1295,7 +1367,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1309,7 +1399,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1330,7 +1438,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1349,7 +1475,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1630,7 +1774,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },
@@ -1659,7 +1821,25 @@
             {
                 "key": "manufacturer",
                 "description": "Manufacturer of the device",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -82,6 +82,7 @@ class PirPixelInterceptor @Inject constructor(
             "m_dbp_email-confirmation_started",
             "m_dbp_email-confirmation_completed",
             "m_dbp_initial-scan_incomplete",
+            "m_dbp_initial_scan_duration",
         )
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -42,7 +42,7 @@ class PirPixelInterceptor @Inject constructor(
 
         return if (ALLOWLIST.any { prefix -> pixel.startsWith(prefix) }) {
             val newUrl = originalRequest.url.newBuilder()
-                .addQueryParameter(KEY_MANUFACTURER, appBuildConfig.manufacturer)
+                .addQueryParameter(KEY_MANUFACTURER, normalizedManufacturer())
                 .build()
             val newRequest = originalRequest.newBuilder().url(newUrl).build()
             chain.proceed(newRequest)
@@ -59,7 +59,7 @@ class PirPixelInterceptor @Inject constructor(
             chain.request().url.newBuilder()
                 .addQueryParameter(
                     KEY_MANUFACTURER,
-                    appBuildConfig.manufacturer,
+                    normalizedManufacturer(),
                 ).build()
         } else {
             chain.request().url
@@ -68,10 +68,33 @@ class PirPixelInterceptor @Inject constructor(
         return chain.proceed(request.url(url).build())
     }
 
+    private fun normalizedManufacturer(): String {
+        val raw = appBuildConfig.manufacturer.lowercase()
+        return if (raw in COMMON_MANUFACTURERS) raw else OTHER_MANUFACTURER
+    }
+
     override fun getInterceptor(): Interceptor = this
 
     companion object {
         private const val KEY_MANUFACTURER = "manufacturer"
+        private const val OTHER_MANUFACTURER = "other"
+        private val COMMON_MANUFACTURERS = setOf(
+            "samsung",
+            "google",
+            "xiaomi",
+            "huawei",
+            "honor",
+            "oneplus",
+            "oppo",
+            "vivo",
+            "motorola",
+            "realme",
+            "sony",
+            "lg",
+            "nokia",
+            "lenovo",
+            "asus",
+        )
         private val ALLOWLIST = listOf(
             "m_dbp_foreground-run_started",
             "m_dbp_foreground-run_completed",

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -114,12 +114,18 @@ interface PirPixelSender {
      * @param batteryOptimizationsEnabled - whether battery optimizations are enabled for the app
      * @param totalScanJobs - the number of scan jobs executed during the run
      * @param totalOptOutJobs - the number of opt-out jobs executed during the run
+     * @param profileQueryCount - the number of profile queries used in the scan
+     * @param brokerCount - the number of active brokers at the start of the scan
+     * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      */
     fun reportManualScanCompleted(
         totalTimeInMillis: Long,
         batteryOptimizationsEnabled: Boolean,
         totalScanJobs: Int,
         totalOptOutJobs: Int,
+        profileQueryCount: Int,
+        brokerCount: Int,
+        isPowerSavingEnabled: Boolean,
     )
 
     /**
@@ -593,6 +599,9 @@ interface PirPixelSender {
     fun reportInitialScanDuration(
         durationMs: Long,
         profileQueryCount: Int,
+        isPowerSavingEnabled: Boolean,
+        batteryOptimizationsEnabled: Boolean,
+        brokerCount: Int,
     )
 
     fun reportBackgroundScanStats(
@@ -636,12 +645,18 @@ class RealPirPixelSender @Inject constructor(
         batteryOptimizationsEnabled: Boolean,
         totalScanJobs: Int,
         totalOptOutJobs: Int,
+        profileQueryCount: Int,
+        brokerCount: Int,
+        isPowerSavingEnabled: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
             PARAM_KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
             PARAM_KEY_TOTAL_SCAN to totalScanJobs.toString(),
             PARAM_KEY_TOTAL_OPTOUT to totalOptOutJobs.toString(),
+            PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
+            PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
+            PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
         )
         fire(PIR_FOREGROUND_RUN_COMPLETED, params)
     }
@@ -1402,11 +1417,17 @@ class RealPirPixelSender @Inject constructor(
     override fun reportInitialScanDuration(
         durationMs: Long,
         profileQueryCount: Int,
+        isPowerSavingEnabled: Boolean,
+        batteryOptimizationsEnabled: Boolean,
+        brokerCount: Int,
     ) {
         val params = mapOf(
             PARAM_KEY_DURATION_MS to durationMs.toString(),
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_TRACKER_BLOCKING to trackerBlockingState(),
+            PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
+            PARAM_KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
+            PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
         )
 
         fire(PIR_INITIAL_SCAN_DURATION, params)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -98,7 +98,15 @@ class RealPirJobsRunner @Inject constructor(
         if (profileQueries.isEmpty()) {
             emitStartPixel(context, executionType, 0, activeBrokers.size)
             logcat { "PIR-JOB-RUNNER: No profile queries available. Completing run." }
-            emitCompletedPixel(context, executionType, startTimeInMillis, totalScanJobs = 0, totalOptOutJobs = 0)
+            emitCompletedPixel(
+                context = context,
+                executionType = executionType,
+                startTimeInMillis = startTimeInMillis,
+                totalScanJobs = 0,
+                totalOptOutJobs = 0,
+                profileQueryCount = 0,
+                brokerCount = activeBrokers.size,
+            )
             return@withContext Result.success(Unit)
         }
 
@@ -121,7 +129,15 @@ class RealPirJobsRunner @Inject constructor(
 
         if (activeBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active brokers available. Completing run." }
-            emitCompletedPixel(context, executionType, startTimeInMillis, totalScanJobs = 0, totalOptOutJobs = 0)
+            emitCompletedPixel(
+                context = context,
+                executionType = executionType,
+                startTimeInMillis = startTimeInMillis,
+                totalScanJobs = 0,
+                totalOptOutJobs = 0,
+                profileQueryCount = profileQueries.size,
+                brokerCount = 0,
+            )
             return@withContext Result.success(Unit)
         }
 
@@ -131,9 +147,16 @@ class RealPirJobsRunner @Inject constructor(
 
         // We emit a pixel after the scans are completed from the foreground scan
         if (executionType == MANUAL) {
+            val isPowerSavingEnabled = runCatching {
+                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
+            }.getOrDefault(false)
+            val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
             pixelSender.reportInitialScanDuration(
                 durationMs = currentTimeProvider.currentTimeMillis() - startTimeInMillis,
                 profileQueryCount = profileQueries.size,
+                isPowerSavingEnabled = isPowerSavingEnabled,
+                batteryOptimizationsEnabled = batteryOptimizationsEnabled,
+                brokerCount = activeBrokers.size,
             )
         }
 
@@ -142,7 +165,15 @@ class RealPirJobsRunner @Inject constructor(
 
         if (activeFormOptOutBrokers.isEmpty()) {
             logcat { "PIR-JOB-RUNNER: No active parent brokers available for optout. Completing run." }
-            emitCompletedPixel(context, executionType, startTimeInMillis, totalScanJobs, totalOptOutJobs = 0)
+            emitCompletedPixel(
+                context = context,
+                executionType = executionType,
+                startTimeInMillis = startTimeInMillis,
+                totalScanJobs = totalScanJobs,
+                totalOptOutJobs = 0,
+                profileQueryCount = profileQueries.size,
+                brokerCount = activeBrokers.size,
+            )
             return@withContext Result.success(Unit)
         }
 
@@ -150,7 +181,15 @@ class RealPirJobsRunner @Inject constructor(
         val totalOptOutJobs = executeOptOutJobs(context, activeFormOptOutBrokers)
 
         logcat { "PIR-JOB-RUNNER: Completed." }
-        emitCompletedPixel(context, executionType, startTimeInMillis, totalScanJobs, totalOptOutJobs)
+        emitCompletedPixel(
+            context = context,
+            executionType = executionType,
+            startTimeInMillis = startTimeInMillis,
+            totalScanJobs = totalScanJobs,
+            totalOptOutJobs = totalOptOutJobs,
+            profileQueryCount = profileQueries.size,
+            brokerCount = activeBrokers.size,
+        )
         return@withContext Result.success(Unit)
     }
 
@@ -193,11 +232,24 @@ class RealPirJobsRunner @Inject constructor(
         startTimeInMillis: Long,
         totalScanJobs: Int,
         totalOptOutJobs: Int,
+        profileQueryCount: Int,
+        brokerCount: Int,
     ) {
         val totalTimeMillis = currentTimeProvider.currentTimeMillis() - startTimeInMillis
         if (executionType == MANUAL) {
             val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
-            pixelSender.reportManualScanCompleted(totalTimeMillis, batteryOptimizationsEnabled, totalScanJobs, totalOptOutJobs)
+            val isPowerSavingEnabled = runCatching {
+                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
+            }.getOrDefault(false)
+            pixelSender.reportManualScanCompleted(
+                totalTimeInMillis = totalTimeMillis,
+                batteryOptimizationsEnabled = batteryOptimizationsEnabled,
+                totalScanJobs = totalScanJobs,
+                totalOptOutJobs = totalOptOutJobs,
+                profileQueryCount = profileQueryCount,
+                brokerCount = brokerCount,
+                isPowerSavingEnabled = isPowerSavingEnabled,
+            )
         } else {
             pixelSender.reportScheduledScanCompleted(totalTimeMillis)
         }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -147,14 +147,11 @@ class RealPirJobsRunner @Inject constructor(
 
         // We emit a pixel after the scans are completed from the foreground scan
         if (executionType == MANUAL) {
-            val isPowerSavingEnabled = runCatching {
-                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
-            }.getOrDefault(false)
             val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
             pixelSender.reportInitialScanDuration(
                 durationMs = currentTimeProvider.currentTimeMillis() - startTimeInMillis,
                 profileQueryCount = profileQueries.size,
-                isPowerSavingEnabled = isPowerSavingEnabled,
+                isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
                 batteryOptimizationsEnabled = batteryOptimizationsEnabled,
                 brokerCount = activeBrokers.size,
             )
@@ -217,9 +214,7 @@ class RealPirJobsRunner @Inject constructor(
         brokerCount: Int,
     ) {
         if (executionType == MANUAL) {
-            val isPowerSavingEnabled = runCatching {
-                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
-            }.getOrDefault(false)
+            val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
             pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount)
         } else {
             pixelSender.reportScheduledScanStarted()
@@ -238,9 +233,6 @@ class RealPirJobsRunner @Inject constructor(
         val totalTimeMillis = currentTimeProvider.currentTimeMillis() - startTimeInMillis
         if (executionType == MANUAL) {
             val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
-            val isPowerSavingEnabled = runCatching {
-                (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
-            }.getOrDefault(false)
             pixelSender.reportManualScanCompleted(
                 totalTimeInMillis = totalTimeMillis,
                 batteryOptimizationsEnabled = batteryOptimizationsEnabled,
@@ -248,7 +240,7 @@ class RealPirJobsRunner @Inject constructor(
                 totalOptOutJobs = totalOptOutJobs,
                 profileQueryCount = profileQueryCount,
                 brokerCount = brokerCount,
-                isPowerSavingEnabled = isPowerSavingEnabled,
+                isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
             )
         } else {
             pixelSender.reportScheduledScanCompleted(totalTimeMillis)
@@ -357,5 +349,11 @@ class RealPirJobsRunner @Inject constructor(
     override fun stop() {
         pirScan.stop()
         pirOptOut.stop()
+    }
+
+    private fun Context.isPowerSavingModeEnabled(): Boolean {
+        return runCatching {
+            (getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
+        }.getOrDefault(false)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
@@ -49,7 +49,7 @@ class PirPixelInterceptorTest {
         )
         whenever(mockChain.proceed(any())).thenReturn(mockResponse)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(30)
-        whenever(mockAppBuildConfig.manufacturer).thenReturn("TestManufacturer")
+        whenever(mockAppBuildConfig.manufacturer).thenReturn("Samsung")
     }
 
     @Test
@@ -90,7 +90,7 @@ class PirPixelInterceptorTest {
 
         val capturedRequest = requestCaptor.firstValue
         val man = capturedRequest.url.queryParameter("manufacturer")
-        assertEquals("TestManufacturer", man)
+        assertEquals("samsung", man)
     }
 
     @Test
@@ -109,7 +109,43 @@ class PirPixelInterceptorTest {
         val capturedRequest = requestCaptor.firstValue
         assertEquals("param", capturedRequest.url.queryParameter("existing"))
         assertEquals("value", capturedRequest.url.queryParameter("another"))
-        assertEquals("TestManufacturer", capturedRequest.url.queryParameter("manufacturer"))
+        assertEquals("samsung", capturedRequest.url.queryParameter("manufacturer"))
+    }
+
+    @Test
+    fun whenManufacturerIsCommonButMixedCaseThenLowercased() = runTest {
+        whenever(mockAppBuildConfig.manufacturer).thenReturn("OnePlus")
+        val request = Request.Builder()
+            .url("https://example.com/m_dbp_initial_scan_duration")
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        assertEquals("oneplus", capturedRequest.url.queryParameter("manufacturer"))
+    }
+
+    @Test
+    fun whenManufacturerIsNotCommonThenReportedAsOther() = runTest {
+        whenever(mockAppBuildConfig.manufacturer).thenReturn("ObscureBrand")
+        val request = Request.Builder()
+            .url("https://example.com/m_dbp_initial_scan_duration")
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        assertEquals("other", capturedRequest.url.queryParameter("manufacturer"))
     }
 
     @Test
@@ -145,7 +181,7 @@ class PirPixelInterceptorTest {
 
         val capturedRequest = requestCaptor.firstValue
         val man = capturedRequest.url.queryParameter("manufacturer")
-        assertEquals("TestManufacturer", man)
+        assertEquals("samsung", man)
     }
 
     @Test
@@ -163,7 +199,7 @@ class PirPixelInterceptorTest {
 
         val capturedRequest = requestCaptor.firstValue
         val man = capturedRequest.url.queryParameter("manufacturer")
-        assertEquals("TestManufacturer", man)
+        assertEquals("samsung", man)
     }
 
     @Test
@@ -181,6 +217,6 @@ class PirPixelInterceptorTest {
 
         val capturedRequest = requestCaptor.firstValue
         val man = capturedRequest.url.queryParameter("manufacturer")
-        assertEquals("TestManufacturer", man)
+        assertEquals("samsung", man)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -68,7 +68,15 @@ class RealPirPixelSenderTest {
     fun whenReportManualScanCompletedThenFiresPixelWithTotalTimeAndBatteryOptimizations() = runTest {
         val totalTimeInMillis = 12345L
 
-        testee.reportManualScanCompleted(totalTimeInMillis, batteryOptimizationsEnabled = false, totalScanJobs = 5, totalOptOutJobs = 3)
+        testee.reportManualScanCompleted(
+            totalTimeInMillis,
+            batteryOptimizationsEnabled = false,
+            totalScanJobs = 5,
+            totalOptOutJobs = 3,
+            profileQueryCount = 3,
+            brokerCount = 10,
+            isPowerSavingEnabled = true,
+        )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender).fire(
@@ -86,6 +94,12 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["total_scan"] == "5")
         assert(paramsCaptor.firstValue.containsKey("total_optout"))
         assert(paramsCaptor.firstValue["total_optout"] == "3")
+        assert(paramsCaptor.firstValue.containsKey("profile_queries"))
+        assert(paramsCaptor.firstValue["profile_queries"] == "3")
+        assert(paramsCaptor.firstValue.containsKey("broker_count"))
+        assert(paramsCaptor.firstValue["broker_count"] == "10")
+        assert(paramsCaptor.firstValue.containsKey("power_saving"))
+        assert(paramsCaptor.firstValue["power_saving"] == "true")
     }
 
     @Test
@@ -996,6 +1010,9 @@ class RealPirPixelSenderTest {
         testee.reportInitialScanDuration(
             durationMs = 45000L,
             profileQueryCount = 3,
+            isPowerSavingEnabled = true,
+            batteryOptimizationsEnabled = false,
+            brokerCount = 10,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -1010,5 +1027,8 @@ class RealPirPixelSenderTest {
         assert(params["duration_in_ms"] == "45000")
         assert(params["profile_queries"] == "3")
         assert(params["tracker_blocking_state"] == "disabled")
+        assert(params["power_saving"] == "true")
+        assert(params["battery-optimizations"] == "false")
+        assert(params["broker_count"] == "10")
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -173,7 +173,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -194,7 +194,7 @@ class RealPirJobsRunnerTest {
         // Then
         assertTrue(result.isSuccess)
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
         verifyNoInteractions(mockEligibleScanJobProvider)
@@ -214,7 +214,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -265,8 +265,8 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2)
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 1)
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -315,9 +315,9 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2)
+        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 2)
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -493,7 +493,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPirScan).stop()
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
                 OptOutJobRecord(
@@ -645,7 +645,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 
@@ -1143,7 +1143,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockBrokerJsonUpdater).update()
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockEligibleScanJobProvider)
     }
@@ -1196,7 +1196,7 @@ class RealPirJobsRunnerTest {
         // Then
         verifyNoInteractions(mockBrokerJsonUpdater)
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
         verifyNoMoreInteractions(mockPixelSender)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214388337340515?focus=true

### Description
Adds additional parameters to initial scan completed and scan duration pixels to help with debugging.

### Steps to test this PR

_QA Optional_
- [ ] Run an initial PIR scan
- [ ] Check for m_dbp_initial_scan_duration_c pixel in logs and make sure it has the new parameters
- [ ] Check for m_dbp_foreground-run_completed pixel in logs and make sure it has the new parameters

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics/pixel payloads and parameter schema, with no effect on PIR scan/opt-out execution aside from additional metadata collection.
> 
> **Overview**
> Adds extra debugging metadata to PIR scan pixels: `m_dbp_initial_scan_duration` and `m_dbp_foreground-run_completed` now include `power_saving`, `battery-optimizations`, `profile_queries`, and `broker_count` (and updates the JSON schema to use booleans/enums where appropriate).
> 
> Normalizes the `manufacturer` query param sent by `PirPixelInterceptor` to a fixed allowlist (lowercased, otherwise `other`) and expands the interceptor allowlist to include `m_dbp_initial_scan_duration`; updates job runner + pixel sender method signatures and tests to pass/verify the new parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2114b6cb46b92ab61ade5b8fcc08b78c33c1aac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->