### PR TITLE
Show tooltip when PDF is displayed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -158,7 +158,9 @@ import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.*
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
+import com.duckduckgo.app.browser.pdf.BubbleTooltipDrawable
 import com.duckduckgo.app.browser.pdf.DdgPdfViewerFragment
+import com.duckduckgo.app.browser.pdf.PdfDownloadTooltipPopup
 import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfPreviewGenerator
 import com.duckduckgo.app.browser.print.CachedPdfPrintDocumentAdapter
@@ -662,6 +664,7 @@ class BrowserTabFragment :
 
     private var popupMenu: BrowserPopupMenu? = null
     private var bottomSheetMenu: BrowserMenuBottomSheet? = null
+    private var pdfDownloadTooltipPopup: PdfDownloadTooltipPopup? = null
     private lateinit var ctaBottomSheet: PromoBottomSheetDialog
     private lateinit var widgetBottomSheetDialog: HomeScreenWidgetBottomSheetDialog
     private val widgetBottomSheetDialogJob: ConflatedJob = ConflatedJob()
@@ -2049,6 +2052,8 @@ class BrowserTabFragment :
     }
 
     override fun onPause() {
+        pdfDownloadTooltipPopup?.dismiss()
+        pdfDownloadTooltipPopup = null
         dismissDownloadFragment()
         super.onPause()
     }
@@ -2277,6 +2282,25 @@ class BrowserTabFragment :
         hidePdf()
         omnibar.setViewMode(ViewMode.Browser(viewModel.url))
         browserNavigationBarIntegration.configureBrowserViewMode()
+    }
+
+    private fun showPdfDownloadTooltip() {
+        val omnibarType = omnibarRepository.omnibarType
+        val isBottomAnchored = omnibarType == OmnibarType.SPLIT || omnibarType == OmnibarType.SINGLE_BOTTOM
+        val anchor: View = if (omnibarType == OmnibarType.SPLIT) {
+            browserNavigationBarIntegration.navigationBarView.popupMenuAnchor
+        } else {
+            view?.findViewById(R.id.browserMenu) ?: return
+        }
+        val wavePosition = if (isBottomAnchored) {
+            BubbleTooltipDrawable.WavePosition.BOTTOM
+        } else {
+            BubbleTooltipDrawable.WavePosition.TOP
+        }
+        pdfDownloadTooltipPopup?.dismiss()
+        pdfDownloadTooltipPopup = PdfDownloadTooltipPopup(requireContext(), wavePosition).also { popup ->
+            popup.show(anchor)
+        }
     }
 
     private fun showPdf(url: String, cachedFileUri: Uri) {
@@ -2992,6 +3016,8 @@ class BrowserTabFragment :
             is Command.ShowPdfInTab -> {
                 showPdf(it.url, it.cachedFileUri)
             }
+
+            is Command.ShowPdfDownloadTooltip -> showPdfDownloadTooltip()
 
             is Command.ExpandOmnibar -> {
                 omnibar.setExpanded(true)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -207,6 +207,7 @@ import com.duckduckgo.app.browser.pageload.PageLoadWideEvent
 import com.duckduckgo.app.browser.pdf.CachedFileDownloader
 import com.duckduckgo.app.browser.pdf.InlinePdfHandler
 import com.duckduckgo.app.browser.pdf.PdfDownloadResult
+import com.duckduckgo.app.browser.pdf.PdfDownloadTooltipDataStore
 import com.duckduckgo.app.browser.pdf.PdfErrorType
 import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfRenderDecision
@@ -539,6 +540,7 @@ class BrowserTabViewModel @Inject constructor(
     private val faviconFetchingFixFeature: FaviconFetchingFixFeature,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val inlinePdfHandler: InlinePdfHandler,
+    private val pdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore,
     private val cachedFileDownloader: CachedFileDownloader,
     private val downloadMenuStateProvider: DownloadMenuStateProvider,
     private val downloadsRepository: DownloadsRepository,
@@ -3715,6 +3717,10 @@ class BrowserTabViewModel @Inject constructor(
                         currentPdfFileName = pdfTitle,
                     )
                     command.value = ShowPdfInTab(url, result.uri)
+                    if (!isCustomTabScreen && pdfDownloadTooltipDataStore.canShow()) {
+                        pdfDownloadTooltipDataStore.incrementShownCount()
+                        command.value = Command.ShowPdfDownloadTooltip
+                    }
                 }
                 is PdfDownloadResult.Failure -> {
                     pixel.fire(

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -524,5 +524,7 @@ sealed class Command {
         val cachedFileUri: Uri,
     ) : Command()
 
+    data object ShowPdfDownloadTooltip : Command()
+
     data object ExpandOmnibar : Command()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/BubbleTooltipDrawable.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/BubbleTooltipDrawable.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import android.content.res.Resources
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Outline
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
+
+/**
+ * Speech-bubble drawable with a wave tail at the top or bottom edge (right-aligned).
+ * Use [WavePosition.TOP] for popups below the anchor, [WavePosition.BOTTOM] for popups above it.
+ */
+class BubbleTooltipDrawable(
+    @ColorInt private val backgroundColor: Int,
+    private val wavePosition: WavePosition = WavePosition.TOP,
+    private val density: Float = DEFAULT_DENSITY,
+) : Drawable() {
+
+    enum class WavePosition { TOP, BOTTOM }
+
+    private val cornerRadiusPx by lazy { dp(12f) }
+    private val cornerRadiusTrPx by lazy { dp(10f) }
+    private val waveWidthPx by lazy { dp(24f) }
+    private val waveHeightPx by lazy { dp(12f) }
+    private val waveOffsetEndPx by lazy { dp(8f) }
+    private val horizPaddingPx by lazy { dp(20f).toInt() }
+    private val vertPaddingPx by lazy { dp(12f).toInt() }
+
+    private val bodyPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+        color = backgroundColor
+    }
+
+    private val bodyPath = Path()
+    private val bodyRect = RectF()
+
+    override fun getPadding(padding: Rect): Boolean {
+        val waveSide = (waveHeightPx + vertPaddingPx).toInt()
+        when (wavePosition) {
+            WavePosition.TOP -> padding.set(horizPaddingPx, waveSide, horizPaddingPx, vertPaddingPx)
+            WavePosition.BOTTOM -> padding.set(horizPaddingPx, vertPaddingPx, horizPaddingPx, waveSide)
+        }
+        return true
+    }
+
+    override fun onBoundsChange(bounds: Rect) {
+        super.onBoundsChange(bounds)
+        rebuildPath(bounds)
+    }
+
+    override fun draw(canvas: Canvas) {
+        val b = bounds
+        if (b.isEmpty) return
+        canvas.drawPath(bodyPath, bodyPaint)
+    }
+
+    // Outline excludes the wave so the elevation shadow follows only the body. setRoundRect
+    // takes a single radius, and Outline.setPath with non-convex paths is API 30+; this is the
+    // minSdk 26 fallback.
+    override fun getOutline(outline: Outline) {
+        val b = bounds
+        if (b.isEmpty) return
+        val waveInset = waveHeightPx.toInt()
+        when (wavePosition) {
+            WavePosition.TOP -> outline.setRoundRect(b.left, b.top + waveInset, b.right, b.bottom, cornerRadiusPx)
+            WavePosition.BOTTOM -> outline.setRoundRect(b.left, b.top, b.right, b.bottom - waveInset, cornerRadiusPx)
+        }
+    }
+
+    override fun setAlpha(alpha: Int) {
+        bodyPaint.alpha = alpha
+        invalidateSelf()
+    }
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        bodyPaint.colorFilter = colorFilter
+        invalidateSelf()
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+
+    override fun getIntrinsicWidth(): Int = -1
+    override fun getIntrinsicHeight(): Int = -1
+
+    private fun rebuildPath(b: Rect) {
+        bodyPath.reset()
+
+        val left = b.left.toFloat()
+        val right = b.right.toFloat()
+        val (bodyTop, bodyBottom) = when (wavePosition) {
+            WavePosition.TOP -> b.top.toFloat() + waveHeightPx to b.bottom.toFloat()
+            WavePosition.BOTTOM -> b.top.toFloat() to b.bottom.toFloat() - waveHeightPx
+        }
+
+        bodyRect.set(left, bodyTop, right, bodyBottom)
+
+        // Corners order: TL, TR, BR, BL. The corner where the wave attaches uses the smaller radius.
+        val radii = when (wavePosition) {
+            WavePosition.TOP -> floatArrayOf(
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusTrPx,
+                cornerRadiusTrPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+            )
+            WavePosition.BOTTOM -> floatArrayOf(
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+                cornerRadiusTrPx,
+                cornerRadiusTrPx,
+                cornerRadiusPx,
+                cornerRadiusPx,
+            )
+        }
+        bodyPath.addRoundRect(bodyRect, radii, Path.Direction.CW)
+
+        val baseRight = right - waveOffsetEndPx
+        val baseLeft = baseRight - waveWidthPx
+        val baselineY = if (wavePosition == WavePosition.TOP) bodyTop else bodyBottom
+        val peakY = if (wavePosition == WavePosition.TOP) b.top.toFloat() else b.bottom.toFloat()
+
+        val wavePath = Path()
+        wavePath.moveTo(baseLeft, baselineY)
+        wavePath.cubicTo(
+            baseLeft + dp(8f),
+            baselineY,
+            baseLeft + dp(10f),
+            peakY,
+            baseLeft + dp(14f),
+            peakY,
+        )
+        wavePath.cubicTo(
+            baseLeft + dp(17f),
+            peakY,
+            baseLeft + dp(19f),
+            baselineY,
+            baseRight,
+            baselineY,
+        )
+        wavePath.close()
+
+        bodyPath.op(wavePath, Path.Op.UNION)
+    }
+
+    private fun dp(value: Float): Float = value * density
+
+    companion object {
+        val DEFAULT_DENSITY: Float
+            get() = Resources.getSystem().displayMetrics.density
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStore.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface PdfDownloadTooltipDataStore {
+    suspend fun incrementShownCount()
+    suspend fun canShow(): Boolean
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SharedPreferencesPdfDownloadTooltipDataStore @Inject constructor(
+    @PdfDownloadTooltip private val dataStore: DataStore<Preferences>,
+    private val dispatchers: DispatcherProvider,
+) : PdfDownloadTooltipDataStore {
+
+    private object Keys {
+        val SHOWN_COUNT_KEY = intPreferencesKey(name = "PDF_DOWNLOAD_TOOLTIP_SHOWN_COUNT")
+    }
+
+    override suspend fun incrementShownCount() {
+        withContext(dispatchers.io()) {
+            dataStore.edit { prefs ->
+                prefs[Keys.SHOWN_COUNT_KEY] = (prefs[Keys.SHOWN_COUNT_KEY] ?: 0) + 1
+            }
+        }
+    }
+
+    override suspend fun canShow(): Boolean = withContext(dispatchers.io()) {
+        val count = dataStore.data.firstOrNull()?.let { it[Keys.SHOWN_COUNT_KEY] } ?: 0
+        count < MAX_SHOWN_COUNT
+    }
+
+    private companion object {
+        const val MAX_SHOWN_COUNT = 3
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStoreModule.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import javax.inject.Qualifier
+
+@ContributesTo(AppScope::class)
+@Module
+object PdfDownloadTooltipDataStoreModule {
+
+    private val Context.pdfDownloadTooltipDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "pdf_download_tooltip",
+    )
+
+    @Provides
+    @PdfDownloadTooltip
+    fun providePdfDownloadTooltipDataStore(context: Context): DataStore<Preferences> = context.pdfDownloadTooltipDataStore
+}
+
+@Qualifier
+annotation class PdfDownloadTooltip

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipPopup.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipPopup.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import android.content.Context
+import android.graphics.Rect
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.mobile.android.R as CommonR
+
+class PdfDownloadTooltipPopup(
+    context: Context,
+    private val wavePosition: BubbleTooltipDrawable.WavePosition,
+) {
+
+    private val contentView: View = LayoutInflater.from(context)
+        .inflate(R.layout.view_pdf_download_tooltip, null, false)
+
+    private val rightInsetPx: Int = context.resources.getDimensionPixelSize(CommonR.dimen.keyline_1)
+
+    private val popupWindow: PopupWindow = PopupWindow(
+        contentView,
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+    ).apply {
+        isFocusable = false
+        isOutsideTouchable = true
+        setBackgroundDrawable(
+            BubbleTooltipDrawable(
+                backgroundColor = context.getColorFromAttr(CommonR.attr.daxColorSurface),
+                wavePosition = wavePosition,
+            ),
+        )
+        elevation = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            ELEVATION_DP,
+            context.resources.displayMetrics,
+        )
+        contentView.setOnClickListener { dismiss() }
+    }
+
+    fun show(anchor: View) {
+        if (popupWindow.isShowing) return
+
+        val unspec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        contentView.measure(unspec, unspec)
+        val drawablePadding = Rect()
+        popupWindow.background?.getPadding(drawablePadding)
+        val popupWidth = contentView.measuredWidth + drawablePadding.left + drawablePadding.right
+        val popupHeight = contentView.measuredHeight + drawablePadding.top + drawablePadding.bottom
+
+        // popupWindow.width must be set before showAsDropDown — Gravity.END's positioning math
+        // breaks with WRAP_CONTENT and pushes the popup off-screen.
+        popupWindow.width = popupWidth
+
+        val yoff = if (wavePosition == BubbleTooltipDrawable.WavePosition.BOTTOM) {
+            -(anchor.height + popupHeight)
+        } else {
+            0
+        }
+        popupWindow.showAsDropDown(anchor, -rightInsetPx, yoff, Gravity.END)
+    }
+
+    fun dismiss() {
+        if (popupWindow.isShowing) popupWindow.dismiss()
+    }
+
+    private companion object {
+        const val ELEVATION_DP = 4f
+    }
+}

--- a/app/src/main/res/layout/view_pdf_download_tooltip.xml
+++ b/app/src/main/res/layout/view_pdf_download_tooltip.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.text.DaxTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/pdfDownloadTooltipText"
+    android:textColor="?attr/daxColorPrimaryText"
+    app:typography="body2" />

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -110,4 +110,6 @@
     <string name="defaultBrowserChangedSurveyNotificationTitle">We noticed a change</string>
     <string name="defaultBrowserChangedSurveyNotificationDescription">DuckDuckGo is no longer your default browser. Mind telling us why?</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Download PDF</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -129,6 +129,7 @@ import com.duckduckgo.app.browser.pageload.PageLoadWideEvent
 import com.duckduckgo.app.browser.pdf.CachedFileDownloader
 import com.duckduckgo.app.browser.pdf.InlinePdfHandler
 import com.duckduckgo.app.browser.pdf.PdfDownloadResult
+import com.duckduckgo.app.browser.pdf.PdfDownloadTooltipDataStore
 import com.duckduckgo.app.browser.pdf.PdfErrorType
 import com.duckduckgo.app.browser.pdf.PdfPixelName
 import com.duckduckgo.app.browser.pdf.PdfRenderDecision
@@ -657,6 +658,7 @@ class BrowserTabViewModelTest {
     private var fakeFaviconFetchingFixFeature = FakeFeatureToggleFactory.create(FaviconFetchingFixFeature::class.java)
     private var fakeProgressBarUpgradeFeature = FakeFeatureToggleFactory.create(ProgressBarUpgradeFeature::class.java)
     private val mockInlinePdfHandler: InlinePdfHandler = mock()
+    private val mockPdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore = mock()
     private val mockCachedFileDownloader: CachedFileDownloader = mock()
     private val mockDownloadMenuStateProvider: DownloadMenuStateProvider = mock()
     private val mockDownloadsRepository: DownloadsRepository = mock()
@@ -688,6 +690,7 @@ class BrowserTabViewModelTest {
 
             whenever(mockDuckChatJSHelper.enrichPageContextIfPossible(any(), any())).thenAnswer { it.getArgument<String>(1) }
             whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.NotApplicable)
+            whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(false)
 
             db =
                 Room
@@ -957,6 +960,7 @@ class BrowserTabViewModelTest {
                 faviconFetchingFixFeature = fakeFaviconFetchingFixFeature,
                 ntpAfterIdleManager = mockNtpAfterIdleManager,
                 inlinePdfHandler = mockInlinePdfHandler,
+                pdfDownloadTooltipDataStore = mockPdfDownloadTooltipDataStore,
                 cachedFileDownloader = mockCachedFileDownloader,
                 downloadMenuStateProvider = mockDownloadMenuStateProvider,
                 downloadsRepository = mockDownloadsRepository,
@@ -10602,6 +10606,60 @@ class BrowserTabViewModelTest {
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", "attachment", "application/pdf", true, false)
 
         verify(mockPixel, never()).fire(PdfPixelName.PDF_FALLBACK)
+    }
+
+    @Test
+    fun whenInlinePdfRendersSuccessfullyAndCanShowReturnsTrueThenTooltipCommandIsEmittedAndStoreIsIncremented() = runTest {
+        whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(true)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val testUri = Uri.parse("file:///cache/test.pdf")
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
+
+        testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
+
+        assertCommandIssued<Command.ShowPdfDownloadTooltip>()
+        verify(mockPdfDownloadTooltipDataStore).incrementShownCount()
+    }
+
+    @Test
+    fun whenInlinePdfRendersSuccessfullyAndCanShowReturnsFalseThenTooltipCommandIsNotEmitted() = runTest {
+        whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(false)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val testUri = Uri.parse("file:///cache/test.pdf")
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
+
+        testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
+
+        assertCommandNotIssued<Command.ShowPdfDownloadTooltip>()
+        verify(mockPdfDownloadTooltipDataStore, never()).incrementShownCount()
+    }
+
+    @Test
+    fun whenInlinePdfDownloadFailsThenTooltipCommandIsNotEmittedAndStoreIsNotIncremented() = runTest {
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
+
+        testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
+
+        assertCommandNotIssued<Command.ShowPdfDownloadTooltip>()
+        verify(mockPdfDownloadTooltipDataStore, never()).incrementShownCount()
+    }
+
+    @Test
+    fun whenInCustomTabModeAndInlinePdfRendersSuccessfullyThenTooltipCommandIsNotEmittedAndStoreIsNotIncremented() = runTest {
+        testee.setIsCustomTab(true)
+        whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(true)
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val testUri = Uri.parse("file:///cache/test.pdf")
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
+
+        testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
+
+        assertCommandNotIssued<Command.ShowPdfDownloadTooltip>()
+        verify(mockPdfDownloadTooltipDataStore, never()).incrementShownCount()
     }
 
     // endregion

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStoreTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/PdfDownloadTooltipDataStoreTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.pdf
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PdfDownloadTooltipDataStoreTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val testDataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = coroutineRule.testScope,
+            produceFile = { context.preferencesDataStoreFile("pdf_download_tooltip") },
+        )
+
+    private val testee: PdfDownloadTooltipDataStore =
+        SharedPreferencesPdfDownloadTooltipDataStore(
+            testDataStore,
+            coroutineRule.testDispatcherProvider,
+        )
+
+    companion object {
+        val SHOWN_COUNT_KEY = intPreferencesKey("PDF_DOWNLOAD_TOOLTIP_SHOWN_COUNT")
+    }
+
+    @Test
+    fun `when canShow called before any increment then returns true`() = runTest {
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun `when incrementShownCount called once then underlying key is one and canShow remains true`() = runTest {
+        testee.incrementShownCount()
+        assertEquals(1, testDataStore.data.firstOrNull()?.get(SHOWN_COUNT_KEY))
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun `when incrementShownCount called twice then canShow remains true`() = runTest {
+        testee.incrementShownCount()
+        testee.incrementShownCount()
+        assertTrue(testee.canShow())
+    }
+
+    @Test
+    fun `when incrementShownCount called three times then canShow returns false`() = runTest {
+        testee.incrementShownCount()
+        testee.incrementShownCount()
+        testee.incrementShownCount()
+        assertFalse(testee.canShow())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1214486594913656?focus=true 

### Description

Adds a one-shot speech-bubble tooltip ("Download PDF") that anchors to the browser-menu icon the first time a user opens an inline-rendered PDF. The tooltip is dismissed on tap or when the fragment pauses, and is shown only once per install.

### Steps to test this PR

_Top omnibar (default)_
- [x] Fresh install → open an inline PDF
- [x] Tooltip appears below the browser-menu icon, wave pointing up at it
- [x] Tap the tooltip — it dismisses

_Bottom omnibar / split mode_
- [x] Fresh install → Switch to "Address bar at the bottom" in settings (or split mode)
- [x] Open an inline PDF
- [x] Tooltip appears ABOVE the menu icon, wave pointing down at it
- [x] Right edge of the tooltip aligns with the menu icon's right edge

_Display tooltip 3 times_
- [x] Fresh install → open an inline PDF
- [x] Tooltip appears below the browser-menu icon
- [x] Repeat 3 times, after 3 times tooltip isn't displayed anymore

### UI changes
| Light  | Dark |
| ------ | ----- |
<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/fb6bccb6-1606-43ff-8f29-c14c810846a6" /> | <img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/f4d7ee19-957e-4be6-9467-f5ec2d91318f" />
<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/1d3f1a25-2230-4d37-95d2-5564f835272e" /> | <img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/eda19e37-ac1b-4cd0-a0ac-e89034707eda" />
<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/29e76d4a-150d-4ce3-b2ce-da9a30426623" /> | <img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/4321daf3-4d01-494a-9d1b-ec36220c6885" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `BrowserTabViewModel` command flow and `BrowserTabFragment` UI/lifecycle to conditionally show a new popup, plus introduces a new DataStore-backed counter; main risk is regressions in PDF open flow or popup positioning/dismissal across omnibar modes.
> 
> **Overview**
> When an inline-rendered PDF successfully opens, the app now *optionally* emits a new `Command.ShowPdfDownloadTooltip` to display a speech-bubble "Download PDF" tooltip anchored to the menu icon (with wave orientation adjusted for top/bottom omnibar and split mode).
> 
> Tooltip display is capped via a new `PdfDownloadTooltipDataStore` (DataStore preferences) which tracks how many times it has been shown (max 3) and is skipped for custom tabs; the fragment dismisses the popup on `onPause` and handles the new command. Adds the tooltip drawable/layout/string and unit tests for both the viewmodel emission and the datastore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e75155a7fc09aaa5d742830c4d0738a31d61fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->