### PR TITLE
Use dax backdrop color for PDF background

### DIFF
--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -124,6 +124,7 @@
                     android:id="@+id/pdfViewerContainer"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:background="?attr/daxColorBackdrop"
                     android:visibility="gone" />
 
                 <include


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1214486367030365?focus=true 

### Description

Use dax color backdrop when PDF is opened in a tab.

### Steps to test this PR

- [x] Open a PDF in the browser
- [x] Check the background is darker than before

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/aea7b8f2-b21c-43fb-8306-c2b06dd470a7" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/cfc9a824-0560-4c83-89f7-1a1bbea7b997" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: sets a theme-backed background on the PDF container, which could only affect PDF tab appearance across themes.
> 
> **Overview**
> Updates `fragment_browser_tab.xml` so the in-tab `pdfViewerContainer` uses the theme attribute `?attr/daxColorBackdrop` as its background, making the PDF viewer area render with the standard darker backdrop when shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c344b78b3ea3e42fcf15ab92b7e5e28afef103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->