### PR TITLE
Duck.AI/Voice chat/Unified input: Fix voice chat icon behavior when on an active chat 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -460,10 +460,18 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun updateVoiceButtons(widget: NativeInputWidget) {
-        val isDuckAiTabSelected = widget.isChatTabSelected()
+        val isOnActiveDuckChat = omnibarController.isDuckAiMode()
         val voiceSearchAvailable = voiceSearchAvailability.isVoiceSearchAvailable
         val voiceSearchDuckAiAvailable = duckAiFeatureState.showVoiceSearchToggle.value
         val voiceChatEntryAvailable = duckAiFeatureState.showVoiceChatEntry.value
+
+        if (isOnActiveDuckChat) {
+            widget.setVoiceSearchAvailable(voiceSearchAvailable && voiceSearchDuckAiAvailable)
+            widget.setVoiceChatAvailable(false)
+            return
+        }
+
+        val isDuckAiTabSelected = widget.isChatTabSelected()
         val shouldShowVoiceSearchForDuckAi = !voiceChatEntryAvailable && voiceSearchDuckAiAvailable
         widget.setVoiceSearchAvailable(voiceSearchAvailable && (!isDuckAiTabSelected || shouldShowVoiceSearchForDuckAi))
         widget.setVoiceChatAvailable(isDuckAiTabSelected && voiceChatEntryAvailable)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214338809591995?focus=true 

### Description
This change makes the Duck.ai chat omnibar's voice icons depend on whether the user is on an **active Duck.ai chat** (omnibar `viewMode == DuckAI`): in that state we always force the **voice chat** icon hidden and only show the **voice search** icon when device voice search and the **Voice Search** Duck.ai shortcut are both available; outside of active chat the existing tab-based logic is preserved. 

### Steps to test this PR
 - [x] Install an internal build with feature flag overrides accessible                                                                                                                                             
  - [x] Device must support speech recognition (real device or emulator with Google voice)                
  - [x] Enable Private Voice Search (via Settings)                                                                                                           
  - [x] Settings → Duck.ai → **Duck.ai Shortcuts** is the source of the **Voice Search** and **Voice Chat** user toggles                                                                                             
  - [x] "Active Duck.ai chat" = inside an ongoing Duck.ai conversation (the chat screen with the input field at the bottom), as opposed to the Duck.ai input/landing screen                                          
                                                                                                                                                                                                                     
  ### 1. Active Duck.ai chat — `duckAiVoiceSearch` enabled, `duckAiVoiceEntryPoint` enabled, **Voice Search** = ON, **Voice Chat** = ON                                                                              
  - [x] Open Duck.ai and start a conversation so the active chat screen is shown                                                                                                                                     
  - [x] Voice **search** icon **IS** visible in the chat input                                                                                                                                                       
  - [x] Voice **chat** icon is **NOT** visible in the chat input                                                                                                                                                     
  - [x] Tapping the voice search icon opens **Private voice search** with **Duck.ai mode** selected                                                                                                                  
  - [x] After speaking, the captured query is **submitted to Duck.ai** (not as a search) and a chat response begins                                                                                                  
                                                                                                                                                                                                                     
  ### 2. Active Duck.ai chat — `duckAiVoiceSearch` disabled, `duckAiVoiceEntryPoint` enabled, **Voice Chat** = ON                                                                                                    
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                     
  - [x] Voice **chat** icon is **NOT** visible (forced hidden in active chat regardless of voice-chat flag/toggle)                                                                                                   
                                                                                                                                                                                                                     
  ### 3. Active Duck.ai chat — `duckAiVoiceSearch` enabled, **Voice Search** = OFF                                                                                                                                   
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                     
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
                                                                                                                                                                                                                   
  ### 4. Active Duck.ai chat — both `duckAiVoiceSearch` and `duckAiVoiceEntryPoint` disabled                                                                                                                         
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                   
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
                                                                                                                                                                                                                     
  ### 5. Active Duck.ai chat — device voice search unavailable (e.g. emulator with no speech recognizer), all flags + toggles ON                                                                                     
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                     
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
                                                                                                                                                                                                                     
  ### 6. NOT in active chat — Duck.ai input/landing screen with chat tab selected, `duckAiVoiceEntryPoint` enabled, **Voice Chat** = ON                                                                              
  - [x] Voice **chat** icon **IS** visible                                                                                                                                                                           
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                     
  - [x] Tapping the voice chat icon launches **voice chat**                                                                                                                                                        
                                                                                                                                                                                                                     
  ### 7. NOT in active chat — Duck.ai input/landing screen with chat tab selected, `duckAiVoiceEntryPoint` disabled, `duckAiVoiceSearch` enabled, **Voice Search** = ON                                              
  - [x] Voice **search** icon **IS** visible                                                                                                                                                                         
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
  - [x] Tapping the voice search icon opens **Private voice search** with **Duck.ai mode** selected                                                                                                                  
   
  ### 8. NOT in active chat — Duck.ai input/landing screen with chat tab selected, **Voice Chat** = OFF and **Voice Search** Duck.ai = OFF                                                                           
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                   
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
                                                                                                                                                                                                                     
  ### 9. NOT in active chat — search tab selected on input/landing screen, `duckAiVoiceSearch` ON
  - [x] Voice **search** icon **IS** visible                                                                                                                                                                         
  - [x] Voice **chat** icon is **NOT** visible                                                                                                                                                                       
  - [x] Tapping the voice search icon opens **Private voice search** with **Search mode** selected (submits as a regular DuckDuckGo search)
                                                                                                                                                                                                                     
  ### 10. NOT in active chat — device voice search unavailable, search tab selected                                                                                                                                
  - [x] Voice **search** icon is **NOT** visible                                                                                                                                                                     
  - [x] Voice **chat** icon is **NOT** visible    


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state change limited to voice button visibility logic; main risk is incorrect mode detection (`isDuckAiMode`) causing voice icons to show/hide unexpectedly in some Duck.ai screens.
> 
> **Overview**
> Updates `NativeInputManager.updateVoiceButtons` so that when the omnibar is in **active Duck.ai mode** (`omnibarController.isDuckAiMode()`), the **voice chat** button is always hidden and **voice search** is shown only if both device voice search and the Duck.ai voice-search toggle are enabled.
> 
> Outside active chat, the existing **tab-based** behavior is preserved (voice chat only on the chat tab when the entry point is enabled, and voice search shown per prior fallback rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca431026c9aa5e8b87d22557dcaa04be3aadc4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->