### PR TITLE
Android: Upload aab as artifact if upload to PS fails during internal release

### DIFF
--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -141,6 +141,15 @@ jobs:
         run: |
           bundle exec fastlane deploy_dogfood aab_path:${{ steps.capture_output.outputs.bundle_path }}
 
+      - name: Upload AAB as artifact
+        if: failure() && steps.create_app_bundle.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: release-aab
+          path: ${{ steps.capture_output.outputs.bundle_path }}
+          retention-days: 1
+
       - name: Tag Internal Release
         if: steps.check_for_changes.outputs.has_changes == 'true'
         id: tag_internal_release


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214498098822034?focus=true

### Description
see attached task description

### Steps to test this PR

QA-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that runs only on job failure; main impact is slightly more artifacts/logging in CI.
> 
> **Overview**
> Improves the internal release GitHub Actions workflow by uploading the generated `.aab` as a short-lived artifact when the Play Store internal-track upload step (`fastlane deploy_dogfood`) fails.
> 
> The artifact upload is guarded by `failure()` and `steps.create_app_bundle.outcome == 'failure'`, uses `continue-on-error`, and retains the bundle for 1 day to aid debugging/retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0de5a438b760a26da7a690275c0626af6b527e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->