### PR TITLE
Supply model selection functionality via plugin (native input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -230,7 +230,6 @@ class RealNativeInputManager @Inject constructor(
         widget: NativeInputWidget,
         widgetRoot: View?,
     ) {
-        if (widget.isModelMenuVisible()) return
         if (omnibarController.isDuckAiMode()) {
             updateWidgetFocus(widget)
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
+import com.duckduckgo.common.utils.plugins.ActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+
+sealed class PromptContribution {
+    data class ModelSelection(val modelId: String) : PromptContribution()
+}
+
+interface NativeInputPlugin : ActivePlugin {
+
+    val containerId: Int
+
+    fun createView(context: Context): View
+
+    fun getPromptContribution(): PromptContribution?
+}
+
+@ContributesActivePluginPoint(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginPointNativeInput",
+)
+private interface NativeInputPluginPointTrigger

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/ModelPickerView.kt
@@ -21,7 +21,6 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.view.inputmethod.InputMethodManager
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -29,9 +28,7 @@ import android.widget.PopupWindow
 import android.widget.ScrollView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.content.getSystemService
 import androidx.core.view.isVisible
-import androidx.core.view.postDelayed
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -54,8 +51,6 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 interface ModelPicker {
-    var onMenuDismissed: (() -> Unit)?
-    fun isMenuVisible(): Boolean
     fun getSelectedModelId(): String?
     fun setPickerEnabled(enabled: Boolean)
 }
@@ -75,13 +70,10 @@ class ModelPickerView @JvmOverloads constructor(
     private val chip: Chip by lazy { findViewById(R.id.modelPickerChip) }
     private var stateJob: Job? = null
     private var popupWindow: PopupWindow? = null
-    override var onMenuDismissed: (() -> Unit)? = null
 
     init {
         inflate(context, R.layout.view_model_picker, this)
     }
-
-    override fun isMenuVisible(): Boolean = viewModel.menuShowing
 
     override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
 
@@ -123,14 +115,7 @@ class ModelPickerView @JvmOverloads constructor(
         if (state.models.isEmpty()) return
 
         viewModel.menuShowing = true
-
-        val imm = context.getSystemService<InputMethodManager>()
-        if (imm?.isAcceptingText == true) {
-            imm.hideSoftInputFromWindow(windowToken, 0)
-            postDelayed(KEYBOARD_DELAY) { if (isAttachedToWindow) showPopupWindow(state) }
-        } else {
-            showPopupWindow(state)
-        }
+        showPopupWindow(state)
     }
 
     private fun showPopupWindow(state: ModelState) {
@@ -159,9 +144,10 @@ class ModelPickerView @JvmOverloads constructor(
             },
             resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.popupMenuWidth),
             LayoutParams.WRAP_CONTENT,
-            true,
+            false,
         ).apply {
             elevation = resources.getDimension(R.dimen.modelPickerMenuElevation)
+            isOutsideTouchable = true
             setOnDismissListener { onPopupDismissed() }
         }
     }
@@ -176,7 +162,6 @@ class ModelPickerView @JvmOverloads constructor(
     private fun onPopupDismissed() {
         viewModel.menuShowing = false
         popupWindow = null
-        onMenuDismissed?.invoke()
     }
 
     override fun onDetachedFromWindow() {
@@ -254,9 +239,5 @@ class ModelPickerView @JvmOverloads constructor(
 
     private fun LinearLayout.addDivider() {
         addView(HorizontalDivider(context))
-    }
-
-    companion object {
-        private const val KEYBOARD_DELAY = 250L
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -148,6 +148,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var chatSuggestionsJob: Job? = null
     private var tierJob: Job? = null
     private var nativeInputStateJob: Job? = null
+    private var pluginsJob: Job? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
     private var nativeInputState: NativeInputState = NativeInputState(
@@ -193,7 +194,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun setupPlugins() {
-        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+        pluginsJob?.cancel()
+        pluginsJob = findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             viewModel.commands.collect { command ->
                 when (command) {
                     is NativeInputModeWidgetViewModel.Command.InstallPlugins -> {
@@ -225,6 +227,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         tierJob = null
         nativeInputStateJob?.cancel()
         nativeInputStateJob = null
+        pluginsJob?.cancel()
+        pluginsJob = null
         widgetRoot = null
         tearDownChatSuggestions()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -92,7 +92,6 @@ interface NativeInputWidget {
     fun setToggleVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
-    fun isModelMenuVisible(): Boolean
     fun storePendingPrompt(query: String)
     fun configure(isDuckAiMode: Boolean, isBottom: Boolean)
     fun isWidgetBottom(): Boolean
@@ -181,22 +180,39 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
 
     private val imageButton: ImageView by lazy { findViewById(R.id.inputFieldImageButton) }
-    private val modelPickerView: ModelPicker by lazy { findViewById<ModelPickerView>(R.id.modelPickerView) }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         imageButton.setOnClickListener { onImageClick?.invoke() }
-        modelPickerView.setPickerEnabled(isChatTabSelected())
-        modelPickerView.onMenuDismissed = {
-            if (hasInputFocus()) {
-                (context as? Activity)?.showKeyboard(inputField)
-            }
-        }
+        setupPlugins()
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
         observeNativeInputState()
         if (onPaidTierChanged != null) observeTier()
+    }
+
+    private fun setupPlugins() {
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+            viewModel.commands.collect { command ->
+                when (command) {
+                    is NativeInputModeWidgetViewModel.Command.InstallPlugins -> {
+                        for (plugin in command.plugins) {
+                            val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
+                            val pluginView = plugin.createView(context)
+                            container.removeAllViews()
+                            container.addView(pluginView)
+                            container.isVisible = isChatTabSelected()
+                        }
+                    }
+                    is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
+                        for (containerId in command.containerIds) {
+                            findViewById<FrameLayout?>(containerId)?.isVisible = command.visible
+                        }
+                    }
+                }
+            }
+        }
     }
 
     override fun onDetachedFromWindow() {
@@ -384,12 +400,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     updateDuckAiSubmitButton()
-                    modelPickerView.setPickerEnabled(isChatTabSelected())
+                    viewModel.updatePluginContainerVisibility(isChatTabSelected())
                 }
                 override fun onTabUnselected(tab: TabLayout.Tab) {}
                 override fun onTabReselected(tab: TabLayout.Tab) {
                     updateDuckAiSubmitButton()
-                    modelPickerView.setPickerEnabled(isChatTabSelected())
+                    viewModel.updatePluginContainerVisibility(isChatTabSelected())
                 }
             },
         )
@@ -473,13 +489,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         ancestors.zip(saved).forEach { (vg, lt) -> vg.layoutTransition = lt }
     }
 
-    override fun getSelectedModelId(): String? = modelPickerView.getSelectedModelId()
-
-    override fun isModelMenuVisible(): Boolean = modelPickerView.isMenuVisible()
+    override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
 
     override fun storePendingPrompt(query: String) {
-        // TODO: This should not be the widget's responsibility
-        viewModel.storePendingPrompt(query, getSelectedModelId())
+        viewModel.storePendingPrompt(query)
     }
 
     override fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -198,7 +198,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         pluginsJob = findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             viewModel.commands.collect { command ->
                 when (command) {
-                    is NativeInputModeWidgetViewModel.Command.InstallPlugins -> {
+                    is NativeInputModeWidgetViewModel.Command.AddPluginViews -> {
                         for (plugin in command.plugins) {
                             val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
                             val pluginView = plugin.createView(context)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -195,21 +195,26 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun setupPlugins() {
         pluginsJob?.cancel()
-        pluginsJob = findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-            viewModel.commands.collect { command ->
-                when (command) {
-                    is NativeInputModeWidgetViewModel.Command.AddPluginViews -> {
-                        for (plugin in command.plugins) {
-                            val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
-                            val pluginView = plugin.createView(context)
-                            container.removeAllViews()
-                            container.addView(pluginView)
-                            container.isVisible = isChatTabSelected()
-                        }
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        pluginsJob = scope.launch {
+            launch {
+                viewModel.plugins.collect { plugins ->
+                    for (plugin in plugins) {
+                        val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
+                        val pluginView = plugin.createView(context)
+                        container.removeAllViews()
+                        container.addView(pluginView)
+                        container.isVisible = isChatTabSelected()
                     }
-                    is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
-                        for (containerId in command.containerIds) {
-                            findViewById<FrameLayout?>(containerId)?.isVisible = command.visible
+                }
+            }
+            launch {
+                viewModel.commands.collect { command ->
+                    when (command) {
+                        is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
+                            for (containerId in command.containerIds) {
+                                findViewById<FrameLayout?>(containerId)?.isVisible = command.visible
+                            }
                         }
                     }
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -40,6 +40,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -59,32 +61,30 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 ) : ViewModel() {
 
     sealed class Command {
-        data class AddPluginViews(val plugins: List<NativeInputPlugin>) : Command()
         data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
     }
+
+    private val _plugins = MutableStateFlow<List<NativeInputPlugin>>(emptyList())
+    val plugins: StateFlow<List<NativeInputPlugin>> = _plugins.asStateFlow()
 
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
     val commands = commandChannel.receiveAsFlow()
 
-    private var activePlugins: List<NativeInputPlugin> = emptyList()
-
     init {
         viewModelScope.launch {
-            val plugins = nativeInputPlugins.getPlugins().toList()
-            activePlugins = plugins
-            commandChannel.trySend(Command.AddPluginViews(plugins))
+            _plugins.value = nativeInputPlugins.getPlugins().toList()
         }
     }
 
     fun updatePluginContainerVisibility(isChatTab: Boolean) {
-        val containerIds = activePlugins.map { it.containerId }
+        val containerIds = _plugins.value.map { it.containerId }
         if (containerIds.isNotEmpty()) {
             commandChannel.trySend(Command.UpdatePluginVisibility(containerIds, isChatTab))
         }
     }
 
     fun getSelectedModelId(): String? {
-        return activePlugins.firstNotNullOfOrNull { plugin ->
+        return _plugins.value.firstNotNullOfOrNull { plugin ->
             (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -20,6 +20,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.ChatState
@@ -28,17 +29,23 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ContributesViewModel(ViewScope::class)
@@ -48,7 +55,39 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     subscriptions: Subscriptions,
     private val pendingNativePromptStore: PendingNativePromptStore,
     private val chatSuggestionsReader: ChatSuggestionsReader,
+    private val nativeInputPlugins: ActivePluginPoint<NativeInputPlugin>,
 ) : ViewModel() {
+
+    sealed class Command {
+        data class InstallPlugins(val plugins: List<NativeInputPlugin>) : Command()
+        data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
+    }
+
+    private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
+    val commands = commandChannel.receiveAsFlow()
+
+    private var activePlugins: List<NativeInputPlugin> = emptyList()
+
+    init {
+        viewModelScope.launch {
+            val plugins = nativeInputPlugins.getPlugins().toList()
+            activePlugins = plugins
+            commandChannel.trySend(Command.InstallPlugins(plugins))
+        }
+    }
+
+    fun updatePluginContainerVisibility(isChatTab: Boolean) {
+        val containerIds = activePlugins.map { it.containerId }
+        if (containerIds.isNotEmpty()) {
+            commandChannel.trySend(Command.UpdatePluginVisibility(containerIds, isChatTab))
+        }
+    }
+
+    fun getSelectedModelId(): String? {
+        return activePlugins.firstNotNullOfOrNull { plugin ->
+            (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
+        }
+    }
 
     private data class WidgetConfig(
         val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
@@ -105,8 +144,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         widgetConfig.value = WidgetConfig(inputContext = context, inputPosition = position)
     }
 
-    fun storePendingPrompt(query: String, modelId: String?) {
-        pendingNativePromptStore.store(query, modelId)
+    fun storePendingPrompt(query: String) {
+        pendingNativePromptStore.store(query, getSelectedModelId())
     }
 
     suspend fun fetchChatSuggestions(query: String): List<ChatSuggestion> =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -59,7 +59,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 ) : ViewModel() {
 
     sealed class Command {
-        data class InstallPlugins(val plugins: List<NativeInputPlugin>) : Command()
+        data class AddPluginViews(val plugins: List<NativeInputPlugin>) : Command()
         data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
     }
 
@@ -72,7 +72,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         viewModelScope.launch {
             val plugins = nativeInputPlugins.getPlugins().toList()
             activePlugins = plugins
-            commandChannel.trySend(Command.InstallPlugins(plugins))
+            commandChannel.trySend(Command.AddPluginViews(plugins))
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/ModelPickerNativeInputPlugin.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.ModelPicker
 import com.duckduckgo.duckchat.impl.ui.ModelPickerView
+import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -36,17 +37,17 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = com.duckduckgo.duckchat.impl.R.id.modelPickerContainer
 
-    private var modelPicker: ModelPicker? = null
+    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
 
     override fun createView(context: Context): View {
         return ModelPickerView(context).also { picker ->
-            modelPicker = picker
+            modelPicker = WeakReference(picker)
             picker.setPickerEnabled(true)
         }
     }
 
     override fun getPromptContribution(): PromptContribution? {
-        val modelId = modelPicker?.getSelectedModelId() ?: return null
+        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
         return PromptContribution.ModelSelection(modelId)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/ModelPickerNativeInputPlugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
+import com.duckduckgo.duckchat.impl.ui.ModelPicker
+import com.duckduckgo.duckchat.impl.ui.ModelPickerView
+import javax.inject.Inject
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginModelPickerNativeInput",
+    parentFeatureName = "pluginPointNativeInput",
+)
+class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+
+    override val containerId: Int = com.duckduckgo.duckchat.impl.R.id.modelPickerContainer
+
+    private var modelPicker: ModelPicker? = null
+
+    override fun createView(context: Context): View {
+        return ModelPickerView(context).also { picker ->
+            modelPicker = picker
+            picker.setPickerEnabled(true)
+        }
+    }
+
+    override fun getPromptContribution(): PromptContribution? {
+        val modelId = modelPicker?.getSelectedModelId() ?: return null
+        return PromptContribution.ModelSelection(modelId)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -176,8 +176,8 @@
                         android:gravity="center_vertical"
                         android:orientation="horizontal">
 
-                        <com.duckduckgo.duckchat.impl.ui.ModelPickerView
-                            android:id="@+id/modelPickerView"
+                        <FrameLayout
+                            android:id="@id/modelPickerContainer"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"

--- a/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <item name="modelPickerContainer" type="id"/>
+</resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -271,7 +270,7 @@ class NativeInputModeWidgetViewModelTest {
     fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = "model-1")
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         viewModel.storePendingPrompt("hello")
 
@@ -281,7 +280,7 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenStorePendingPromptWithNoPluginsThenModelIdIsNull() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         viewModel.storePendingPrompt("hello")
 
@@ -403,7 +402,7 @@ class NativeInputModeWidgetViewModelTest {
     fun whenNoPluginsThenInstallPluginsCommandHasEmptyList() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
 
-        val command = viewModel.commands.first()
+        val command = viewModel.commands.firstOrNull()
 
         assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
         assertTrue((command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins.isEmpty())
@@ -414,7 +413,7 @@ class NativeInputModeWidgetViewModelTest {
         val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
         val viewModel = createViewModel(plugins = listOf(plugin))
 
-        val command = viewModel.commands.first()
+        val command = viewModel.commands.firstOrNull()
 
         assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
         val plugins = (command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins
@@ -425,7 +424,7 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         assertNull(viewModel.getSelectedModelId())
     }
@@ -434,7 +433,7 @@ class NativeInputModeWidgetViewModelTest {
     fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         assertEquals("claude-3", viewModel.getSelectedModelId())
     }
@@ -443,7 +442,7 @@ class NativeInputModeWidgetViewModelTest {
     fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = null)
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         assertNull(viewModel.getSelectedModelId())
     }
@@ -452,11 +451,11 @@ class NativeInputModeWidgetViewModelTest {
     fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
         val plugin = fakePlugin(containerId = 99, modelId = null)
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.first()
+        viewModel.commands.firstOrNull()
 
         viewModel.updatePluginContainerVisibility(isChatTab = true)
 
-        val command = viewModel.commands.first()
+        val command = viewModel.commands.firstOrNull()
         assertTrue(command is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility)
         val update = command as NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility
         assertEquals(listOf(99), update.containerIds)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -404,8 +404,8 @@ class NativeInputModeWidgetViewModelTest {
 
         val command = viewModel.commands.firstOrNull()
 
-        assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
-        assertTrue((command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins.isEmpty())
+        assertTrue(command is NativeInputModeWidgetViewModel.Command.AddPluginViews)
+        assertTrue((command as NativeInputModeWidgetViewModel.Command.AddPluginViews).plugins.isEmpty())
     }
 
     @Test
@@ -415,8 +415,8 @@ class NativeInputModeWidgetViewModelTest {
 
         val command = viewModel.commands.firstOrNull()
 
-        assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
-        val plugins = (command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins
+        assertTrue(command is NativeInputModeWidgetViewModel.Command.AddPluginViews)
+        val plugins = (command as NativeInputModeWidgetViewModel.Command.AddPluginViews).plugins
         assertEquals(1, plugins.size)
         assertEquals(42, plugins[0].containerId)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -270,7 +270,6 @@ class NativeInputModeWidgetViewModelTest {
     fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = "model-1")
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.firstOrNull()
 
         viewModel.storePendingPrompt("hello")
 
@@ -280,7 +279,6 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenStorePendingPromptWithNoPluginsThenModelIdIsNull() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
-        viewModel.commands.firstOrNull()
 
         viewModel.storePendingPrompt("hello")
 
@@ -399,24 +397,18 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenNoPluginsThenInstallPluginsCommandHasEmptyList() = runTest {
+    fun whenNoPluginsThenPluginsStateIsEmpty() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
 
-        val command = viewModel.commands.firstOrNull()
-
-        assertTrue(command is NativeInputModeWidgetViewModel.Command.AddPluginViews)
-        assertTrue((command as NativeInputModeWidgetViewModel.Command.AddPluginViews).plugins.isEmpty())
+        assertTrue(viewModel.plugins.value.isEmpty())
     }
 
     @Test
-    fun whenPluginsExistThenInstallPluginsCommandContainsThem() = runTest {
+    fun whenPluginsExistThenPluginsStateContainsThem() = runTest {
         val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
         val viewModel = createViewModel(plugins = listOf(plugin))
 
-        val command = viewModel.commands.firstOrNull()
-
-        assertTrue(command is NativeInputModeWidgetViewModel.Command.AddPluginViews)
-        val plugins = (command as NativeInputModeWidgetViewModel.Command.AddPluginViews).plugins
+        val plugins = viewModel.plugins.value
         assertEquals(1, plugins.size)
         assertEquals(42, plugins[0].containerId)
     }
@@ -424,7 +416,6 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
-        viewModel.commands.firstOrNull()
 
         assertNull(viewModel.getSelectedModelId())
     }
@@ -433,7 +424,6 @@ class NativeInputModeWidgetViewModelTest {
     fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.firstOrNull()
 
         assertEquals("claude-3", viewModel.getSelectedModelId())
     }
@@ -442,7 +432,6 @@ class NativeInputModeWidgetViewModelTest {
     fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
         val plugin = fakePlugin(containerId = 1, modelId = null)
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.firstOrNull()
 
         assertNull(viewModel.getSelectedModelId())
     }
@@ -451,7 +440,6 @@ class NativeInputModeWidgetViewModelTest {
     fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
         val plugin = fakePlugin(containerId = 99, modelId = null)
         val viewModel = createViewModel(plugins = listOf(plugin))
-        viewModel.commands.firstOrNull()
 
         viewModel.updatePluginContainerVisibility(isChatTab = true)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -16,22 +16,29 @@
 
 package com.duckduckgo.duckchat.impl.ui
 
+import android.content.Context
+import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -65,6 +72,11 @@ class NativeInputModeWidgetViewModelTest {
     private val chatSuggestionsUserEnabledFlow = MutableStateFlow(true)
     private val entitlementsFlow = MutableStateFlow<List<Product>>(emptyList())
 
+    private var fakePlugins: List<NativeInputPlugin> = emptyList()
+    private val fakePluginPoint = object : ActivePluginPoint<NativeInputPlugin> {
+        override suspend fun getPlugins(): Collection<NativeInputPlugin> = fakePlugins
+    }
+
     private lateinit var testee: NativeInputModeWidgetViewModel
 
     @Before
@@ -76,12 +88,18 @@ class NativeInputModeWidgetViewModelTest {
         whenever(duckChatInternal.chatState).thenReturn(chatStateFlow)
         whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementsFlow)
 
-        testee = NativeInputModeWidgetViewModel(
+        testee = createViewModel()
+    }
+
+    private fun createViewModel(plugins: List<NativeInputPlugin> = emptyList()): NativeInputModeWidgetViewModel {
+        fakePlugins = plugins
+        return NativeInputModeWidgetViewModel(
             duckChatInternal = duckChatInternal,
             duckAiFeatureState = duckAiFeatureState,
             subscriptions = subscriptions,
             pendingNativePromptStore = pendingNativePromptStore,
             chatSuggestionsReader = chatSuggestionsReader,
+            nativeInputPlugins = fakePluginPoint,
         )
     }
 
@@ -95,13 +113,7 @@ class NativeInputModeWidgetViewModelTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true
 
-        val freshTestee = NativeInputModeWidgetViewModel(
-            duckChatInternal = duckChatInternal,
-            duckAiFeatureState = duckAiFeatureState,
-            subscriptions = subscriptions,
-            pendingNativePromptStore = pendingNativePromptStore,
-            chatSuggestionsReader = chatSuggestionsReader,
-        )
+        val freshTestee = createViewModel()
 
         assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, freshTestee.state.firstOrNull()!!.inputMode)
     }
@@ -256,10 +268,24 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenStorePendingPromptThenDelegatesToStore() {
-        testee.storePendingPrompt("hello", "model-1")
+    fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = "model-1")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+        viewModel.commands.first()
+
+        viewModel.storePendingPrompt("hello")
 
         verify(pendingNativePromptStore).store("hello", "model-1")
+    }
+
+    @Test
+    fun whenStorePendingPromptWithNoPluginsThenModelIdIsNull() = runTest {
+        val viewModel = createViewModel(plugins = emptyList())
+        viewModel.commands.first()
+
+        viewModel.storePendingPrompt("hello")
+
+        verify(pendingNativePromptStore).store("hello", null)
     }
 
     @Test
@@ -371,5 +397,78 @@ class NativeInputModeWidgetViewModelTest {
         testee.fetchChatSuggestions("hello world")
 
         verify(chatSuggestionsReader).fetchSuggestions("hello world")
+    }
+
+    @Test
+    fun whenNoPluginsThenInstallPluginsCommandHasEmptyList() = runTest {
+        val viewModel = createViewModel(plugins = emptyList())
+
+        val command = viewModel.commands.first()
+
+        assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
+        assertTrue((command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins.isEmpty())
+    }
+
+    @Test
+    fun whenPluginsExistThenInstallPluginsCommandContainsThem() = runTest {
+        val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+
+        val command = viewModel.commands.first()
+
+        assertTrue(command is NativeInputModeWidgetViewModel.Command.InstallPlugins)
+        val plugins = (command as NativeInputModeWidgetViewModel.Command.InstallPlugins).plugins
+        assertEquals(1, plugins.size)
+        assertEquals(42, plugins[0].containerId)
+    }
+
+    @Test
+    fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
+        val viewModel = createViewModel(plugins = emptyList())
+        viewModel.commands.first()
+
+        assertNull(viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+        viewModel.commands.first()
+
+        assertEquals("claude-3", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = null)
+        val viewModel = createViewModel(plugins = listOf(plugin))
+        viewModel.commands.first()
+
+        assertNull(viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
+        val plugin = fakePlugin(containerId = 99, modelId = null)
+        val viewModel = createViewModel(plugins = listOf(plugin))
+        viewModel.commands.first()
+
+        viewModel.updatePluginContainerVisibility(isChatTab = true)
+
+        val command = viewModel.commands.first()
+        assertTrue(command is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility)
+        val update = command as NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility
+        assertEquals(listOf(99), update.containerIds)
+        assertTrue(update.visible)
+    }
+
+    private fun fakePlugin(containerId: Int, modelId: String?): NativeInputPlugin {
+        return object : NativeInputPlugin {
+            override val containerId: Int = containerId
+            override fun createView(context: Context): View = View(context)
+            override fun getPromptContribution(): PromptContribution? =
+                modelId?.let { PromptContribution.ModelSelection(it) }
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214428657149681?focus=true

### Description

- In order to decouple each piece of functionality from the native input, I've added a plugin point and the first plugin `ModelPickerNativeInputPlugin`

### Steps to test this PR

_With native input enabled_
- [ ] Verify that the model picker works as expected


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new native-input plugin system and moves model selection into it, changing how the widget builds UI and derives the model id for prompts; regressions could affect chat prompt routing or widget visibility.
> 
> **Overview**
> Decouples native input “extras” by introducing a `NativeInputPlugin` plugin point with optional `PromptContribution`s, and wiring `NativeInputModeWidget` to dynamically inflate plugin-provided views into container slots.
> 
> Moves model selection behind this plugin mechanism: the model picker is now provided by `ModelPickerNativeInputPlugin`, the widget layout replaces the direct `ModelPickerView` with a `FrameLayout` container, and `NativeInputModeWidgetViewModel` now derives the selected model id from plugin contributions when storing pending prompts or submitting DuckAI queries.
> 
> Also simplifies model picker popup behavior (no keyboard-hide delay; popup is non-focusable/outside-touch dismissible) and removes the keyboard-hide guard that previously skipped handling when the model menu was visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5433610804e5f44ff5ef509859840563489c1290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->