### PR TITLE
Add Duck.ai start-chat icon to unified input field

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1037,12 +1037,12 @@
 
     <issue
         id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.NativeInputWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.ui.NativeInputWidget"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"
-            line="36"
+            line="40"
             column="1"/>
     </issue>
 
@@ -12434,9 +12434,9 @@
 
     <issue
         id="NoImplImportsInAppModule"
-        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.NativeInputWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
-        errorLine1="import com.duckduckgo.duckchat.impl.ui.NativeInputWidget"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Modules should not import from :*-impl modules.&#xA;Consider using the public API instead: com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget&#xA;If the API doesn&apos;t expose what you need, extend the API module first."
+        errorLine1="import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt"/>
     </issue>

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.impl.ui.NativeInputWidget
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
 import com.duckduckgo.voice.api.VoiceSearchAvailability

--- a/app/src/main/res/layout/input_mode_widget_card_view.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view.xml
@@ -32,7 +32,7 @@
         app:cardElevation="6dp"
         app:cardUseCompatPadding="true">
 
-        <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+        <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
             android:id="@+id/inputModeWidget"
             android:paddingHorizontal="8dp"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -31,7 +31,7 @@
         app:cardElevation="3dp"
         app:cardUseCompatPadding="false">
 
-        <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+        <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
             android:id="@+id/inputModeWidget"
             android:paddingHorizontal="8dp"
             android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
-import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.google.android.material.card.MaterialCardView

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -442,6 +442,12 @@ open class InputModeWidget @JvmOverloads constructor(
         }
     }
 
+    fun submitAsChat() {
+        val textToSubmit = inputField.text.getTextToSubmit()?.toString() ?: return
+        onChatSent?.invoke(textToSubmit)
+        inputField.clearFocus()
+    }
+
     fun selectTab(index: Int) {
         inputModeSwitch.post {
             inputModeSwitch.getTabAt(index)?.select()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -442,10 +442,11 @@ open class InputModeWidget @JvmOverloads constructor(
         }
     }
 
-    fun submitAsChat() {
-        val textToSubmit = inputField.text.getTextToSubmit()?.toString() ?: return
+    fun submitAsChat(): Boolean {
+        val textToSubmit = inputField.text.getTextToSubmit()?.toString() ?: return false
         onChatSent?.invoke(textToSubmit)
         inputField.clearFocus()
+        return true
     }
 
     fun selectTab(index: Int) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.plugins
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginModelPickerNativeInput",
+    parentFeatureName = "pluginPointNativeInput",
+)
+class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+
+    override val containerId: Int = R.id.modelPickerContainer
+
+    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
+
+    override fun createView(context: Context): View {
+        return ModelPickerView(context).also { picker ->
+            modelPicker = WeakReference(picker)
+            picker.setPickerEnabled(true)
+        }
+    }
+
+    override fun getPromptContribution(): PromptContribution? {
+        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
+        return PromptContribution.ModelSelection(modelId)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -23,9 +23,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
-import java.lang.ref.WeakReference
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -38,17 +36,7 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.startChatContainer
 
-    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
+    override fun createView(context: Context): View = StartChatView(context)
 
-    override fun createView(context: Context): View {
-        return ModelPickerView(context).also { picker ->
-            modelPicker = WeakReference(picker)
-            picker.setPickerEnabled(true)
-        }
-    }
-
-    override fun getPromptContribution(): PromptContribution? {
-        // no-op
-        return null
-    }
+    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -14,28 +14,29 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.ui.nativeinput
+package com.duckduckgo.duckchat.impl.ui.nativeinput.plugins
 
 import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
-import com.duckduckgo.duckchat.impl.ui.ModelPicker
-import com.duckduckgo.duckchat.impl.ui.ModelPickerView
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NativeInputPlugin::class,
-    featureName = "pluginModelPickerNativeInput",
+    featureName = "pluginStartChatNativeInput",
     parentFeatureName = "pluginPointNativeInput",
 )
-class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
-    override val containerId: Int = com.duckduckgo.duckchat.impl.R.id.modelPickerContainer
+    override val containerId: Int = R.id.startChatContainer
 
     private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
 
@@ -47,7 +48,7 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     }
 
     override fun getPromptContribution(): PromptContribution? {
-        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
-        return PromptContribution.ModelSelection(modelId)
+        // no-op
+        return null
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.ui
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import android.content.Context
 import android.text.TextUtils

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.ui
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.ui
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import android.app.Activity
 import android.content.Context
@@ -53,6 +53,8 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAd
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
+import com.duckduckgo.duckchat.impl.ui.NativeInputState
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.Job

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -93,6 +93,7 @@ interface NativeInputWidget {
     fun setVoiceSearchAvailable(available: Boolean)
     fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
+    fun submitAsChat()
     fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
@@ -210,7 +211,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
                         val pluginView = plugin.createView(context)
                         container.removeAllViews()
                         container.addView(pluginView)
-                        container.isVisible = isChatTabSelected()
+                        // The start-chat container drives its own visibility from input mode.
+                        if (plugin.containerId != R.id.startChatContainer) {
+                            container.isVisible = isChatTabSelected()
+                        }
                     }
                 }
             }
@@ -219,6 +223,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     when (command) {
                         is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
                             for (containerId in command.containerIds) {
+                                if (containerId == R.id.startChatContainer) continue
                                 findViewById<FrameLayout?>(containerId)?.isVisible = command.visible
                             }
                         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -93,7 +93,7 @@ interface NativeInputWidget {
     fun setVoiceSearchAvailable(available: Boolean)
     fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
-    fun submitAsChat()
+    fun submitAsChat(): Boolean
     fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
@@ -16,12 +16,76 @@
 
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.R
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ViewScope::class)
-class StartChatView {
+class StartChatView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
 
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
 
+    private val viewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[StartChatViewModel::class.java]
+    }
 
+    private val icon: ImageView by lazy { findViewById(R.id.aiChatIconMenu) }
+    private var visibilityJob: Job? = null
+
+    init {
+        inflate(context, R.layout.view_start_chat, this)
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        icon.setOnClickListener { findNativeInputWidget()?.submitAsChat() }
+        observeVisibility()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        visibilityJob?.cancel()
+        visibilityJob = null
+    }
+
+    private fun observeVisibility() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        visibilityJob?.cancel()
+        visibilityJob = viewModel.isVisible
+            .onEach { visible ->
+                isVisible = visible
+                (parent as? View)?.isVisible = visible
+            }
+            .launchIn(scope)
+    }
+
+    private fun findNativeInputWidget(): NativeInputWidget? {
+        var node: View? = this
+        while (node != null) {
+            if (node is NativeInputWidget) return node
+            node = node.parent as? View
+        }
+        return null
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.di.scopes.ViewScope
+
+@InjectWith(ViewScope::class)
+class StartChatView {
+
+
+
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
@@ -59,7 +59,10 @@ class StartChatView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
-        icon.setOnClickListener { findNativeInputWidget()?.submitAsChat() }
+        icon.setOnClickListener {
+            val submitted = findNativeInputWidget()?.submitAsChat() == true
+            if (!submitted) viewModel.openNewChat()
+        }
         observeVisibility()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -21,10 +21,8 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
-import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @ContributesViewModel(ViewScope::class)
@@ -33,17 +31,18 @@ class StartChatViewModel @Inject constructor(
     duckChatInternal: DuckChatInternal,
 ) : ViewModel() {
 
-    val inputMode: Flow<InputMode> = combine(
+    /**
+     * Show the start-chat icon only when Duck.ai is available (feature enabled +
+     * user setting on) but the input-screen toggle is off — i.e. the user has Duck.ai
+     * but is in `SEARCH_ONLY` mode. Mapping `inputMode == SEARCH_ONLY` directly would
+     * also match the case where Duck.ai is entirely disabled, which would let the icon
+     * navigate to a Duck.ai URL the user has opted out of.
+     */
+    val isVisible: Flow<Boolean> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
     ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled ->
-        if (isFeatureEnabled && isUserEnabled && isInputScreenUserSettingEnabled) {
-            InputMode.SEARCH_AND_DUCK_AI
-        } else {
-            InputMode.SEARCH_ONLY
-        }
+        isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled
     }
-
-    val isVisible: Flow<Boolean> = inputMode.map { it == InputMode.SEARCH_ONLY }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class StartChatViewModel @Inject constructor(
+    duckAiFeatureState: DuckAiFeatureState,
+    duckChatInternal: DuckChatInternal,
+) : ViewModel() {
+
+    val inputMode: Flow<InputMode> = combine(
+        duckAiFeatureState.showSettings,
+        duckChatInternal.observeEnableDuckChatUserSetting(),
+        duckChatInternal.observeInputScreenUserSettingEnabled(),
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled ->
+        if (isFeatureEnabled && isUserEnabled && isInputScreenUserSettingEnabled) {
+            InputMode.SEARCH_AND_DUCK_AI
+        } else {
+            InputMode.SEARCH_ONLY
+        }
+    }
+
+    val isVisible: Flow<Boolean> = inputMode.map { it == InputMode.SEARCH_ONLY }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 @ContributesViewModel(ViewScope::class)
 class StartChatViewModel @Inject constructor(
     duckAiFeatureState: DuckAiFeatureState,
-    duckChatInternal: DuckChatInternal,
+    private val duckChatInternal: DuckChatInternal,
 ) : ViewModel() {
 
     /**
@@ -44,5 +44,9 @@ class StartChatViewModel @Inject constructor(
         duckChatInternal.observeInputScreenUserSettingEnabled(),
     ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled ->
         isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled
+    }
+
+    fun openNewChat() {
+        duckChatInternal.openNewDuckChatSession()
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai.xml
@@ -368,7 +368,7 @@
             app:cardElevation="4dp"
             app:cardUseCompatPadding="false">
 
-            <com.duckduckgo.duckchat.impl.ui.NativeInputModeWidget
+            <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
                 android:id="@+id/contextualNativeInputWidget"
                 android:paddingHorizontal="8dp"
                 android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -164,6 +164,14 @@
                         android:visibility="gone"
                         app:srcCompat="@drawable/ic_close_circle_small_secondary_24" />
 
+                    <FrameLayout
+                        android:id="@id/startChatContainer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
+
                 </LinearLayout>
 
                 <FrameLayout

--- a/duckchat/duckchat-impl/src/main/res/layout/view_start_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_start_chat.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <ImageView
+        android:id="@+id/aiChatIconMenu"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:layout_gravity="center"
+        android:background="@drawable/selectable_circular_container_ripple"
+        android:contentDescription="@string/duckChatStartChatContentDescription"
+        android:scaleType="center"
+        android:src="@drawable/ic_ai_chat_24"
+        tools:visibility="visible" />
+
+</merge>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -31,4 +31,7 @@
     <string name="duckAiVoiceNotificationTitle">Duck.ai Voice Chat Active</string>
     <string name="duckAiVoiceNotificationMessage">Microphone is in use by Duck.ai</string>
     <string name="duckAiVoiceNotificationChannelName">Duck.ai Voice Chat</string>
+
+    <!-- Start chat icon content description -->
+    <string name="duckChatStartChatContentDescription">Start chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/native_input_plugin_ids.xml
@@ -16,4 +16,5 @@
 
 <resources>
     <item name="modelPickerContainer" type="id"/>
+    <item name="startChatContainer" type="id"/>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -111,7 +111,6 @@
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>
-    <string name="duckChatStartChatContentDescription" tools:ignore="MissingTranslation">Start chat</string>
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -111,7 +111,7 @@
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>
-    <string name="duckChatStartChatContentDescription">Start chat</string>
+    <string name="duckChatStartChatContentDescription" tools:ignore="MissingTranslation">Start chat</string>
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -111,6 +111,7 @@
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>
+    <string name="duckChatStartChatContentDescription">Start chat</string>
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.duckchat.impl.ui
 
 import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputContext
 import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputMode
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowCardRowBack
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowToggleRowBack
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214387687457006                                              
                                                 
  ### Description                                                                                                                                  
   
  Adds an AI chat icon to the unified input field for users who have the Duck.ai toggle disabled (input mode = `SEARCH_ONLY`). Tapping the icon    
  submits the current input directly to Duck.ai.                    
                                                                                                                                                   
  **New plugin** `StartChatNativeInputPlugin` (`@ContributesActivePlugin`, `boundType = NativeInputPlugin`) targeting a new                        
  `R.id.startChatContainer`. Constructs a `StartChatView`.
                                                                                                                                                   
  **New view** `StartChatView` — `FrameLayout` with `@InjectWith(ViewScope::class)`, inflating `view_start_chat.xml` (single ImageView using       
  `ic_ai_chat_24`). Walks the parent view tree to find the enclosing `NativeInputWidget` and routes the click to the new `submitAsChat()` method.
                                                                                                                                                   
  **New view model** `StartChatViewModel` (`@ContributesViewModel(ViewScope::class)`) — combines `DuckAiFeatureState.showSettings`,                
  `DuckChatInternal.observeEnableDuckChatUserSetting()`, and `DuckChatInternal.observeInputScreenUserSettingEnabled()` to derive `InputMode`
  (mirrors `NativeInputModeWidgetViewModel.getInputMode`). Exposes `isVisible: Flow<Boolean>` = `inputMode == SEARCH_ONLY`.                        
                                                                    
  **New widget contract method** `InputModeWidget.submitAsChat()` — reads the current input field text via the existing `getTextToSubmit()` (trim +
   `ifBlank { null }`) and invokes `onChatSent?.invoke(textToSubmit)` directly, bypassing the tab-position check that `submitMessage` performs.
  Added to the `NativeInputWidget` interface.                                                                                                      
                                                                    
  **Visibility ownership** — the widget's plugin-loop visibility flow (which toggles all plugin containers based on chat-tab selection) explicitly 
  skips `R.id.startChatContainer`. The view + container drive themselves from `InputMode`.
                                                                                                                                                   
  ### Steps to test this PR                                         

  _Visibility_
  - [x] Toggle **OFF** the Duck.ai input-screen user setting (or disable the relevant feature flag) so the input mode resolves to `SEARCH_ONLY`
  - [x] Open the unified input field — confirm the AI chat icon (`ic_ai_chat_24`) is visible on the right side of the input row                    
  - [x] Toggle **ON** the Duck.ai setting so the input mode becomes `SEARCH_AND_DUCK_AI`                                                           
  - [x] Open the unified input field again — confirm the icon is gone and its container leaves no empty space                                      
  - [x] In `SEARCH_AND_DUCK_AI`, switch between Search and Chat tabs — confirm the icon stays hidden in both (driven by input mode, not tab        
  selection)                                                                                                                                       
                                                                    
  _Click action_                                                                                                                                   
  - [x] With the icon visible (`SEARCH_ONLY`), focus the input and type a query (e.g. "kotlin coroutines")
  - [x] Tap the AI chat icon — confirm the query is submitted to Duck.ai (full-screen Duck.ai opens with the prompt), not as a regular search      
  - [x] Tap the icon while the input field is empty — confirm it's a no-op (matches existing `submitMessage` semantics)                            
                                                                                                                                                   
  _Regression_                                                                                                                                     
  - [x] Model picker still appears on the chat tab and hides on the search tab                                                                     
  - [x] Tab switches still hide/show the model picker and other plugin containers correctly
  - [x] Existing `submitMessage` is unchanged — typed query in chat tab still submits via `onChatSent`; in search tab still submits via            
  `onSearchSent`                                                                                                                                   
                                                                                                                                                   
  ### UI changes                                                                                                                                   
  | Before | After |                                                
  | ------ | ----- |
  | (no AI chat icon in `SEARCH_ONLY` input field) | (AI chat icon visible on the right of the input field) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new plugin/view/viewmodel and a new submission path (`submitAsChat`) in the unified input widget, which could regress input submission or plugin visibility behavior if conditions are wrong. Changes are UI/feature-flag driven and do not touch auth or sensitive data flows.
> 
> **Overview**
> Adds a *Duck.ai start-chat icon* to the unified native input field that appears when Duck.ai is available but the input-screen toggle is disabled (`SEARCH_ONLY`), and routes clicks to either submit the current text as a Duck.ai chat or open a new chat session.
> 
> Refactors native-input UI classes into the `com.duckduckgo.duckchat.impl.ui.nativeinput.*` namespace, updates app and XML references accordingly, and extends the `NativeInputWidget` contract with `submitAsChat()` while adjusting plugin-container visibility handling to exclude the new `startChatContainer` (it controls its own visibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49bf48128ee2bc25930dfa8f65ff119a9b01880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->