### PR TITLE
Pixel definitions and implementation about PDF rendering

### DIFF
--- a/PixelDefinitions/pixels/definitions/pdf_viewer.json5
+++ b/PixelDefinitions/pixels/definitions/pdf_viewer.json5
@@ -1,6 +1,20 @@
 {
     "m_pdf_viewer_opened": {
-        "description": "Fired when a PDF is successfully rendered inline in a browser tab",
+        "description": "Fired every time a PDF is successfully rendered inline in a browser tab",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_pdf_viewer_opened_daily": {
+        "description": "Fired once per calendar day when a PDF is successfully rendered inline in a browser tab",
+        "owners": ["GerardPaligot"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_pdf_viewer_opened_unique": {
+        "description": "Fired once per install the first time a PDF is successfully rendered inline in a browser tab",
         "owners": ["GerardPaligot"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -158,6 +158,7 @@ import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.*
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.pdf.DdgPdfViewerFragment
+import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfPreviewGenerator
 import com.duckduckgo.app.browser.print.PrintDocumentAdapterFactory
 import com.duckduckgo.app.browser.print.PrintInjector
@@ -1811,6 +1812,7 @@ class BrowserTabFragment :
                 viewModel.onShareSelected()
             }
             onMenuItemClicked(downloadPdfMenuItem) {
+                pixel.fire(PdfPixelName.PDF_DOWNLOAD_MENU_ITEM_PRESSED)
                 viewModel.onDownloadPdfMenuItemClicked()
             }
             onMenuItemClicked(addToHomeMenuItem) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2290,6 +2290,11 @@ class BrowserTabFragment :
 
         binding.pdfViewerContainer.show()
         val pdfFragment = DdgPdfViewerFragment()
+        pdfFragment.errorListener = object : DdgPdfViewerFragment.ErrorListener {
+            override fun onLoadDocumentError(throwable: Throwable) {
+                viewModel.onPdfRenderFailure(throwable)
+            }
+        }
         childFragmentManager.beginTransaction()
             .replace(R.id.pdfViewerContainer, pdfFragment, PDF_VIEWER_FRAGMENT_TAG)
             .commitNowAllowingStateLoss()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3684,7 +3684,7 @@ class BrowserTabViewModel @Inject constructor(
             }
             return
         }
-        when (inlinePdfHandler.decideForPdf(url, contentDisposition, mimeType)) {
+        when (inlinePdfHandler.classifyPdfRequest(url, contentDisposition, mimeType)) {
             PdfRenderDecision.Inline -> handlePdfUrl(url, contentDisposition, mimeType, requestUserConfirmation)
             PdfRenderDecision.Fallback -> {
                 pixel.fire(PdfPixelName.PDF_FALLBACK)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -206,6 +206,9 @@ import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
 import com.duckduckgo.app.browser.pageload.PageLoadWideEvent
 import com.duckduckgo.app.browser.pdf.CachedFileDownloader
 import com.duckduckgo.app.browser.pdf.InlinePdfHandler
+import com.duckduckgo.app.browser.pdf.PdfDownloadResult
+import com.duckduckgo.app.browser.pdf.PdfPixelName
+import com.duckduckgo.app.browser.pdf.PdfRenderDecision
 import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
@@ -3679,10 +3682,15 @@ class BrowserTabViewModel @Inject constructor(
             } else {
                 command.value = ConvertBlobToDataUri(url, mimeType)
             }
-        } else if (inlinePdfHandler.shouldRenderPdfInline(url, contentDisposition, mimeType)) {
-            handlePdfUrl(url, contentDisposition, mimeType, requestUserConfirmation)
-        } else {
-            sendRequestFileDownloadCommand(url, contentDisposition, mimeType, requestUserConfirmation)
+            return
+        }
+        when (inlinePdfHandler.decideForPdf(url, contentDisposition, mimeType)) {
+            PdfRenderDecision.Inline -> handlePdfUrl(url, contentDisposition, mimeType, requestUserConfirmation)
+            PdfRenderDecision.Fallback -> {
+                pixel.fire(PdfPixelName.PDF_FALLBACK)
+                sendRequestFileDownloadCommand(url, contentDisposition, mimeType, requestUserConfirmation)
+            }
+            PdfRenderDecision.NotApplicable -> sendRequestFileDownloadCommand(url, contentDisposition, mimeType, requestUserConfirmation)
         }
     }
 
@@ -3692,18 +3700,28 @@ class BrowserTabViewModel @Inject constructor(
         pdfDownloadJob += viewModelScope.launch {
             // downloadToCache wraps its own work in withContext(io); viewModelScope.launch
             // defaults to Main, so we stay on Main for the LiveData updates below.
-            val cachedUri = inlinePdfHandler.downloadToCache(url)
+            val result = inlinePdfHandler.downloadToCache(url)
             loadingViewState.value = currentLoadingViewState().copy(isLoading = false, progress = 100)
-            if (cachedUri != null) {
-                val pdfTitle = inlinePdfHandler.extractFileName(url)
-                pageChanged(url, pdfTitle)
-                browserViewState.value = currentBrowserViewState().copy(
-                    currentPdfCachedUri = cachedUri,
-                    currentPdfFileName = pdfTitle,
-                )
-                command.value = ShowPdfInTab(url, cachedUri)
-            } else {
-                sendRequestFileDownloadCommand(url, contentDisposition, mimeType, requestUserConfirmation)
+            when (result) {
+                is PdfDownloadResult.Success -> {
+                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED)
+                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_DAILY, type = Daily())
+                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_UNIQUE, type = Unique())
+                    val pdfTitle = inlinePdfHandler.extractFileName(url)
+                    pageChanged(url, pdfTitle)
+                    browserViewState.value = currentBrowserViewState().copy(
+                        currentPdfCachedUri = result.uri,
+                        currentPdfFileName = pdfTitle,
+                    )
+                    command.value = ShowPdfInTab(url, result.uri)
+                }
+                is PdfDownloadResult.Failure -> {
+                    pixel.fire(
+                        PdfPixelName.PDF_RENDER_FAILURE,
+                        parameters = mapOf("error_type" to result.errorType.paramValue),
+                    )
+                    sendRequestFileDownloadCommand(url, contentDisposition, mimeType, requestUserConfirmation)
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -207,6 +207,7 @@ import com.duckduckgo.app.browser.pageload.PageLoadWideEvent
 import com.duckduckgo.app.browser.pdf.CachedFileDownloader
 import com.duckduckgo.app.browser.pdf.InlinePdfHandler
 import com.duckduckgo.app.browser.pdf.PdfDownloadResult
+import com.duckduckgo.app.browser.pdf.PdfErrorType
 import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfRenderDecision
 import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
@@ -3727,6 +3728,13 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun pdfDownloadCommands(): Flow<DownloadCommand> = pdfDownloadCommandFlow.asSharedFlow()
+
+    fun onPdfRenderFailure(@Suppress("UNUSED_PARAMETER") throwable: Throwable) {
+        pixel.fire(
+            PdfPixelName.PDF_RENDER_FAILURE,
+            parameters = mapOf("error_type" to PdfErrorType.UNKNOWN.paramValue),
+        )
+    }
 
     /**
      * Called by the fragment when the inline PDF is hidden (back press, navigation).

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/DdgPdfViewerFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/DdgPdfViewerFragment.kt
@@ -35,6 +35,12 @@ import com.duckduckgo.app.browser.R
 @SuppressLint("RestrictedApi")
 class DdgPdfViewerFragment : PdfViewerFragmentV2() {
 
+    interface ErrorListener {
+        fun onLoadDocumentError(throwable: Throwable)
+    }
+
+    var errorListener: ErrorListener? = null
+
     override fun onGetLayoutInflater(savedInstanceState: Bundle?): LayoutInflater {
         val inflater = super.onGetLayoutInflater(savedInstanceState)
         val themedContext = ContextThemeWrapper(
@@ -46,5 +52,10 @@ class DdgPdfViewerFragment : PdfViewerFragmentV2() {
 
     fun documentUri(uri: Uri) {
         documentUri = uri
+    }
+
+    override fun onLoadDocumentError(throwable: Throwable) {
+        super.onLoadDocumentError(throwable)
+        errorListener?.onLoadDocumentError(throwable)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -49,28 +49,28 @@ import kotlin.coroutines.coroutineContext
 interface InlinePdfHandler {
 
     /**
-     * Determines whether a download response should be rendered as an inline PDF
-     * inside the browser tab instead of triggering a standard file download.
+     * Decides how a download response should be handled for PDF rendering.
      *
-     * Checks SDK level (>= Android 12), MIME type or `.pdf` URL extension, and
-     * rejects `Content-Disposition: attachment` responses.
-     *
-     * @param url the URL of the PDF document
-     * @param contentDisposition the value of the `Content-Disposition` header, if present
-     * @param mimeType the MIME type of the response, if provided by the server
-     * @return true if the response should be rendered inline, false to trigger a download
+     * - [PdfRenderDecision.Inline]: feature flag on, SDK >= Android 12, MIME or
+     *   `.pdf` URL extension matches, and `Content-Disposition: attachment` not set.
+     * - [PdfRenderDecision.Fallback]: same eligibility but the device is below
+     *   Android 12 — caller should fall back to the standard file download.
+     * - [PdfRenderDecision.NotApplicable]: response is not an inline-eligible PDF
+     *   (or the feature flag is off).
      */
-    fun shouldRenderPdfInline(url: String, contentDisposition: String?, mimeType: String): Boolean
+    fun decideForPdf(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision
 
     /**
      * Downloads the PDF at [url] into internal cache for inline rendering.
      *
      * Forwards WebView cookies for authenticated downloads, validates the file
-     * starts with `%PDF-` magic bytes, and returns a `file://` URI on success.
+     * starts with `%PDF-` magic bytes, and returns [PdfDownloadResult.Success] on
+     * success.
      *
-     * Returns `null` if the server returns an error or the downloaded file is not a
-     * valid PDF. The feature flag and SDK gate live in [shouldRenderPdfInline] so
-     * callers shouldn't reach this method when the feature is off.
+     * Returns [PdfDownloadResult.Failure] with an error category when the network,
+     * server, or file content prevents inline rendering. The feature flag and SDK
+     * gate live in [decideForPdf] so callers shouldn't reach this method when the
+     * feature is off.
      *
      * Cancellation-safe: if the calling coroutine is cancelled (e.g. the user
      * navigates away), the in-flight HTTP request is aborted and any partial
@@ -78,7 +78,7 @@ interface InlinePdfHandler {
      *
      * @param url the URL of the PDF to download
      */
-    suspend fun downloadToCache(url: String): Uri?
+    suspend fun downloadToCache(url: String): PdfDownloadResult
 
     /**
      * Extracts a sanitized filename from the PDF [url]'s last path segment.
@@ -86,6 +86,23 @@ interface InlinePdfHandler {
      * @param url the URL of the PDF document
      */
     fun extractFileName(url: String): String
+}
+
+sealed class PdfRenderDecision {
+    data object Inline : PdfRenderDecision()
+    data object Fallback : PdfRenderDecision()
+    data object NotApplicable : PdfRenderDecision()
+}
+
+sealed class PdfDownloadResult {
+    data class Success(val uri: Uri) : PdfDownloadResult()
+    data class Failure(val errorType: PdfErrorType) : PdfDownloadResult()
+}
+
+enum class PdfErrorType(val paramValue: String) {
+    IO_ERROR("io_error"),
+    SECURITY_ERROR("security_error"),
+    UNKNOWN("unknown"),
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -98,21 +115,23 @@ class RealInlinePdfHandler @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : InlinePdfHandler {
 
-    override fun shouldRenderPdfInline(url: String, contentDisposition: String?, mimeType: String): Boolean {
-        if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return false
-        if (Build.VERSION.SDK_INT < 31) return false
+    override fun decideForPdf(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision {
+        if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return PdfRenderDecision.NotApplicable
         // Use lastPathSegment so query strings and fragments don't break the .pdf check
         // (e.g. signed URLs like https://cdn.example.com/report.pdf?auth=token).
         val pathEndsInPdf = url.toUri().lastPathSegment?.endsWith(".pdf", ignoreCase = true) == true
-        if (mimeType != "application/pdf" && !pathEndsInPdf) return false
-        if (contentDisposition != null && contentDisposition.trim().startsWith("attachment", ignoreCase = true)) return false
-        return true
+        if (mimeType != "application/pdf" && !pathEndsInPdf) return PdfRenderDecision.NotApplicable
+        if (contentDisposition != null && contentDisposition.trim().startsWith("attachment", ignoreCase = true)) {
+            return PdfRenderDecision.NotApplicable
+        }
+        if (Build.VERSION.SDK_INT < 31) return PdfRenderDecision.Fallback
+        return PdfRenderDecision.Inline
     }
 
     private val cacheDir: File
         get() = File(context.cacheDir, PDF_CACHE_DIR).also { it.mkdirs() }
 
-    override suspend fun downloadToCache(url: String): Uri? = withContext(dispatcherProvider.io()) {
+    override suspend fun downloadToCache(url: String): PdfDownloadResult = withContext(dispatcherProvider.io()) {
         val fileName = extractFileName(url)
         // Prefix the cache filename with the URL hash so two URLs sharing a last path segment
         // (e.g. report.pdf at site A and site B) don't collide and serve stale content.
@@ -122,7 +141,7 @@ class RealInlinePdfHandler @Inject constructor(
                 // Bump mtime so LRU eviction treats this file as recently *used*,
                 // not just recently *written*.
                 targetFile.setLastModified(System.currentTimeMillis())
-                return@withContext Uri.fromFile(targetFile)
+                return@withContext PdfDownloadResult.Success(Uri.fromFile(targetFile))
             }
 
             val requestBuilder = Request.Builder().url(url)
@@ -135,7 +154,7 @@ class RealInlinePdfHandler @Inject constructor(
             executeRequestCancellably(okHttpClient.newCall(requestBuilder.build())).use { response ->
                 if (!response.isSuccessful) {
                     logcat { "PDF download failed: HTTP ${response.code}" }
-                    return@withContext null
+                    return@withContext PdfDownloadResult.Failure(PdfErrorType.UNKNOWN)
                 }
 
                 response.body?.byteStream()?.use { input ->
@@ -149,7 +168,7 @@ class RealInlinePdfHandler @Inject constructor(
                     }
                 } ?: run {
                     logcat { "PDF download failed: empty response body" }
-                    return@withContext null
+                    return@withContext PdfDownloadResult.Failure(PdfErrorType.UNKNOWN)
                 }
             }
 
@@ -158,19 +177,22 @@ class RealInlinePdfHandler @Inject constructor(
             if (!hasPdfMagicBytes(targetFile)) {
                 logcat { "PDF download failed: file does not start with %PDF magic bytes" }
                 targetFile.delete()
-                return@withContext null
+                return@withContext PdfDownloadResult.Failure(PdfErrorType.UNKNOWN)
             }
 
             enforceCacheBudget(keepFile = targetFile, maxFiles = MAX_CACHED_FILES)
 
-            Uri.fromFile(targetFile)
+            PdfDownloadResult.Success(Uri.fromFile(targetFile))
         } catch (e: CancellationException) {
             logcat { "PDF download cancelled, cleaning up partial file" }
             targetFile.delete()
             throw e
         } catch (e: IOException) {
             logcat { "PDF download failed: ${e.message}" }
-            null
+            PdfDownloadResult.Failure(PdfErrorType.IO_ERROR)
+        } catch (e: SecurityException) {
+            logcat { "PDF download denied: ${e.message}" }
+            PdfDownloadResult.Failure(PdfErrorType.SECURITY_ERROR)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -58,7 +58,7 @@ interface InlinePdfHandler {
      * - [PdfRenderDecision.NotApplicable]: response is not an inline-eligible PDF
      *   (or the feature flag is off).
      */
-    fun decideForPdf(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision
+    fun classifyPdfRequest(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision
 
     /**
      * Downloads the PDF at [url] into internal cache for inline rendering.
@@ -69,7 +69,7 @@ interface InlinePdfHandler {
      *
      * Returns [PdfDownloadResult.Failure] with an error category when the network,
      * server, or file content prevents inline rendering. The feature flag and SDK
-     * gate live in [decideForPdf] so callers shouldn't reach this method when the
+     * gate live in [classifyPdfRequest] so callers shouldn't reach this method when the
      * feature is off.
      *
      * Cancellation-safe: if the calling coroutine is cancelled (e.g. the user
@@ -115,7 +115,7 @@ class RealInlinePdfHandler @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : InlinePdfHandler {
 
-    override fun decideForPdf(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision {
+    override fun classifyPdfRequest(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision {
         if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return PdfRenderDecision.NotApplicable
         // Use lastPathSegment so query strings and fragments don't break the .pdf check
         // (e.g. signed URLs like https://cdn.example.com/report.pdf?auth=token).

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfPixelName.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 
 enum class PdfPixelName(override val pixelName: String) : Pixel.PixelName {
     PDF_VIEWER_OPENED("m_pdf_viewer_opened"),
+    PDF_VIEWER_OPENED_DAILY("m_pdf_viewer_opened_daily"),
+    PDF_VIEWER_OPENED_UNIQUE("m_pdf_viewer_opened_unique"),
     PDF_RENDER_FAILURE("m_pdf_render_failure"),
     PDF_DOWNLOAD_MENU_ITEM_PRESSED("m_nav_pdf_download_menu_item_pressed"),
     PDF_FALLBACK("m_pdf_fallback"),

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10579,6 +10579,13 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnPdfRenderFailureThenRenderFailurePixelFiresWithUnknownErrorType() {
+        testee.onPdfRenderFailure(RuntimeException("malformed pdf"))
+
+        verify(mockPixel).fire(PdfPixelName.PDF_RENDER_FAILURE, parameters = mapOf("error_type" to "unknown"))
+    }
+
+    @Test
     fun whenDecisionIsFallbackThenFallbackPixelFiresAndStandardDownloadCommandIssued() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Fallback)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -687,7 +687,7 @@ class BrowserTabViewModelTest {
             swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
 
             whenever(mockDuckChatJSHelper.enrichPageContextIfPossible(any(), any())).thenAnswer { it.getArgument<String>(1) }
-            whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+            whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
 
             db =
                 Room
@@ -10122,7 +10122,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenShouldNotRenderPdfInlineThenDownloadFile() {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
         assertCommandIssued<Command.RequestFileDownload>()
@@ -10130,7 +10130,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfEnabledAndApi31ThenDownloadToCacheAndEmitShowPdfCommand() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
@@ -10145,7 +10145,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadToCacheFailsThenFallbackToStandardDownload() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
@@ -10156,7 +10156,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfInlineThenExpandOmnibarCommandIsEmitted() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
@@ -10168,7 +10168,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadStartsThenLoadingStateShowsProgress() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
@@ -10181,7 +10181,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadFailsThenLoadingStateIsReset() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
@@ -10193,7 +10193,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenShouldNotRenderPdfInlineThenExpandOmnibarNotEmitted() {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
         assertCommandNotIssued<Command.ExpandOmnibar>()
@@ -10203,12 +10203,12 @@ class BrowserTabViewModelTest {
     fun whenBlobUrlThenPdfHandlerNotCalled() {
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "blob:https://example.com/abc", null, "application/pdf", true, false)
-        verify(mockInlinePdfHandler, never()).decideForPdf(any(), anyOrNull(), any())
+        verify(mockInlinePdfHandler, never()).classifyPdfRequest(any(), anyOrNull(), any())
     }
 
     @Test
     fun whenPdfWithContentDispositionInlineThenShowPdf() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
@@ -10220,7 +10220,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfNotInlineThenFallbackToDownloadWhenContentDispositionIsAttachment() {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", "attachment", "application/pdf", true, false)
@@ -10231,7 +10231,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadInProgressAndUserNavigatesAwayThenShowPdfNotEmitted() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         // Return COROUTINE_SUSPENDED to simulate a long-running download that never completes
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenAnswer {
             COROUTINE_SUSPENDED
@@ -10251,7 +10251,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSecondPdfRequestedDuringFirstThenSecondShows() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val urlA = "https://example.com/a.pdf"
         val urlB = "https://example.com/b.pdf"
         val uriB = Uri.parse("file:///cache/b.pdf")
@@ -10276,7 +10276,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfShownThenCurrentPdfStatePopulated() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
         val cachedUri = Uri.parse("file:///cache/doc.pdf")
         whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(cachedUri))
@@ -10291,7 +10291,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfShownAfterFreshViewModelThenPerPageMenuFlagsArePopulated() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
         whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
@@ -10544,7 +10544,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfRenderedInlineThenAllThreeOpenedPixelsFire() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/doc.pdf")
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
             .thenReturn(PdfDownloadResult.Success(testUri))
@@ -10558,7 +10558,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadFailsWithIoErrorThenRenderFailurePixelFiresWithErrorType() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
             .thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
 
@@ -10569,7 +10569,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadFailsWithUnknownThenRenderFailurePixelFiresWithUnknownErrorType() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
             .thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
 
@@ -10580,7 +10580,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenDecisionIsFallbackThenFallbackPixelFiresAndStandardDownloadCommandIssued() = runTest {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Fallback)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Fallback)
 
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
 
@@ -10590,7 +10590,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenDecisionIsNotApplicableThenNoFallbackPixelFires() {
-        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
 
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", "attachment", "application/pdf", true, false)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -128,6 +128,10 @@ import com.duckduckgo.app.browser.omnibar.StandardizedLeadingIconFeatureToggle
 import com.duckduckgo.app.browser.pageload.PageLoadWideEvent
 import com.duckduckgo.app.browser.pdf.CachedFileDownloader
 import com.duckduckgo.app.browser.pdf.InlinePdfHandler
+import com.duckduckgo.app.browser.pdf.PdfDownloadResult
+import com.duckduckgo.app.browser.pdf.PdfErrorType
+import com.duckduckgo.app.browser.pdf.PdfPixelName
+import com.duckduckgo.app.browser.pdf.PdfRenderDecision
 import com.duckduckgo.app.browser.progressbar.ProgressBarUpgradeFeature
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.santize.NonHttpAppLinkChecker
@@ -10117,7 +10121,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenShouldNotRenderPdfInlineThenDownloadFile() {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(false)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
         assertCommandIssued<Command.RequestFileDownload>()
@@ -10125,9 +10129,9 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfEnabledAndApi31ThenDownloadToCacheAndEmitShowPdfCommand() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(testUri)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -10140,8 +10144,8 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadToCacheFailsThenFallbackToStandardDownload() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(null)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -10151,9 +10155,9 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfInlineThenExpandOmnibarCommandIsEmitted() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(testUri)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -10163,9 +10167,9 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadStartsThenLoadingStateShowsProgress() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(testUri)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -10176,8 +10180,8 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadFailsThenLoadingStateIsReset() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(null)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -10188,7 +10192,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenShouldNotRenderPdfInlineThenExpandOmnibarNotEmitted() {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(false)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
         assertCommandNotIssued<Command.ExpandOmnibar>()
@@ -10198,14 +10202,14 @@ class BrowserTabViewModelTest {
     fun whenBlobUrlThenPdfHandlerNotCalled() {
         val webView: WebView = mock()
         testee.requestFileDownload(webView, "blob:https://example.com/abc", null, "application/pdf", true, false)
-        verify(mockInlinePdfHandler, never()).shouldRenderPdfInline(any(), anyOrNull(), any())
+        verify(mockInlinePdfHandler, never()).decideForPdf(any(), anyOrNull(), any())
     }
 
     @Test
     fun whenPdfWithContentDispositionInlineThenShowPdf() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(testUri)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", "inline", "application/pdf", true, false)
@@ -10215,7 +10219,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfNotInlineThenFallbackToDownloadWhenContentDispositionIsAttachment() {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(false)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", "attachment", "application/pdf", true, false)
@@ -10226,7 +10230,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfDownloadInProgressAndUserNavigatesAwayThenShowPdfNotEmitted() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         // Return COROUTINE_SUSPENDED to simulate a long-running download that never completes
         whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenAnswer {
             COROUTINE_SUSPENDED
@@ -10246,7 +10250,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenSecondPdfRequestedDuringFirstThenSecondShows() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val urlA = "https://example.com/a.pdf"
         val urlB = "https://example.com/b.pdf"
         val uriB = Uri.parse("file:///cache/b.pdf")
@@ -10256,7 +10260,7 @@ class BrowserTabViewModelTest {
         whenever(mockInlinePdfHandler.downloadToCache(urlA)).thenAnswer {
             COROUTINE_SUSPENDED
         }
-        whenever(mockInlinePdfHandler.downloadToCache(urlB)).thenReturn(uriB)
+        whenever(mockInlinePdfHandler.downloadToCache(urlB)).thenReturn(PdfDownloadResult.Success(uriB))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, urlA, null, "application/pdf", true, false)
@@ -10271,10 +10275,10 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfShownThenCurrentPdfStatePopulated() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
         val cachedUri = Uri.parse("file:///cache/doc.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(cachedUri)
+        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(cachedUri))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
         val webView: WebView = mock()
 
@@ -10286,9 +10290,9 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenPdfShownAfterFreshViewModelThenPerPageMenuFlagsArePopulated() = runTest {
-        whenever(mockInlinePdfHandler.shouldRenderPdfInline(any(), anyOrNull(), any())).thenReturn(true)
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
-        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(Uri.parse("file:///cache/doc.pdf"))
+        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
         testee.browserViewState.value = browserViewState().copy(
             canSaveSite = false,
@@ -10535,6 +10539,61 @@ class BrowserTabViewModelTest {
 
         assertTrue(emitted.any { it is DownloadCommand.ShowDownloadFailedMessage })
         assertFalse(emitted.any { it is DownloadCommand.ShowDownloadSuccessMessage })
+    }
+
+    @Test
+    fun whenPdfRenderedInlineThenAllThreeOpenedPixelsFire() = runTest {
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val testUri = Uri.parse("file:///cache/doc.pdf")
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+            .thenReturn(PdfDownloadResult.Success(testUri))
+
+        testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
+
+        verify(mockPixel).fire(PdfPixelName.PDF_VIEWER_OPENED)
+        verify(mockPixel).fire(PdfPixelName.PDF_VIEWER_OPENED_DAILY, type = Daily())
+        verify(mockPixel).fire(PdfPixelName.PDF_VIEWER_OPENED_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenPdfDownloadFailsWithIoErrorThenRenderFailurePixelFiresWithErrorType() = runTest {
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+            .thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
+
+        testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
+
+        verify(mockPixel).fire(PdfPixelName.PDF_RENDER_FAILURE, parameters = mapOf("error_type" to "io_error"))
+    }
+
+    @Test
+    fun whenPdfDownloadFailsWithUnknownThenRenderFailurePixelFiresWithUnknownErrorType() = runTest {
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+            .thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
+
+        testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
+
+        verify(mockPixel).fire(PdfPixelName.PDF_RENDER_FAILURE, parameters = mapOf("error_type" to "unknown"))
+    }
+
+    @Test
+    fun whenDecisionIsFallbackThenFallbackPixelFiresAndStandardDownloadCommandIssued() = runTest {
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Fallback)
+
+        testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
+
+        verify(mockPixel).fire(PdfPixelName.PDF_FALLBACK)
+        assertCommandIssued<Command.RequestFileDownload>()
+    }
+
+    @Test
+    fun whenDecisionIsNotApplicableThenNoFallbackPixelFires() {
+        whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+
+        testee.requestFileDownload(mock(), "https://example.com/doc.pdf", "attachment", "application/pdf", true, false)
+
+        verify(mockPixel, never()).fire(PdfPixelName.PDF_FALLBACK)
     }
 
     // endregion

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -687,6 +687,7 @@ class BrowserTabViewModelTest {
             swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
 
             whenever(mockDuckChatJSHelper.enrichPageContextIfPossible(any(), any())).thenAnswer { it.getArgument<String>(1) }
+            whenever(mockInlinePdfHandler.decideForPdf(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
 
             db =
                 Room

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import okhttp3.OkHttpClient
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -65,17 +65,34 @@ class InlinePdfHandlerPreApi31Test {
     }
 
     @Test
-    fun whenApiBelow31AndPdfMimeTypeThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", null, "application/pdf"))
+    fun whenApiBelow31AndPdfMimeTypeThenDecisionIsFallback() {
+        assertEquals(
+            PdfRenderDecision.Fallback,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"),
+        )
     }
 
     @Test
-    fun whenApiBelow31AndContentDispositionInlineThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", "inline", "application/pdf"))
+    fun whenApiBelow31AndContentDispositionInlineThenDecisionIsFallback() {
+        assertEquals(
+            PdfRenderDecision.Fallback,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "inline", "application/pdf"),
+        )
     }
 
     @Test
-    fun whenApiBelow31AndUrlEndsInPdfWithOctetMimeThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", null, "application/octet-stream"))
+    fun whenApiBelow31AndUrlEndsInPdfWithOctetMimeThenDecisionIsFallback() {
+        assertEquals(
+            PdfRenderDecision.Fallback,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/octet-stream"),
+        )
+    }
+
+    @Test
+    fun whenApiBelow31AndContentDispositionAttachmentThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
+        )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
@@ -68,7 +68,7 @@ class InlinePdfHandlerPreApi31Test {
     fun whenApiBelow31AndPdfMimeTypeThenDecisionIsFallback() {
         assertEquals(
             PdfRenderDecision.Fallback,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/pdf"),
         )
     }
 
@@ -76,7 +76,7 @@ class InlinePdfHandlerPreApi31Test {
     fun whenApiBelow31AndContentDispositionInlineThenDecisionIsFallback() {
         assertEquals(
             PdfRenderDecision.Fallback,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "inline", "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", "inline", "application/pdf"),
         )
     }
 
@@ -84,7 +84,7 @@ class InlinePdfHandlerPreApi31Test {
     fun whenApiBelow31AndUrlEndsInPdfWithOctetMimeThenDecisionIsFallback() {
         assertEquals(
             PdfRenderDecision.Fallback,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/octet-stream"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/octet-stream"),
         )
     }
 
@@ -92,7 +92,7 @@ class InlinePdfHandlerPreApi31Test {
     fun whenApiBelow31AndContentDispositionAttachmentThenDecisionIsNotApplicable() {
         assertEquals(
             PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -140,18 +140,18 @@ class InlinePdfHandlerTest {
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
 
-    // region decideForPdf tests
+    // region classifyPdfRequest tests
 
     @Test
     fun whenPdfMimeTypeThenDecisionIsInline() {
-        assertEquals(PdfRenderDecision.Inline, inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"))
+        assertEquals(PdfRenderDecision.Inline, inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/pdf"))
     }
 
     @Test
     fun whenContentDispositionIsAttachmentThenDecisionIsNotApplicable() {
         assertEquals(
             PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
         )
     }
 
@@ -159,7 +159,7 @@ class InlinePdfHandlerTest {
     fun whenMimeTypeIsNotPdfAndUrlNotPdfThenDecisionIsNotApplicable() {
         assertEquals(
             PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.txt", null, "text/plain"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.txt", null, "text/plain"),
         )
     }
 
@@ -167,7 +167,7 @@ class InlinePdfHandlerTest {
     fun whenMimeTypeIsNotPdfButUrlEndsPdfThenDecisionIsInline() {
         assertEquals(
             PdfRenderDecision.Inline,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/octet-stream"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/octet-stream"),
         )
     }
 
@@ -175,7 +175,7 @@ class InlinePdfHandlerTest {
     fun whenUrlEndsInPdfWithQueryParamsThenDecisionIsInline() {
         assertEquals(
             PdfRenderDecision.Inline,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf?auth=token", null, "application/octet-stream"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf?auth=token", null, "application/octet-stream"),
         )
     }
 
@@ -183,7 +183,7 @@ class InlinePdfHandlerTest {
     fun whenUrlEndsInPdfWithFragmentThenDecisionIsInline() {
         assertEquals(
             PdfRenderDecision.Inline,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf#page=5", null, "application/octet-stream"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf#page=5", null, "application/octet-stream"),
         )
     }
 
@@ -191,7 +191,7 @@ class InlinePdfHandlerTest {
     fun whenContentDispositionIsExplicitInlineThenDecisionIsInline() {
         assertEquals(
             PdfRenderDecision.Inline,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "inline", "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", "inline", "application/pdf"),
         )
     }
 
@@ -199,7 +199,7 @@ class InlinePdfHandlerTest {
     fun whenContentDispositionHasLeadingWhitespaceAttachmentThenDecisionIsNotApplicable() {
         assertEquals(
             PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "  attachment; filename=doc.pdf", "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", "  attachment; filename=doc.pdf", "application/pdf"),
         )
     }
 
@@ -213,7 +213,7 @@ class InlinePdfHandlerTest {
 
         assertEquals(
             PdfRenderDecision.NotApplicable,
-            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"),
+            inlinePdfHandler.classifyPdfRequest("https://example.com/doc.pdf", null, "application/pdf"),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -35,8 +35,7 @@ import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -95,21 +94,21 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(pdfBytes)),
         )
 
-        val uri = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString())
 
-        assertNotNull(uri)
-        val file = File(uri!!.path!!)
+        assertTrue(result is PdfDownloadResult.Success)
+        val file = File((result as PdfDownloadResult.Success).uri.path!!)
         assertTrue(file.exists())
         assertEquals(pdfBytes.size.toLong(), file.length())
     }
 
     @Test
-    fun whenServerReturnsErrorThenReturnsNull() = runTest {
+    fun whenServerReturnsErrorThenReturnsFailureUnknown() = runTest {
         server.enqueue(MockResponse().setResponseCode(404))
 
-        val uri = inlinePdfHandler.downloadToCache(server.url("/missing.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/missing.pdf").toString())
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
 
     @Test
@@ -121,14 +120,14 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(pdfBytes)),
         )
 
-        val uri = inlinePdfHandler.downloadToCache(server.url("/document").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/document").toString())
 
-        assertNotNull(uri)
-        assertTrue(uri!!.path!!.endsWith(".pdf"))
+        assertTrue(result is PdfDownloadResult.Success)
+        assertTrue((result as PdfDownloadResult.Success).uri.path!!.endsWith(".pdf"))
     }
 
     @Test
-    fun whenDownloadedFileIsNotPdfThenReturnsNullAndDeletesFile() = runTest {
+    fun whenDownloadedFileIsNotPdfThenReturnsFailureUnknownAndDeletesFile() = runTest {
         val htmlBytes = "<html><body>Not a PDF</body></html>".toByteArray()
         server.enqueue(
             MockResponse()
@@ -136,51 +135,72 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(htmlBytes)),
         )
 
-        val uri = inlinePdfHandler.downloadToCache(server.url("/fake.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/fake.pdf").toString())
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
 
-    // region shouldRenderPdfInline tests
+    // region decideForPdf tests
 
     @Test
-    fun whenPdfMimeTypeThenShouldRenderInline() {
-        assertTrue(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", null, "application/pdf"))
-    }
-
-    @Test
-    fun whenContentDispositionIsAttachmentThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"))
+    fun whenPdfMimeTypeThenDecisionIsInline() {
+        assertEquals(PdfRenderDecision.Inline, inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"))
     }
 
     @Test
-    fun whenMimeTypeIsNotPdfAndUrlNotPdfThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.txt", null, "text/plain"))
+    fun whenContentDispositionIsAttachmentThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "attachment; filename=doc.pdf", "application/pdf"),
+        )
     }
 
     @Test
-    fun whenMimeTypeIsNotPdfButUrlEndsPdfThenShouldRenderInline() {
-        assertTrue(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", null, "application/octet-stream"))
+    fun whenMimeTypeIsNotPdfAndUrlNotPdfThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.txt", null, "text/plain"),
+        )
     }
 
     @Test
-    fun whenUrlEndsInPdfWithQueryParamsThenShouldRenderInline() {
-        assertTrue(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf?auth=token", null, "application/octet-stream"))
+    fun whenMimeTypeIsNotPdfButUrlEndsPdfThenDecisionIsInline() {
+        assertEquals(
+            PdfRenderDecision.Inline,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/octet-stream"),
+        )
     }
 
     @Test
-    fun whenUrlEndsInPdfWithFragmentThenShouldRenderInline() {
-        assertTrue(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf#page=5", null, "application/octet-stream"))
+    fun whenUrlEndsInPdfWithQueryParamsThenDecisionIsInline() {
+        assertEquals(
+            PdfRenderDecision.Inline,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf?auth=token", null, "application/octet-stream"),
+        )
     }
 
     @Test
-    fun whenContentDispositionIsExplicitInlineThenShouldRenderInline() {
-        assertTrue(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", "inline", "application/pdf"))
+    fun whenUrlEndsInPdfWithFragmentThenDecisionIsInline() {
+        assertEquals(
+            PdfRenderDecision.Inline,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf#page=5", null, "application/octet-stream"),
+        )
     }
 
     @Test
-    fun whenContentDispositionHasLeadingWhitespaceAttachmentThenShouldNotRenderInline() {
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", "  attachment; filename=doc.pdf", "application/pdf"))
+    fun whenContentDispositionIsExplicitInlineThenDecisionIsInline() {
+        assertEquals(
+            PdfRenderDecision.Inline,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "inline", "application/pdf"),
+        )
+    }
+
+    @Test
+    fun whenContentDispositionHasLeadingWhitespaceAttachmentThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", "  attachment; filename=doc.pdf", "application/pdf"),
+        )
     }
 
     // endregion
@@ -188,10 +208,13 @@ class InlinePdfHandlerTest {
     // region feature flag tests
 
     @Test
-    fun whenFeatureDisabledThenShouldRenderPdfInlineReturnsFalse() {
+    fun whenFeatureDisabledThenDecisionIsNotApplicable() {
         androidBrowserConfigFeature.pdfViewer().setRawStoredState(State(enable = false))
 
-        assertFalse(inlinePdfHandler.shouldRenderPdfInline("https://example.com/doc.pdf", null, "application/pdf"))
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.decideForPdf("https://example.com/doc.pdf", null, "application/pdf"),
+        )
     }
 
     @Test
@@ -204,13 +227,13 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/cached.pdf").toString()
 
-        val firstUri = inlinePdfHandler.downloadToCache(url)
-        assertNotNull(firstUri)
+        val firstResult = inlinePdfHandler.downloadToCache(url)
+        assertTrue(firstResult is PdfDownloadResult.Success)
         assertEquals(1, server.requestCount)
 
-        val secondUri = inlinePdfHandler.downloadToCache(url)
-        assertNotNull(secondUri)
-        assertEquals(firstUri, secondUri)
+        val secondResult = inlinePdfHandler.downloadToCache(url)
+        assertTrue(secondResult is PdfDownloadResult.Success)
+        assertEquals((firstResult as PdfDownloadResult.Success).uri, (secondResult as PdfDownloadResult.Success).uri)
         assertEquals(1, server.requestCount)
     }
 
@@ -223,12 +246,16 @@ class InlinePdfHandlerTest {
         val urlA = server.url("/site-a/report.pdf").toString()
         val urlB = server.url("/site-b/report.pdf").toString()
 
-        val uriA = inlinePdfHandler.downloadToCache(urlA)
-        val uriB = inlinePdfHandler.downloadToCache(urlB)
+        val resultA = inlinePdfHandler.downloadToCache(urlA)
+        val resultB = inlinePdfHandler.downloadToCache(urlB)
 
-        assertNotNull(uriA)
-        assertNotNull(uriB)
-        assertFalse("Cache files for distinct URLs sharing last path segment must differ", uriA == uriB)
+        assertTrue(resultA is PdfDownloadResult.Success)
+        assertTrue(resultB is PdfDownloadResult.Success)
+        assertNotEquals(
+            "Cache files for distinct URLs sharing last path segment must differ",
+            (resultA as PdfDownloadResult.Success).uri,
+            (resultB as PdfDownloadResult.Success).uri,
+        )
         assertEquals(2, server.requestCount)
     }
 
@@ -287,9 +314,9 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/auth.pdf").toString()
 
-        val uri = handlerWithCookies.downloadToCache(url)
+        val result = handlerWithCookies.downloadToCache(url)
 
-        assertNotNull(uri)
+        assertTrue(result is PdfDownloadResult.Success)
         val recordedRequest = server.takeRequest()
         assertEquals("session=abc123", recordedRequest.getHeader("Cookie"))
     }
@@ -301,16 +328,16 @@ class InlinePdfHandlerTest {
     }
 
     @Test
-    fun whenServerReturnsEmptyBodyThenReturnsNull() = runTest {
+    fun whenServerReturnsEmptyBodyThenReturnsFailureUnknown() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(""))
 
-        val uri = inlinePdfHandler.downloadToCache(server.url("/empty.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/empty.pdf").toString())
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
 
     @Test
-    fun whenServerReturnsBodyShorterThanMagicBytesThenReturnsNullAndDeletesFile() = runTest {
+    fun whenServerReturnsBodyShorterThanMagicBytesThenReturnsFailureUnknownAndDeletesFile() = runTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(200)
@@ -318,9 +345,9 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/short.pdf").toString()
 
-        val uri = inlinePdfHandler.downloadToCache(url)
+        val result = inlinePdfHandler.downloadToCache(url)
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
         val cacheDir = File(
             InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
             "pdf_cache",
@@ -332,7 +359,7 @@ class InlinePdfHandlerTest {
     }
 
     @Test
-    fun whenDnsFailsThenReturnsNull() = runTest {
+    fun whenDnsFailsThenReturnsFailureIoError() = runTest {
         val throwingClient = OkHttpClient.Builder()
             .addInterceptor { throw UnknownHostException("test DNS failure") }
             .build()
@@ -344,13 +371,13 @@ class InlinePdfHandlerTest {
             androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
-        val uri = handlerWithFailingDns.downloadToCache("https://example.com/test.pdf")
+        val result = handlerWithFailingDns.downloadToCache("https://example.com/test.pdf")
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), result)
     }
 
     @Test
-    fun whenConnectionResetMidBodyThenReturnsNull() = runTest {
+    fun whenConnectionResetMidBodyThenReturnsFailureIoError() = runTest {
         val partialBody = ("%PDF-1.4 " + "x".repeat(8192)).toByteArray()
         server.enqueue(
             MockResponse()
@@ -360,9 +387,9 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/reset.pdf").toString()
 
-        val uri = inlinePdfHandler.downloadToCache(url)
+        val result = inlinePdfHandler.downloadToCache(url)
 
-        assertNull(uri)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), result)
     }
 
     // endregion
@@ -431,9 +458,9 @@ class InlinePdfHandlerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         val url = server.url("/touch.pdf").toString()
 
-        val firstUri = inlinePdfHandler.downloadToCache(url)
-        assertNotNull(firstUri)
-        val cachedFile = File(firstUri!!.path!!)
+        val firstResult = inlinePdfHandler.downloadToCache(url)
+        assertTrue(firstResult is PdfDownloadResult.Success)
+        val cachedFile = File((firstResult as PdfDownloadResult.Success).uri.path!!)
 
         // Backdate the file so we can detect that the cache-hit path bumps it forward.
         val backdated = System.currentTimeMillis() - 60_000L


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213892682193788?focus=true 

### Description

Tracks success rate, failure reasons, fallback usage, and explicit user-initiated downloads so we can monitor PDF rendering health post-rollout.

**Pixels implemented**

| Pixel                                         | When it fires                                                                                                                                                                                       |
|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `m_pdf_viewer_opened` (+ `_daily`, `_unique`) | A PDF is successfully rendered inline in a browser tab. Three variants give us per-occurrence count, daily active.                                                   |
| `m_pdf_render_failure`                        | The download/validate pipeline failed for an inline-eligible PDF. Includes an `error_type` parameter (`io_error`, `security_error`, `unknown`). The user still gets the standard download fallback. |
| `m_pdf_fallback`                              | The page is an eligible PDF but the device runs Android < 12, so the standard download flow runs instead of inline rendering.                                                                       |
| `m_nav_pdf_download_menu_item_pressed`        | The user taps the "Download PDF" item in the browser overflow menu while a PDF is rendered inline.                                                                                                  |

### Steps to test this PR

_PDF render success_
- [x] Install on an Android 12+ device with the inline PDF feature flag enabled
- [x] Open a public PDF URL
- [x] Confirm the PDF renders inline and that `m_pdf_viewer_opened`, `m_pdf_viewer_opened_daily`, and `m_pdf_viewer_opened_unique` all fire

_PDF render failure_
- [x] Open a malformed PDF file
- [x] Confirm `m_pdf_render_failure` fires

_Fallback_
- [x] Run on an Android 11 (or older) device or emulator
- [x] Open a PDF URL
- [x] Confirm `m_pdf_fallback` fires once

_User-initiated download_
- [x] With a PDF rendered inline, open the browser overflow menu and tap **Download PDF**
- [x] Confirm `m_nav_pdf_download_menu_item_pressed` fires once and the file appears in Downloads

### UI changes

n/a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PDF download/render decision path and changes return types/flow control, which could affect whether PDFs render inline vs download and how failures fall back. Risk is mitigated by added tests and preserving the standard download fallback.
> 
> **Overview**
> Adds expanded PDF viewer telemetry: `m_pdf_viewer_opened` now fires on every inline render and new daily/unique variants are emitted on success, plus `m_pdf_render_failure` (with `error_type`) and `m_pdf_fallback` when devices below API 31 must download instead of rendering inline.
> 
> Refactors the inline-PDF pipeline to return explicit `PdfRenderDecision` and `PdfDownloadResult` (with categorized `PdfErrorType`), wires `DdgPdfViewerFragment` load errors back to `BrowserTabViewModel`, and fires a pixel when the in-viewer **Download PDF** menu item is tapped; unit tests are updated/expanded accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367f9331f8bc3d9b931fd3d217f607236d6ddb92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->