### PR TITLE
PIR: Add profile queries and broker count to scheduled scans

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1526,6 +1526,16 @@
                 "key": "cpuUsage",
                 "description": "Average CPU usage percent",
                 "type": "string"
+            },
+            {
+                "key": "profile_queries",
+                "description": "The number of profile queries used in the scan",
+                "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },
@@ -1615,6 +1625,16 @@
                 "key": "tries",
                 "description": "Number of tries it took to complete the stage",
                 "type": "string"
+            },
+            {
+                "key": "profile_queries",
+                "description": "The number of profile queries used in the scan",
+                "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1475,6 +1475,16 @@
                     "asus",
                     "other"
                 ]
+            },
+            {
+                "key": "profile_queries",
+                "description": "The number of profile queries used in the scan",
+                "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },
@@ -1512,6 +1522,16 @@
                     "asus",
                     "other"
                 ]
+            },
+            {
+                "key": "profile_queries",
+                "description": "The number of profile queries used in the scan",
+                "type": "integer"
+            },
+            {
+                "key": "broker_count",
+                "description": "The number of active brokers at the start of the scan",
+                "type": "integer"
             }
         ]
     },
@@ -1526,16 +1546,6 @@
                 "key": "cpuUsage",
                 "description": "Average CPU usage percent",
                 "type": "string"
-            },
-            {
-                "key": "profile_queries",
-                "description": "The number of profile queries used in the scan",
-                "type": "integer"
-            },
-            {
-                "key": "broker_count",
-                "description": "The number of active brokers at the start of the scan",
-                "type": "integer"
             }
         ]
     },
@@ -1625,16 +1635,6 @@
                 "key": "tries",
                 "description": "Number of tries it took to complete the stage",
                 "type": "string"
-            },
-            {
-                "key": "profile_queries",
-                "description": "The number of profile queries used in the scan",
-                "type": "integer"
-            },
-            {
-                "key": "broker_count",
-                "description": "The number of active brokers at the start of the scan",
-                "type": "integer"
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -150,14 +150,26 @@ interface PirPixelSender {
 
     /**
      * Emits a pixel to signal that s scheduled scan run has started.
+     *
+     * @param profileQueryCount - the number of profile queries used in the scan
+     * @param brokerCount - the number of active brokers at the start of the scan
      */
-    fun reportScheduledScanStarted()
+    fun reportScheduledScanStarted(
+        profileQueryCount: Int,
+        brokerCount: Int,
+    )
 
     /**
      * Emits a pixel to signal that a scheduled scan run has been completed.
+     *
+     * @param totalTimeInMillis - how long it took for the scan to complete
+     * @param profileQueryCount - the number of profile queries used in the scan
+     * @param brokerCount - the number of active brokers at the start of the scan
      */
     fun reportScheduledScanCompleted(
         totalTimeInMillis: Long,
+        profileQueryCount: Int,
+        brokerCount: Int,
     )
 
     /**
@@ -683,15 +695,26 @@ class RealPirPixelSender @Inject constructor(
         fire(PIR_SCHEDULED_RUN_SCHEDULED)
     }
 
-    override fun reportScheduledScanStarted() {
-        fire(PIR_SCHEDULED_RUN_STARTED)
+    override fun reportScheduledScanStarted(
+        profileQueryCount: Int,
+        brokerCount: Int,
+    ) {
+        val params = mapOf(
+            PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
+            PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
+        )
+        fire(PIR_SCHEDULED_RUN_STARTED, params)
     }
 
     override fun reportScheduledScanCompleted(
         totalTimeInMillis: Long,
+        profileQueryCount: Int,
+        brokerCount: Int,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
+            PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
+            PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
         )
         fire(PIR_SCHEDULED_RUN_COMPLETED, params)
     }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -217,7 +217,7 @@ class RealPirJobsRunner @Inject constructor(
             val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
             pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount, executionType)
         } else {
-            pixelSender.reportScheduledScanStarted()
+            pixelSender.reportScheduledScanStarted(profileQueryCount, brokerCount)
         }
     }
 
@@ -244,7 +244,7 @@ class RealPirJobsRunner @Inject constructor(
                 executionType = executionType,
             )
         } else {
-            pixelSender.reportScheduledScanCompleted(totalTimeMillis)
+            pixelSender.reportScheduledScanCompleted(totalTimeMillis, profileQueryCount, brokerCount)
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -200,7 +200,10 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportScheduledScanStartedThenFiresCorrectPixel() = runTest {
-        testee.reportScheduledScanStarted()
+        testee.reportScheduledScanStarted(
+            profileQueryCount = 3,
+            brokerCount = 10,
+        )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender).fire(
@@ -210,14 +213,21 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue.isEmpty())
+        assert(paramsCaptor.firstValue.containsKey("profile_queries"))
+        assert(paramsCaptor.firstValue["profile_queries"] == "3")
+        assert(paramsCaptor.firstValue.containsKey("broker_count"))
+        assert(paramsCaptor.firstValue["broker_count"] == "10")
     }
 
     @Test
     fun whenReportScheduledScanCompletedThenFiresPixelWithTotalTime() = runTest {
         val totalTimeInMillis = 54321L
 
-        testee.reportScheduledScanCompleted(totalTimeInMillis)
+        testee.reportScheduledScanCompleted(
+            totalTimeInMillis = totalTimeInMillis,
+            profileQueryCount = 3,
+            brokerCount = 10,
+        )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixelSender).fire(
@@ -229,6 +239,10 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue.containsKey("totalTimeInMillis"))
         assert(paramsCaptor.firstValue["totalTimeInMillis"] == "54321")
+        assert(paramsCaptor.firstValue.containsKey("profile_queries"))
+        assert(paramsCaptor.firstValue["profile_queries"] == "3")
+        assert(paramsCaptor.firstValue.containsKey("broker_count"))
+        assert(paramsCaptor.firstValue["broker_count"] == "10")
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -398,8 +398,8 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, SCHEDULED)
 
         // Then
-        verify(mockPixelSender).reportScheduledScanStarted()
-        verify(mockPixelSender).reportScheduledScanCompleted(any())
+        verify(mockPixelSender).reportScheduledScanStarted(any(), any())
+        verify(mockPixelSender).reportScheduledScanCompleted(any(), any(), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214486367595488?focus=true

### Description
Adds two new properties to the scheduled scan pixels.

### Steps to test this PR
QA optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change, but it updates the `PirPixelSender` API for scheduled scans and could break any out-of-module callers if missed.
> 
> **Overview**
> Adds `profile_queries` and `broker_count` parameters to the scheduled scan *started* and *completed* pixels (`m_dbp_scheduled-run_started`, `m_dbp_scheduled-run_completed`).
> 
> Updates `PirPixelSender`/`RealPirPixelSender` so `reportScheduledScanStarted` and `reportScheduledScanCompleted` accept and send these values, and wires the counts through `PirJobsRunner` for scheduled executions. Tests are updated to assert the new pixel parameters and the new method signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a441ab983d982ed8b4a6711a0f998be7feee43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->