### PR TITLE
Translate string for the PDF tooltip

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Възстановяване на моите неща</string>
     <string name="syncRestoreDialogSecondaryCta">Пропускане</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Изтегляне на PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Копиране на текста на връзката</string>
     <string name="linkTextCopied">Копиран текст на връзката</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Obnovit moje věci</string>
     <string name="syncRestoreDialogSecondaryCta">Přeskočit</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Stáhnout PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopírovat text odkazu</string>
     <string name="linkTextCopied">Text odkazu zkopírován</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Gendan mine data</string>
     <string name="syncRestoreDialogSecondaryCta">Spring over</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Download PDF-fil</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopier linktekst</string>
     <string name="linkTextCopied">Linktekst kopieret</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Meine Sachen wiederherstellen</string>
     <string name="syncRestoreDialogSecondaryCta">Überspringen</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">PDF herunterladen</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Linktext kopieren</string>
     <string name="linkTextCopied">Linktext kopiert</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Επαναφορά των στοιχείων μου</string>
     <string name="syncRestoreDialogSecondaryCta">Παράλειψη</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Λήψη PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Αντιγραφή κειμένου συνδέσμου</string>
     <string name="linkTextCopied">Το κείμενο του συνδέσμου αντιγράφηκε</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Restaura mis cosas</string>
     <string name="syncRestoreDialogSecondaryCta">Omitir</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Descargar PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copiar texto del enlace</string>
     <string name="linkTextCopied">Texto del enlace copiado</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Taasta minu andmed</string>
     <string name="syncRestoreDialogSecondaryCta">Jäta vahele</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Laadi alla PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopeeri lingi tekst</string>
     <string name="linkTextCopied">Lingi tekst on kopeeritud</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Palauta tiedot</string>
     <string name="syncRestoreDialogSecondaryCta">Ohita</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Lataa PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopioi linkin teksti</string>
     <string name="linkTextCopied">Linkin teksti kopioitu</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Rétablir mes données</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorer</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Télécharger le PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copier le texte du lien</string>
     <string name="linkTextCopied">Texte du lien copié</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Vrati mi stvari</string>
     <string name="syncRestoreDialogSecondaryCta">Preskoči</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Preuzmi PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopiraj tekst poveznice</string>
     <string name="linkTextCopied">Tekst poveznice je kopiran</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Saját adataim visszaállítása</string>
     <string name="syncRestoreDialogSecondaryCta">Kihagyás</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">PDF letöltése</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Link szövegének másolása</string>
     <string name="linkTextCopied">Link szövege másolva</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Ripristina i miei contenuti</string>
     <string name="syncRestoreDialogSecondaryCta">Salta</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Scarica PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copia il testo del link</string>
     <string name="linkTextCopied">Testo del link copiato</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Atkurti mano duomenis</string>
     <string name="syncRestoreDialogSecondaryCta">Praleisti</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Atsisiųsti PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopijuoti nuorodos tekstą</string>
     <string name="linkTextCopied">Nuorodos tekstas nukopijuotas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1004,6 +1004,9 @@
     <string name="syncRestoreDialogPrimaryCta">Manas lietas atjaunošana</string>
     <string name="syncRestoreDialogSecondaryCta">Izlaist</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Lejupielādēt PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Saites teksta kopēšana</string>
     <string name="linkTextCopied">Saites teksts nokopēts</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Gjenopprett innholdet mitt</string>
     <string name="syncRestoreDialogSecondaryCta">Hopp over</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Last ned PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopier lenketekst</string>
     <string name="linkTextCopied">Lenketeksten er kopiert</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Herstel mijn gegevens</string>
     <string name="syncRestoreDialogSecondaryCta">Overslaan</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">PDF downloaden</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Linktekst kopiëren</string>
     <string name="linkTextCopied">Linktekst gekopieerd</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Przywróć moje dane</string>
     <string name="syncRestoreDialogSecondaryCta">Pomiń</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Pobierz PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopiuj tekst linku</string>
     <string name="linkTextCopied">Skopiowano tekst linku</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Restaurar as minhas coisas</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorar</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Descarregar PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copiar texto do link</string>
     <string name="linkTextCopied">Texto do link copiado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1004,6 +1004,9 @@
     <string name="syncRestoreDialogPrimaryCta">Restaurează lucrurile mele</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorare</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Descarcă PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copiază textul linkului</string>
     <string name="linkTextCopied">Textul linkului a fost copiat</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Восстановить мои данные</string>
     <string name="syncRestoreDialogSecondaryCta">Пропустить</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Скачать PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Скопировать текст ссылки</string>
     <string name="linkTextCopied">Текст ссылки скопирован</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Obnoviť moje veci</string>
     <string name="syncRestoreDialogSecondaryCta">Preskočiť</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Stiahnuť PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopírovať text odkazu</string>
     <string name="linkTextCopied">Skopírovaný text prepojenia</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1024,6 +1024,9 @@
     <string name="syncRestoreDialogPrimaryCta">Obnovi moje stvari</string>
     <string name="syncRestoreDialogSecondaryCta">Preskoči</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Prenesi PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopiraj besedilo povezave</string>
     <string name="linkTextCopied">Besedilo povezave je bilo kopirano</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Återställ mitt innehåll</string>
     <string name="syncRestoreDialogSecondaryCta">Hoppa över</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Ladda ner PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Kopiera länktext</string>
     <string name="linkTextCopied">Länktext kopierad</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -984,6 +984,9 @@
     <string name="syncRestoreDialogPrimaryCta">Geri Yükle</string>
     <string name="syncRestoreDialogSecondaryCta">Atla</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">PDF indir</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Bağlantı Metnini Kopyala</string>
     <string name="linkTextCopied">Bağlantı metni kopyalandı</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -109,7 +109,4 @@
     <!-- Default browser changed survey -->
     <string name="defaultBrowserChangedSurveyNotificationTitle">We noticed a change</string>
     <string name="defaultBrowserChangedSurveyNotificationDescription">DuckDuckGo is no longer your default browser. Mind telling us why?</string>
-
-    <!-- PDF download tooltip -->
-    <string name="pdfDownloadTooltipText">Download PDF</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -983,6 +983,9 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
+    <!-- PDF download tooltip -->
+    <string name="pdfDownloadTooltipText">Download PDF</string>
+
     <!-- Sharing options -->
     <string name="copyLinkText">Copy Link Text</string>
     <string name="linkTextCopied">Link text copied</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1214511669578004?focus=true 

### Description

Translate pdfDownloadTooltipText for PDF tooltip

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk localization-only change that adds a new translatable string entry and removes it from `donottranslate.xml`. Main risk is missing/incorrect translations or resource-merge conflicts across locales.
> 
> **Overview**
> Adds the `pdfDownloadTooltipText` string to `values/strings.xml` and propagates translated values across multiple `values-xx/strings.xml` locales for the PDF download tooltip.
> 
> Removes `pdfDownloadTooltipText` from `values/donottranslate.xml` so the tooltip can be localized instead of hardcoded in the non-translatable resource set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ff0c6aa42c7277b9417b663766b43047cbdee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->