### PR TITLE
Duck.Ai/Voice chat: Add pixel for when digital assistant is launched from digital assistant 

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -385,6 +385,13 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_aichat_voice_session_digital-assistant_started": {
+        "description": "Fires when Duck.ai voice chat is launched as the digital assistant (e.g. via Google Assistant ACTION_ASSIST intent)",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
     "m_aichat_settings_default_toggle_position_changed": {
         "description": "User changed the default toggle position setting in AI Features settings",
         "owners": ["YoussefKeyrouz"],

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -529,4 +529,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     GET_DESKTOP_BROWSER_DISMISSED("m_get_desktop_browser_dismissed"),
     GET_DESKTOP_BROWSER_SHARE_DOWNLOAD_LINK_CLICK("m_get_desktop_browser_share_download_link_click"),
     GET_DESKTOP_BROWSER_LINK_CLICK("m_get_desktop_browser_link_click"),
+
+    AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED("m_aichat_voice_session_digital-assistant_started"),
 }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchPixelParamRemovalPlugin.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.systemsearch
+
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SystemSearchPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            AppPixelName.AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED.pixelName to PixelParameter.removeAtb(),
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -316,7 +316,10 @@ class SystemSearchViewModel @Inject constructor(
     fun onDigitalAssistOpened(intent: Intent) {
         viewModelScope.launch {
             command.value = when {
-                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isEnabled() -> Command.LaunchDuckAiVoiceChat
+                duckAiFeatureState.allowDuckAiAsDigitalAssistant.value && duckChat.isEnabled() -> {
+                    pixel.fire(AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED)
+                    Command.LaunchDuckAiVoiceChat
+                }
                 else -> Command.LaunchAssistSearch(intent)
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -859,6 +859,7 @@ class SystemSearchViewModelTest {
         testee.onDigitalAssistOpened(mock())
 
         verify(commandObserver).onChanged(Command.LaunchDuckAiVoiceChat)
+        verify(mockPixel).fire(AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED)
     }
 
     @Test
@@ -870,6 +871,7 @@ class SystemSearchViewModelTest {
         testee.onDigitalAssistOpened(intent)
 
         verify(commandObserver).onChanged(Command.LaunchAssistSearch(intent))
+        verify(mockPixel, never()).fire(AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED)
     }
 
     @Test
@@ -880,6 +882,7 @@ class SystemSearchViewModelTest {
         testee.onDigitalAssistOpened(intent)
 
         verify(commandObserver).onChanged(Command.LaunchAssistSearch(intent))
+        verify(mockPixel, never()).fire(AICHAT_VOICE_SESSION_DIGITAL_ASSISTANT_STARTED)
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214072346939312?focus=true 

### Description
Fires a new pixel `m_aichat_voice_session_digital-assistant_started` when Duck.ai voice chat is launched as the device's digital assistant (i.e. via Google Assistant `ACTION_ASSIST`). This lets us measure how often the digital-assistant entry point routes into Duck.ai voice chat versus the standard assist search.

### Steps to test this PR
### Setup                                                                                                                                                                                                        
  - [x] Install an `internalDebug` build on the device
  - [x] Set DuckDuckGo as the device's digital assistant (Settings → Apps → Default apps → Digital assistant app → DuckDuckGo)                                                                                       
  - [x] Filter ‘Pixel sent’ in your logcat                                                                                                           
  - [x] Trigger the assist intent each time via the Assist gesture, long-press home, or `adb shell am start -a android.intent.action.ASSIST`                                                                         
                                                                                                                                                                                                                     
### 1. `digitalAssistantDuckAi` enabled, Duck.ai user toggle ON                                                                                                                                                    
  - [x] Remote `digitalAssistantDuckAi` feature is enabled and Duck.ai is enabled in app settings                                                                                                                    
  - [x] Triggering the assist intent opens **Duck.ai voice chat** (not the standard assist search)                                                                                                                   
  - [x] Pixel `m_aichat_voice_session_digital-assistant_started` **IS** fired exactly once                                                                                                                           
  - [x] Pixel includes `appVersion` parameter and a `_android_phone` / `_android_tablet` form-factor suffix                                                                                                          
  - [x] Pixel does **NOT** include `atb`                                                                                                                                                                             
                                                                                                                                                                                                                     
### 2. `digitalAssistantDuckAi` enabled, Duck.ai user toggle OFF                                                                                                                                                   
  - [x] Disable Duck.ai in app settings (Settings → Duck.ai → toggle off)                                                                                                                                          
  - [x] Triggering the assist intent opens the **standard assist search** (not Duck.ai voice chat)                                                                                                                   
  - [x] Pixel `m_aichat_voice_session_digital-assistant_started` is **NOT** fired                                                                                                                                    
                                                                                                                                                                                                                     
### 3. `digitalAssistantDuckAi` disabled, Duck.ai user toggle ON                                                                                                                                                   
  - [x] Remote `digitalAssistantDuckAi` feature is disabled (override locally if needed)                                                                                                                           
  - [x] Triggering the assist intent opens the **standard assist search**                                                                                                                                            
  - [x] Pixel `m_aichat_voice_session_digital-assistant_started` is **NOT** fired


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive analytics change gated behind existing feature/toggle checks; minimal behavioral impact beyond firing a new pixel.
> 
> **Overview**
> Adds a new Duck.ai telemetry event `m_aichat_voice_session_digital-assistant_started` to measure when the system assist intent routes into Duck.ai voice chat.
> 
> The system-search digital assistant entry point now fires this pixel when `allowDuckAiAsDigitalAssistant` is enabled and Duck.ai is on, with a new `PixelParamRemovalPlugin` ensuring `atb` is stripped from the event; unit tests were updated to assert the pixel fires only on the Duck.ai voice-chat path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a23b5681818f06edea35fb4a9a27ba225276642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->