### PR TITLE
Hide toggle when contextual Duck.ai is active

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -93,7 +93,7 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     private fun setupWidget(widget: NativeInputModeWidget, onSearchSubmitted: (String) -> Unit, onImageButtonPressed: () -> Unit) {
-        widget.selectChatTab()
+        widget.configureContextual()
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.onImageClick = onImageButtonPressed

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -96,6 +96,7 @@ interface NativeInputWidget {
     fun getSelectedModelId(): String?
     fun storePendingPrompt(query: String)
     fun configure(isDuckAiMode: Boolean, isBottom: Boolean)
+    fun configureContextual()
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
@@ -519,6 +520,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
         if (isDuckAiMode) selectChatTab()
         applyOmnibarShape(isBottom)
+    }
+
+    override fun configureContextual() {
+        viewModel.configureContextual()
+        selectChatTab()
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState.isBottom

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -148,6 +148,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         pendingNativePromptStore.store(query, getSelectedModelId())
     }
 
+    fun configureContextual() {
+        widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
+    }
+
     suspend fun fetchChatSuggestions(query: String): List<ChatSuggestion> =
         runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -36,6 +36,9 @@ data class NativeInputState(
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
-    val defaultToggleSelection: ToggleSelection get() =
-        if (inputContext == InputContext.DUCK_AI || inputContext == InputContext.DUCK_AI_CONTEXTUAL) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
+    val defaultToggleSelection: ToggleSelection
+        get() = when (inputContext) {
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ToggleSelection.DUCK_AI
+            InputContext.BROWSER -> ToggleSelection.SEARCH
+        }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -32,7 +32,7 @@ data class NativeInputState(
 
     enum class InputPosition { TOP, BOTTOM }
 
-    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -26,16 +26,16 @@ data class NativeInputState(
         SEARCH_ONLY,
     }
 
-    enum class InputContext { BROWSER, DUCK_AI }
+    enum class InputContext { BROWSER, DUCK_AI, DUCK_AI_CONTEXTUAL }
 
     enum class ToggleSelection { SEARCH, DUCK_AI }
 
     enum class InputPosition { TOP, BOTTOM }
 
-    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI_CONTEXTUAL
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
     val defaultToggleSelection: ToggleSelection get() =
-        if (inputContext == InputContext.DUCK_AI) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
+        if (inputContext == InputContext.DUCK_AI || inputContext == InputContext.DUCK_AI_CONTEXTUAL) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -204,20 +204,35 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true
         testee.setDuckAiMode(true)
+
+        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenConfigureContextualThenContextIsDuckAiContextual() = runTest {
+        testee.configureContextual()
+
+        assertEquals(NativeInputState.InputContext.DUCK_AI_CONTEXTUAL, testee.state.firstOrNull()!!.inputContext)
+    }
+
+    @Test
+    fun whenContextIsDuckAiContextualAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        testee.configureContextual()
 
         assertFalse(testee.state.firstOrNull()!!.toggleVisible)
     }
 
     @Test
-    fun whenContextIsBrowserAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
-        setIsEnabled(true)
-        inputScreenUserSettingFlow.value = true
+    fun whenContextIsDuckAiContextualThenDefaultToggleSelectionIsDuckAi() = runTest {
+        testee.configureContextual()
 
-        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -204,6 +204,23 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        testee.setDuckAiMode(true)
+
+        assertFalse(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenContextIsBrowserAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+
+        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
     fun whenSetDuckAiModeThenInputModeUnchanged() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214387687457007

### Description

When the contextual Duck.ai sheet is in use, only the Duck.ai side should be shown — the Search/Duck.ai toggle is not relevant in this context.

`NativeInputState.toggleVisible` previously only checked `inputMode`. It now also requires `inputContext != DUCK_AI`, so the toggle is hidden whenever the widget is operating inside the contextual sheet. The existing `applyState` logic already selects the Duck.ai tab before hiding the toggle, so no further changes are needed there.

### Steps to test this PR

_Contextual Duck.ai sheet_
- [ ] Open the contextual Duck.ai sheet from the browser
- [ ] Confirm the Search/Duck.ai toggle is not visible
- [ ] Confirm the Duck.ai input is shown and functional

_Omnibar (browser context)_
- [ ] Open a new tab / use the omnibar
- [ ] Confirm the Search/Duck.ai toggle is still visible when the native input setting is enabled

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that only affects how the native input widget configures and displays its toggle in contextual Duck.ai mode; limited to widget state/configuration logic with added unit coverage.
> 
> **Overview**
> Ensures the contextual Duck.ai sheet shows *only* Duck.ai by introducing a new `NativeInputState.InputContext.DUCK_AI_CONTEXTUAL` and treating it as Duck.ai for default tab selection.
> 
> Adds `configureContextual()` to the widget/viewmodel and updates contextual sheet setup to use it, while changing `toggleVisible` to hide the Search/Duck.ai toggle whenever the contextual context is active. Unit tests were extended to cover the new context and toggle visibility behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433fabec08d38d3848dc465aec36c670c1221e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->