### PR TITLE
PIR: Add vpn state to initial scan pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1304,6 +1304,11 @@
                 "description": "What triggered the scan run",
                 "type": "string",
                 "enum": ["onboarding", "profile_edit", "scheduled"]
+            },
+            {
+                "key": "vpn_connection_state",
+                "description": "Reported VPN connection state when the foreground run started",
+                "type": "string"
             }
         ]
     },
@@ -1377,6 +1382,11 @@
                 "description": "What triggered the scan run",
                 "type": "string",
                 "enum": ["onboarding", "profile_edit", "scheduled"]
+            },
+            {
+                "key": "vpn_connection_state",
+                "description": "Reported VPN connection state when the foreground run completed",
+                "type": "string"
             }
         ]
     },
@@ -1490,11 +1500,6 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
-            },
-            {
-                "key": "vpn_connection_state",
-                "description": "Reported VPN connection state when the foreground run completed",
-                "type": "string"
             }
         ]
     },
@@ -1542,11 +1547,6 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
-            },
-            {
-                "key": "vpn_connection_state",
-                "description": "Reported VPN connection state when the foreground run started",
-                "type": "string"
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -34,7 +34,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the submission succeeded",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             },
             {
                 "key": "vpn_bypass",
@@ -116,7 +117,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the failure happened",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             },
             {
                 "key": "vpn_bypass",
@@ -402,7 +404,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the scan happened",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             },
             {
                 "key": "vpn_bypass",
@@ -453,7 +456,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the scan happened",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             },
             {
                 "key": "vpn_bypass",
@@ -535,7 +539,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the error happened",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             },
             {
                 "key": "vpn_bypass",
@@ -1024,7 +1029,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the submission succeeded",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1043,7 +1049,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the submission succeeded",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1062,7 +1069,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the pixel is fired",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1076,7 +1084,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the pixel is fired",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1218,7 +1227,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the initial scan completed",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1308,7 +1318,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the foreground run started",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },
@@ -1386,7 +1397,8 @@
             {
                 "key": "vpn_connection_state",
                 "description": "Reported VPN connection state when the foreground run completed",
-                "type": "string"
+                "type": "string",
+                "enum": ["connected", "disconnected"]
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1214,6 +1214,11 @@
                 "description": "What triggered the scan run",
                 "type": "string",
                 "enum": ["onboarding", "profile_edit", "scheduled"]
+            },
+            {
+                "key": "vpn_connection_state",
+                "description": "Reported VPN connection state when the initial scan completed",
+                "type": "string"
             }
         ]
     },
@@ -1485,6 +1490,11 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
+            },
+            {
+                "key": "vpn_connection_state",
+                "description": "Reported VPN connection state when the foreground run completed",
+                "type": "string"
             }
         ]
     },
@@ -1532,6 +1542,11 @@
                 "key": "broker_count",
                 "description": "The number of active brokers at the start of the scan",
                 "type": "integer"
+            },
+            {
+                "key": "vpn_connection_state",
+                "description": "Reported VPN connection state when the foreground run started",
+                "type": "string"
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -103,7 +103,7 @@ interface PirPixelSender {
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
      */
-    fun reportManualScanStarted(
+    suspend fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
         brokerCount: Int,
@@ -122,7 +122,7 @@ interface PirPixelSender {
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
      */
-    fun reportManualScanCompleted(
+    suspend fun reportManualScanCompleted(
         totalTimeInMillis: Long,
         batteryOptimizationsEnabled: Boolean,
         totalScanJobs: Int,
@@ -613,7 +613,7 @@ interface PirPixelSender {
 
     fun reportInitialScanIncomplete()
 
-    fun reportInitialScanDuration(
+    suspend fun reportInitialScanDuration(
         durationMs: Long,
         profileQueryCount: Int,
         isPowerSavingEnabled: Boolean,
@@ -645,7 +645,7 @@ class RealPirPixelSender @Inject constructor(
     private val networkProtectionState: NetworkProtectionState,
     private val pirRemoteFeatures: PirRemoteFeatures,
 ) : PirPixelSender {
-    override fun reportManualScanStarted(
+    override suspend fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
         brokerCount: Int,
@@ -655,12 +655,13 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
+            PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
         )
         fire(PIR_FOREGROUND_RUN_STARTED, params)
     }
 
-    override fun reportManualScanCompleted(
+    override suspend fun reportManualScanCompleted(
         totalTimeInMillis: Long,
         batteryOptimizationsEnabled: Boolean,
         totalScanJobs: Int,
@@ -678,6 +679,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
+            PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
         )
         fire(PIR_FOREGROUND_RUN_COMPLETED, params)
@@ -1447,7 +1449,7 @@ class RealPirPixelSender @Inject constructor(
         fire(PIR_INITIAL_SCAN_INCOMPLETE)
     }
 
-    override fun reportInitialScanDuration(
+    override suspend fun reportInitialScanDuration(
         durationMs: Long,
         profileQueryCount: Int,
         isPowerSavingEnabled: Boolean,
@@ -1463,6 +1465,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
+            PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
         )
 
         fire(PIR_INITIAL_SCAN_DURATION, params)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -207,7 +207,7 @@ class RealPirJobsRunner @Inject constructor(
         }
     }
 
-    private fun emitStartPixel(
+    private suspend fun emitStartPixel(
         context: Context,
         executionType: PirExecutionType,
         profileQueryCount: Int,
@@ -221,7 +221,7 @@ class RealPirJobsRunner @Inject constructor(
         }
     }
 
-    private fun emitCompletedPixel(
+    private suspend fun emitCompletedPixel(
         context: Context,
         executionType: PirExecutionType,
         startTimeInMillis: Long,

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -167,9 +167,7 @@ class RealPirPixelSenderTest {
     }
 
     @Test
-    fun whenReportManualScanStartFailedThenEnqueuesPixelWithVpnState() = runTest {
-        whenever(mockNetworkProtectionState.isRunning()).thenReturn(true)
-
+    fun whenReportManualScanStartFailedThenEnqueuesCorrectPixel() = runTest {
         testee.reportManualScanStartFailed()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -180,13 +178,11 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
+        assert(paramsCaptor.firstValue.isEmpty())
     }
 
     @Test
-    fun whenReportManualScanLowMemoryThenEnqueuesPixelWithVpnState() = runTest {
-        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
-
+    fun whenReportManualScanLowMemoryThenEnqueuesCorrectPixel() = runTest {
         testee.reportManualScanLowMemory()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -197,7 +193,7 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
+        assert(paramsCaptor.firstValue.isEmpty())
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -47,6 +47,8 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportManualScanStartedThenFiresPixelWithPowerSavingParam() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
+
         testee.reportManualScanStarted(
             isPowerSavingEnabled = true,
             profileQueryCount = 3,
@@ -69,10 +71,13 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue.containsKey("broker_count"))
         assert(paramsCaptor.firstValue["broker_count"] == "10")
         assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
     }
 
     @Test
     fun whenReportManualScanStartedWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(true)
+
         testee.reportManualScanStarted(
             isPowerSavingEnabled = false,
             profileQueryCount = 1,
@@ -89,10 +94,12 @@ class RealPirPixelSenderTest {
         )
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
     }
 
     @Test
     fun whenReportManualScanCompletedThenFiresPixelWithTotalTimeAndBatteryOptimizations() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
         val totalTimeInMillis = 12345L
 
         testee.reportManualScanCompleted(
@@ -129,10 +136,13 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue.containsKey("power_saving"))
         assert(paramsCaptor.firstValue["power_saving"] == "true")
         assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
     }
 
     @Test
     fun whenReportManualScanCompletedWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(true)
+
         testee.reportManualScanCompleted(
             totalTimeInMillis = 1L,
             batteryOptimizationsEnabled = false,
@@ -153,10 +163,13 @@ class RealPirPixelSenderTest {
         )
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
     }
 
     @Test
-    fun whenReportManualScanStartFailedThenEnqueuesCorrectPixel() = runTest {
+    fun whenReportManualScanStartFailedThenEnqueuesPixelWithVpnState() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(true)
+
         testee.reportManualScanStartFailed()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -167,11 +180,13 @@ class RealPirPixelSenderTest {
             type = any(),
         )
 
-        assert(paramsCaptor.firstValue.isEmpty())
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
     }
 
     @Test
-    fun whenReportManualScanLowMemoryThenEnqueuesPixelWithMemoryLevel() = runTest {
+    fun whenReportManualScanLowMemoryThenEnqueuesPixelWithVpnState() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
+
         testee.reportManualScanLowMemory()
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -181,6 +196,8 @@ class RealPirPixelSenderTest {
             encodedParameters = any(),
             type = any(),
         )
+
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
     }
 
     @Test
@@ -1074,6 +1091,8 @@ class RealPirPixelSenderTest {
 
     @Test
     fun whenReportInitialScanDurationThenFiresPixelWithAllParameters() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
+
         testee.reportInitialScanDuration(
             durationMs = 45000L,
             profileQueryCount = 3,
@@ -1099,10 +1118,13 @@ class RealPirPixelSenderTest {
         assert(params["battery-optimizations"] == "false")
         assert(params["broker_count"] == "10")
         assert(params["scan_trigger"] == "onboarding")
+        assert(params["vpn_connection_state"] == "disconnected")
     }
 
     @Test
     fun whenReportInitialScanDurationWithEditProfileThenScanTriggerIsProfileEdit() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(true)
+
         testee.reportInitialScanDuration(
             durationMs = 1L,
             profileQueryCount = 0,
@@ -1121,5 +1143,6 @@ class RealPirPixelSenderTest {
         )
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
+        assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214486367595491?focus=true

### Description
Adds VPN state param to initial scan pixels to understand the impact.

### Steps to test this PR
QA optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics metadata and adding a new parameter to emitted pixels, with small signature updates to make a few pixel-sender methods `suspend`. Main risk is downstream analytics/schema expectations if the new enum values or parameter presence are mishandled.
> 
> **Overview**
> Adds `vpn_connection_state` (enum: `connected`/`disconnected`) to the PIR pixel definitions for opt-out/scan events and to the *initial scan duration* and *foreground run start/completion* pixels.
> 
> Updates `RealPirPixelSender` to attach the VPN state (via `NetworkProtectionState.isRunning()`) when firing those pixels, and changes `reportManualScanStarted`, `reportManualScanCompleted`, and `reportInitialScanDuration` to `suspend` (with `PirJobsRunner` updated accordingly). Tests are adjusted to assert the new `vpn_connection_state` parameter and to expect empty params for the low-memory pixel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b559905dd530dbbae5cef336b4d52cf4d244ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->