### PR TITLE
Capture aab as artefact before uploading to play store

### DIFF
--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -93,6 +93,13 @@ jobs:
           output=$(find app/build/outputs/bundle/playRelease -name "*.aab")
           echo "bundle_path=$output" >> "$GITHUB_OUTPUT"
 
+      - name: Upload AAB as artifact
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: release-aab
+          path: ${{ steps.capture_output.outputs.bundle_path }}
+
       - name: Upload bundle to Play Store
         id: upload_bundle_play
         run: |


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214490351312992?focus=true

### Description
Add a step to the app build workflow to capture the `aab` as an artefact in case it's ever needed to manually re-submit to the Play Store using it.

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-code change but it modifies the production release GitHub Actions workflow; misconfiguration could break or delay the Play Store upload job or retain unexpected artifacts.
> 
> **Overview**
> **Production release workflow now saves the generated Play Store `.aab` bundle as a GitHub Actions artifact** (`release-aab`) after building and before running the Fastlane Play Store upload, using the captured bundle path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1d644e37475e84d311f6d0dec5d2d9ada0af03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->