### PR TITLE
Non-toggle widget, ddg seach in duck.ai

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1359,6 +1359,15 @@ class BrowserTabFragment :
                 onImageButtonPressed = {
                     // To be implemented
                 },
+                onNewTabRequested = { query ->
+                    if (query == null) {
+                        browserActivity?.launchNewTab()
+                    } else if (swipingTabsFeature.isEnabled) {
+                        browserActivity?.launchNewTab(query = query, sourceTabId = tabId)
+                    } else {
+                        browserActivity?.openInNewTab(query = query, sourceTabId = tabId)
+                    }
+                },
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -56,6 +56,7 @@ class NativeInputCallbacks(
     val onStopTapped: () -> Unit,
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
     val onImageButtonPressed: () -> Unit = {},
+    val onNewTabRequested: (query: String?) -> Unit = {},
 )
 
 interface NativeInputManager {
@@ -421,6 +422,10 @@ class RealNativeInputManager @Inject constructor(
             onPaidTierChanged = { isPaid ->
                 val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
                 omnibarController.updateTierTitle(tier) { launchUpgrade() }
+            }
+            onOpenNewTabTapped = { query ->
+                hideNativeInput(isNavigation = true)
+                callbacks.onNewTabRequested(query)
             }
             if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -129,6 +129,7 @@ open class InputModeWidget @JvmOverloads constructor(
     var onTabSwitcherTapped: (() -> Unit)? = null
     var onMenuTapped: (() -> Unit)? = null
     var onClearTextTapped: (() -> Unit)? = null
+    var onOpenNewTabTapped: ((query: String?) -> Unit)? = null
 
     var text: String
         get() = inputField.text.toString()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/SearchInNewTabNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/SearchInNewTabNativeInputPlugin.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.plugins
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.SearchInNewTabButtonView
+import javax.inject.Inject
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginSearchInNewTabNativeInput",
+    parentFeatureName = "pluginPointNativeInput",
+)
+class SearchInNewTabNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+
+    override val containerId: Int = R.id.searchInNewTabContainer
+
+    override fun createView(context: Context): View = SearchInNewTabButtonView(context)
+
+    override fun getPromptContribution(): PromptContribution? = null
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -72,6 +72,7 @@ interface NativeInputWidget {
     var onSearchSelected: ((animate: Boolean) -> Unit)?
     var onChatSelected: ((animate: Boolean) -> Unit)?
     var onClearTextTapped: (() -> Unit)?
+    var onOpenNewTabTapped: ((query: String?) -> Unit)?
     var onStopTapped: (() -> Unit)?
     var onVoiceSearchClick: (() -> Unit)?
     var onVoiceChatClick: (() -> Unit)?
@@ -94,6 +95,7 @@ interface NativeInputWidget {
     fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
     fun submitAsChat(): Boolean
+    fun isDuckAiContext(): Boolean
     fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
@@ -541,6 +543,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun isWidgetBottom(): Boolean = nativeInputState.isBottom
+
+    override fun isDuckAiContext(): Boolean = nativeInputState.inputContext == NativeInputState.InputContext.DUCK_AI
 
     override fun setWidgetPosition(isBottom: Boolean) {
         doOnAttach {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/SearchInNewTabButtonView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/SearchInNewTabButtonView.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.content.Context
+import android.view.Gravity
+import android.view.View
+import android.view.ViewTreeObserver
+import android.widget.FrameLayout.LayoutParams
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.R
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class SearchInNewTabButtonView(context: Context) : AppCompatImageView(context) {
+
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    private val viewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[SearchInNewTabViewModel::class.java]
+    }
+
+    private var widget: NativeInputWidget? = null
+    private var isModeAllowed: Boolean = false
+    private var modeJob: Job? = null
+
+    init {
+        val size = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.toolbarIcon)
+        layoutParams = LayoutParams(size, size, Gravity.TOP)
+        setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.selectable_item_rounded_corner_background)
+        scaleType = ScaleType.CENTER_INSIDE
+        setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_find_search_24)
+        contentDescription = context.getString(R.string.duckAiInputScreenSearchInNewTabContentDescription)
+        setOnClickListener { onClick() }
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        widget = findNativeInputWidget()
+        viewTreeObserver.addOnGlobalFocusChangeListener(globalFocusListener)
+        observeMode()
+    }
+
+    override fun onDetachedFromWindow() {
+        viewTreeObserver.removeOnGlobalFocusChangeListener(globalFocusListener)
+        modeJob?.cancel()
+        modeJob = null
+        widget = null
+        super.onDetachedFromWindow()
+    }
+
+    private fun observeMode() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        modeJob?.cancel()
+        modeJob = viewModel.isModeAllowed
+            .onEach { allowed ->
+                isModeAllowed = allowed
+                updateVisibility()
+            }
+            .launchIn(scope)
+    }
+
+    private fun onClick() {
+        val widget = widget ?: return
+        val query = widget.text.trim().ifEmpty { null }
+        widget.onOpenNewTabTapped?.invoke(query)
+    }
+
+    private fun updateVisibility() {
+        val w = widget
+        isVisible = isModeAllowed && w?.isDuckAiContext() == true && w.hasInputFocus()
+    }
+
+    private val globalFocusListener = ViewTreeObserver.OnGlobalFocusChangeListener { _, _ ->
+        updateVisibility()
+    }
+
+    private fun findNativeInputWidget(): NativeInputWidget? {
+        var node: View? = this
+        while (node != null) {
+            if (node is NativeInputWidget) return node
+            node = node.parent as? View
+        }
+        return null
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/SearchInNewTabViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/SearchInNewTabViewModel.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class SearchInNewTabViewModel @Inject constructor(
+    duckAiFeatureState: DuckAiFeatureState,
+    duckChatInternal: DuckChatInternal,
+) : ViewModel() {
+
+    /**
+     * The search-in-new-tab icon is only useful when the toggle is hidden — i.e. the user
+     * is in `SEARCH_ONLY` mode (Duck.ai disabled at the feature level, or Duck.ai enabled
+     * but the input-screen toggle is off). In toggle mode the user can already reach search
+     * via the toggle, so the icon is redundant.
+     */
+    val isModeAllowed: Flow<Boolean> = combine(
+        duckAiFeatureState.showSettings,
+        duckChatInternal.observeEnableDuckChatUserSetting(),
+        duckChatInternal.observeInputScreenUserSettingEnabled(),
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled ->
+        !(isFeatureEnabled && isUserEnabled && isInputScreenUserSettingEnabled)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -172,6 +172,14 @@
                         android:visibility="gone"
                         tools:visibility="visible" />
 
+                    <FrameLayout
+                        android:id="@id/searchInNewTabContainer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="top"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
+
                 </LinearLayout>
 
                 <FrameLayout

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -34,4 +34,7 @@
 
     <!-- Start chat icon content description -->
     <string name="duckChatStartChatContentDescription">Start chat</string>
+
+    <!-- Search-in-new-tab icon content description -->
+    <string name="duckAiInputScreenSearchInNewTabContentDescription">Search in new tab</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
@@ -17,4 +17,5 @@
 <resources>
     <item name="modelPickerContainer" type="id"/>
     <item name="startChatContainer" type="id"/>
+    <item name="searchInNewTabContainer" type="id"/>
 </resources>


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1214289349539844?focus=true

### Description

### Steps to test this PR
- open duck.ai in non-toggle mode.
- write something in duckai chat 
- observe search icon
- clicking on search starts a new tab with the text
- clicking back takes you back to duck.ai 

### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/fcb262a1-7fd5-4e70-a1af-ed6a4940fb99" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new UI + navigation wiring that opens a new browser tab from the Duck.ai input screen, which could affect tab creation/back-stack behavior across different tab implementations (swiping-tabs vs legacy).
> 
> **Overview**
> Enables a **Search in new tab** action from the Duck.ai native input when running in *non-toggle/search-only* mode.
> 
> This introduces a new native-input plugin/view (`SearchInNewTabButtonView` + `SearchInNewTabViewModel`) and layout container, exposes a new `onNewTabRequested` callback through `NativeInputManager`, and handles the request in `BrowserTabFragment` by opening a blank tab or a query tab (choosing `launchNewTab` vs `openInNewTab` based on `swipingTabsFeature`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac1331f8d9a7fc14aba4ca50cf359d5c693fb7ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->