### PR TITLE
Update content scope scripts to version 14.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.74.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.3.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.4.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1e417da9e53e44c3d683b5d8d15837df80a3dd16",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#311aa9498f17f7078a5e5d5e80fdcd928c3a6f7c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.1.tgz",
-      "integrity": "sha512-/cQTMJRd4/7zpgFHWqe+9wqiRPGTy+BhqfkxplvejPgq8d6spBjC6bSJV61rVHJZw5F4KOO5ReKOvuguaKG28A==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.3.tgz",
+      "integrity": "sha512-kmExhWF9NVWoVt/XHkAX56iZxuTwNsoxcyR19hH/UVvvZVFeFrmu0d/h8JPpaRieImIgPh1FpF1zKAoA/odTwQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.14.1",
-        "@ghostery/adblocker-extended-selectors": "^2.14.1",
+        "@ghostery/adblocker-content": "^2.14.3",
+        "@ghostery/adblocker-extended-selectors": "^2.14.3",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.23"
+        "tldts-experimental": "^7.0.28"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.1.tgz",
-      "integrity": "sha512-hDE6RAL9xgQonJQiK1knOHy527PEwlAuvKaha4snE0XO6Vmtk0HThce1M2JFVRxGayWR3nTxoWbvEfGWXU7O/A==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.3.tgz",
+      "integrity": "sha512-23YCZCvZOSQj7sfcfymHXuKaAfAiLPdOZSmGN4ctfK9sr0P3d1dY0pVpWPx5SvO9BIaPn1Bl2/IWVGcSy8zhaA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.14.1"
+        "@ghostery/adblocker-extended-selectors": "^2.14.3"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.1.tgz",
-      "integrity": "sha512-3RARO2ukDrfwDqVEMD+HKZIwsM9QjjII+U1zqxhLXZ0dZRHjbtUHlZCsokqfjZ1JAa3ZVKcZrF0nZv5SA2LgyA==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.3.tgz",
+      "integrity": "sha512-eKLscNyvUv45AxXyhCZ9B3DMjBSSkyp4wkfdPZho7guJFH070A2U3qERjYIUOsCuB8Hs1c6gGRzfZPzJRozMxg==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.28.tgz",
-      "integrity": "sha512-z000DWdcayJ6TctJCb50BtJb89aeXw7WVUp5OREZZrkg56jEwLT18ySbSB28bJvEcNQ4D3JG5SLS/eSViGlRuA==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.29.tgz",
+      "integrity": "sha512-7Lbk4nLf30nRLLm+vFtqBN4rPAJ7jjPj9QwvMiaZuSAl5d6Udz5GCuhH7hjquYXbaSlPKmd3SrClLBSHVlZKiQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.29"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.74.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.3.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.4.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1214410805593460/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it updates `content-scope-scripts` and related blocking/parsing libraries, which can subtly affect privacy/blocking behavior at runtime.
> 
> **Overview**
> Updates the app’s bundled privacy tooling by bumping `@duckduckgo/content-scope-scripts` from `14.3.0` to `14.4.0` (and updating the locked git SHA accordingly).
> 
> Refreshes `package-lock.json` to match the new dependency graph, including transitive bumps such as `@ghostery/adblocker` `2.14.1` → `2.14.3` and `tldts-*` `7.0.28` → `7.0.29`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9d98339526c10ad1fab8bc9dd8d5590ba9c890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->