### PR TITLE
Hide toggle when contextual Duck.ai is active

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -93,7 +93,7 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     private fun setupWidget(widget: NativeInputModeWidget, onSearchSubmitted: (String) -> Unit, onImageButtonPressed: () -> Unit) {
-        widget.selectChatTab()
+        widget.configureContextual()
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.onImageClick = onImageButtonPressed

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -96,6 +96,7 @@ interface NativeInputWidget {
     fun getSelectedModelId(): String?
     fun storePendingPrompt(query: String)
     fun configure(isDuckAiMode: Boolean, isBottom: Boolean)
+    fun configureContextual()
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
@@ -519,6 +520,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
         if (isDuckAiMode) selectChatTab()
         applyOmnibarShape(isBottom)
+    }
+
+    override fun configureContextual() {
+        viewModel.configureContextual()
+        selectChatTab()
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState.isBottom

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -739,7 +739,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 }
 
 internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
-    toggleVisible && inputContext != NativeInputState.InputContext.DUCK_AI
+    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
-    !toggleVisible && inputContext != NativeInputState.InputContext.DUCK_AI
+    !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -148,6 +148,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         pendingNativePromptStore.store(query, getSelectedModelId())
     }
 
+    fun configureContextual() {
+        widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
+    }
+
     suspend fun fetchChatSuggestions(query: String): List<ChatSuggestion> =
         runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -36,6 +36,9 @@ data class NativeInputState(
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
-    val defaultToggleSelection: ToggleSelection get() =
-        if (inputContext == InputContext.DUCK_AI || inputContext == InputContext.DUCK_AI_CONTEXTUAL) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
+    val defaultToggleSelection: ToggleSelection
+        get() = when (inputContext) {
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ToggleSelection.DUCK_AI
+            InputContext.BROWSER -> ToggleSelection.SEARCH
+        }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -32,7 +32,7 @@ data class NativeInputState(
 
     enum class InputPosition { TOP, BOTTOM }
 
-    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputState.kt
@@ -26,16 +26,16 @@ data class NativeInputState(
         SEARCH_ONLY,
     }
 
-    enum class InputContext { BROWSER, DUCK_AI }
+    enum class InputContext { BROWSER, DUCK_AI, DUCK_AI_CONTEXTUAL }
 
     enum class ToggleSelection { SEARCH, DUCK_AI }
 
     enum class InputPosition { TOP, BOTTOM }
 
-    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI_CONTEXTUAL
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
     val defaultToggleSelection: ToggleSelection get() =
-        if (inputContext == InputContext.DUCK_AI) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
+        if (inputContext == InputContext.DUCK_AI || inputContext == InputContext.DUCK_AI_CONTEXTUAL) ToggleSelection.DUCK_AI else ToggleSelection.SEARCH
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -74,6 +74,18 @@ class NativeInputModeWidgetBackButtonsTest {
         assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI).shouldShowCardRowBack())
     }
 
+    @Test
+    fun `toggle row back is hidden in duck ai contextual context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack())
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack())
+    }
+
+    @Test
+    fun `card row back is hidden in duck ai contextual context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowCardRowBack())
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowCardRowBack())
+    }
+
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
         NativeInputState(inputMode = inputMode, inputContext = inputContext)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -204,20 +204,35 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true
         testee.setDuckAiMode(true)
+
+        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenConfigureContextualThenContextIsDuckAiContextual() = runTest {
+        testee.configureContextual()
+
+        assertEquals(NativeInputState.InputContext.DUCK_AI_CONTEXTUAL, testee.state.firstOrNull()!!.inputContext)
+    }
+
+    @Test
+    fun whenContextIsDuckAiContextualAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        testee.configureContextual()
 
         assertFalse(testee.state.firstOrNull()!!.toggleVisible)
     }
 
     @Test
-    fun whenContextIsBrowserAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
-        setIsEnabled(true)
-        inputScreenUserSettingFlow.value = true
+    fun whenContextIsDuckAiContextualThenDefaultToggleSelectionIsDuckAi() = runTest {
+        testee.configureContextual()
 
-        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -204,6 +204,23 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+        testee.setDuckAiMode(true)
+
+        assertFalse(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
+    fun whenContextIsBrowserAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
+        setIsEnabled(true)
+        inputScreenUserSettingFlow.value = true
+
+        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+    }
+
+    @Test
     fun whenSetDuckAiModeThenInputModeUnchanged() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214387687457007

### Description

When the contextual Duck.ai sheet is in use, only the Duck.ai side should be shown — the Search/Duck.ai toggle is not relevant in this context.

`NativeInputState.toggleVisible` previously only checked `inputMode`. It now also requires `inputContext != DUCK_AI`, so the toggle is hidden whenever the widget is operating inside the contextual sheet. The existing `applyState` logic already selects the Duck.ai tab before hiding the toggle, so no further changes are needed there.

### Steps to test this PR

_Contextual Duck.ai sheet_
- [ ] Open the contextual Duck.ai sheet from the browser
- [ ] Confirm the Search/Duck.ai toggle is not visible
- [ ] Confirm the Duck.ai input is shown and functional

_Omnibar (browser context)_
- [ ] Open a new tab / use the omnibar
- [ ] Confirm the Search/Duck.ai toggle is still visible when the native input setting is enabled

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to the native input widget; main risk is unintended toggle/back-button visibility regressions across contexts.
> 
> **Overview**
> Adds a new `DUCK_AI_CONTEXTUAL` input context for the native input widget and updates state logic so the Search/Duck.ai toggle is **hidden** in this contextual mode while defaulting selection to the Duck.ai tab.
> 
> Introduces `configureContextual()` on `NativeInputModeWidget`/ViewModel and uses it from the contextual sheet manager; back-button visibility checks are tightened to only show in `BROWSER` context. Updates unit tests to cover the new contextual context and toggle visibility behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0fefc7045b477f05320e69d75c7290205cc93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->