### PR TITLE
abort Sync Setup wide event flow when restore selected

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncPreviousSessionReadyViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncPreviousSessionReadyViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.ContinueSetup
 import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.StartRestore
+import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -34,6 +35,7 @@ import javax.inject.Inject
 @ContributesViewModel(FragmentScope::class)
 class SyncPreviousSessionReadyViewModel @Inject constructor(
     private val syncPixels: SyncPixels,
+    private val syncSetupWideEvent: SyncSetupWideEvent,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -56,6 +58,7 @@ class SyncPreviousSessionReadyViewModel @Inject constructor(
     fun onResumeClicked() {
         syncPixels.fireAutoRestoreSettingsRestoreTapped(source)
         viewModelScope.launch {
+            syncSetupWideEvent.onSyncRestoreStarted()
             command.send(StartRestore)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEvent.kt
@@ -46,6 +46,7 @@ interface SyncSetupWideEvent {
     suspend fun onRecoveryCodeShown()
     suspend fun onRecoveryCodeGenerationFailed()
     suspend fun onFlowCancelled()
+    suspend fun onSyncRestoreStarted()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -227,6 +228,14 @@ class SyncSetupWideEventImpl @Inject constructor(
             wideEventId = id,
             status = FlowStatus.Cancelled,
         )
+        cachedFlowId = null
+    }
+
+    override suspend fun onSyncRestoreStarted() {
+        if (!isFeatureEnabled()) return
+        val id = getCurrentWideEventId() ?: return
+
+        wideEventClient.flowAbort(wideEventId = id)
         cachedFlowId = null
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SyncPreviousSessionReadyViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/setup/SyncPreviousSessionReadyViewModelTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.setup
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.ContinueSetup
+import com.duckduckgo.sync.impl.ui.setup.SyncPreviousSessionReadyViewModel.Command.StartRestore
+import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class SyncPreviousSessionReadyViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val syncPixels: SyncPixels = mock()
+    private val syncSetupWideEvent: SyncSetupWideEvent = mock()
+
+    private val testee = SyncPreviousSessionReadyViewModel(
+        syncPixels = syncPixels,
+        syncSetupWideEvent = syncSetupWideEvent,
+    )
+
+    @Test
+    fun `onScreenShown fires ready shown pixel`() = runTest {
+        testee.onScreenShown(SOURCE)
+
+        verify(syncPixels).fireAutoRestoreSettingsReadyShown(SOURCE)
+        verifyNoInteractions(syncSetupWideEvent)
+    }
+
+    @Test
+    fun `onResumeClicked fires restore tapped pixel and notifies sync setup wide event orchestrator`() = runTest {
+        testee.onScreenShown(SOURCE)
+
+        testee.onResumeClicked()
+
+        verify(syncPixels).fireAutoRestoreSettingsRestoreTapped(SOURCE)
+        verify(syncSetupWideEvent).onSyncRestoreStarted()
+    }
+
+    @Test
+    fun `onResumeClicked sends StartRestore command`() = runTest {
+        testee.onResumeClicked()
+
+        testee.commands().test {
+            assertTrue(awaitItem() is StartRestore)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onContinueSetupClicked fires skip restore pixel and sends ContinueSetup command`() = runTest {
+        testee.onScreenShown(SOURCE)
+
+        testee.onContinueSetupClicked()
+
+        verify(syncPixels).fireAutoRestoreSettingsSkipRestoreTapped(SOURCE)
+        verifyNoInteractions(syncSetupWideEvent)
+        testee.commands().test {
+            assertTrue(awaitItem() is ContinueSetup)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onCloseClicked fires cancelled pixel and sends Close command`() = runTest {
+        testee.onScreenShown(SOURCE)
+
+        testee.onCloseClicked()
+
+        verify(syncPixels).fireAutoRestoreSettingsCancelled(SOURCE)
+        verifyNoInteractions(syncSetupWideEvent)
+        testee.commands().test {
+            assertTrue(awaitItem() is Close)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private companion object {
+        const val SOURCE = "settings"
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/wideevents/SyncSetupWideEventImplTest.kt
@@ -315,6 +315,16 @@ class SyncSetupWideEventImplTest {
     }
 
     @Test
+    fun `onSyncRestoreStarted aborts the flow`() = runTest {
+        whenever(wideEventClient.getFlowIds(any()))
+            .thenReturn(Result.success(listOf(1L)))
+
+        wideEvent.onSyncRestoreStarted()
+
+        verify(wideEventClient).flowAbort(wideEventId = 1L)
+    }
+
+    @Test
     fun `operations without flowId are no-ops`() = runTest {
         whenever(wideEventClient.getFlowIds(any()))
             .thenReturn(Result.success(emptyList()))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1214489384580025?focus=true

### Description
Abort Sync Setup wide event flow if the user selects to restore the configuration.

### Steps to test this PR

#### Scenario 1: Setting up sync for the first time
- [ ] Filter logcat by "wide_sync-setup_c"
- [ ] Clear app data / clean install
- [ ] Open Settings -> Sync & Backup
- [ ] Choose to `Sync and Back Up This Device`, go through the flow and ensure you keep `Restore on App Reinstall` checked
- [ ] Verify wide event request in logs:
  - [ ] Pixel enqueued: wide_sync-setup_c
  - [ ] feature.status=SUCCESS
- [ ] Uninstall the app (do not clear app data; has to be uninstall)

#### Scenario 2: Setting up sync from scratch, even though restore is available

- [ ] Reinstall the app
- [ ] In onboarding, **do not** choose to restore. Instead choose `Skip Onboarding` at the top
- [ ] Open Settings -> Sync & Backup
- [ ] Choose to `Sync and Back Up This Device`
- [ ] Select `Set Up New Sync`
- [ ] Continue with the flow and ensure you keep `Restore on App Reinstall` checked
- [ ] Verify wide event request in logs:
  - [ ] Pixel enqueued: wide_sync-setup_c
  - [ ] feature.status=SUCCESS
- [ ] Uninstall the app (do not clear app data; has to be uninstall)

#### Scenario 3: Cancelling setup

- [ ] Reinstall the app
- [ ] In onboarding, **do not** choose to restore. Instead choose `Skip Onboarding` at the top
- [ ] Open Settings -> Sync & Backup
- [ ] Choose to `Sync and Back Up This Device`
- [ ] Click `close (X)` button or use device's back button/gesture
- [ ] Verify wide event request in logs:
  - [ ] Pixel enqueued: wide_sync-setup_c
  - [ ] feature.status=CANCELLED

#### Scenario 4: Restoring sync

- [ ] Choose to `Sync and Back Up This Device` again
- [ ] Select `Restore Sync & Backup`
- [ ] Continue with the flow
- [ ] Once done, force-close and re-open the app
- [ ] Verify no wide event request in logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only wide-event telemetry flow lifecycle when users choose restore, plus adds unit coverage; no sync data or auth logic is modified.
> 
> **Overview**
> Ensures the `sync-setup` wide event flow is **aborted** when the user opts to restore an existing sync configuration.
> 
> Adds `SyncSetupWideEvent.onSyncRestoreStarted()` (implemented via `WideEventClient.flowAbort` and clearing the cached flow id) and calls it from `SyncPreviousSessionReadyViewModel.onResumeClicked()` before emitting the `StartRestore` command. New unit tests cover the view model interaction and the wide event abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a829d985e713ed664e4ae1a82edd7fe5684c2318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->