### PR TITLE
Duck.AI/Voice chat: Update voice chat icon colors for dark mode

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-colors.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-colors.xml
@@ -99,6 +99,9 @@
     <attr name="daxColorFabSecondaryText" format="color"/>
     <attr name="daxColorFabSecondaryIcon" format="color"/>
 
+    <attr name="daxColorAccentAltContentPrimary" format="color"/>
+    <attr name="daxColorAccentAltPrimary" format="color"/>
+
     <attr name="daxColorTabHighlight" format="color"/>
 
     <attr name="daxColorButtonPrimaryText" format="color"/>

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -255,6 +255,8 @@
         <item name="daxColorFabSecondaryContainerPressed">@color/blue20</item>
         <item name="daxColorFabSecondaryText">@color/blue70</item>
         <item name="daxColorFabSecondaryIcon">@color/blue70</item>
+        <item name="daxColorAccentAltPrimary">@color/blue60</item>
+        <item name="daxColorAccentAltContentPrimary">@color/blue0</item>
 
         <!-- Tab -->
         <item name="daxColorTabHighlight">@color/gray50</item>
@@ -392,6 +394,8 @@
         <item name="daxColorFabSecondaryContainerPressed">@color/blue20</item>
         <item name="daxColorFabSecondaryText">@color/blue70</item>
         <item name="daxColorFabSecondaryIcon">@color/blue70</item>
+        <item name="daxColorAccentAltPrimary">@color/blue0</item>
+        <item name="daxColorAccentAltContentPrimary">@color/blue80</item>
 
         <!-- Tab -->
         <item name="daxColorTabHighlight">@color/gray60</item>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_screen_buttons.xml
@@ -40,12 +40,13 @@
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:background="@drawable/background_input_screen_button"
-        android:backgroundTint="?attr/daxColorFabSecondaryContainer"
+        android:backgroundTint="?attr/daxColorAccentAltPrimary"
         android:foreground="@drawable/selectable_circular_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:src="@drawable/ic_ai_chat_voice_24"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:tint="?attr/daxColorAccentAltContentPrimary" />
 
     <ImageView
         android:id="@+id/actionNewLine"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214355390459333?focus=true

### Description
Update colors of icon according to figma spec https://www.figma.com/design/VY5H9N5GaCupAKjEZLqGSd/Voice-chat-access?node-id=0-1&p=f&m=dev

### Steps to test this PR
### Setup                                                                                                                                                                                                                                     
  - [ ] Open the Duck.ai input screen on the chat tab so the voice chat icon is visible                                                                                                                              
                                                                                                                                                                                                                     
  ### 1. Light mode                                                                                                                                                                                                  
  - [ ] System theme is set to **Light** (or app theme = Light)                                                                                                                                                      
  - [ ] Voice chat icon **IS** visible on the Duck.ai input screen                                                                                                                                                   
  - [ ] The button **background** is light blue (Accent ALT, `#CCDAFF` / `blue0`)                                                                                                                                  
  - [ ] The microphone/voice glyph **inside** the button is dark navy (`blue80`, `#14307E`)                                                                                                                          
  - [ ] Tapping the button opens the existing voice chat flow (no behavioral regression vs. develop)                                                                                                                 
                                                                                                                                                                                                                     
  ### 2. Dark mode                                                                                                                                                                                                   
  - [ ] System theme is set to **Dark** (or app theme = Dark)                                                                                                                                                        
  - [ ] Voice chat icon **IS** visible on the Duck.ai input screen                                                                                                                                                   
  - [ ] The button **background** is royal blue (Accent ALT, `#2B55CA` / `blue60`)                                                                                                                                 
  - [ ] The microphone/voice glyph **inside** the button is light blue (`#CCDAFF` / `blue0`)                                                                                                                         
  - [ ] Tapping the button opens the existing voice chat flow (no behavioral regression vs. develop)   

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="voicechaticon-dark-before" src="https://github.com/user-attachments/assets/002b589a-6dcb-459f-94e1-1d2d2a9ace26" /> | <img width="1080" height="2400" alt="voicechaticon-dark-after" src="https://github.com/user-attachments/assets/dd05f445-aba2-4775-a73b-a80e6e425bf6" />|
|<img width="1080" height="2340" alt="voicechaticon-ligght-before" src="https://github.com/user-attachments/assets/028d9ec2-c5fa-4df4-ae0e-997bf39af4f0" /> | <img width="1080" height="2400" alt="voicechaticon-light-after" src="https://github.com/user-attachments/assets/f18d97d8-2cd2-41c4-9930-00492ccd8c03" />|
|<img width="1080" height="2340" alt="voicechat-fab-dark-before" src="https://github.com/user-attachments/assets/940c6070-8679-4a3a-9bcd-a538abb92db9" /> | <img width="1080" height="2400" alt="voicechatfab-dark-after" src="https://github.com/user-attachments/assets/9800cda3-e82d-4af3-ac8a-96999b7e8411" />|
|<img width="1080" height="2340" alt="voicechat-fab-light-before" src="https://github.com/user-attachments/assets/2a55f85f-0eba-4459-9e49-008d2b5a75e9" /> | <img width="1080" height="2400" alt="voicechaticonfab-light-after" src="https://github.com/user-attachments/assets/a4b0fc1f-4898-4d66-a2eb-fafca67d5745" />|






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: resource/theme attribute additions and a layout tint change only affect the Duck.AI voice chat button appearance, with no behavioral or data-handling changes.
> 
> **Overview**
> Updates the Duck.AI voice chat button styling to match the latest spec in both light and dark mode.
> 
> Adds new design-system theme attributes `daxColorAccentAltPrimary` and `daxColorAccentAltContentPrimary` with light/dark values, and switches the `actionVoiceChat` button to use these for its background tint and icon tint instead of the previous secondary FAB container color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748cd5da3fa5b43d279ad8e84b6d8dc608451894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->