### PR TITLE
Fix: Incorrect title being shown for the tab items

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -393,12 +393,12 @@ class TabSwitcherAdapter(
                 loadTabPreviewImage(tab.tabEntity, Glide.with(viewHolder.rootView), viewHolder.tabPreview, viewHolder)
             }
 
-            bundle.getString(DIFF_KEY_URL)?.let {
+            if (bundle.containsKey(DIFF_KEY_URL)) {
                 loadFavicon(tab.tabEntity, Glide.with(viewHolder.rootView), viewHolder.favicon, viewHolder)
             }
 
-            bundle.getString(DIFF_KEY_TITLE)?.let {
-                viewHolder.title.text = it
+            if (bundle.containsKey(DIFF_KEY_TITLE)) {
+                viewHolder.title.text = extractTabTitle(tab.tabEntity, viewHolder.rootView.context)
             }
 
             if (bundle.containsKey(DIFF_KEY_SELECTION)) {
@@ -422,14 +422,15 @@ class TabSwitcherAdapter(
                 logcat(VERBOSE) { "$key changed - Need an update for ${tab.tabEntity}" }
             }
 
-            bundle.getString(DIFF_KEY_URL)?.let {
-                viewHolder.url.show()
-                viewHolder.url.text = formatUrl(it)
+            if (bundle.containsKey(DIFF_KEY_URL)) {
+                val url = tab.tabEntity.url
+                viewHolder.url.text = formatUrl(url)
+                viewHolder.url.visibility = if (url.isNullOrEmpty()) View.GONE else View.VISIBLE
                 loadFavicon(tab.tabEntity, Glide.with(viewHolder.rootView), viewHolder.favicon, viewHolder)
             }
 
-            bundle.getString(DIFF_KEY_TITLE)?.let {
-                viewHolder.title.text = it
+            if (bundle.containsKey(DIFF_KEY_TITLE)) {
+                viewHolder.title.text = extractTabTitle(tab.tabEntity, viewHolder.rootView.context)
             }
 
             if (bundle.containsKey(DIFF_KEY_SELECTION)) {
@@ -455,8 +456,8 @@ class TabSwitcherAdapter(
             if (bundle.containsKey(DIFF_KEY_PREVIEW)) {
                 loadTabPreviewImage(tab.tabEntity, Glide.with(viewHolder.rootView), viewHolder.tabPreview, viewHolder)
             }
-            bundle.getString(DIFF_KEY_TITLE)?.let {
-                viewHolder.title.text = it
+            if (bundle.containsKey(DIFF_KEY_TITLE)) {
+                viewHolder.title.text = extractTabTitle(tab.tabEntity, viewHolder.rootView.context)
             }
             if (bundle.containsKey(DIFF_KEY_SELECTION)) {
                 loadSelectionState(viewHolder, tab)
@@ -477,8 +478,8 @@ class TabSwitcherAdapter(
             for (key in bundle.keySet()) {
                 logcat(VERBOSE) { "$key changed - Need an update for ${tab.tabEntity}" }
             }
-            bundle.getString(DIFF_KEY_TITLE)?.let {
-                viewHolder.url.text = it
+            if (bundle.containsKey(DIFF_KEY_TITLE)) {
+                viewHolder.url.text = tab.tabEntity.title.orEmpty()
             }
             if (bundle.containsKey(DIFF_KEY_SELECTION)) {
                 loadSelectionState(viewHolder, tab)

--- a/app/src/test/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallbackTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallbackTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.tabs.adapter
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_TITLE
+import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_URL
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TabSwitcherItemDiffCallbackTest {
+
+    private val callback = TabSwitcherItemDiffCallback(isDragging = { false })
+
+    @Test
+    fun `when title transitions from non-null to null then payload contains DIFF_KEY_TITLE with null value`() {
+        // Reproduces the bug precondition: pageChanged() persists (newUrl, null) before titleReceived()
+        // fires, so the differ sees a tab whose title goes from "Some Title" to null.
+        val oldTab = NormalTab(
+            entity = TabEntity(tabId = "1", url = "https://huel.com/help", title = "How can we help? | Huel ES", position = 0),
+            isActive = false,
+        )
+        val newTab = NormalTab(
+            entity = TabEntity(tabId = "1", url = "https://clicks.easyjet.com/redirect", title = null, position = 0),
+            isActive = false,
+        )
+
+        val bundle = callback.getChangePayload(oldTab, newTab)
+
+        assertTrue("payload should mark title as changed", bundle!!.containsKey(DIFF_KEY_TITLE))
+        assertNull("payload's title value is null - this is what caused the original bug", bundle.getString(DIFF_KEY_TITLE))
+        assertTrue("payload should also mark url as changed", bundle.containsKey(DIFF_KEY_URL))
+    }
+
+    @Test
+    fun `when only title changes to non-null then payload contains DIFF_KEY_TITLE with new value`() {
+        val oldTab = NormalTab(
+            entity = TabEntity(tabId = "1", url = "https://huel.com", title = "Old Title", position = 0),
+            isActive = false,
+        )
+        val newTab = NormalTab(
+            entity = TabEntity(tabId = "1", url = "https://huel.com", title = "New Title", position = 0),
+            isActive = false,
+        )
+
+        val bundle = callback.getChangePayload(oldTab, newTab)
+
+        assertTrue(bundle!!.containsKey(DIFF_KEY_TITLE))
+        assertFalse(bundle.containsKey(DIFF_KEY_URL))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapterTest.kt
@@ -145,12 +145,6 @@ class TabSwitcherAdapterTest {
     }
 
     // --- Title rendering on payload-based bind (regression: stale title kept after URL changed) ---
-    //
-    // Repro: the differ produces a payload Bundle where DIFF_KEY_TITLE is present-but-null
-    // (transition to null title can happen between pageChanged() and titleReceived() in the
-    // BrowserTabViewModel). Before the fix, `bundle.getString(KEY)?.let { ... }` skipped on null,
-    // leaving the previously-rendered text in place. After the fix, the title is re-derived from
-    // the entity (via displayTitle() with URL-host fallback).
 
     @Test
     fun `payload with null title re-derives title from entity instead of leaving stale text`() {

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapterTest.kt
@@ -16,11 +16,19 @@
 
 package com.duckduckgo.app.tabs.ui
 
+import android.content.Context
+import android.os.Bundle
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.lifecycle.LifecycleOwner
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.AddressDisplayFormatter
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
+import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_TITLE
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
@@ -123,7 +131,7 @@ class TabSwitcherAdapterTest {
     @Test
     fun `NormalTab in grid mode returns GRID_TAB`() {
         val entity = TabEntity("1", url = "https://example.com", position = 0)
-        adapter.updateData(listOf(NormalTab(entity, isActive = false)))
+        adapter.updateData(listOf(NormalTab(entity = entity, isActive = false)))
         adapter.onLayoutTypeChanged(GRID)
         assertEquals(GRID_TAB, adapter.getItemViewType(0))
     }
@@ -131,8 +139,74 @@ class TabSwitcherAdapterTest {
     @Test
     fun `NormalTab in list mode returns LIST_TAB`() {
         val entity = TabEntity("1", url = "https://example.com", position = 0)
-        adapter.updateData(listOf(NormalTab(entity, isActive = false)))
+        adapter.updateData(listOf(NormalTab(entity = entity, isActive = false)))
         adapter.onLayoutTypeChanged(LIST)
         assertEquals(LIST_TAB, adapter.getItemViewType(0))
+    }
+
+    // --- Title rendering on payload-based bind (regression: stale title kept after URL changed) ---
+    //
+    // Repro: the differ produces a payload Bundle where DIFF_KEY_TITLE is present-but-null
+    // (transition to null title can happen between pageChanged() and titleReceived() in the
+    // BrowserTabViewModel). Before the fix, `bundle.getString(KEY)?.let { ... }` skipped on null,
+    // leaving the previously-rendered text in place. After the fix, the title is re-derived from
+    // the entity (via displayTitle() with URL-host fallback).
+
+    @Test
+    fun `payload with null title re-derives title from entity instead of leaving stale text`() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val entity = TabEntity(tabId = "1", url = "https://clicks.easyjet.com/redirect", title = null, position = 0)
+        adapter.updateData(listOf(NormalTab(entity = entity, isActive = false)))
+        adapter.onLayoutTypeChanged(LIST)
+
+        val holder = listHolderWithStaleTitle(context, staleTitle = "How can we help? | Huel ES")
+
+        // The diff callback writes the new title (null) under DIFF_KEY_TITLE - this is the buggy
+        // bundle that previously caused the holder's TextView to keep its prior text.
+        val payload = Bundle().apply { putString(DIFF_KEY_TITLE, null) }
+
+        adapter.onBindViewHolder(holder, 0, mutableListOf(payload))
+
+        // displayTitle() falls back to URL host when title is null
+        assertEquals("clicks.easyjet.com", holder.title.text.toString())
+    }
+
+    @Test
+    fun `payload with non-null title still updates TextView`() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val entity = TabEntity(tabId = "1", url = "https://example.com", title = "Fresh Title", position = 0)
+        adapter.updateData(listOf(NormalTab(entity = entity, isActive = false)))
+        adapter.onLayoutTypeChanged(LIST)
+
+        val holder = listHolderWithStaleTitle(context, staleTitle = "Old Title")
+
+        val payload = Bundle().apply { putString(DIFF_KEY_TITLE, "Fresh Title") }
+
+        adapter.onBindViewHolder(holder, 0, mutableListOf(payload))
+
+        assertEquals("Fresh Title", holder.title.text.toString())
+    }
+
+    private fun listHolderWithStaleTitle(
+        context: Context,
+        staleTitle: String,
+    ): TabSwitcherAdapter.TabSwitcherViewHolder.ListTabViewHolder {
+        val titleView = TextView(context).apply { text = staleTitle }
+        val holder = TabSwitcherAdapter.TabSwitcherViewHolder.ListTabViewHolder(
+            rootView = FrameLayout(context),
+            favicon = ImageView(context),
+            title = titleView,
+            close = ImageView(context),
+            tabUnread = ImageView(context),
+            selectionIndicator = ImageView(context),
+            url = TextView(context),
+        )
+        // RecyclerView normally sets mItemViewType when binding. Hand-constructed holders default
+        // to INVALID_TYPE, which would make the adapter's `when (holder.itemViewType)` dispatch
+        // miss LIST_TAB and silently drop the payload. Force it here.
+        val field = RecyclerView.ViewHolder::class.java.getDeclaredField("mItemViewType")
+        field.isAccessible = true
+        field.setInt(holder, LIST_TAB)
+        return holder
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214422592174952?focus=true

### Description

Fixes a tab switcher bug where a tab's title could appear stale (showing a previously visited site's title) while its URL and favicon were already updated. The root cause was in `TabSwitcherAdapter.handlePayloadsFor*`: when a diff payload reported a title change with a `null` new value (which can happen during the brief window between `pageChanged` and `titleReceived` in `BrowserTabViewModel`), `bundle.getString(DIFF_KEY_TITLE)?.let { ... }` silently skipped and the TextView kept its previous text. `DIFF_KEY_TITLE`/`DIFF_KEY_URL` are now treated as presence flags and the adapter re-derives the displayed values from the latest `TabEntity`, matching the initial-bind behavior (including the URL-host fallback when title is `null`).

### Steps to test this PR

_Tab switcher title rendering_
- [x] Generate 100 tab in the internal developer settings
- [x] Open the app and browse several sites across multiple tabs
- [x] Open the tab switcher and confirm each tab's title matches its URL and favicon
- [x] Pick a tab, navigate it to a page on a different host, return to the tab switcher, and confirm the row's title, URL, and favicon are all consistent for that tab
- [x] Scroll through 30+ tabs and confirm no row shows a title belonging to a different site than its URL/favicon
- [x] Toggle between grid and list view and confirm titles render correctly in both modes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts RecyclerView payload handling to refresh title/URL from the latest `TabEntity` even when diff payload values are `null`, plus adds regression tests.
> 
> **Overview**
> Fixes a tab switcher rendering bug where a tab row could keep a **stale title** when the diff payload reported a title change to `null` during navigation.
> 
> `TabSwitcherAdapter` now treats `DIFF_KEY_TITLE`/`DIFF_KEY_URL` as *presence flags* (using `containsKey`) and re-derives the displayed title/URL (including URL visibility) from the current `TabEntity`, ensuring consistent title/favicon updates across grid/list and Duck AI variants.
> 
> Adds new instrumentation tests covering the diff payload case where title transitions to `null`, and a regression test verifying payload-based binds update the title instead of leaving prior text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9986bcf26f6585745447791b6d6a986c19d6457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


