### PR TITLE
Support PDF printing and hide find in PDF file

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5766,7 +5766,7 @@ class BrowserTabFragment :
         val pdfPath = state.currentPdfCachedUri?.path ?: return null
         val pdfFile = File(pdfPath).takeIf { it.exists() } ?: return null
         val displayName = state.currentPdfFileName ?: pdfFile.name
-        return CachedPdfPrintDocumentAdapter(pdfFile, displayName)
+        return CachedPdfPrintDocumentAdapter(pdfFile, displayName, dispatchers)
     }
 
     private fun showSitePermissionsDialog(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -37,6 +37,7 @@ import android.os.Environment
 import android.os.Handler
 import android.os.Message
 import android.print.PrintAttributes
+import android.print.PrintDocumentAdapter
 import android.print.PrintManager
 import android.provider.MediaStore
 import android.text.Spanned
@@ -159,6 +160,7 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.pdf.DdgPdfViewerFragment
 import com.duckduckgo.app.browser.pdf.PdfPreviewGenerator
+import com.duckduckgo.app.browser.print.CachedPdfPrintDocumentAdapter
 import com.duckduckgo.app.browser.print.PrintDocumentAdapterFactory
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
@@ -5740,22 +5742,31 @@ class BrowserTabFragment :
     ) {
         if (viewModel.isPrinting()) return
 
-        (activity?.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let { printManager ->
-            webView?.createSafePrintDocumentAdapter(url)?.let { webViewPrintDocumentAdapter ->
+        val printManager = activity?.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
+        val sourceAdapter = pdfPrintDocumentAdapterOrNull() ?: webView?.createSafePrintDocumentAdapter(url) ?: return
+        val printAdapter = PrintDocumentAdapterFactory.createPrintDocumentAdapter(
+            sourceAdapter,
+            onStartCallback = { viewModel.onStartPrint() },
+            onFinishCallback = { viewModel.onFinishPrint() },
+        )
+        printManager.print(
+            url,
+            printAdapter,
+            PrintAttributes.Builder().setMediaSize(defaultMediaSize).build(),
+        )
+    }
 
-                val printAdapter =
-                    PrintDocumentAdapterFactory.createPrintDocumentAdapter(
-                        webViewPrintDocumentAdapter,
-                        onStartCallback = { viewModel.onStartPrint() },
-                        onFinishCallback = { viewModel.onFinishPrint() },
-                    )
-                printManager.print(
-                    url,
-                    printAdapter,
-                    PrintAttributes.Builder().setMediaSize(defaultMediaSize).build(),
-                )
-            }
-        }
+    /**
+     * If an inline PDF is currently showing, build an adapter that prints the cached PDF
+     * file directly instead of routing through the WebView (which is still on the page that
+     * linked to the PDF — printing it would emit the parent page).
+     */
+    private fun pdfPrintDocumentAdapterOrNull(): PrintDocumentAdapter? {
+        val state = viewModel.browserViewState.value ?: return null
+        val pdfPath = state.currentPdfCachedUri?.path ?: return null
+        val pdfFile = File(pdfPath).takeIf { it.exists() } ?: return null
+        val displayName = state.currentPdfFileName ?: pdfFile.name
+        return CachedPdfPrintDocumentAdapter(pdfFile, displayName)
     }
 
     private fun showSitePermissionsDialog(

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -151,7 +151,7 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
             canChangeBrowsingMode = browserViewState.canChangeBrowsingMode,
             isDesktopBrowsingMode = browserViewState.isDesktopBrowsingMode,
             hasPreviousAppLink = browserViewState.previousAppLink != null,
-            canFindInPage = browserViewState.canFindInPage,
+            canFindInPage = browserViewState.canFindInPage && browserViewState.currentPdfCachedUri == null,
             addToHomeVisible = browserViewState.addToHomeVisible,
             addToHomeEnabled = browserViewState.addToHomeEnabled,
             canChangePrivacyProtection = browserViewState.canChangePrivacyProtection,

--- a/app/src/main/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapter.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.print
+
+import android.os.Bundle
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.print.PageRange
+import android.print.PrintAttributes
+import android.print.PrintDocumentAdapter
+import android.print.PrintDocumentInfo
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+
+/**
+ * Streams an already-cached PDF [pdfFile] into the Android print framework's destination.
+ */
+class CachedPdfPrintDocumentAdapter(
+    private val pdfFile: File,
+    private val displayName: String,
+) : PrintDocumentAdapter() {
+
+    override fun onLayout(
+        oldAttributes: PrintAttributes?,
+        newAttributes: PrintAttributes?,
+        cancellationSignal: CancellationSignal?,
+        callback: LayoutResultCallback,
+        extras: Bundle?,
+    ) {
+        if (cancellationSignal?.isCanceled == true) {
+            callback.onLayoutCancelled()
+            return
+        }
+        val info = PrintDocumentInfo.Builder(displayName)
+            .setContentType(PrintDocumentInfo.CONTENT_TYPE_DOCUMENT)
+            .setPageCount(PrintDocumentInfo.PAGE_COUNT_UNKNOWN)
+            .build()
+        callback.onLayoutFinished(info, true)
+    }
+
+    override fun onWrite(
+        pages: Array<out PageRange>?,
+        destination: ParcelFileDescriptor,
+        cancellationSignal: CancellationSignal?,
+        callback: WriteResultCallback,
+    ) {
+        try {
+            FileInputStream(pdfFile).use { input ->
+                FileOutputStream(destination.fileDescriptor).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    var bytesRead: Int
+                    while (input.read(buffer).also { bytesRead = it } > 0) {
+                        if (cancellationSignal?.isCanceled == true) {
+                            callback.onWriteCancelled()
+                            return
+                        }
+                        output.write(buffer, 0, bytesRead)
+                    }
+                }
+            }
+            callback.onWriteFinished(arrayOf(PageRange.ALL_PAGES))
+        } catch (e: IOException) {
+            logcat(WARN) { "PDF print failed while copying bytes: ${e.asLog()}" }
+            callback.onWriteFailed(e.message)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapter.kt
@@ -23,6 +23,11 @@ import android.print.PageRange
 import android.print.PrintAttributes
 import android.print.PrintDocumentAdapter
 import android.print.PrintDocumentInfo
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
@@ -37,7 +42,10 @@ import java.io.IOException
 class CachedPdfPrintDocumentAdapter(
     private val pdfFile: File,
     private val displayName: String,
+    private val dispatcherProvider: DispatcherProvider,
 ) : PrintDocumentAdapter() {
+
+    private val writeScope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
 
     override fun onLayout(
         oldAttributes: PrintAttributes?,
@@ -63,24 +71,30 @@ class CachedPdfPrintDocumentAdapter(
         cancellationSignal: CancellationSignal?,
         callback: WriteResultCallback,
     ) {
-        try {
-            FileInputStream(pdfFile).use { input ->
-                FileOutputStream(destination.fileDescriptor).use { output ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    var bytesRead: Int
-                    while (input.read(buffer).also { bytesRead = it } > 0) {
-                        if (cancellationSignal?.isCanceled == true) {
-                            callback.onWriteCancelled()
-                            return
+        writeScope.launch {
+            try {
+                FileInputStream(pdfFile).use { input ->
+                    FileOutputStream(destination.fileDescriptor).use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var bytesRead: Int
+                        while (input.read(buffer).also { bytesRead = it } > 0) {
+                            if (cancellationSignal?.isCanceled == true) {
+                                callback.onWriteCancelled()
+                                return@launch
+                            }
+                            output.write(buffer, 0, bytesRead)
                         }
-                        output.write(buffer, 0, bytesRead)
                     }
                 }
+                callback.onWriteFinished(arrayOf(PageRange.ALL_PAGES))
+            } catch (e: IOException) {
+                logcat(WARN) { "PDF print failed while copying bytes: ${e.asLog()}" }
+                callback.onWriteFailed(e.message)
             }
-            callback.onWriteFinished(arrayOf(PageRange.ALL_PAGES))
-        } catch (e: IOException) {
-            logcat(WARN) { "PDF print failed while copying bytes: ${e.asLog()}" }
-            callback.onWriteFailed(e.message)
         }
+    }
+
+    override fun onFinish() {
+        writeScope.cancel()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
@@ -356,6 +356,46 @@ class RealBrowserMenuViewStateFactoryTest {
     }
 
     @Test
+    fun `when an inline PDF is showing then canFindInPage is hidden even if the underlying state allows it`() = runTest {
+        val browserViewState = BrowserViewState(
+            canFindInPage = true,
+            currentPdfCachedUri = mock(),
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser("https://example.com/doc.pdf"),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+        )
+
+        assertFalse((result as BrowserMenuViewState.Browser).canFindInPage)
+    }
+
+    @Test
+    fun `when no inline PDF is showing then canFindInPage propagates from the underlying state`() = runTest {
+        val browserViewState = BrowserViewState(
+            canFindInPage = true,
+            currentPdfCachedUri = null,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser("https://example.com/page"),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+        )
+
+        assertTrue((result as BrowserMenuViewState.Browser).canFindInPage)
+    }
+
+    @Test
     fun `when site has url and title then page context header is Visible`() = runTest {
         val result = testee.create(
             omnibarViewMode = ViewMode.Browser("https://www.example.com/"),

--- a/app/src/test/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapterTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.print
+
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.print.PageRange
+import android.print.PrintAttributes
+import android.print.PrintDocumentAdapter
+import android.print.PrintDocumentInfo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class CachedPdfPrintDocumentAdapterTest {
+
+    @Test
+    fun whenLayoutThenReportsPdfDocumentInfoWithDisplayName() {
+        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("hello", "%PDF-1.4 hello".toByteArray()), "hello.pdf")
+        val callback = mock<PrintDocumentAdapter.LayoutResultCallback>()
+
+        adapter.onLayout(null, PrintAttributes.Builder().build(), null, callback, null)
+
+        val captor = argumentCaptor<PrintDocumentInfo>()
+        verify(callback).onLayoutFinished(captor.capture(), any())
+        assertEquals("hello.pdf", captor.firstValue.name)
+        assertEquals(PrintDocumentInfo.CONTENT_TYPE_DOCUMENT, captor.firstValue.contentType)
+    }
+
+    @Test
+    fun whenLayoutAndCancellationAlreadyTriggeredThenLayoutCancelled() {
+        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("doc", "%PDF-1.4".toByteArray()), "doc.pdf")
+        val callback = mock<PrintDocumentAdapter.LayoutResultCallback>()
+        val signal = CancellationSignal().apply { cancel() }
+
+        adapter.onLayout(null, PrintAttributes.Builder().build(), signal, callback, null)
+
+        verify(callback).onLayoutCancelled()
+        verify(callback, never()).onLayoutFinished(any(), any())
+    }
+
+    @Test
+    fun whenWriteThenPdfFileBytesCopiedToDestination() {
+        val pdfBytes = "%PDF-1.4 lorem ipsum dolor sit amet".toByteArray()
+        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("doc", pdfBytes), "doc.pdf")
+        val outFile = File.createTempFile("printed", ".pdf").apply { deleteOnExit() }
+        val pfd = ParcelFileDescriptor.open(
+            outFile,
+            ParcelFileDescriptor.MODE_WRITE_ONLY or ParcelFileDescriptor.MODE_TRUNCATE,
+        )
+        val callback = mock<PrintDocumentAdapter.WriteResultCallback>()
+
+        adapter.onWrite(arrayOf(PageRange.ALL_PAGES), pfd, null, callback)
+        pfd.close()
+
+        verify(callback).onWriteFinished(arrayOf(PageRange.ALL_PAGES))
+        assertArrayEquals(pdfBytes, outFile.readBytes())
+    }
+
+    @Test
+    fun whenWriteAndSourceFileMissingThenFailureReported() {
+        val ghostFile = File.createTempFile("ghost", ".pdf").apply { delete() }
+        val adapter = CachedPdfPrintDocumentAdapter(ghostFile, "ghost.pdf")
+        val outFile = File.createTempFile("printed", ".pdf").apply { deleteOnExit() }
+        val pfd = ParcelFileDescriptor.open(outFile, ParcelFileDescriptor.MODE_WRITE_ONLY)
+        val callback = mock<PrintDocumentAdapter.WriteResultCallback>()
+
+        adapter.onWrite(arrayOf(PageRange.ALL_PAGES), pfd, null, callback)
+        pfd.close()
+
+        verify(callback).onWriteFailed(any())
+        verify(callback, never()).onWriteFinished(any())
+    }
+
+    private fun createTempPdf(prefix: String, bytes: ByteArray): File =
+        File.createTempFile(prefix, ".pdf").apply {
+            deleteOnExit()
+            writeBytes(bytes)
+        }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/print/CachedPdfPrintDocumentAdapterTest.kt
@@ -23,8 +23,12 @@ import android.print.PrintAttributes
 import android.print.PrintDocumentAdapter
 import android.print.PrintDocumentInfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -39,9 +43,12 @@ import java.io.File
 @Config(sdk = [34])
 class CachedPdfPrintDocumentAdapterTest {
 
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
     @Test
-    fun whenLayoutThenReportsPdfDocumentInfoWithDisplayName() {
-        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("hello", "%PDF-1.4 hello".toByteArray()), "hello.pdf")
+    fun whenLayoutThenReportsPdfDocumentInfoWithDisplayName() = runTest {
+        val adapter = adapter(createTempPdf("hello", "%PDF-1.4 hello".toByteArray()), "hello.pdf")
         val callback = mock<PrintDocumentAdapter.LayoutResultCallback>()
 
         adapter.onLayout(null, PrintAttributes.Builder().build(), null, callback, null)
@@ -53,8 +60,8 @@ class CachedPdfPrintDocumentAdapterTest {
     }
 
     @Test
-    fun whenLayoutAndCancellationAlreadyTriggeredThenLayoutCancelled() {
-        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("doc", "%PDF-1.4".toByteArray()), "doc.pdf")
+    fun whenLayoutAndCancellationAlreadyTriggeredThenLayoutCancelled() = runTest {
+        val adapter = adapter(createTempPdf("doc", "%PDF-1.4".toByteArray()), "doc.pdf")
         val callback = mock<PrintDocumentAdapter.LayoutResultCallback>()
         val signal = CancellationSignal().apply { cancel() }
 
@@ -65,9 +72,9 @@ class CachedPdfPrintDocumentAdapterTest {
     }
 
     @Test
-    fun whenWriteThenPdfFileBytesCopiedToDestination() {
+    fun whenWriteThenPdfFileBytesCopiedToDestination() = runTest {
         val pdfBytes = "%PDF-1.4 lorem ipsum dolor sit amet".toByteArray()
-        val adapter = CachedPdfPrintDocumentAdapter(createTempPdf("doc", pdfBytes), "doc.pdf")
+        val adapter = adapter(createTempPdf("doc", pdfBytes), "doc.pdf")
         val outFile = File.createTempFile("printed", ".pdf").apply { deleteOnExit() }
         val pfd = ParcelFileDescriptor.open(
             outFile,
@@ -76,6 +83,7 @@ class CachedPdfPrintDocumentAdapterTest {
         val callback = mock<PrintDocumentAdapter.WriteResultCallback>()
 
         adapter.onWrite(arrayOf(PageRange.ALL_PAGES), pfd, null, callback)
+        advanceUntilIdle()
         pfd.close()
 
         verify(callback).onWriteFinished(arrayOf(PageRange.ALL_PAGES))
@@ -83,19 +91,26 @@ class CachedPdfPrintDocumentAdapterTest {
     }
 
     @Test
-    fun whenWriteAndSourceFileMissingThenFailureReported() {
+    fun whenWriteAndSourceFileMissingThenFailureReported() = runTest {
         val ghostFile = File.createTempFile("ghost", ".pdf").apply { delete() }
-        val adapter = CachedPdfPrintDocumentAdapter(ghostFile, "ghost.pdf")
+        val adapter = adapter(ghostFile, "ghost.pdf")
         val outFile = File.createTempFile("printed", ".pdf").apply { deleteOnExit() }
         val pfd = ParcelFileDescriptor.open(outFile, ParcelFileDescriptor.MODE_WRITE_ONLY)
         val callback = mock<PrintDocumentAdapter.WriteResultCallback>()
 
         adapter.onWrite(arrayOf(PageRange.ALL_PAGES), pfd, null, callback)
+        advanceUntilIdle()
         pfd.close()
 
         verify(callback).onWriteFailed(any())
         verify(callback, never()).onWriteFinished(any())
     }
+
+    private fun adapter(pdfFile: File, displayName: String) = CachedPdfPrintDocumentAdapter(
+        pdfFile,
+        displayName,
+        coroutineTestRule.testDispatcherProvider,
+    )
 
     private fun createTempPdf(prefix: String, bytes: ByteArray): File =
         File.createTempFile(prefix, ".pdf").apply {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214429769498528 

### Description

- Print the inline PDF, not the parent page.
- Hide Find in Page when an inline PDF is showing

### Steps to test this PR

_Print the inline PDF_

- [x] Open DuckDuckGo Internal Debug, navigate to `https://sample-files.com/documents/pdf/`.
- [x] Tap any "Download" link in the table — the PDF renders inline in the tab.
- [x] Open the browser menu and tap **Print**.
- [x] In the system print preview, verify the document is the PDF you opened.
- [x] Cancel the print dialog. Press back to dismiss the PDF.
- [x] Open the browser menu on the underlying page and tap Print — confirm the WebView page (regular HTML) is what's previewed.

_Find in Page is hidden on PDFs_

- [x] With the same setup, open an inline PDF.
- [x] Open the browser menu and verify **Find in Page** is **not** in the list.
- [x] Press back to dismiss the PDF. Open the browser menu on the underlying webpage — Find in Page is back in the list, behaving as before.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/416a831c-e1fc-462e-9f03-10afb190db49" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/cdf3d58c-0cdf-4d07-80be-96d42132fa6e" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/b4b5dc4f-2fe8-4c43-a892-34b8dad30686" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/b21ca863-a5b3-401c-9ed4-bb1a5513a0bf" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the print pipeline to stream cached PDF files directly into Android’s print framework, which could affect printing behavior and error handling. Also tweaks menu state logic to hide Find-in-Page during inline PDF viewing, with low UI risk but potential edge cases around PDF cache paths.
> 
> **Overview**
> Fixes inline PDF printing by detecting when a PDF is being viewed and printing the **cached PDF file** (via new `CachedPdfPrintDocumentAdapter`) instead of printing the underlying WebView page.
> 
> Updates the browser menu state so **Find in Page** is suppressed while an inline PDF is showing, and adds unit tests covering both the new adapter behavior and the menu visibility rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ccdee501699a4e6b7167e21783f1213890e7515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->