### PR TITLE
Add secure storage unavailable daily pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/autofill.json5
+++ b/PixelDefinitions/pixels/definitions/autofill.json5
@@ -485,6 +485,13 @@
             }
         ]
     },
+    "autofill_device_capability_secure_storage_unavailable_daily": {
+        "description": "Fired when secure storage is unavailable for autofill on app start (daily)",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
     "autofill_harmony_update_key_rollback_failed": {
         "description": "Rolling back legacy key write after Harmony write failure also failed (daily unique)",
         "owners": ["CrisBarreiro"],

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -85,7 +85,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
-            line="21"
+            line="23"
             column="1"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
-            line="22"
+            line="24"
             column="1"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
-            line="23"
+            line="25"
             column="1"/>
     </issue>
 
@@ -118,7 +118,18 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
-            line="24"
+            line="26"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="NoImplImportsInAppModule"
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
+            line="27"
             column="1"/>
     </issue>
 
@@ -129,7 +140,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt"
-            line="25"
+            line="28"
             column="1"/>
     </issue>
 

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -202,6 +202,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AutofillPixelNames.AUTOFILL_PREFERENCES_KEY_MISSING.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_STORE_KEY_ALREADY_EXISTS.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_HARMONY_UPDATE_KEY_ROLLBACK_FAILED.pixelName to PixelParameter.removeAtb(),
+            AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_PREFERENCES_UPDATE_KEY_NULL_FILE.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_HARMONY_PREFERENCES_UPDATE_KEY_NULL_FILE.pixelName to PixelParameter.removeAtb(),
             AutofillPixelNames.AUTOFILL_PREFERENCES_GET_KEY_NULL_FILE.pixelName to PixelParameter.removeAtb(),

--- a/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.pixel
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
@@ -54,6 +55,7 @@ class AutofillUniquePixelSenderTest {
         dispatchers = coroutineTestRule.testDispatcherProvider,
     )
 
+    @SuppressLint("DenyListedApi")
     @Before
     fun before() {
         whenever(context.getSharedPreferences(SHARED_PREFS_FILE, Context.MODE_PRIVATE)).thenReturn(fakePreferences)

--- a/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
@@ -18,10 +18,12 @@ package com.duckduckgo.autofill.pixel
 
 import android.content.Context
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_CAPABLE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY
 import com.duckduckgo.autofill.impl.pixel.AutofillUniquePixelSender
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
@@ -91,6 +93,12 @@ class AutofillUniquePixelSenderTest {
     fun whenDeviceAuthDisabledAndSecureStorageIsNotAvailableThenSendCorrectPixel() {
         testee.sendCapabilitiesPixel(secureStorageAvailable = false, deviceAuthAvailable = false)
         verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED)
+    }
+
+    @Test
+    fun whenSecureStorageUnavailableDailyPixelSentThenFiresAsDailyPixel() {
+        testee.sendSecureStorageUnavailableDailyPixel()
+        verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY, type = Daily())
     }
 
     private fun configureSharePreferencesMissingKey() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillDeviceCapabilityReporter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillDeviceCapabilityReporter.kt
@@ -50,13 +50,18 @@ class AutofillDeviceCapabilityReporter @Inject constructor(
         logcat(VERBOSE) { "Autofill device capability reporter created" }
 
         appCoroutineScope.launch(dispatchers.io()) {
-            if (pixel.hasDeterminedCapabilities()) {
-                logcat(VERBOSE) { "Already determined device autofill capabilities previously" }
-                return@launch
-            }
-
             try {
                 val secureStorageAvailable = secureStorage.canAccessSecureStorage()
+
+                if (!secureStorageAvailable) {
+                    pixel.sendSecureStorageUnavailableDailyPixel()
+                }
+
+                if (pixel.hasDeterminedCapabilities()) {
+                    logcat(VERBOSE) { "Already determined device autofill capabilities previously" }
+                    return@launch
+                }
+
                 val deviceAuthAvailable = deviceAuthenticator.hasValidDeviceAuthentication()
 
                 logcat {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -155,6 +155,7 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
 
     AUTOFILL_DEVICE_CAPABILITY_CAPABLE("m_autofill_device_capability_capable"),
     AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE("m_autofill_device_capability_secure_storage_unavailable"),
+    AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY("autofill_device_capability_secure_storage_unavailable_daily"),
     AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED("m_autofill_device_capability_device_auth_disabled"),
     AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED(
         "m_autofill_device_capability_secure_storage_unavailable_and_device_auth_disabled",

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelSender.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAP
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -44,6 +45,8 @@ interface AutofillPixelSender {
     )
 
     fun sendCapabilitiesUndeterminablePixel()
+
+    fun sendSecureStorageUnavailableDailyPixel()
 }
 
 @ContributesBinding(AppScope::class)
@@ -78,6 +81,12 @@ class AutofillUniquePixelSender @Inject constructor(
         appCoroutineScope.launch(dispatchers.io()) {
             pixel.fire(AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR)
             preferences.edit { putBoolean(KEY_CAPABILITIES_DETERMINED, true) }
+        }
+    }
+
+    override fun sendSecureStorageUnavailableDailyPixel() {
+        appCoroutineScope.launch(dispatchers.io()) {
+            pixel.fire(AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1214395603545554?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change; main behavior change is that a new daily pixel is fired on app start whenever secure storage cannot be accessed, even if capability determination was previously recorded.
> 
> **Overview**
> Adds a new telemetry event, `autofill_device_capability_secure_storage_unavailable_daily`, and wires it into autofill startup so secure-storage access failures emit a **daily** pixel (`AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_DAILY`) before the existing one-time capability reporting.
> 
> Updates pixel definitions and parameter-cleaning (`PixelParamRemovalInterceptor`) accordingly, and extends `AutofillPixelSender`/`AutofillUniquePixelSender` plus tests to support firing this daily pixel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb372a890773c18f2798e49cc326f566e83a2d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->