### PR TITLE
PIR: Add scan trigger to initial scan pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1208,6 +1208,12 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
+            },
+            {
+                "key": "scan_trigger",
+                "description": "What triggered the scan run",
+                "type": "string",
+                "enum": ["onboarding", "profile_edit", "scheduled"]
             }
         ]
     },
@@ -1287,6 +1293,12 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
+            },
+            {
+                "key": "scan_trigger",
+                "description": "What triggered the scan run",
+                "type": "string",
+                "enum": ["onboarding", "profile_edit", "scheduled"]
             }
         ]
     },
@@ -1354,6 +1366,12 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
+            },
+            {
+                "key": "scan_trigger",
+                "description": "What triggered the scan run",
+                "type": "string",
+                "enum": ["onboarding", "profile_edit", "scheduled"]
             }
         ]
     },

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -427,7 +427,7 @@ class PirEndToEndTest {
         println("==================== STEP 2: Run Eligible Scan and Opt-Out Jobs ====================")
 
         // Run eligible jobs - this will trigger PirScan and PirOptOut
-        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL)
+        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL_INITIAL)
         assertTrue("Scan should succeed", scanResult.isSuccess)
 
         // Verify: Scan jobs created only for active broker
@@ -659,7 +659,7 @@ class PirEndToEndTest {
         println("==================== STEP 2: Run scan - should fail gracefully ====================")
 
         // Run eligible jobs - should not crash even though scan step has unknown action
-        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL)
+        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL_INITIAL)
         assertTrue("Scan should succeed overall (not crash)", scanResult.isSuccess)
 
         // Verify scan job was created
@@ -726,7 +726,7 @@ class PirEndToEndTest {
         println("==================== STEP 2: Run scan - should succeed (scan step is valid) ====================")
 
         // Run scan - should succeed since the scan step is valid
-        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL)
+        val scanResult = pirJobsRunner.runEligibleJobs(context, PirExecutionType.MANUAL_INITIAL)
         assertTrue("Scan should succeed", scanResult.isSuccess)
 
         // Check scan job record

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandler.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.pir.impl.dashboard.messaging.handlers
 
 import android.content.Context
-import android.content.Intent
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -32,6 +31,7 @@ import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
@@ -77,6 +77,9 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
         }
 
         appCoroutineScope.launch(dispatcherProvider.io()) {
+            // capture before update so we can tell onboarding (no prior profiles) vs profile edit
+            val hadExistingProfiles = repository.getAllUserProfileQueries().isNotEmpty()
+
             val isProfileUpdateSuccess = handleProfileQueryUpdates()
 
             if (!isProfileUpdateSuccess) {
@@ -93,8 +96,14 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
                 response = PirWebMessageResponse.DefaultResponse.SUCCESS,
             )
 
+            val executionType = if (hadExistingProfiles) {
+                PirExecutionType.MANUAL_EDIT_PROFILE
+            } else {
+                PirExecutionType.MANUAL_INITIAL
+            }
+
             // start the initial scan at this point as startScanAndOptOut message is not reliable
-            startAndScheduleInitialScan()
+            startAndScheduleInitialScan(executionType)
 
             pirWebProfileStateHolder.clear()
         }
@@ -171,8 +180,8 @@ class PirWebSaveProfileMessageHandler @Inject constructor(
         }
     }
 
-    private fun startAndScheduleInitialScan() {
-        context.startForegroundService(Intent(context, PirForegroundScanService::class.java))
+    private fun startAndScheduleInitialScan(executionType: PirExecutionType) {
+        context.startForegroundService(PirForegroundScanService.intentFor(context, executionType))
         scanScheduler.scheduleScans()
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -86,6 +86,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCHEDULED_RUN_STARTED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_UPDATE_BROKER_FAILURE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_UPDATE_BROKER_SUCCESS
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_WEEKLY_CHILD_ORPHANED_OPTOUTS
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.squareup.anvil.annotations.ContributesBinding
 import logcat.logcat
 import javax.inject.Inject
@@ -100,11 +101,13 @@ interface PirPixelSender {
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      * @param profileQueryCount - the number of profile queries used in the scan
      * @param brokerCount - the number of active brokers at the start of the scan
+     * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
      */
     fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
         brokerCount: Int,
+        executionType: PirExecutionType,
     )
 
     /**
@@ -117,6 +120,7 @@ interface PirPixelSender {
      * @param profileQueryCount - the number of profile queries used in the scan
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
+     * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
      */
     fun reportManualScanCompleted(
         totalTimeInMillis: Long,
@@ -126,6 +130,7 @@ interface PirPixelSender {
         profileQueryCount: Int,
         brokerCount: Int,
         isPowerSavingEnabled: Boolean,
+        executionType: PirExecutionType,
     )
 
     /**
@@ -602,6 +607,7 @@ interface PirPixelSender {
         isPowerSavingEnabled: Boolean,
         batteryOptimizationsEnabled: Boolean,
         brokerCount: Int,
+        executionType: PirExecutionType,
     )
 
     fun reportBackgroundScanStats(
@@ -631,11 +637,13 @@ class RealPirPixelSender @Inject constructor(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
         brokerCount: Int,
+        executionType: PirExecutionType,
     ) {
         val params = mapOf(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
+            PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
         )
         fire(PIR_FOREGROUND_RUN_STARTED, params)
     }
@@ -648,6 +656,7 @@ class RealPirPixelSender @Inject constructor(
         profileQueryCount: Int,
         brokerCount: Int,
         isPowerSavingEnabled: Boolean,
+        executionType: PirExecutionType,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
@@ -657,6 +666,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
+            PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
         )
         fire(PIR_FOREGROUND_RUN_COMPLETED, params)
     }
@@ -1420,6 +1430,7 @@ class RealPirPixelSender @Inject constructor(
         isPowerSavingEnabled: Boolean,
         batteryOptimizationsEnabled: Boolean,
         brokerCount: Int,
+        executionType: PirExecutionType,
     ) {
         val params = mapOf(
             PARAM_KEY_DURATION_MS to durationMs.toString(),
@@ -1428,6 +1439,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
             PARAM_KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
+            PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
         )
 
         fire(PIR_INITIAL_SCAN_DURATION, params)
@@ -1506,6 +1518,12 @@ class RealPirPixelSender @Inject constructor(
         }
     }
 
+    private fun PirExecutionType.toScanTriggerParam(): String = when (this) {
+        PirExecutionType.MANUAL_INITIAL -> "onboarding"
+        PirExecutionType.MANUAL_EDIT_PROFILE -> "profile_edit"
+        PirExecutionType.SCHEDULED -> "scheduled"
+    }
+
     companion object {
         private const val PARAM_KEY_TOTAL_TIME = "totalTimeInMillis"
         private const val PARAM_KEY_CPU_USAGE = "cpuUsage"
@@ -1546,5 +1564,6 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_TOTAL_OPTOUT = "total_optout"
         private const val PARAM_KEY_BROKER_COUNT = "broker_count"
         private const val PARAM_KEY_TRACKER_BLOCKING = "tracker_blocking_state"
+        private const val PARAM_KEY_SCAN_TRIGGER = "scan_trigger"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanService.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanService.kt
@@ -109,7 +109,9 @@ class PirForegroundScanService : Service(), CoroutineScope by MainScope() {
                 return@launch
             }
 
-            val result = pirJobsRunner.runEligibleJobs(this@PirForegroundScanService, PirExecutionType.MANUAL)
+            val executionType = intent?.getStringExtra(EXTRA_EXECUTION_TYPE)?.let { PirExecutionType.valueOf(it) }
+                ?: PirExecutionType.MANUAL_INITIAL
+            val result = pirJobsRunner.runEligibleJobs(this@PirForegroundScanService, executionType)
             if (result.isSuccess) {
                 pirNotificationManager.showScanStatusNotification(
                     title = getString(R.string.pirNotificationTitleComplete),
@@ -139,6 +141,14 @@ class PirForegroundScanService : Service(), CoroutineScope by MainScope() {
 
     companion object {
         private const val PIR_SCAN_NOTIFICATION_ID = 8791
+        private const val EXTRA_EXECUTION_TYPE = "extra_execution_type"
+
+        fun intentFor(
+            context: Context,
+            executionType: PirExecutionType,
+        ): Intent = Intent(context, PirForegroundScanService::class.java).apply {
+            putExtra(EXTRA_EXECUTION_TYPE, executionType.name)
+        }
 
         // This method was deprecated in API level 26. As of Build.VERSION_CODES.O,
         // this method is no longer available to third party applications.

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirExecutionType.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirExecutionType.kt
@@ -18,8 +18,17 @@ package com.duckduckgo.pir.impl.scheduling
 
 /**
  * This class tells us if PIR was triggered by a scheduled work or manually run by the user.
+ *
+ * The two manual variants distinguish between the user's initial manual scan
+ * ([MANUAL_INITIAL]) and the user having edited an already-saved profile later
+ * ([MANUAL_EDIT_PROFILE]). This is used to attribute foreground-scan pixels to the right source.
  */
 enum class PirExecutionType {
-    MANUAL,
+    MANUAL_INITIAL,
+    MANUAL_EDIT_PROFILE,
     SCHEDULED,
+    ;
+
+    val isManual: Boolean
+        get() = this == MANUAL_INITIAL || this == MANUAL_EDIT_PROFILE
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord
 import com.duckduckgo.pir.impl.optout.PirOptOut
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scan.PirScan
-import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
 import com.squareup.anvil.annotations.ContributesBinding
@@ -146,7 +145,7 @@ class RealPirJobsRunner @Inject constructor(
         val totalScanJobs = executeScanJobs(context, executionType, activeBrokers)
 
         // We emit a pixel after the scans are completed from the foreground scan
-        if (executionType == MANUAL) {
+        if (executionType.isManual) {
             val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
             pixelSender.reportInitialScanDuration(
                 durationMs = currentTimeProvider.currentTimeMillis() - startTimeInMillis,
@@ -154,6 +153,7 @@ class RealPirJobsRunner @Inject constructor(
                 isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
                 batteryOptimizationsEnabled = batteryOptimizationsEnabled,
                 brokerCount = activeBrokers.size,
+                executionType = executionType,
             )
         }
 
@@ -213,9 +213,9 @@ class RealPirJobsRunner @Inject constructor(
         profileQueryCount: Int,
         brokerCount: Int,
     ) {
-        if (executionType == MANUAL) {
+        if (executionType.isManual) {
             val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
-            pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount)
+            pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount, executionType)
         } else {
             pixelSender.reportScheduledScanStarted()
         }
@@ -231,7 +231,7 @@ class RealPirJobsRunner @Inject constructor(
         brokerCount: Int,
     ) {
         val totalTimeMillis = currentTimeProvider.currentTimeMillis() - startTimeInMillis
-        if (executionType == MANUAL) {
+        if (executionType.isManual) {
             val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
             pixelSender.reportManualScanCompleted(
                 totalTimeInMillis = totalTimeMillis,
@@ -241,6 +241,7 @@ class RealPirJobsRunner @Inject constructor(
                 profileQueryCount = profileQueryCount,
                 brokerCount = brokerCount,
                 isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
+                executionType = executionType,
             )
         } else {
             pixelSender.reportScheduledScanCompleted(totalTimeMillis)
@@ -290,7 +291,7 @@ class RealPirJobsRunner @Inject constructor(
     ): Int {
         val eligibleJobs = eligibleScanJobProvider.getAllEligibleScanJobs(currentTimeProvider.currentTimeMillis())
             .filter { it.brokerName in activeBrokers }
-        val runType = if (executionType == MANUAL) {
+        val runType = if (executionType.isManual) {
             RunType.MANUAL
         } else {
             RunType.SCHEDULED

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.scheduling.JobRecordUpdater
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.store.PirRepository
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -166,7 +167,7 @@ class PirWebSaveProfileMessageHandlerTest {
                 profileQueryIdsToDelete = emptyList(),
             )
             verifyResponse(jsMessage, true, mockJsMessaging)
-            verifyStartAndScheduleInitialScan()
+            verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_INITIAL)
             verify(mockPirWebProfileStateHolder).clear()
         }
 
@@ -200,7 +201,7 @@ class PirWebSaveProfileMessageHandlerTest {
             profileQueryIdsToDelete = emptyList(),
         )
         verifyResponse(jsMessage, true, mockJsMessaging)
-        verifyStartAndScheduleInitialScan()
+        verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_INITIAL)
         verify(mockPirWebProfileStateHolder).clear()
     }
 
@@ -231,7 +232,7 @@ class PirWebSaveProfileMessageHandlerTest {
             profileQueryIdsToDelete = emptyList(),
         )
         verifyResponse(jsMessage, true, mockJsMessaging)
-        verifyStartAndScheduleInitialScan()
+        verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_INITIAL)
         verify(mockPirWebProfileStateHolder).clear()
     }
 
@@ -263,7 +264,7 @@ class PirWebSaveProfileMessageHandlerTest {
             profileQueryIdsToDelete = emptyList(),
         )
         verifyResponse(jsMessage, true, mockJsMessaging)
-        verifyStartAndScheduleInitialScan()
+        verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_INITIAL)
         verify(mockPirWebProfileStateHolder).clear()
     }
 
@@ -580,6 +581,31 @@ class PirWebSaveProfileMessageHandlerTest {
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
 
+    @Test
+    fun whenExistingProfilesPresentThenScanIntentMarkedAsEditProfile() = runTest {
+        // Given - user already has a saved profile, so this save is an edit
+        val jsMessage = createJsMessage("""""", SAVE_PROFILE)
+        val currentYear = 2025
+        val currentDateTime = LocalDateTime.of(currentYear, 1, 1, 0, 0)
+        val existingProfileQuery = createProfileQuery(id = 1, firstName = "Existing", lastName = "User")
+        val newProfileQuery = createProfileQuery(id = 0, firstName = "New", lastName = "User")
+
+        whenever(mockPirWebProfileStateHolder.isProfileComplete).thenReturn(true)
+        whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(currentDateTime)
+        whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
+            listOf(existingProfileQuery.copy(id = 0), newProfileQuery),
+        )
+        whenever(mockRepository.getValidUserProfileQueries()).thenReturn(listOf(existingProfileQuery))
+        whenever(mockRepository.getAllExtractedProfiles()).thenReturn(emptyList())
+        whenever(mockRepository.updateProfileQueries(any(), any(), any())).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verifyStartAndScheduleInitialScan(PirExecutionType.MANUAL_EDIT_PROFILE)
+    }
+
     private fun createProfileQuery(
         id: Long = 1,
         firstName: String = "Test",
@@ -600,12 +626,13 @@ class PirWebSaveProfileMessageHandlerTest {
         )
     }
 
-    private fun verifyStartAndScheduleInitialScan() {
+    private fun verifyStartAndScheduleInitialScan(expectedExecutionType: PirExecutionType) {
         val intentCaptor = argumentCaptor<Intent>()
         verify(mockContext).startForegroundService(intentCaptor.capture())
 
         val capturedIntent = intentCaptor.firstValue
         assertEquals(PirForegroundScanService::class.java.name, capturedIntent.component?.className)
+        assertEquals(expectedExecutionType.name, capturedIntent.getStringExtra("extra_execution_type"))
 
         verify(mockScanScheduler).scheduleScans()
     }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSaveProfileMessageHandlerTest.kt
@@ -69,7 +69,9 @@ class PirWebSaveProfileMessageHandlerTest {
     private val testScope = TestScope()
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
+        whenever(mockRepository.getAllUserProfileQueries()).thenReturn(emptyList())
+
         testee = PirWebSaveProfileMessageHandler(
             pirWebProfileStateHolder = mockPirWebProfileStateHolder,
             repository = mockRepository,
@@ -595,6 +597,7 @@ class PirWebSaveProfileMessageHandlerTest {
         whenever(mockPirWebProfileStateHolder.toProfileQueries(currentYear)).thenReturn(
             listOf(existingProfileQuery.copy(id = 0), newProfileQuery),
         )
+        whenever(mockRepository.getAllUserProfileQueries()).thenReturn(listOf(existingProfileQuery))
         whenever(mockRepository.getValidUserProfileQueries()).thenReturn(listOf(existingProfileQuery))
         whenever(mockRepository.getAllExtractedProfiles()).thenReturn(emptyList())
         whenever(mockRepository.updateProfileQueries(any(), any(), any())).thenReturn(true)

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -46,7 +47,12 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportManualScanStartedThenFiresPixelWithPowerSavingParam() = runTest {
-        testee.reportManualScanStarted(isPowerSavingEnabled = true, profileQueryCount = 3, brokerCount = 10)
+        testee.reportManualScanStarted(
+            isPowerSavingEnabled = true,
+            profileQueryCount = 3,
+            brokerCount = 10,
+            executionType = PirExecutionType.MANUAL_INITIAL,
+        )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender, times(2)).fire(
@@ -62,6 +68,27 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["profile_queries"] == "3")
         assert(paramsCaptor.firstValue.containsKey("broker_count"))
         assert(paramsCaptor.firstValue["broker_count"] == "10")
+        assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
+    }
+
+    @Test
+    fun whenReportManualScanStartedWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        testee.reportManualScanStarted(
+            isPowerSavingEnabled = false,
+            profileQueryCount = 1,
+            brokerCount = 5,
+            executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+        )
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender, times(2)).fire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
     }
 
     @Test
@@ -76,6 +103,7 @@ class RealPirPixelSenderTest {
             profileQueryCount = 3,
             brokerCount = 10,
             isPowerSavingEnabled = true,
+            executionType = PirExecutionType.MANUAL_INITIAL,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -100,6 +128,31 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["broker_count"] == "10")
         assert(paramsCaptor.firstValue.containsKey("power_saving"))
         assert(paramsCaptor.firstValue["power_saving"] == "true")
+        assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
+    }
+
+    @Test
+    fun whenReportManualScanCompletedWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        testee.reportManualScanCompleted(
+            totalTimeInMillis = 1L,
+            batteryOptimizationsEnabled = false,
+            totalScanJobs = 0,
+            totalOptOutJobs = 0,
+            profileQueryCount = 0,
+            brokerCount = 0,
+            isPowerSavingEnabled = false,
+            executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+        )
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).fire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
     }
 
     @Test
@@ -1013,6 +1066,7 @@ class RealPirPixelSenderTest {
             isPowerSavingEnabled = true,
             batteryOptimizationsEnabled = false,
             brokerCount = 10,
+            executionType = PirExecutionType.MANUAL_INITIAL,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -1030,5 +1084,28 @@ class RealPirPixelSenderTest {
         assert(params["power_saving"] == "true")
         assert(params["battery-optimizations"] == "false")
         assert(params["broker_count"] == "10")
+        assert(params["scan_trigger"] == "onboarding")
+    }
+
+    @Test
+    fun whenReportInitialScanDurationWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        testee.reportInitialScanDuration(
+            durationMs = 1L,
+            profileQueryCount = 0,
+            isPowerSavingEnabled = false,
+            batteryOptimizationsEnabled = true,
+            brokerCount = 0,
+            executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+        )
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).fire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -33,7 +33,8 @@ import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord.ScanJob
 import com.duckduckgo.pir.impl.optout.PirOptOut
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scan.PirScan
-import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_EDIT_PROFILE
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_INITIAL
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType.SCHEDULED
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
@@ -43,6 +44,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -168,12 +170,12 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(emptyList())
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -189,12 +191,12 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(emptyList())
 
         // When
-        val result = testee.runEligibleJobs(mockContext, MANUAL)
+        val result = testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         assertTrue(result.isSuccess)
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
         verifyNoInteractions(mockEligibleScanJobProvider)
@@ -209,12 +211,12 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(testUserProfileQueries)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -260,13 +262,13 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 1)
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 1, MANUAL_INITIAL)
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -311,19 +313,50 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 2)
+        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 2, MANUAL_INITIAL)
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
             RunType.MANUAL,
         )
         verifyNoMoreInteractions(mockPixelSender)
+    }
+
+    @Test
+    fun whenManualEditProfileExecutionTypeThenForwardsTriggerToPixelSender() = runTest {
+        // Given
+        whenever(mockPirRepository.getAllActiveBrokers()).thenReturn(listOf(testBrokerName))
+        whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(listOf(testProfileQuery))
+        whenever(mockPirRepository.getBrokersForOptOut(true)).thenReturn(emptyList())
+        whenever(
+            mockPirSchedulingRepository.getValidScanJobRecord(
+                testBrokerName,
+                testProfileQuery.id,
+            ),
+        ).thenReturn(testScanJobRecord)
+        whenever(mockEligibleScanJobProvider.getAllEligibleScanJobs(testCurrentTime)).thenReturn(
+            emptyList(),
+        )
+        whenever(mockPirRepository.getAllExtractedProfiles()).thenReturn(emptyList())
+        whenever(mockEligibleOptOutJobProvider.getAllEligibleOptOutJobs(testCurrentTime)).thenReturn(
+            emptyList(),
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTime)
+        whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
+
+        // When
+        testee.runEligibleJobs(mockContext, MANUAL_EDIT_PROFILE)
+
+        // Then
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
+        verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
     }
 
     @Test
@@ -398,7 +431,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository, never()).saveScanJobRecords(any())
@@ -427,7 +460,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository).saveScanJobRecords(
@@ -456,7 +489,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository, never()).saveScanJobRecords(any())
@@ -488,12 +521,12 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirScan).stop()
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
                 OptOutJobRecord(
@@ -531,7 +564,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository).saveOptOutJobRecords(
@@ -571,7 +604,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(any())
@@ -606,7 +639,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(any())
@@ -641,11 +674,11 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 
@@ -678,7 +711,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirOptOut).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
@@ -708,7 +741,7 @@ class RealPirJobsRunnerTest {
             whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
             // When
-            testee.runEligibleJobs(mockContext, MANUAL)
+            testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
             // Then
             verify(mockPirOptOut, never()).executeOptOutForJobs(
@@ -757,7 +790,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         // Verify all major operations are called
@@ -801,7 +834,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirScan).stop()
@@ -834,7 +867,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         // Should create opt-out job even for deprecated profile if it has extracted profiles
@@ -880,7 +913,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         // Should not create new opt-out job if one already exists
@@ -928,7 +961,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         // Should create scan job only for non-deprecated profile
@@ -984,7 +1017,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(0L)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirRepository).setLatestBackgroundScanRunInMs(any())
@@ -1071,7 +1104,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
@@ -1085,7 +1118,7 @@ class RealPirJobsRunnerTest {
         whenever(mockBrokerJsonUpdater.update()).thenReturn(true)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockBrokerJsonUpdater).update()
@@ -1123,7 +1156,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then - scan should proceed (scan jobs attempted, not just completing with empty brokers)
         verify(mockBrokerJsonUpdater).update()
@@ -1138,12 +1171,12 @@ class RealPirJobsRunnerTest {
         whenever(mockBrokerJsonUpdater.update()).thenReturn(false)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verify(mockBrokerJsonUpdater).update()
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockEligibleScanJobProvider)
     }
@@ -1177,7 +1210,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verifyNoInteractions(mockBrokerJsonUpdater)
@@ -1191,12 +1224,12 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(testUserProfileQueries)
 
         // When
-        testee.runEligibleJobs(mockContext, MANUAL)
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
         verifyNoInteractions(mockBrokerJsonUpdater)
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any())
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any())
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
         verifyNoMoreInteractions(mockPixelSender)
     }
 }

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirRemoteWorkerService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.store.PirEventsRepository
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
@@ -154,7 +155,7 @@ class PirDevScanActivity : DuckDuckGoActivity() {
                     saveUserInputToDatabase()
                 }
             }
-            startForegroundService(Intent(this, PirForegroundScanService::class.java))
+            startForegroundService(PirForegroundScanService.intentFor(this, PirExecutionType.MANUAL_EDIT_PROFILE))
             globalActivityStarter.start(this, PirResultsScreenParams.PirScanResultsScreen)
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214388337340518?focus=true

### Description
Add a new param to scan started, completed and duration pixels to differentiate between onboarding and profile edit scans

### Steps to test this PR

- [ ] Go through PIR onboarding and complete a scan
- [ ] Verify you see `scan_trigger=onboarding `in `m_dbp_foreground-run_started`, `m_dbp_foreground-run_completed` and `m_dbp_initial_scan_duration` pixels
- [ ] Edit the profile to start a new scan
- [ ] Verify you see `scan_trigger=profile_edit` in `m_dbp_foreground-run_started`, `m_dbp_foreground-run_completed` and `m_dbp_initial_scan_duration` pixels

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `PirExecutionType` model and threads a new execution-type extra through the foreground scan service, which could affect pixel attribution and manual/scheduled branching if mis-set, but does not change scan/opt-out job logic itself.
> 
> **Overview**
> Adds `scan_trigger` to PIR foreground-run and initial-scan-duration pixels to attribute scans to **onboarding**, **profile edit**, or **scheduled** runs.
> 
> Introduces new manual execution types (`MANUAL_INITIAL`, `MANUAL_EDIT_PROFILE`) and propagates them from profile-save and dev-scan entry points through `PirForegroundScanService`/`PirJobsRunner` into `RealPirPixelSender`, updating tests accordingly and adding a service `Intent` extra to carry the execution type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d965a3f8ca651c29e691f9d8c8411d5458a0dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->