### PR TITLE
Use granular interval buckets for page-load durations

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -23,17 +23,17 @@
             {
                 "key": "feature.data.ext.elapsed_time_to_finish_ms_bucketed",
                 "description": "Total duration from page_start to page_finish, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_visible_ms_bucketed",
                 "description": "Duration from page_start to page_visible, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.elapsed_time_to_escaped_fixed_progress_ms_bucketed",
                 "description": "Duration from page_start to page_escaped_fixed_progress, bucketed. Uses lower end of the bucket.",
-                "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                "enum": ["0", "1000", "2000", "3000", "4000", "5000", "10000", "30000", "60000"]
             },
             {
                 "key": "feature.data.ext.webview_version",

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -41,7 +41,9 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Tracks page load events as Wide Event flows with multi-phase tracking.
@@ -143,16 +145,19 @@ class RealPageLoadWideEvent @Inject constructor(
                     wideEventClient.intervalStart(
                         wideEventId = flowId,
                         key = KEY_ELAPSED_TIME_TO_FINISH,
+                        buckets = PAGE_LOAD_INTERVAL_BUCKETS,
                     )
 
                     wideEventClient.intervalStart(
                         wideEventId = flowId,
                         key = KEY_ELAPSED_TIME_TO_VISIBLE,
+                        buckets = PAGE_LOAD_INTERVAL_BUCKETS,
                     )
 
                     wideEventClient.intervalStart(
                         wideEventId = flowId,
                         key = KEY_ELAPSED_TIME_TO_ESCAPED_FIXED_PROGRESS,
+                        buckets = PAGE_LOAD_INTERVAL_BUCKETS,
                     )
                 }.onFailure { error ->
                     logcat { "Failed to start page load flow for tabId=$tabId: ${error.message}" }
@@ -302,6 +307,16 @@ class RealPageLoadWideEvent @Inject constructor(
     private companion object {
         const val ABOUT_BLANK = "about:blank"
         val CLEANUP_TIMEOUT = 5.minutes
+        val PAGE_LOAD_INTERVAL_BUCKETS: Set<Duration> = setOf(
+            1.seconds,
+            2.seconds,
+            3.seconds,
+            4.seconds,
+            5.seconds,
+            10.seconds,
+            30.seconds,
+            1.minutes,
+        )
         const val PAGE_LOAD_FEATURE_NAME = "page-load"
         const val STEP_PAGE_START = "page_start"
         const val STEP_PAGE_VISIBLE = "page_visible"

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -104,9 +104,9 @@ class PageLoadWideEventTest {
             success = true,
             metadata = emptyMap(),
         )
-        verify(wideEventClient).intervalStart(123L, "elapsed_time_to_finish_ms_bucketed", null)
-        verify(wideEventClient).intervalStart(123L, "elapsed_time_to_visible_ms_bucketed", null)
-        verify(wideEventClient).intervalStart(123L, "elapsed_time_to_escaped_fixed_progress_ms_bucketed", null)
+        verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_finish_ms_bucketed"), eq(null), any())
+        verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_visible_ms_bucketed"), eq(null), any())
+        verify(wideEventClient).intervalStart(eq(123L), eq("elapsed_time_to_escaped_fixed_progress_ms_bucketed"), eq(null), any())
     }
 
     @Test
@@ -364,9 +364,9 @@ class PageLoadWideEventTest {
         )
 
         // Verify all intervals were managed
-        verify(wideEventClient).intervalStart(500L, "elapsed_time_to_finish_ms_bucketed", null)
-        verify(wideEventClient).intervalStart(500L, "elapsed_time_to_visible_ms_bucketed", null)
-        verify(wideEventClient).intervalStart(500L, "elapsed_time_to_escaped_fixed_progress_ms_bucketed", null)
+        verify(wideEventClient).intervalStart(eq(500L), eq("elapsed_time_to_finish_ms_bucketed"), eq(null), any())
+        verify(wideEventClient).intervalStart(eq(500L), eq("elapsed_time_to_visible_ms_bucketed"), eq(null), any())
+        verify(wideEventClient).intervalStart(eq(500L), eq("elapsed_time_to_escaped_fixed_progress_ms_bucketed"), eq(null), any())
         verify(wideEventClient).intervalEnd(500L, "elapsed_time_to_visible_ms_bucketed")
         verify(wideEventClient).intervalEnd(500L, "elapsed_time_to_escaped_fixed_progress_ms_bucketed")
         verify(wideEventClient).intervalEnd(500L, "elapsed_time_to_finish_ms_bucketed")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1213821280790924?focus=true

### Description

Switches the three page-load timing intervals to a more granular bucket set: `1s, 2s, 3s, 4s, 5s, 10s, 30s, 1m`. Splits the previously coarse 1–5s bucket into 1-second steps to make small performance improvements more visible.

> Stacked on top of #8381 — that PR introduces the `buckets` parameter this change consumes. Merge #8381 first.

### Steps to test this PR

_Granular buckets are recorded for page-load durations_
- [x] Install this PR build and load a page on one of the supported sites (e.g. `bbc.com`, `amazon.com`, `apple.com`).
- [x] Inspect the `wide_page-load` pixel and confirm each of `elapsed_time_to_finish_ms_bucketed`, `elapsed_time_to_visible_ms_bucketed`, `elapsed_time_to_escaped_fixed_progress_ms_bucketed` carries one of the new bucket values: \`0\`, \`1000\`, \`2000\`, \`3000\`, \`4000\`, \`5000\`, \`10000\`, \`30000\`, \`60000\` — not the previous \`0/1000/5000/10000/…\`.

### UI changes

No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only telemetry bucket definitions and passes an explicit bucket set into `WideEventClient.intervalStart`, with corresponding test updates.
> 
> **Overview**
> Switches the `wide_page-load` timing parameters to a more granular bucket enum (adds 2–4s buckets and removes the very large 5–600s buckets) so small performance changes are measurable.
> 
> Updates `RealPageLoadWideEvent` to pass an explicit `PAGE_LOAD_INTERVAL_BUCKETS` set into the three page-load intervals (`finish`, `visible`, `escaped_fixed_progress`) and adjusts unit tests to match the new `intervalStart` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9f70172d900d057728ef8b2163dbedc9c90cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->