### PR TITLE
Hide VPN menu item when Privacy Pro isn't available

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
@@ -48,6 +48,9 @@ class VpnMenuStateProviderImpl @Inject constructor(
             subscriptions.getEntitlementStatus(),
             networkProtectionState.getConnectionStateFlow(),
         ) { subscriptionStatus, entitlements, connectionState ->
+            if (!subscriptions.isEligible()) {
+                return@combine VpnMenuState.Hidden
+            }
             if (!androidBrowserConfigFeature.vpnMenuItem().isEnabled() && !androidBrowserConfigFeature.vpnMenuItemInternational().isEnabled()) {
                 return@combine VpnMenuState.Hidden
             }

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
@@ -71,6 +71,7 @@ class VpnMenuStateProviderTest {
         whenever(vpnMenuItemInternationalToggle.isEnabled()).thenReturn(true)
         whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(true)
         whenever(subscriptions.isFreeTrialEligible()).thenReturn(true)
+        whenever(subscriptions.isEligible()).thenReturn(true)
         testee = VpnMenuStateProviderImpl(
             subscriptions,
             networkProtectionState,
@@ -350,6 +351,38 @@ class VpnMenuStateProviderTest {
             testee.getVpnMenuState().test {
                 val state = awaitItem()
                 assertEquals(VpnMenuState.NotSubscribedNoPill, state)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when subscriptions are not eligible then return Hidden regardless of subscription status`() =
+        runTest {
+            whenever(subscriptions.isEligible()).thenReturn(false)
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when subscriptions are not eligible and user has no subscription then return Hidden`() =
+        runTest {
+            whenever(subscriptions.isEligible()).thenReturn(false)
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.UNKNOWN))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214422188114412?focus=true 

### Description

On F-Droid builds the side menu's "VPN" entry was visible for every user but tapping it did nothing, because Privacy Pro isn't shipped in that flavour. `VpnMenuStateProvider` only inspected subscription status and entitlements — both technically truthful but neither captures the fact that Privacy Pro can't be surfaced at all in this build

### Steps to test this PR

_F-Droid build (regression fix)_
- [x] `./gradlew installFdroidDebug`
- [x] Open the browser, tap the side menu — confirm the **VPN** entry is no longer present
- [x] Check in all modes (Browsing, NTP, Duck.AI, Custom Tabs)    

### UI changes
<img width="270" height="480" alt="image" src="https://github.com/user-attachments/assets/61d8f378-367c-4c8f-85e0-107d91a1d95c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized gating change to a UI state provider plus unit tests; no auth, payment, or data-handling logic is modified.
> 
> **Overview**
> Updates `VpnMenuStateProvider` to **short-circuit to `VpnMenuState.Hidden`** when `Subscriptions.isEligible()` is false, preventing the VPN side-menu item from appearing in builds where Privacy Pro cannot be offered.
> 
> Extends `VpnMenuStateProviderTest` to default `isEligible()` to true and adds coverage asserting the menu stays hidden when eligibility is false, regardless of subscription status/entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f698d17554c4fa22079473bc9bd49a1c53597489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->