### PR TITLE
Align fire-mode-impl with the newe anvil-ksp approach

### DIFF
--- a/fire-mode/fire-mode-impl/build.gradle
+++ b/fire-mode/fire-mode-impl/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
@@ -30,7 +31,7 @@ android {
 }
 
 dependencies {
-    anvil project(path: ':anvil-compiler')
+    ksp project(':anvil-ksp')
     implementation project(path: ':anvil-annotations')
 
     implementation project(path: ':di')


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214447478271298/task/1214489515741573?focus=true

### Description
Aligns fire-mode-impl with the Metro/Anvil PR (#8411) migration from anvil-compiler (KAPT-era) to anvil-ksp (KSP). 

### Steps to test this PR
- QA optional (all checks will pass to confirm this works)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-only change that switches annotation processing for `fire-mode-impl` from the Anvil compiler dependency to KSP; primary risk is build/config regressions rather than runtime behavior changes.
> 
> **Overview**
> Updates `fire-mode-impl`’s Gradle setup to use KSP for Anvil code generation by applying the `com.google.devtools.ksp` plugin and replacing the `anvil` compiler dependency with `ksp project(':anvil-ksp')`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6f2d7404fc7abcd83d9336d6fdb75231c364a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->