### PR TITLE
PIR: Add notifications permission param

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1229,6 +1229,11 @@
                 "description": "Reported VPN connection state when the initial scan completed",
                 "type": "string",
                 "enum": ["connected", "disconnected"]
+            },
+            {
+                "key": "notifications_permission_granted",
+                "description": "Whether the user has granted the POST_NOTIFICATIONS runtime permission",
+                "type": "boolean"
             }
         ]
     },
@@ -1320,6 +1325,11 @@
                 "description": "Reported VPN connection state when the foreground run started",
                 "type": "string",
                 "enum": ["connected", "disconnected"]
+            },
+            {
+                "key": "notifications_permission_granted",
+                "description": "Whether the user has granted the POST_NOTIFICATIONS runtime permission",
+                "type": "boolean"
             }
         ]
     },
@@ -1399,6 +1409,11 @@
                 "description": "Reported VPN connection state when the foreground run completed",
                 "type": "string",
                 "enum": ["connected", "disconnected"]
+            },
+            {
+                "key": "notifications_permission_granted",
+                "description": "Whether the user has granted the POST_NOTIFICATIONS runtime permission",
+                "type": "boolean"
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -102,12 +102,14 @@ interface PirPixelSender {
      * @param profileQueryCount - the number of profile queries used in the scan
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
+     * @param notificationsPermissionGranted - whether the user has granted the POST_NOTIFICATIONS runtime permission
      */
     suspend fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
         profileQueryCount: Int,
         brokerCount: Int,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     )
 
     /**
@@ -121,6 +123,7 @@ interface PirPixelSender {
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
+     * @param notificationsPermissionGranted - whether the user has granted the POST_NOTIFICATIONS runtime permission
      */
     suspend fun reportManualScanCompleted(
         totalTimeInMillis: Long,
@@ -131,6 +134,7 @@ interface PirPixelSender {
         brokerCount: Int,
         isPowerSavingEnabled: Boolean,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     )
 
     /**
@@ -620,6 +624,7 @@ interface PirPixelSender {
         batteryOptimizationsEnabled: Boolean,
         brokerCount: Int,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     )
 
     fun reportBackgroundScanStats(
@@ -650,6 +655,7 @@ class RealPirPixelSender @Inject constructor(
         profileQueryCount: Int,
         brokerCount: Int,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
@@ -657,6 +663,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
             PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
+            PARAM_KEY_NOTIFICATIONS_PERMISSION to notificationsPermissionGranted.toString(),
         )
         fire(PIR_FOREGROUND_RUN_STARTED, params)
     }
@@ -670,6 +677,7 @@ class RealPirPixelSender @Inject constructor(
         brokerCount: Int,
         isPowerSavingEnabled: Boolean,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
@@ -681,6 +689,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
             PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
+            PARAM_KEY_NOTIFICATIONS_PERMISSION to notificationsPermissionGranted.toString(),
         )
         fire(PIR_FOREGROUND_RUN_COMPLETED, params)
     }
@@ -1456,6 +1465,7 @@ class RealPirPixelSender @Inject constructor(
         batteryOptimizationsEnabled: Boolean,
         brokerCount: Int,
         executionType: PirExecutionType,
+        notificationsPermissionGranted: Boolean,
     ) {
         val params = mapOf(
             PARAM_KEY_DURATION_MS to durationMs.toString(),
@@ -1466,6 +1476,7 @@ class RealPirPixelSender @Inject constructor(
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
             PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
             PARAM_KEY_VPN_STATE to networkProtectionState.safeIsVpnRunning().toVpnConnectionState(),
+            PARAM_KEY_NOTIFICATIONS_PERMISSION to notificationsPermissionGranted.toString(),
         )
 
         fire(PIR_INITIAL_SCAN_DURATION, params)
@@ -1591,5 +1602,6 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_BROKER_COUNT = "broker_count"
         private const val PARAM_KEY_TRACKER_BLOCKING = "tracker_blocking_state"
         private const val PARAM_KEY_SCAN_TRIGGER = "scan_trigger"
+        private const val PARAM_KEY_NOTIFICATIONS_PERMISSION = "notifications_permission_granted"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -102,7 +102,7 @@ interface PirPixelSender {
      * @param profileQueryCount - the number of profile queries used in the scan
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
-     * @param notificationsPermissionGranted - whether the user has granted the POST_NOTIFICATIONS runtime permission
+     * @param notificationsPermissionGranted - whether notifications are enabled for the app
      */
     suspend fun reportManualScanStarted(
         isPowerSavingEnabled: Boolean,
@@ -123,7 +123,7 @@ interface PirPixelSender {
      * @param brokerCount - the number of active brokers at the start of the scan
      * @param isPowerSavingEnabled - whether the device is currently in power saving mode
      * @param executionType - which manual flow triggered the scan (onboarding or profile edit)
-     * @param notificationsPermissionGranted - whether the user has granted the POST_NOTIFICATIONS runtime permission
+     * @param notificationsPermissionGranted - whether notifications are enabled for the app
      */
     suspend fun reportManualScanCompleted(
         totalTimeInMillis: Long,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -16,8 +16,11 @@
 
 package com.duckduckgo.pir.impl.scheduling
 
+import android.Manifest.permission.POST_NOTIFICATIONS
 import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.PowerManager
+import androidx.core.app.ActivityCompat
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.isIgnoringBatteryOptimizations
@@ -154,6 +157,7 @@ class RealPirJobsRunner @Inject constructor(
                 batteryOptimizationsEnabled = batteryOptimizationsEnabled,
                 brokerCount = activeBrokers.size,
                 executionType = executionType,
+                notificationsPermissionGranted = context.areNotificationsPermissionGranted(),
             )
         }
 
@@ -215,7 +219,13 @@ class RealPirJobsRunner @Inject constructor(
     ) {
         if (executionType.isManual) {
             val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
-            pixelSender.reportManualScanStarted(isPowerSavingEnabled, profileQueryCount, brokerCount, executionType)
+            pixelSender.reportManualScanStarted(
+                isPowerSavingEnabled = isPowerSavingEnabled,
+                profileQueryCount = profileQueryCount,
+                brokerCount = brokerCount,
+                executionType = executionType,
+                notificationsPermissionGranted = context.areNotificationsPermissionGranted(),
+            )
         } else {
             pixelSender.reportScheduledScanStarted(profileQueryCount, brokerCount)
         }
@@ -242,6 +252,7 @@ class RealPirJobsRunner @Inject constructor(
                 brokerCount = brokerCount,
                 isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
                 executionType = executionType,
+                notificationsPermissionGranted = context.areNotificationsPermissionGranted(),
             )
         } else {
             pixelSender.reportScheduledScanCompleted(totalTimeMillis, profileQueryCount, brokerCount)
@@ -355,6 +366,12 @@ class RealPirJobsRunner @Inject constructor(
     private fun Context.isPowerSavingModeEnabled(): Boolean {
         return runCatching {
             (getSystemService(Context.POWER_SERVICE) as PowerManager).isPowerSaveMode
+        }.getOrDefault(false)
+    }
+
+    private fun Context.areNotificationsPermissionGranted(): Boolean {
+        return runCatching {
+            ActivityCompat.checkSelfPermission(this, POST_NOTIFICATIONS) == PERMISSION_GRANTED
         }.getOrDefault(false)
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -16,11 +16,9 @@
 
 package com.duckduckgo.pir.impl.scheduling
 
-import android.Manifest.permission.POST_NOTIFICATIONS
 import android.content.Context
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.PowerManager
-import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.isIgnoringBatteryOptimizations
@@ -371,7 +369,7 @@ class RealPirJobsRunner @Inject constructor(
 
     private fun Context.areNotificationsPermissionGranted(): Boolean {
         return runCatching {
-            ActivityCompat.checkSelfPermission(this, POST_NOTIFICATIONS) == PERMISSION_GRANTED
+            NotificationManagerCompat.from(this).areNotificationsEnabled()
         }.getOrDefault(false)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -54,6 +54,7 @@ class RealPirPixelSenderTest {
             profileQueryCount = 3,
             brokerCount = 10,
             executionType = PirExecutionType.MANUAL_INITIAL,
+            notificationsPermissionGranted = true,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -72,6 +73,7 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["broker_count"] == "10")
         assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
+        assert(paramsCaptor.firstValue["notifications_permission_granted"] == "true")
     }
 
     @Test
@@ -83,6 +85,7 @@ class RealPirPixelSenderTest {
             profileQueryCount = 1,
             brokerCount = 5,
             executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+            notificationsPermissionGranted = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -95,6 +98,7 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
+        assert(paramsCaptor.firstValue["notifications_permission_granted"] == "false")
     }
 
     @Test
@@ -111,6 +115,7 @@ class RealPirPixelSenderTest {
             brokerCount = 10,
             isPowerSavingEnabled = true,
             executionType = PirExecutionType.MANUAL_INITIAL,
+            notificationsPermissionGranted = true,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -137,6 +142,7 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["power_saving"] == "true")
         assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding")
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "disconnected")
+        assert(paramsCaptor.firstValue["notifications_permission_granted"] == "true")
     }
 
     @Test
@@ -152,6 +158,7 @@ class RealPirPixelSenderTest {
             brokerCount = 0,
             isPowerSavingEnabled = false,
             executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+            notificationsPermissionGranted = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -164,6 +171,7 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
+        assert(paramsCaptor.firstValue["notifications_permission_granted"] == "false")
     }
 
     @Test
@@ -1096,6 +1104,7 @@ class RealPirPixelSenderTest {
             batteryOptimizationsEnabled = false,
             brokerCount = 10,
             executionType = PirExecutionType.MANUAL_INITIAL,
+            notificationsPermissionGranted = true,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -1115,6 +1124,7 @@ class RealPirPixelSenderTest {
         assert(params["broker_count"] == "10")
         assert(params["scan_trigger"] == "onboarding")
         assert(params["vpn_connection_state"] == "disconnected")
+        assert(params["notifications_permission_granted"] == "true")
     }
 
     @Test
@@ -1128,6 +1138,7 @@ class RealPirPixelSenderTest {
             batteryOptimizationsEnabled = true,
             brokerCount = 0,
             executionType = PirExecutionType.MANUAL_EDIT_PROFILE,
+            notificationsPermissionGranted = false,
         )
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
@@ -1140,5 +1151,6 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue["scan_trigger"] == "profile_edit")
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
+        assert(paramsCaptor.firstValue["notifications_permission_granted"] == "false")
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -174,8 +174,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -195,8 +195,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         assertTrue(result.isSuccess)
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
         verifyNoInteractions(mockEligibleScanJobProvider)
@@ -215,8 +215,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockPirSchedulingRepository)
@@ -265,10 +265,10 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 1, MANUAL_INITIAL)
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportInitialScanDuration(eq(0L), eq(2), eq(false), eq(false), eq(1), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -316,10 +316,10 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         // we just dont attempt what the mock for time provider is giving us
-        verify(mockPixelSender).reportInitialScanDuration(0L, 2, false, false, 2, MANUAL_INITIAL)
+        verify(mockPixelSender).reportInitialScanDuration(eq(0L), eq(2), eq(false), eq(false), eq(2), eq(MANUAL_INITIAL), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,
@@ -354,9 +354,9 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL_EDIT_PROFILE)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
-        verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
+        verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
     }
 
     @Test
@@ -525,8 +525,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirScan).stop()
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirSchedulingRepository, never()).saveOptOutJobRecords(
             listOf(
                 OptOutJobRecord(
@@ -677,8 +677,8 @@ class RealPirJobsRunnerTest {
         testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
 
         // Then
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirOptOut, never()).executeOptOutForJobs(listOf(testOptOutJobRecord), mockContext)
     }
 
@@ -1175,8 +1175,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockBrokerJsonUpdater).update()
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockEligibleScanJobProvider)
     }
@@ -1228,8 +1228,8 @@ class RealPirJobsRunnerTest {
 
         // Then
         verifyNoInteractions(mockBrokerJsonUpdater)
-        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL))
-        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL))
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verifyNoMoreInteractions(mockPixelSender)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214486367595494?focus=true

### Description
Adds notification permission state to initial scan pixel

### Steps to test this PR
QA optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that adds a new boolean parameter to several PIR scan pixels and threads it through the scan runner; main risk is missing/incorrect parameter wiring causing pixel schema mismatches.
> 
> **Overview**
> Adds a new `notifications_permission_granted` boolean parameter to PIR scan-related pixels (initial scan duration, foreground run started/completed) in `personal_information_removal.json5`.
> 
> Updates `PirPixelSender`/`RealPirPixelSender` and `RealPirJobsRunner` to collect notification enablement via `NotificationManagerCompat.areNotificationsEnabled()` and attach it to the relevant manual scan pixel payloads, with unit tests adjusted to assert/accept the new param.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6e91c3b8aa4163ad933c5662331df23dbbaee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->