### PR TITLE
Default new users to NTP at app open

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -70,6 +70,10 @@ class FirstScreenHandlerImpl @Inject constructor(
         }
         appCoroutineScope.launch {
             logcat { "FirstScreen: onOpen isFreshLaunch $isFreshLaunch" }
+            // Persist the new-user default eagerly so screens that read optionFlow
+            // (e.g. GeneralSettings) don't fall back to LastOpenedTab before the
+            // after-inactivity flow has had a chance to run.
+            showOnAppLaunchOptionHandler.ensureNewUserDefault()
             handleFirstScreen(isFreshLaunch)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -38,6 +38,7 @@ import logcat.logcat
 import javax.inject.Inject
 
 interface ShowOnAppLaunchOptionHandler {
+    suspend fun ensureNewUserDefault()
     suspend fun handleAfterInactivityOption(wasIdle: Boolean)
     suspend fun handleAppLaunchOption()
     suspend fun handleResolvedUrlStorage(
@@ -58,14 +59,15 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private val systemAutofillEngagement: SystemAutofillEngagement,
 ) : ShowOnAppLaunchOptionHandler {
 
-    override suspend fun handleAfterInactivityOption(wasIdle: Boolean) {
-        // new users see New Tab
-        logcat { "FirstScreen: Inactivity Timer passed" }
+    override suspend fun ensureNewUserDefault() {
         if (appBuildConfig.isNewInstall() && !showOnAppLaunchOptionDataStore.hasOptionSelected()) {
             logcat { "FirstScreen: setting New Tab for new users" }
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(NewTabPage)
         }
-        // existing users see whatever they had selected
+    }
+
+    override suspend fun handleAfterInactivityOption(wasIdle: Boolean) {
+        logcat { "FirstScreen: Inactivity Timer passed" }
         applyShowOnAppLaunchOption(fromInactivity = wasIdle)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -37,7 +37,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -87,6 +87,42 @@ class FirstScreenHandlerImplTest {
         )
     }
 
+    // --- ensureNewUserDefault is invoked on every onOpen ---
+
+    @Test
+    fun whenOnOpenWithIdleReturnEnabledThenInvokesEnsureNewUserDefault() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+    }
+
+    @Test
+    fun whenOnOpenWithIdleReturnDisabledAndShowOnAppLaunchEnabledThenInvokesEnsureNewUserDefault() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
+        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+    }
+
+    @Test
+    fun whenOnOpenWithBothFeaturesDisabledThenStillInvokesEnsureNewUserDefault() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
+        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(false)
+
+        testee.onOpen(isFreshLaunch = false)
+        testScope.testScheduler.advanceUntilIdle()
+
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+    }
+
     // --- Idle return enabled (covers both fresh and non-fresh launches) ---
 
     @Test
@@ -125,7 +161,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -138,7 +175,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -189,7 +227,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -252,7 +291,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -262,7 +302,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
         verify(showOnAppLaunchToggle, never()).isEnabled()
     }
 
@@ -282,7 +323,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -330,7 +372,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -475,7 +518,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     // --- RC default used directly ---
@@ -511,7 +555,8 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verifyNoInteractions(showOnAppLaunchOptionHandler)
+        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
@@ -805,7 +805,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         testee.ensureNewUserDefault()
 
         assertTrue(fakeDataStore.hasOptionSelected())
-        assertEquals(NewTabPage, fakeDataStore.optionFlow.first())
+        assertEquals(NewTabPage, fakeDataStore.optionFlow.firstOrNull())
     }
 
     @Test
@@ -815,7 +815,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
         testee.ensureNewUserDefault()
 
-        assertEquals(LastOpenedTab, fakeDataStore.optionFlow.first())
+        assertEquals(LastOpenedTab, fakeDataStore.optionFlow.firstOrNull())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
@@ -795,19 +796,52 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         }
     }
 
+    // ensureNewUserDefault tests
+
+    @Test
+    fun whenEnsureDefaultAndNewInstallAndNoOptionThenPersistsNewTabPage() = runTest {
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+
+        testee.ensureNewUserDefault()
+
+        assertTrue(fakeDataStore.hasOptionSelected())
+        assertEquals(NewTabPage, fakeDataStore.optionFlow.first())
+    }
+
+    @Test
+    fun whenEnsureDefaultAndNewInstallAndOptionAlreadySelectedThenDoesNotOverwrite() = runTest {
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+        fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+
+        testee.ensureNewUserDefault()
+
+        assertEquals(LastOpenedTab, fakeDataStore.optionFlow.first())
+    }
+
+    @Test
+    fun whenEnsureDefaultAndExistingInstallAndNoOptionThenDoesNothing() = runTest {
+        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+
+        testee.ensureNewUserDefault()
+
+        assertTrue(!fakeDataStore.hasOptionSelected())
+    }
+
     // handleAfterInactivityOption tests
 
     @Test
     fun whenNewInstallAndNoOptionSelectedThenSetsNewTabPage() = runTest {
         whenever(appBuildConfig.isNewInstall()).thenReturn(true)
 
+        // Mirrors FirstScreenHandlerImpl.onOpen which calls ensureNewUserDefault first.
+        testee.ensureNewUserDefault()
         testee.handleAfterInactivityOption(wasIdle = true)
 
         fakeTabRepository.flowTabs.test {
             val tabs = awaitItem()
             awaitComplete()
 
-            // NewTabPage was set, then handleAppLaunchOption added a tab
+            // NewTabPage was set by ensureNewUserDefault, then handleAfterInactivityOption added a tab
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "")
         }
@@ -912,12 +946,14 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     @Test
     fun whenNtpSetOnFirstInactivityThenSubsequentInactivityAfterUpdateStillShowsNtp() = runTest {
-        // First inactivity on new install: NTP is persisted in the store
+        // First inactivity on new install: NTP is persisted by ensureNewUserDefault
         whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+        testee.ensureNewUserDefault()
         testee.handleAfterInactivityOption(wasIdle = true)
 
         // After an app update isNewInstall() returns false, but the stored NTP option is preserved
         whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+        testee.ensureNewUserDefault()
         testee.handleAfterInactivityOption(wasIdle = true)
 
         fakeTabRepository.flowTabs.test {


### PR DESCRIPTION
  Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214491294419942
                                                                                                   
  ### Description                                                                                  
                                                                                                   
  Persists `NewTabPage` as the show-on-app-launch option for new installs that haven't picked      
  anything yet, on every app open instead of waiting for the after-inactivity timeout.
                                                                                                   
  **Problem:** `ShowOnAppLaunchOptionDataStore.optionFlow` falls back to `LastOpenedTab` when      
  nothing is persisted. The "new user → NewTabPage" rule lived inside
  `ShowOnAppLaunchOptionHandlerImpl.handleAfterInactivityOption`, which only runs once the         
  inactivity timeout passes. With the default 5-minute (and up to 30-minute) timeout, a new user
  can open General Settings well before the persist happens — and `GeneralSettingsViewModel` reads
  `optionFlow`, so the row's secondary text incorrectly shows "Last Opened Tab". Same issue in
  `ShowOnAppLaunchActivity`.

  **Change:**                                                                                      
  - Added `suspend fun ensureNewUserDefault()` to `ShowOnAppLaunchOptionHandler`. The impl persists
   `NewTabPage` only when `appBuildConfig.isNewInstall() && !hasOptionSelected()` — same condition 
  as before, just extracted.                             
  - `FirstScreenHandlerImpl.onOpen` now calls `ensureNewUserDefault()` at the very start of its    
  coroutine, before any feature-flag / timeout gating in `handleFirstScreen`. The default is now   
  persisted on every app open, not only when the inactivity flow fires.
  - Removed the duplicated logic from `handleAfterInactivityOption` — it's centralised in `onOpen` 
  now.                                                                                             
   
  ### Steps to test this PR                                                                        
                                                         
  _New install path_                                                                               
  - [x] Uninstall the app
  - [x] Install a fresh build                                                                      
  - [x] Open the app, then immediately go to **Settings → General**                                
  - [x] Confirm the row "Show on app launch" shows **"New Tab Page"** as the secondary text        
  (previously: "Last Opened Tab")                                                                  
  - [x] Tap the row to enter `ShowOnAppLaunchActivity` and confirm the **New Tab Page** radio is   
  selected                                                                                         
                                                         
  _Existing user path (regression)_                                                                
  - [x] Without uninstalling, open an existing install of the app
  - [x] Go to **Settings → General**                                                               
  - [x] Confirm the previously-selected option (or "Last Opened Tab" for users who never picked
  one) is preserved — **not** overwritten with New Tab Page                                        
  - [x] If you'd previously selected "Specific Page" or "Last Opened Tab", confirm it's still that
  option                                                                                           
                                                         
  _After-inactivity flow (regression)_                                                             
  - [ ] With NTP-after-idle enabled, set the inactivity timeout to a short value (e.g. 1 min) in
  General Settings                                                                                 
  - [x] Background the app, wait past the timeout, foreground it
  - [x] Confirm the after-inactivity behaviour still works (NTP shown for new users, persisted     
  preference shown for existing users)                                                             
                                                                                                   
  _Automated_                                                                                      
  - [x] `./gradlew :app:testPlayDebugUnitTest --tests    
  "com.duckduckgo.app.generalsettings.showonapplaunch.*"` passes                                   
   
  ### UI changes                                                                                   
  No UI changes — only the default selection state for new installs changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, gated persistence change for new installs only, plus test updates; main risk is unintended default persistence timing affecting edge cases around install detection.
> 
> **Overview**
> Ensures new installs default to **New Tab Page** immediately by persisting the show-on-launch option on every `onOpen`, rather than waiting for the after-inactivity path.
> 
> Extracts the “new install + no prior selection” logic into `ShowOnAppLaunchOptionHandler.ensureNewUserDefault()` and calls it early from `FirstScreenHandlerImpl.onOpen`, with unit tests updated/added to assert the new call order and non-overwrite behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11972a7d46f67895431989ba9edbb0a877802595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->