### PR TITLE
Translate menu item browserMenuDownloadPdf key

### DIFF
--- a/browser/browser-ui/src/main/res/values-bg/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-bg/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Отпечатване</string>
     <string name="browserMenuOpenAppLink">Отваряне в приложението</string>
     <string name="browserMenuAddToHome">Добавете към Начална Страница</string>
+    <string name="browserMenuDownloadPdf">Изтегляне на PDF</string>
     <string name="browserMenuReportBrokenSite">Подаване на сигнал за повреден сайт</string>
     <string name="browserMenuAutofill">Пароли</string>
     <string name="browserMenuDownloads">Изтеглени файлове</string>

--- a/browser/browser-ui/src/main/res/values-cs/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-cs/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Vytisknout</string>
     <string name="browserMenuOpenAppLink">Otevřít v aplikaci</string>
     <string name="browserMenuAddToHome">Přidat na domovskou obrazovku</string>
+    <string name="browserMenuDownloadPdf">Stáhnout PDF</string>
     <string name="browserMenuReportBrokenSite">Nahlásit nefunkční webové stránky</string>
     <string name="browserMenuAutofill">Hesla</string>
     <string name="browserMenuDownloads">Stahování</string>

--- a/browser/browser-ui/src/main/res/values-da/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-da/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Print</string>
     <string name="browserMenuOpenAppLink">Åbn i app</string>
     <string name="browserMenuAddToHome">Tilføj til startskærm</string>
+    <string name="browserMenuDownloadPdf">Download PDF-fil</string>
     <string name="browserMenuReportBrokenSite">Rapporter ødelagt websted</string>
     <string name="browserMenuAutofill">Adgangskoder</string>
     <string name="browserMenuDownloads">Downloads</string>

--- a/browser/browser-ui/src/main/res/values-de/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-de/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Drucken</string>
     <string name="browserMenuOpenAppLink">In App öffnen</string>
     <string name="browserMenuAddToHome">Zum Startbildschirm hinzufügen</string>
+    <string name="browserMenuDownloadPdf">PDF herunterladen</string>
     <string name="browserMenuReportBrokenSite">Fehlerhafte Seite melden</string>
     <string name="browserMenuAutofill">Passwörter</string>
     <string name="browserMenuDownloads">Downloads</string>

--- a/browser/browser-ui/src/main/res/values-el/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-el/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Εκτύπωση</string>
     <string name="browserMenuOpenAppLink">Ανοίξτε στην εφαρμογή</string>
     <string name="browserMenuAddToHome">Προσθήκη στην Αρχική Οθόνη</string>
+    <string name="browserMenuDownloadPdf">Λήψη PDF</string>
     <string name="browserMenuReportBrokenSite">Αναφορά ιστότοπου που δεν λειτουργεί</string>
     <string name="browserMenuAutofill">Κωδικοί πρόσβασης</string>
     <string name="browserMenuDownloads">Λήψεις</string>

--- a/browser/browser-ui/src/main/res/values-es/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-es/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Imprimir</string>
     <string name="browserMenuOpenAppLink">Abrir en la aplicación</string>
     <string name="browserMenuAddToHome">Añadir a la Pantalla de Inicio</string>
+    <string name="browserMenuDownloadPdf">Descargar PDF</string>
     <string name="browserMenuReportBrokenSite">Informar de sitio web dañado</string>
     <string name="browserMenuAutofill">Contraseñas</string>
     <string name="browserMenuDownloads">Descargas</string>

--- a/browser/browser-ui/src/main/res/values-et/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-et/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Prindi</string>
     <string name="browserMenuOpenAppLink">Ava rakenduses</string>
     <string name="browserMenuAddToHome">Lisa kodukuvale</string>
+    <string name="browserMenuDownloadPdf">Laadi alla PDF</string>
     <string name="browserMenuReportBrokenSite">Teata mittetoimivast saidist</string>
     <string name="browserMenuAutofill">Paroolid</string>
     <string name="browserMenuDownloads">Allalaadimised</string>

--- a/browser/browser-ui/src/main/res/values-fi/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-fi/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Tulosta</string>
     <string name="browserMenuOpenAppLink">Avaa sovelluksessa</string>
     <string name="browserMenuAddToHome">Lisää kotinäytölle</string>
+    <string name="browserMenuDownloadPdf">Lataa PDF</string>
     <string name="browserMenuReportBrokenSite">Ilmoita viallisesta sivustosta</string>
     <string name="browserMenuAutofill">Salasanat</string>
     <string name="browserMenuDownloads">Lataukset</string>

--- a/browser/browser-ui/src/main/res/values-fr/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-fr/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Imprimer</string>
     <string name="browserMenuOpenAppLink">Ouvrir dans l\'application</string>
     <string name="browserMenuAddToHome">Ajouter à la page d\'accueil</string>
+    <string name="browserMenuDownloadPdf">Télécharger le PDF</string>
     <string name="browserMenuReportBrokenSite">Signaler un problème de site</string>
     <string name="browserMenuAutofill">Mots de passe</string>
     <string name="browserMenuDownloads">Téléchargements</string>

--- a/browser/browser-ui/src/main/res/values-hr/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-hr/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Ispis</string>
     <string name="browserMenuOpenAppLink">Otvori u aplikaciji</string>
     <string name="browserMenuAddToHome">Dodaj na početni zaslon</string>
+    <string name="browserMenuDownloadPdf">Preuzmi PDF</string>
     <string name="browserMenuReportBrokenSite">Prijavi neispravno web-mjesto</string>
     <string name="browserMenuAutofill">Lozinke</string>
     <string name="browserMenuDownloads">Preuzimanja</string>

--- a/browser/browser-ui/src/main/res/values-hu/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-hu/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Nyomtatás</string>
     <string name="browserMenuOpenAppLink">Megnyitás az alkalmazásban</string>
     <string name="browserMenuAddToHome">Hozzáadás a kezdőlaphoz</string>
+    <string name="browserMenuDownloadPdf">PDF letöltése</string>
     <string name="browserMenuReportBrokenSite">Hibás weboldal jelentése</string>
     <string name="browserMenuAutofill">Jelszavak</string>
     <string name="browserMenuDownloads">Letöltések</string>

--- a/browser/browser-ui/src/main/res/values-it/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-it/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Stampa</string>
     <string name="browserMenuOpenAppLink">Apri nell\'app</string>
     <string name="browserMenuAddToHome">Aggiungi alla Schermata Home</string>
+    <string name="browserMenuDownloadPdf">Scarica PDF</string>
     <string name="browserMenuReportBrokenSite">Segnala sito danneggiato</string>
     <string name="browserMenuAutofill">Password</string>
     <string name="browserMenuDownloads">Download</string>

--- a/browser/browser-ui/src/main/res/values-lt/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-lt/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Spausdinti</string>
     <string name="browserMenuOpenAppLink">Atidaryti programėlėje</string>
     <string name="browserMenuAddToHome">Pridėti prie pagrindinio ekrano</string>
+    <string name="browserMenuDownloadPdf">Atsisiųsti PDF</string>
     <string name="browserMenuReportBrokenSite">Pranešti apie sugadintą svetainę</string>
     <string name="browserMenuAutofill">Slaptažodžiai</string>
     <string name="browserMenuDownloads">Atsisiuntimai</string>

--- a/browser/browser-ui/src/main/res/values-lv/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-lv/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Drukāt</string>
     <string name="browserMenuOpenAppLink">Atvērt lietotnē</string>
     <string name="browserMenuAddToHome">Pievienot sākuma ekrānam</string>
+    <string name="browserMenuDownloadPdf">Lejupielādēt PDF</string>
     <string name="browserMenuReportBrokenSite">Ziņot par bojātu vietni</string>
     <string name="browserMenuAutofill">Paroles</string>
     <string name="browserMenuDownloads">Lejupielādes</string>

--- a/browser/browser-ui/src/main/res/values-nb/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-nb/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Skriv ut</string>
     <string name="browserMenuOpenAppLink">Åpne i appen</string>
     <string name="browserMenuAddToHome">Legg til på startskjermen</string>
+    <string name="browserMenuDownloadPdf">Last ned PDF</string>
     <string name="browserMenuReportBrokenSite">Rapporter nettstedfeil</string>
     <string name="browserMenuAutofill">Passord</string>
     <string name="browserMenuDownloads">Nedlastinger</string>

--- a/browser/browser-ui/src/main/res/values-nl/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-nl/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Afdrukken</string>
     <string name="browserMenuOpenAppLink">Openen in de app</string>
     <string name="browserMenuAddToHome">Toevoegen aan Home Screen</string>
+    <string name="browserMenuDownloadPdf">PDF downloaden</string>
     <string name="browserMenuReportBrokenSite">Defecte website melden</string>
     <string name="browserMenuAutofill">Wachtwoorden</string>
     <string name="browserMenuDownloads">Downloads</string>

--- a/browser/browser-ui/src/main/res/values-pl/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-pl/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Drukuj</string>
     <string name="browserMenuOpenAppLink">Otwórz w aplikacji</string>
     <string name="browserMenuAddToHome">Dodaj do ekranu głównego</string>
+    <string name="browserMenuDownloadPdf">Pobierz PDF</string>
     <string name="browserMenuReportBrokenSite">Zgłoś uszkodzoną witrynę</string>
     <string name="browserMenuAutofill">Hasła</string>
     <string name="browserMenuDownloads">Pobrane</string>

--- a/browser/browser-ui/src/main/res/values-pt/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-pt/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Imprimir</string>
     <string name="browserMenuOpenAppLink">Abrir na app</string>
     <string name="browserMenuAddToHome">Adicionar à Página Inicial</string>
+    <string name="browserMenuDownloadPdf">Descarregar PDF</string>
     <string name="browserMenuReportBrokenSite">Denunciar site danificado</string>
     <string name="browserMenuAutofill">Palavras-passe</string>
     <string name="browserMenuDownloads">Transferências</string>

--- a/browser/browser-ui/src/main/res/values-ro/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-ro/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Tipărire</string>
     <string name="browserMenuOpenAppLink">Deschide în aplicație</string>
     <string name="browserMenuAddToHome">Adaugă pe ecranul de pornire</string>
+    <string name="browserMenuDownloadPdf">Descarcă PDF</string>
     <string name="browserMenuReportBrokenSite">Raportează Site-ul Defect</string>
     <string name="browserMenuAutofill">Parole</string>
     <string name="browserMenuDownloads">Descărcări</string>

--- a/browser/browser-ui/src/main/res/values-ru/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-ru/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Распечатать</string>
     <string name="browserMenuOpenAppLink">Открыть в приложении</string>
     <string name="browserMenuAddToHome">Добавить на домашнюю страницу</string>
+    <string name="browserMenuDownloadPdf">Скачать PDF</string>
     <string name="browserMenuReportBrokenSite">Сообщить о неработающем сайте</string>
     <string name="browserMenuAutofill">Пароли</string>
     <string name="browserMenuDownloads">Загрузки</string>

--- a/browser/browser-ui/src/main/res/values-sk/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-sk/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Vytlačiť</string>
     <string name="browserMenuOpenAppLink">Otvoriť v aplikácii</string>
     <string name="browserMenuAddToHome">Pridať na domovskú obrazovku</string>
+    <string name="browserMenuDownloadPdf">Stiahnuť PDF</string>
     <string name="browserMenuReportBrokenSite">Nahlásiť nefunkčný web</string>
     <string name="browserMenuAutofill">Heslá</string>
     <string name="browserMenuDownloads">Stiahnuté</string>

--- a/browser/browser-ui/src/main/res/values-sl/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-sl/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Natisni</string>
     <string name="browserMenuOpenAppLink">Odpri v aplikaciji</string>
     <string name="browserMenuAddToHome">Dodaj na Domači Zaslon</string>
+    <string name="browserMenuDownloadPdf">Prenesi PDF</string>
     <string name="browserMenuReportBrokenSite">Prijavite poškodovano spletno mesto</string>
     <string name="browserMenuAutofill">Gesla</string>
     <string name="browserMenuDownloads">Prenosi</string>

--- a/browser/browser-ui/src/main/res/values-sv/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-sv/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Skriv ut</string>
     <string name="browserMenuOpenAppLink">Öppna i appen</string>
     <string name="browserMenuAddToHome">Lägg till på hemskärmen</string>
+    <string name="browserMenuDownloadPdf">Ladda ner PDF</string>
     <string name="browserMenuReportBrokenSite">Rapportera skadad webbplats</string>
     <string name="browserMenuAutofill">Lösenord</string>
     <string name="browserMenuDownloads">Nerladdningar</string>

--- a/browser/browser-ui/src/main/res/values-tr/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values-tr/strings-browser-menu.xml
@@ -36,6 +36,7 @@
     <string name="browserMenuPrintSite">Yazdır</string>
     <string name="browserMenuOpenAppLink">Uygulamada Aç</string>
     <string name="browserMenuAddToHome">Ana ekrana ekle</string>
+    <string name="browserMenuDownloadPdf">PDF indir</string>
     <string name="browserMenuReportBrokenSite">Hatalı Siteyi Bildirin</string>
     <string name="browserMenuAutofill">Şifreler</string>
     <string name="browserMenuDownloads">İndirilenler</string>

--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -22,6 +22,5 @@
     <string name="newTabReturnHatchDuckChatPlaceholderTitle">Duck.ai by DuckDuckGo. Private AI chat. Free.</string>
     <string name="duck_ai_tab_label">Duck.ai</string>
     <string name="duck_ai_tab_icon_content_description">Duck.ai icon</string>
-    <string name="browserMenuDownloadPdf">Download PDF</string>
 
 </resources>

--- a/browser/browser-ui/src/main/res/values/strings-browser-menu.xml
+++ b/browser/browser-ui/src/main/res/values/strings-browser-menu.xml
@@ -35,6 +35,7 @@
     <string name="browserMenuPrintSite">Print</string>
     <string name="browserMenuOpenAppLink">Open in App</string>
     <string name="browserMenuAddToHome">Add to Home Screen</string>
+    <string name="browserMenuDownloadPdf">Download PDF</string>
     <string name="browserMenuReportBrokenSite">Report Broken Site</string>
     <string name="browserMenuAutofill">Passwords</string>
     <string name="browserMenuDownloads">Downloads</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214388879545628?focus=true 

### Description

Translate PDF download menu item

### Steps to test this PR

QA optional

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: resource-only changes that add localized strings and move the English `browserMenuDownloadPdf` entry out of `donottranslate.xml`, with no behavior or logic changes.
> 
> **Overview**
> Adds localized translations for the browser menu item `browserMenuDownloadPdf` across multiple `values-xx/strings-browser-menu.xml` locales.
> 
> Moves the English `browserMenuDownloadPdf` string from `values/donottranslate.xml` into `values/strings-browser-menu.xml` so it can be translated normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930721b9a82567032563fdfd58174cc407f6e17e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->