### PR TITLE
Bug fix: Text input gets deselected after typing in bottom bar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -207,6 +207,11 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
             LayoutTransition().apply {
                 enableTransitionType(LayoutTransition.CHANGING)
                 setDuration(ANIMATION_DURATION_MS)
+                // Animating parent bounds tweens parents' top/bottom via ObjectAnimator.
+                // On Android 14+ Pixels, View.sizeChange fired during that tween clears focus
+                // on focused descendants, dropping the EditText focus when the bottom-bar
+                // widget settles. Keep the transition local to children's own bounds.
+                setAnimateParentHierarchy(false)
             }
         }
         widgetView.findViewById<ViewGroup?>(R.id.inputModeWidgetCard)?.layoutTransition = changingTransition()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214417865950834?focus=true

### Description
 On Pixel devices (Android 14+), opening the native input field with the **bottom address bar** caused the input field to lose focus right after appearing. The keyboard stayed up but the cursor disappeared, so typing went into an unfocused-looking field. 
 
  ## Why was it happening?                                                                                                                                                                                         
  After the entry animation, the widget installs a `LayoutTransition.CHANGING` on its containers so content (suggestions, buttons, tabs) animates smoothly. By default that transition also tweens the *parents'*    
  `top`/`bottom` via an `ObjectAnimator`. On Android 14+ Pixels, `View.sizeChange` during that tween clears focus on focused descendants — yanking the EditText.
                                                                                                                                                                                                                     
  Bottom config repros and top doesn't because bottom is the only config where the widget root itself also gets a `LayoutTransition`, adding one more level of parent animation.                                     
   
  Focus-loss stack captured while debugging:                                                                                                                                                                         
  View.clearFocusInternal                                                                                                                                                                                          
  ViewGroup.clearFocus  (×7)                                                                                                                                                                                         
  View.sizeChange                                                                                                                                                                                                  
  View.setTop                                                                                                                                                                                                        
  ObjectAnimator.animateValue
                                                                                                                                                                                                                     
  ## The fix                                                                                                                                                                                                       

  One line in `NativeInputAnimator.applyLayoutTransitions`:  setAnimateParentHierarchy(false)                                                                                                                                                                                 

  Children still animate; only the parent-bounds animator (the focus thief) is disabled.                                                                                                                             
   
  Scope                                                                                                                                                                                                              
                                                                                                                                                                                                                   
  - Native input widget only — gated behind the Native Input Field user setting.                                                                                                                                     
  - Visual: when widget content resizes, parent containers relayout in one frame instead of tweening. Imperceptible in practice.                                                                                   
  - No functional impact on entry/exit animations, suggestions, submission, voice, or model picker.                                                                                                                  
  - Not a regression — bug has existed since the bottom-bar layout was added.                

### Steps to test this PR

### Setup                                                                                                                                                                                                          
  - [x] Settings → AI Chat → **Native Input Field** is ON                                                                                                                                                            
  - [x] Test on a Pixel device running Android 14 or 15 (primary repro target)                                                                                                                                       
  - [x] Repeat suite with a non-Pixel device available (Samsung / OnePlus) to confirm parity                                                                                                                         
  - [x] Settings → Appearance → **Address bar position** is set per case below                                                                                                                                       
  - [x] Soft keyboard is the active input method (Gboard recommended)                                                                                                                                                
                                                                                                                                                                                                                     
  ### 1. Address bar = **Bottom**, Browser mode, **Search** tab                                                                                                                                                      
  - [x] Tap the omnibar to open the native input widget                                                                                                                                                            
  - [x] Input field gains focus (cursor is blinking, keyboard is up)                                                                                                                                                 
  - [x] Type 5+ characters continuously — focus is **retained** for every keystroke                                                                                                                                  
  - [x] Cursor stays in the input field; text appears without re-tapping                                                                                                                                             
  - [x] Autocomplete suggestions list appears above the widget without dropping focus                                                                                                                                
  - [x] Submitting the query (IME Go) sends the search                                                                                                                                                               
                                                                                                                                                                                                                     
  ### 2. Address bar = **Bottom**, Browser mode, **Duck.ai** tab                                                                                                                                                     
  - [x] Tap the omnibar to open the native input widget; switch to the Duck.ai tab                                                                                                                                   
  - [x] Input field has focus                                                                                                                                                                                        
  - [x] Type 5+ characters continuously — focus is **retained**                                                                                                                                                    
  - [x] Chat suggestions list appears without dropping focus                                                                                                                                                         
  - [x] **Send** button becomes visible as text is entered (without focus loss)                                                                                                                                    
  - [x] Submitting the message sends to Duck.ai                                                                                                                                                                                         
                                                                                                                                                                                                                   
  ### 3. Address bar = **Top**, Browser mode, **Search** tab (regression)                                                                                                                                            
  - [x] Tap the omnibar to open the native input widget                                                                                                                                                            
  - [x] Input field has focus                                                                                                                                                                                        
  - [x] Type 5+ characters — focus is **retained**                                                                                                                                                                 
  - [x] Autocomplete suggestions list appears below the widget normally                                                                                                                                              
  - [x] Submitting the query sends the search
                                                                                                                                                                                                                     
  ### 4. Address bar = **Top**, Browser mode, **Duck.ai** tab (regression)                                                                                                                                         
  - [x] Tap the omnibar; switch to the Duck.ai tab                                                                                                                                                                   
  - [x] Input field has focus                                                                                                                                                                                        
  - [x] Type 5+ characters — focus is **retained**
  - [x] Submitting the message sends to Duck.ai                                                                                                                                                                      
                                                                                                                                                                                                                     
  ### 5. Native Input Field = **OFF** (feature gate regression)
  - [x] Settings → AI Chat → **Native Input Field** = OFF                                                                                                                                                            
  - [x] Repeat opening the omnibar in browser mode at top and bottom positions                                                                                                                                       
  - [x] Behavior is unchanged from before the fix (no native input widget; legacy omnibar focus behavior)                                                                                                            
                                                                                                                                                                                                                     
  ### [Optional] Regression checks                                                                                                                                                                                              
  - [ ] Widget entry animation (omnibar → expanded card) plays smoothly at top and bottom                                                                                                                            
  - [ ] Widget exit animation (collapse back to omnibar) plays smoothly at top and bottom                                                                                                                            
  - [ ] Tab switching between **Search** and **Duck.ai** still animates without jank
  - [ ] Toggling the **Send** button visibility (text typed → cleared) does not cause visible snap on the widget card                                                                                                
  - [ ] Suggestions list appearing / clearing as you type is visually smooth (no jarring widget bounds jump)                                                                                                         
  - [ ] Model picker (Duck.ai tab) opens / closes without widget layout glitches                                                                                                                                     
  - [ ] `canExpand` multi-line growth (paste a long string into the input) animates as before                                                                                                                        
  - [ ] Voice search / voice chat entry from the widget still opens the correct screen and submits correctly
         
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bb0d80229389ce168a05cf97f213a78868e2c9c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->