### PR TITLE
Fix pixel definitions to use array instead of string

### DIFF
--- a/PixelDefinitions/pixels/definitions/autofill.json5
+++ b/PixelDefinitions/pixels/definitions/autofill.json5
@@ -77,9 +77,12 @@
             "error",
             {
                 "key": "key",
-                "description": "The name of the key that failed to update",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that failed to update",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -117,9 +120,12 @@
             "error",
             {
                 "key": "key",
-                "description": "The name of the key that failed to update in Harmony",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that failed to update in Harmony",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -157,9 +163,12 @@
             "error",
             {
                 "key": "key",
-                "description": "The name of the key that failed to read from Harmony",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that failed to read from Harmony",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -197,9 +206,12 @@
             "error",
             {
                 "key": "key",
-                "description": "The name of the key that failed to read from legacy",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that failed to read from legacy",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -236,9 +248,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key whose value failed to decode from legacy",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) whose value failed to decode from legacy",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -275,9 +290,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key whose value failed to decode from Harmony",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) whose value failed to decode from Harmony",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -314,9 +332,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key that has a mismatch between Harmony and legacy",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that has a mismatch between Harmony and legacy",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -353,9 +374,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key that is missing from Harmony",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that is missing from Harmony",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -392,9 +416,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key that is missing from legacy preferences",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that is missing from legacy preferences",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -431,9 +458,12 @@
             "appVersion",
             {
                 "key": "key",
-                "description": "The name of the key that already exists and was protected from overwrite",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that already exists and was protected from overwrite",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",
@@ -478,9 +508,12 @@
             "error",
             {
                 "key": "key",
-                "description": "The name of the key that failed to rollback",
-                "type": "string",
-                "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                "description": "The name of the key(s) that failed to rollback",
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["KEY_GENERATED_PASSWORD", "KEY_L1KEY", "KEY_PASSWORD_SALT", "KEY_ENCRYPTED_L2KEY", "KEY_ENCRYPTED_L2KEY_IV"]
+                }
             },
             {
                 "key": "useHarmony",

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/store/keys/SecureStorageKeyStore.kt
@@ -192,8 +192,8 @@ class RealSecureStorageKeyStore(
         return harmonyPreferencesDeferred.await()
     }
 
-    private fun Array<out Pair<String, ByteArray>>.getKeys(): String =
-        this.map { it.first }.toString()
+    private fun Array<out Pair<String, ByteArray>>.getKeys(): List<String> =
+        this.map { it.first }
 
     @SuppressLint("UseKtx")
     override suspend fun updateKey(
@@ -210,7 +210,7 @@ class RealSecureStorageKeyStore(
                     pixel.fire(
                         AUTOFILL_PREFERENCES_UPDATE_KEY_NULL_FILE,
                         getPixelParams(
-                            keyName = keyValues.getKeys(),
+                            keyNames = keyValues.getKeys(),
                             harmonyFlags = harmonyFlags,
                         ),
                         type = Daily(),
@@ -227,7 +227,7 @@ class RealSecureStorageKeyStore(
                         pixel.fire(
                             AUTOFILL_HARMONY_PREFERENCES_UPDATE_KEY_NULL_FILE,
                             getPixelParams(
-                                keyName = keyValues.getKeys(),
+                                keyNames = keyValues.getKeys(),
                                 harmonyFlags = harmonyFlags,
                             ),
                             type = Daily(),
@@ -246,7 +246,7 @@ class RealSecureStorageKeyStore(
                     pixel.fire(
                         AUTOFILL_STORE_KEY_ALREADY_EXISTS,
                         getPixelParams(
-                            keyName = keyValue.first,
+                            keyNames = listOf(keyValue.first),
                             harmonyFlags = harmonyFlags,
                         ),
                         type = Daily(),
@@ -298,7 +298,7 @@ class RealSecureStorageKeyStore(
                     pixel.fire(
                         AUTOFILL_HARMONY_PREFERENCES_UPDATE_KEY_FAILED,
                         getPixelParams(
-                            keyName = keyValues.getKeys(),
+                            keyNames = keyValues.getKeys(),
                             throwable = error,
                             harmonyFlags = harmonyFlags,
                         ),
@@ -316,7 +316,7 @@ class RealSecureStorageKeyStore(
                                 pixel.fire(
                                     AutofillPixelNames.AUTOFILL_HARMONY_UPDATE_KEY_ROLLBACK_FAILED,
                                     getPixelParams(
-                                        keyName = keyValues.getKeys(),
+                                        keyNames = keyValues.getKeys(),
                                         harmonyFlags = harmonyFlags,
                                     ),
                                     type = Daily(),
@@ -326,7 +326,7 @@ class RealSecureStorageKeyStore(
                             pixel.fire(
                                 AutofillPixelNames.AUTOFILL_HARMONY_UPDATE_KEY_ROLLBACK_FAILED,
                                 getPixelParams(
-                                    keyName = keyValues.getKeys(),
+                                    keyNames = keyValues.getKeys(),
                                     throwable = rollbackError,
                                     harmonyFlags = harmonyFlags,
                                 ),
@@ -392,7 +392,7 @@ class RealSecureStorageKeyStore(
                     if (it == null) {
                         pixel.fire(
                             AUTOFILL_PREFERENCES_GET_KEY_NULL_FILE,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -411,7 +411,7 @@ class RealSecureStorageKeyStore(
                     if (it == null) {
                         pixel.fire(
                             AUTOFILL_HARMONY_PREFERENCES_GET_KEY_NULL_FILE,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -429,7 +429,7 @@ class RealSecureStorageKeyStore(
                     pixel.fire(
                         AUTOFILL_PREFERENCES_GET_KEY_FAILED,
                         getPixelParams(
-                            keyName = keyName,
+                            keyNames = listOf(keyName),
                             throwable = it,
                             harmonyFlags = harmonyFlags,
                         ),
@@ -446,7 +446,7 @@ class RealSecureStorageKeyStore(
                 if (decoded == null) {
                     pixel.fire(
                         AUTOFILL_PREFERENCES_GET_KEY_DECODE_FAILED,
-                        getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                        getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                         type = Daily(),
                     )
                     throw SecureStorageException.InternalSecureStorageException("Legacy preferences key value is present but cannot be decoded")
@@ -462,7 +462,7 @@ class RealSecureStorageKeyStore(
                     pixel.fire(
                         AUTOFILL_HARMONY_PREFERENCES_GET_KEY_FAILED,
                         getPixelParams(
-                            keyName = keyName,
+                            keyNames = listOf(keyName),
                             throwable = it,
                             harmonyFlags = harmonyFlags,
                         ),
@@ -478,7 +478,7 @@ class RealSecureStorageKeyStore(
                     if (decoded == null) {
                         pixel.fire(
                             AUTOFILL_HARMONY_PREFERENCES_GET_KEY_DECODE_FAILED,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -498,7 +498,7 @@ class RealSecureStorageKeyStore(
                     harmonyPrefs != null && harmonyEncoded == null && legacyValue != null -> {
                         pixel.fire(
                             AUTOFILL_HARMONY_KEY_MISSING,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -508,7 +508,7 @@ class RealSecureStorageKeyStore(
                     legacyPrefs != null && harmonyValue != null && legacyEncoded == null -> {
                         pixel.fire(
                             AUTOFILL_PREFERENCES_KEY_MISSING,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -518,7 +518,7 @@ class RealSecureStorageKeyStore(
                     harmonyValue != null && legacyValue != null && !harmonyValue.contentEquals(legacyValue) -> {
                         pixel.fire(
                             AUTOFILL_HARMONY_KEY_MISMATCH,
-                            getPixelParams(keyName = keyName, harmonyFlags = harmonyFlags),
+                            getPixelParams(keyNames = listOf(keyName), harmonyFlags = harmonyFlags),
                             type = Daily(),
                         )
                         if (harmonyFlags.readFromHarmony) {
@@ -545,8 +545,8 @@ class RealSecureStorageKeyStore(
         }
     }
 
-    private fun getPixelParams(keyName: String? = null, throwable: Throwable? = null, harmonyFlags: HarmonyFlags) = buildMap {
-        keyName?.let { put("key", it) }
+    private fun getPixelParams(keyNames: List<String>? = null, throwable: Throwable? = null, harmonyFlags: HarmonyFlags) = buildMap {
+        keyNames?.let { put("key", it.map { name -> "\"$name\"" }.toString()) }
         put("useHarmony", harmonyFlags.useHarmony.toString())
         put("initialHarmonyValue", initialUseHarmonyValue.toString())
         put("readFromHarmony", harmonyFlags.readFromHarmony.toString())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210856607616307/task/1214280563850698?focus=true

### Description
Original pixel definition was a String, but what we're firing is an array. Replace definition with array, and format keys properly

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes pixel metadata and how pixel parameters are formatted, not the secure storage read/write behavior. Main risk is analytics/schema mismatch if downstream expects the old single-string `key` value.
> 
> **Overview**
> Updates autofill pixel definitions so the `key` parameter for secure-storage-related pixels is an **array of key names** (instead of a single string), aligning schema with cases where multiple keys are updated/read.
> 
> Adjusts `RealSecureStorageKeyStore` pixel firing to pass `keyNames` (lists) and updates `getPixelParams` to serialize those lists into the `key` param for all relevant error/diagnostic pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175d84a0e5d8567fd134eb67e5a45839cf2af6e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->