### PR TITLE
Use copy change in native input only

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -432,6 +432,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun EditText.applyChatInputType() {
+        hint = context.getString(R.string.native_input_chat_hint)
         imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
         setRawInputType(
             InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE or

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -20,6 +20,7 @@
     <string name="input_screen_user_pref_without_ai_updated">Search only</string>
     <string name="input_screen_user_pref_with_ai_updated">Toggle between\nSearch and Duck.ai</string>
     <string name="duckAiChatSearchDuckDuckGo">Search DuckDuckGo</string>
+    <string name="native_input_chat_hint">Ask anything privately…</string>
 
     <!-- Model Picker -->
     <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -58,7 +58,7 @@
 
     <!-- Input Screen  -->
     <string name="input_screen_search_hint">Search or enter address</string>
-    <string name="input_screen_chat_hint">Ask anything privately…</string>
+    <string name="input_screen_chat_hint">Ask privately</string>
     <string name="input_screen_user_pref_without_ai">Search Only</string>
     <string name="input_screen_user_pref_with_ai">Search &amp; Duck.ai</string>
     <string name="input_screen_user_pref_description">Try the new option to ask Duck.ai directly from the Address Bar. <annotation type="share_feedback">Share Feedback</annotation></string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214437532811665?focus=true

### Description

- Reverts https://github.com/duckduckgo/Android/pull/8404 and only updates the native input’s copy

### Steps to test this PR

_With native input enabled_
- [ ] Toggle to Duck.ai
- [ ] Verify that the hint copy is `Ask anything privately…`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts hint strings and which resource is used; main risk is unintended copy changes or missing translations in affected surfaces.
> 
> **Overview**
> Updates the Duck.ai chat input hint copy and scopes the longer “Ask anything privately…” hint to *native input mode only*.
> 
> `NativeInputModeWidget.applyChatInputType` now sets its own hint via a new `native_input_chat_hint` string, while the shared `input_screen_chat_hint` text is shortened to “Ask privately” for other chat entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6254b95ccf043a292ed6073388920a0dc668ff89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->