### PR TITLE
Duck.ai race condition onAttach

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidget.kt
@@ -29,6 +29,7 @@ import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Space
+import androidx.core.view.doOnAttach
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doOnTextChanged
@@ -517,21 +518,27 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {
-        viewModel.configure(isDuckAiMode, isBottom)
-        viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
-        if (isDuckAiMode) selectChatTab()
-        applyOmnibarShape(isBottom)
+        doOnAttach {
+            viewModel.configure(isDuckAiMode, isBottom)
+            viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
+            if (isDuckAiMode) selectChatTab()
+            applyOmnibarShape(isBottom)
+        }
     }
 
     override fun configureContextual() {
-        viewModel.configureContextual()
-        selectChatTab()
+        doOnAttach {
+            viewModel.configureContextual()
+            selectChatTab()
+        }
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState.isBottom
 
     override fun setWidgetPosition(isBottom: Boolean) {
-        viewModel.setWidgetPosition(isBottom)
+        doOnAttach {
+            viewModel.setWidgetPosition(isBottom)
+        }
     }
 
     private fun applyOmnibarShape(isBottom: Boolean) {


### PR DESCRIPTION
 Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214458717529652                                                    
                                                 
  ### Description                                                                                                                                        
   
  Fixes a `UninitializedPropertyAccessException` crash on `NativeInputModeWidget.viewModelFactory`.                                                      
                                                                    
  **Root cause:** `viewModelFactory` is injected in `InputModeWidget.onAttachedToWindow()` via `AndroidSupportInjection.inject(this)`.                   
  `RealNativeInputManager.attachWidget()` calls `widget.configure()` immediately after `addView()`, which assumes `onAttachedToWindow` has already fired
  synchronously. When the rootView is not yet attached to a window at that moment (repro path: NTP-after-idle resumes on NTP, then a tab-switcher close  
  triggers `evaluateDuckAIPage` → `showDuckAI` → `attachWidget` before the new fragment view tree is attached), the lateinit is still uninitialized and
  `configure()` crashes.

  **Fix:** wrapped the bodies of `configure()`, `configureContextual()`, and `setWidgetPosition()` in `NativeInputModeWidget` in `doOnAttach { ... }`.   
  When the view is already attached, the lambda runs immediately — same behaviour as before. When it is not, the work is deferred until
  `onAttachedToWindow` runs and DI has completed, eliminating the race.                                                                                  
                                                                    
  ### Steps to test this PR

  _Crash repro_                                                                                                                                          
  - [x] Enable NTP-after-idle (set to NTP and Always)
  - [x] Create several chats in different tabs                                                                                                           
  - [x] Close the app and reopen — app opens on NTP                 
  - [x] Open the tab switcher and close the NTP tab                                                                                                      
  - [ ] Expected: the last tab (chat) is shown, no crash
  - [ ] Without the fix: app crashes with `lateinit property viewModelFactory has not been initialized`                                                  
                                                                                                                                                         
  _Regression check_
  - [x] Open Duck.ai from a normal browser tab — input widget appears and works                                                                          
  - [x] Switch between Search and Chat tabs — toggle behaves normally
  - [ ] Submit a search and a chat prompt — both work                                                                                                    
  - [ ] Rotate the device while the input widget is visible — no crash, widget rebinds correctly
                                                                                                                                                         
  ### UI changes                                                    
  No UI changes.     

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small lifecycle-timing change that defers `configure`/`setWidgetPosition` work until the view is attached, primarily affecting when ViewModel/DI-dependent code runs.
> 
> **Overview**
> Prevents a race where `NativeInputModeWidget` could run configuration logic before `onAttachedToWindow`/DI completed (crashing on uninitialized `viewModelFactory`).
> 
> Wraps `configure()`, `configureContextual()`, and `setWidgetPosition()` bodies in `doOnAttach { ... }` so the same work runs immediately when already attached or is deferred until attachment when not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c950ac430ce8e5116ed684b29e97c30f84070e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->