### PR TITLE
Widget duck.ai keyboard action should be submit

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -433,9 +433,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun EditText.applyChatInputType() {
         hint = context.getString(R.string.native_input_chat_hint)
-        imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+        imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO
         setRawInputType(
-            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+            InputType.TYPE_CLASS_TEXT or
                 InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
         )
         setHorizontallyScrolling(false)


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214459740299085?focus=true

### Steps to test this PR
- open duck.ai widget
- keyboard action is submit not carriage return.

### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/18bd1fba-dd32-4c4a-9c77-59e6352fcf35" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/input configuration change limited to IME options and input type flags for the duck.ai widget; main risk is minor behavior differences across OEM keyboards.
> 
> **Overview**
> Updates the duck.ai widget chat text field to show a *submit* keyboard action by adding `EditorInfo.IME_ACTION_GO` to its IME options.
> 
> Adjusts the chat input `rawInputType` to no longer force multiline input, aligning the keyboard behavior with the intended “send/submit” action instead of inserting a carriage return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bfd683d818ef4edc887f5428135c932cdd624a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->