### PR TITLE
Prevent flaky maestro test from being a release blocker: Custom Tabs navigation

### DIFF
--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -1,7 +1,5 @@
 appId: com.duckduckgo.mobile.android
 name: "Custom Tabs navigation"
-tags:
-  - customTabsTest
 ---
 - retry:
     maxRetries: 3


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214452443152209/task/1214486884346745?focus=true 

### Description
This maestro test has been flaky over the last week and is currently a release-blocker when it fails which we don't tolerate any flakiness in. Removing its tag so it isn't treated as a release-blocker (and a follow-up to investigate / reinstate will follow)

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7671547b17fa895862a7c81eb8e7fcd322cedce4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->