### PR TITLE
Fire Mode: WebView Profiles capability check & feature flag

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -408,6 +408,8 @@ dependencies {
     implementation project(':fingerprint-protection-impl')
     implementation project(':fingerprint-protection-store')
 
+    implementation project(':fire-mode-impl')
+
     implementation project(':element-hiding-impl')
     implementation project(':element-hiding-store')
 

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DeleteBrowsingData
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.MultiProfile
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
@@ -56,6 +57,7 @@ class RealWebViewCapabilityChecker @Inject constructor(
             DocumentStartJavaScript -> isDocumentStartJavaScriptSupported()
             WebMessageListener -> isWebMessageListenerSupported()
             DeleteBrowsingData -> isDeleteBrowsingDataSupported()
+            MultiProfile -> isMultiProfileSupported()
         }
 
     override fun onStart(owner: LifecycleOwner) {

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/api/WebViewCapabilityChecker.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/api/WebViewCapabilityChecker.kt
@@ -49,5 +49,11 @@ interface WebViewCapabilityChecker {
          * The ability to delete browsing data for specific sites via WebStorageCompat
          */
         data object DeleteBrowsingData : WebViewCapability
+
+        /**
+         * MultiProfile
+         * The ability to use named WebView Profiles to isolate cookies, storage and cache.
+         */
+        data object MultiProfile : WebViewCapability
     }
 }

--- a/fire-mode/fire-mode-impl/build.gradle
+++ b/fire-mode/fire-mode-impl/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace 'com.duckduckgo.firemode.impl'
+    anvil {
+        generateDaggerFactories = true
+    }
+}
+
+dependencies {
+    anvil project(path: ':anvil-compiler')
+    implementation project(path: ':anvil-annotations')
+
+    implementation project(path: ':di')
+    implementation project(path: ':feature-toggles-api')
+
+    implementation Google.dagger
+    implementation KotlinX.coroutines.core
+}

--- a/fire-mode/fire-mode-impl/src/main/java/com/duckduckgo/firemode/impl/FireModeFeature.kt
+++ b/fire-mode/fire-mode-impl/src/main/java/com/duckduckgo/firemode/impl/FireModeFeature.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.firemode.impl
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "fireMode",
+)
+interface FireModeFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun fireTabs(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214422244237719?focus=true

### Description

- Creates a fire-mode-impl Modue
- Adds `fireTabs` feature flag toggle to `FireModeFeature`
- Adds a MultiProfile capability to `WebViewCapabilityChecker` (mirroring the existing DeleteBrowsingData one) and gate the feature on BOTH feature flag AND `MULTI_PROFILE` being supported — users without either don't see Fire Tabs

API Proposal: https://app.asana.com/1/137249556945/project/1202552961248957/task/1214422244237724?focus=true

### Steps to test this PR

QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f1db644648f52861fc2bcd8e7cd66db62f22a0c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->