### PR TITLE
Unified Input animates smoothly with favorites

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -207,6 +207,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
             LayoutTransition().apply {
                 enableTransitionType(LayoutTransition.CHANGING)
                 setDuration(ANIMATION_DURATION_MS)
+                setAnimateParentHierarchy(false)
             }
         }
         widgetView.findViewById<ViewGroup?>(R.id.inputModeWidgetCard)?.layoutTransition = changingTransition()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser.nativeinput
 
+import android.animation.LayoutTransition
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -136,6 +137,19 @@ class NativeInputLayoutCoordinator(
 
         val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
 
+        // Animate child reflows when the widget toggles Search ↔ DuckAI changes our padding.
+        val ntpGroup = newTabContent as? ViewGroup
+        val previousNtpTransition = ntpGroup?.layoutTransition
+        ntpGroup?.layoutTransition = LayoutTransition().apply {
+            disableTransitionType(LayoutTransition.APPEARING)
+            disableTransitionType(LayoutTransition.DISAPPEARING)
+            disableTransitionType(LayoutTransition.CHANGE_APPEARING)
+            disableTransitionType(LayoutTransition.CHANGE_DISAPPEARING)
+            enableTransitionType(LayoutTransition.CHANGING)
+            setDuration(RealNativeInputAnimator.ANIMATION_DURATION_MS)
+            setAnimateParentHierarchy(false)
+        }
+
         fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
             view.setPadding(
                 padding.left,
@@ -191,6 +205,7 @@ class NativeInputLayoutCoordinator(
                 override fun onViewAttachedToWindow(v: View) = Unit
 
                 override fun onViewDetachedFromWindow(v: View) {
+                    ntpGroup?.layoutTransition = previousNtpTransition
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
                     }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214156122159496?focus=true

### Description

### Steps to test this PR
- Enable unified input: https://app.asana.com/1/137249556945/project/1212608036467427/task/1213908965428414?focus=true
- add one or more favorites.
- Switch between search/duckai and observe the smooth transition.

### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/a6169973-dd62-4882-abdc-a6966371cce0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes that tweak `LayoutTransition` behavior and temporarily enable CHANGING transitions on the NTP container; main risk is unintended layout animation/jank or transitions persisting if cleanup is missed.
> 
> **Overview**
> Improves unified input mode switching (Search ↔ DuckAI) by animating layout reflows instead of snapping when padding/content offsets change.
> 
> This updates widget `LayoutTransition` setup to avoid animating the parent hierarchy, and temporarily enables a `CHANGING`-only `LayoutTransition` on the New Tab Page container during content offset adjustments, restoring the previous transition when the widget detaches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c2558e25824eb0df07c1c74b2822dbb5fcf1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->