### PR TITLE
Update PIR broker bundle - 2026-05-04

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
@@ -1,7 +1,7 @@
 {
   "name": "BeenVerified",
   "url": "beenverified.com",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts",
   "mirrorSites": [
     {
@@ -259,6 +259,9 @@
             },
             "addressCityState": {
               "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "94f0c65d-cac1-4724-ba3a-4da7fd59ab2c"

--- a/pir/pir-impl/src/main/assets/brokers/freepeopledirectory.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/freepeopledirectory.com.json
@@ -1,7 +1,7 @@
 {
   "name": "FreePeopleDirectory",
   "url": "freepeopledirectory.com",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "parent": "spokeo.com",
   "addedDatetime": 1674540000000,
   "optOutUrl": "https://freepeopledirectory.com/contact",
@@ -54,6 +54,9 @@
                 },
                 "phone": {
                   "selector": "//p[a[span[normalize-space(text())='Phone']]]/following-sibling::div[contains(@class, 'content-elements')]//p"
+                },
+                "profileUrl": {
+                  "identifierType": "hash"
                 }
               }
             }

--- a/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
@@ -1,7 +1,7 @@
 {
   "name": "MugshotLook",
   "url": "mugshotlook.com",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.mugshotlook.com/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "3ecc7abc-8bfc-40db-80b0-e7087b99bcef"

--- a/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
@@ -1,7 +1,7 @@
 {
   "name": "NeighborWho",
   "url": "neighborwho.com",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.neighborwho.com/svc/optout/search/optouts",
   "mirrorSites": [
@@ -204,6 +204,9 @@
             },
             "addressCityState": {
               "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "7775ef9d-aebf-4176-80e6-2959fc9f5c8a"

--- a/pir/pir-impl/src/main/assets/brokers/officialusa.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/officialusa.com.json
@@ -1,7 +1,7 @@
 {
   "name": "OfficialUSA",
   "url": "officialusa.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "neighbor.report",
   "addedDatetime": 1692594000000,
   "optOutUrl": "https://www.officialusa.com/opt-out/",
@@ -46,7 +46,9 @@
               "selector": ".//span[@itemprop='telephone']"
             },
             "relativesList": null,
-            "profileUrl": null
+            "profileUrl": {
+              "identifierType": "hash"
+            }
           }
         }
       ]

--- a/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleLooker",
   "url": "peoplelooker.com",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.peoplelooker.com/svc/optout/search/optouts",
   "steps": [
@@ -195,6 +195,9 @@
             },
             "addressCityState": {
               "selector": ".MuiGrid-item.MuiGrid-grid-xs-12 > p.MuiTypography-body1"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "4285ef9d-aebf-4176-80e6-2959fc9f5c8a"

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearcher",
   "url": "peoplesearcher.com",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearcher.com/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "b235a497-3ceb-4dee-9704-dcda0349bd3a"

--- a/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateReports",
   "url": "privatereports.com",
-  "version": "0.996.0",
+  "version": "0.996.1",
   "optOutUrl": "https://www.privatereports.com/api/helper/optOutLight/search",
   "steps": [
     {
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "9d919f33-30f6-4433-9eb4-6e3139a13a08"

--- a/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PublicSearcher",
   "url": "publicsearcher.com",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.publicsearcher.com/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "a75cc46f-81dd-4257-b241-964632818184"

--- a/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
@@ -1,7 +1,7 @@
 {
   "name": "SecretInfo",
   "url": "secretinfo.org",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.secretinfo.org/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "2edfae8c-bbf5-469f-a052-68f75f0659b3"

--- a/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/spyfly.com.json
@@ -1,7 +1,7 @@
 {
   "name": "SpyFly",
   "url": "spyfly.com",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "addedDatetime": 1775214750818,
   "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
   "steps": [
@@ -121,6 +121,9 @@
           "profile": {
             "name": {
               "selector": "h2"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "bab84c87-785a-427d-b38b-add9dba0aa3d"

--- a/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
@@ -1,7 +1,7 @@
 {
   "name": "TruthRecord",
   "url": "truthrecord.org",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.truthrecord.org/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "cd0f0aa3-fba2-4330-b4ab-6d7700aad9cb"

--- a/pir/pir-impl/src/main/assets/brokers/weinform.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/weinform.org.json
@@ -1,7 +1,7 @@
 {
   "name": "WeInform",
   "url": "weinform.org",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.weinform.org/api/helper/optOutLight/search",
   "steps": [
@@ -149,6 +149,9 @@
             "addressCityStateList": {
               "selector": ".//span[contains(text(), 'Locations')]/following-sibling::span[1]",
               "separator": "/(?<=, [A-Z]{2}), /"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
             }
           },
           "id": "fd69267b-59ce-4b1a-ba94-e1fd3dd99474"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1214470526733946/f 

 ----- 
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (13):**
- beenverified.com.json (0.10.0 → 0.10.1)
- freepeopledirectory.com.json (0.7.0 → 0.7.1)
- mugshotlook.com.json (0.6.0 → 0.6.1)
- neighborwho.com.json (0.6.0 → 0.6.1)
- officialusa.com.json (0.6.0 → 0.7.0)
- peoplelooker.com.json (0.6.0 → 0.6.1)
- peoplesearcher.com.json (0.7.0 → 0.7.1)
- privatereports.com.json (0.996.0 → 0.996.1)
- publicsearcher.com.json (0.6.0 → 0.6.1)
- secretinfo.org.json (0.5.0 → 0.5.1)
- spyfly.com.json (0.5.0 → 0.5.1)
- truthrecord.org.json (0.5.0 → 0.5.1)
- weinform.org.json (0.1.0 → 0.1.1)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Configuration-only changes, but they affect PIR scan/extract behavior across multiple brokers; mistakes could reduce match accuracy or break opt-out flows until corrected.
> 
> **Overview**
> Updates 13 PIR broker JSON definitions with version bumps and **adds `profile.profileUrl` generation using `identifierType: "hash"`** for several extract profiles (including switching `officialusa.com` from `profileUrl: null` to hashed). This enables consistent profile URL identifiers in scan results without relying on site-specific URL selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9e6eee7a951e29707d85f7a6f33b8589815a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->