### PR TITLE
Hatch: Ensure new default is set correctly

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -45,7 +45,7 @@ import javax.inject.Inject
     boundType = BrowserLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
-class FirstScreenHandlerImpl     @Inject constructor(
+class FirstScreenHandlerImpl @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature,
     private val settingsDataStore: SettingsDataStore,

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -19,9 +19,12 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
@@ -42,11 +45,13 @@ import javax.inject.Inject
     boundType = BrowserLifecycleObserver::class,
 )
 @SingleInstanceIn(AppScope::class)
-class FirstScreenHandlerImpl @Inject constructor(
+class FirstScreenHandlerImpl     @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature,
     private val settingsDataStore: SettingsDataStore,
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val appBuildConfig: AppBuildConfig,
     private val dispatcherProvider: DispatcherProvider,
     private val duckChat: DuckChat,
     private val tabRepository: TabRepository,
@@ -73,8 +78,16 @@ class FirstScreenHandlerImpl @Inject constructor(
             // Persist the new-user default eagerly so screens that read optionFlow
             // (e.g. GeneralSettings) don't fall back to LastOpenedTab before the
             // after-inactivity flow has had a chance to run.
-            showOnAppLaunchOptionHandler.ensureNewUserDefault()
+            ensureNewUserDefault()
             handleFirstScreen(isFreshLaunch)
+        }
+    }
+
+    private suspend fun ensureNewUserDefault() {
+        val ntpAfterIdleEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled()
+        if (ntpAfterIdleEnabled && appBuildConfig.isNewInstall() && !showOnAppLaunchOptionDataStore.hasOptionSelected()) {
+            logcat { "FirstScreen: setting New Tab for new users" }
+            showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(NewTabPage)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchO
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.isHttpOrHttps
 import com.duckduckgo.di.scopes.AppScope
@@ -38,7 +37,6 @@ import logcat.logcat
 import javax.inject.Inject
 
 interface ShowOnAppLaunchOptionHandler {
-    suspend fun ensureNewUserDefault()
     suspend fun handleAfterInactivityOption(wasIdle: Boolean)
     suspend fun handleAppLaunchOption()
     suspend fun handleResolvedUrlStorage(
@@ -53,18 +51,10 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val tabRepository: TabRepository,
-    private val appBuildConfig: AppBuildConfig,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val settingsDataStore: SettingsDataStore,
     private val systemAutofillEngagement: SystemAutofillEngagement,
 ) : ShowOnAppLaunchOptionHandler {
-
-    override suspend fun ensureNewUserDefault() {
-        if (appBuildConfig.isNewInstall() && !showOnAppLaunchOptionDataStore.hasOptionSelected()) {
-            logcat { "FirstScreen: setting New Tab for new users" }
-            showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(NewTabPage)
-        }
-    }
 
     override suspend fun handleAfterInactivityOption(wasIdle: Boolean) {
         logcat { "FirstScreen: Inactivity Timer passed" }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -19,16 +19,23 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -37,7 +44,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -50,6 +57,8 @@ class FirstScreenHandlerImplTest {
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature = mock()
     private val settingsDataStore: SettingsDataStore = mock()
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler = mock()
+    private lateinit var showOnAppLaunchOptionDataStore: FakeShowOnAppLaunchOptionDataStore
+    private val appBuildConfig: AppBuildConfig = mock()
     private val duckChat: DuckChat = mock()
     private val tabRepository: TabRepository = mock()
     private val systemAutofillEngagement: SystemAutofillEngagement = mock()
@@ -65,18 +74,22 @@ class FirstScreenHandlerImplTest {
 
     @Before
     fun setup() {
+        showOnAppLaunchOptionDataStore = FakeShowOnAppLaunchOptionDataStore()
         whenever(androidBrowserConfigFeature.showNTPAfterIdleReturn()).thenReturn(idleReturnToggle)
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
         whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
         whenever(customTabDetector.isCustomTab()).thenReturn(false)
         whenever(tabRepository.liveSelectedTab).thenReturn(liveSelectedTab)
+        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
 
         testee = FirstScreenHandlerImpl(
             androidBrowserConfigFeature = androidBrowserConfigFeature,
             showOnAppLaunchFeature = showOnAppLaunchFeature,
             settingsDataStore = settingsDataStore,
             showOnAppLaunchOptionHandler = showOnAppLaunchOptionHandler,
+            showOnAppLaunchOptionDataStore = showOnAppLaunchOptionDataStore,
+            appBuildConfig = appBuildConfig,
             duckChat = duckChat,
             tabRepository = tabRepository,
             ntpAfterIdleManager = ntpAfterIdleManager,
@@ -87,40 +100,58 @@ class FirstScreenHandlerImplTest {
         )
     }
 
-    // --- ensureNewUserDefault is invoked on every onOpen ---
+    // --- new-user default is persisted on onOpen when conditions are met ---
 
     @Test
-    fun whenOnOpenWithIdleReturnEnabledThenInvokesEnsureNewUserDefault() = runTest {
+    fun whenOnOpenWithIdleReturnEnabledAndNewInstallAndNoOptionThenPersistsNewTabPage() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        assertEquals(NewTabPage, showOnAppLaunchOptionDataStore.optionFlow.firstOrNull())
     }
 
     @Test
-    fun whenOnOpenWithIdleReturnDisabledAndShowOnAppLaunchEnabledThenInvokesEnsureNewUserDefault() = runTest {
+    fun whenOnOpenWithIdleReturnDisabledThenDoesNotPersistDefault() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        assertFalse(showOnAppLaunchOptionDataStore.hasOptionSelected())
     }
 
     @Test
-    fun whenOnOpenWithBothFeaturesDisabledThenStillInvokesEnsureNewUserDefault() = runTest {
-        whenever(idleReturnToggle.isEnabled()).thenReturn(false)
-        whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(false)
+    fun whenOnOpenAndNotNewInstallThenDoesNotPersistDefault() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
+        assertFalse(showOnAppLaunchOptionDataStore.hasOptionSelected())
+    }
+
+    @Test
+    fun whenOnOpenAndOptionAlreadySelectedThenDoesNotOverwrite() = runTest {
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
+        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+        showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+
+        testee.onOpen(isFreshLaunch = true)
+        testScope.testScheduler.advanceUntilIdle()
+
+        assertEquals(LastOpenedTab, showOnAppLaunchOptionDataStore.optionFlow.firstOrNull())
     }
 
     // --- Idle return enabled (covers both fresh and non-fresh launches) ---
@@ -161,8 +192,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -175,8 +205,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -227,8 +256,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -291,8 +319,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -302,8 +329,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
         verify(showOnAppLaunchToggle, never()).isEnabled()
     }
 
@@ -323,8 +349,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -372,8 +397,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test
@@ -518,8 +542,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     // --- RC default used directly ---
@@ -555,8 +578,7 @@ class FirstScreenHandlerImplTest {
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
 
-        verify(showOnAppLaunchOptionHandler).ensureNewUserDefault()
-        verifyNoMoreInteractions(showOnAppLaunchOptionHandler)
+        verifyNoInteractions(showOnAppLaunchOptionHandler)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -62,7 +61,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     private lateinit var fakeDataStore: FakeShowOnAppLaunchOptionDataStore
     private lateinit var fakeTabRepository: TabRepository
-    private val appBuildConfig: AppBuildConfig = mock()
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
     private val settingsDataStore: SettingsDataStore = mock()
     private val systemAutofillEngagement: SystemAutofillEngagement = mock()
@@ -72,13 +70,11 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     fun setup() {
         fakeDataStore = FakeShowOnAppLaunchOptionDataStore()
         fakeTabRepository = FakeTabRepository()
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
         testee = ShowOnAppLaunchOptionHandlerImpl(
             dispatcherProvider,
             fakeDataStore,
             fakeTabRepository,
-            appBuildConfig,
             ntpAfterIdleManager,
             settingsDataStore,
             systemAutofillEngagement,
@@ -796,60 +792,10 @@ class ShowOnAppLaunchOptionHandlerImplTest {
         }
     }
 
-    // ensureNewUserDefault tests
-
-    @Test
-    fun whenEnsureDefaultAndNewInstallAndNoOptionThenPersistsNewTabPage() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
-
-        testee.ensureNewUserDefault()
-
-        assertTrue(fakeDataStore.hasOptionSelected())
-        assertEquals(NewTabPage, fakeDataStore.optionFlow.firstOrNull())
-    }
-
-    @Test
-    fun whenEnsureDefaultAndNewInstallAndOptionAlreadySelectedThenDoesNotOverwrite() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
-        fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
-
-        testee.ensureNewUserDefault()
-
-        assertEquals(LastOpenedTab, fakeDataStore.optionFlow.firstOrNull())
-    }
-
-    @Test
-    fun whenEnsureDefaultAndExistingInstallAndNoOptionThenDoesNothing() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
-
-        testee.ensureNewUserDefault()
-
-        assertTrue(!fakeDataStore.hasOptionSelected())
-    }
-
     // handleAfterInactivityOption tests
 
     @Test
-    fun whenNewInstallAndNoOptionSelectedThenSetsNewTabPage() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
-
-        // Mirrors FirstScreenHandlerImpl.onOpen which calls ensureNewUserDefault first.
-        testee.ensureNewUserDefault()
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        fakeTabRepository.flowTabs.test {
-            val tabs = awaitItem()
-            awaitComplete()
-
-            // NewTabPage was set by ensureNewUserDefault, then handleAfterInactivityOption added a tab
-            assertTrue(tabs.size == 1)
-            assertTrue(tabs.last().url == "")
-        }
-    }
-
-    @Test
-    fun whenNewInstallAndOptionAlreadySelectedThenDoesNotOverrideOption() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
+    fun whenLastOpenedTabSelectedThenNoTabAdded() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
 
         testee.handleAfterInactivityOption(wasIdle = true)
@@ -858,29 +804,12 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             val tabs = awaitItem()
             awaitComplete()
 
-            // LastOpenedTab was preserved, no tab added
             assertTrue(tabs.isEmpty())
         }
     }
 
     @Test
-    fun whenNotNewInstallThenDoesNotSetNewTabPage() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
-
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        fakeTabRepository.flowTabs.test {
-            val tabs = awaitItem()
-            awaitComplete()
-
-            // No option was set, default is LastOpenedTab → no tab added
-            assertTrue(tabs.isEmpty())
-        }
-    }
-
-    @Test
-    fun whenNotNewInstallWithExistingOptionThenHandlesExistingOption() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+    fun whenNewTabPageSelectedThenTabIsAdded() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
 
         testee.handleAfterInactivityOption(wasIdle = true)
@@ -895,8 +824,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     }
 
     @Test
-    fun whenNotNewInstallWithSpecificPageOptionThenNavigatesToSpecificPage() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
+    fun whenSpecificPageSelectedThenNavigatesToSpecificPage() = runTest {
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage("https://example.com/"))
 
         testee.handleAfterInactivityOption(wasIdle = true)
@@ -907,62 +835,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
             assertTrue(tabs.size == 1)
             assertTrue(tabs.last().url == "https://example.com/")
-        }
-    }
-
-    @Test
-    fun whenNewInstallWithSpecificPageAlreadySelectedThenPreservesSpecificPage() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
-        fakeDataStore.setShowOnAppLaunchOption(SpecificPage("https://example.com/"))
-
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        fakeTabRepository.flowTabs.test {
-            val tabs = awaitItem()
-            awaitComplete()
-
-            assertTrue(tabs.size == 1)
-            assertTrue(tabs.last().url == "https://example.com/")
-        }
-    }
-
-    @Test
-    fun whenUpdatedFromNewInstallBeforeFirstInactivityFiredThenGetsLastOpenedTab() = runTest {
-        // Simulates a user who installed fresh but updated the app before the inactivity
-        // timeout ever fired. isNewInstall() returns false post-update so the NTP default
-        // is not applied — this is an accepted trade-off. Without the isNewInstall() guard,
-        // existing users who never explicitly set a preference would incorrectly get NTP.
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
-
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        fakeTabRepository.flowTabs.test {
-            val tabs = awaitItem()
-            awaitComplete()
-
-            assertTrue(tabs.isEmpty())
-        }
-    }
-
-    @Test
-    fun whenNtpSetOnFirstInactivityThenSubsequentInactivityAfterUpdateStillShowsNtp() = runTest {
-        // First inactivity on new install: NTP is persisted by ensureNewUserDefault
-        whenever(appBuildConfig.isNewInstall()).thenReturn(true)
-        testee.ensureNewUserDefault()
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        // After an app update isNewInstall() returns false, but the stored NTP option is preserved
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
-        testee.ensureNewUserDefault()
-        testee.handleAfterInactivityOption(wasIdle = true)
-
-        fakeTabRepository.flowTabs.test {
-            val tabs = awaitItem()
-            awaitComplete()
-
-            // Both inactivity returns opened NTP
-            assertTrue(tabs.size == 2)
-            assertTrue(tabs.all { it.url == "" })
         }
     }
 
@@ -970,7 +842,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     @Test
     fun whenInactivityWasIdleTrueAndOptionNewTabPageAndSelectedTabHasUrlThenIdleReturnIsNotified() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = "https://example.com", position = 0)
@@ -984,7 +855,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     fun whenInactivityWasIdleTrueAndOptionNewTabPageAndSelectedTabIsAlreadyNtpThenIdleReturnIsNotified() = runTest {
         // Even when no new tab is added because the user is already on an NTP, the handler should
         // still notify — the currently-shown NTP counts as an after-idle shown event.
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = null, position = 0)
@@ -996,7 +866,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     @Test
     fun whenInactivityWasIdleFalseAndOptionNewTabPageThenIdleReturnNotNotified() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
 
         testee.handleAfterInactivityOption(wasIdle = false)
@@ -1006,7 +875,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     @Test
     fun whenInactivityOptionLastOpenedTabThenIdleReturnNotNotified() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         fakeDataStore.setShowOnAppLaunchOption(LastOpenedTab)
 
         testee.handleAfterInactivityOption(wasIdle = true)
@@ -1016,7 +884,6 @@ class ShowOnAppLaunchOptionHandlerImplTest {
 
     @Test
     fun whenInactivityOptionSpecificPageThenIdleReturnNotNotified() = runTest {
-        whenever(appBuildConfig.isNewInstall()).thenReturn(false)
         fakeDataStore.setShowOnAppLaunchOption(SpecificPage("https://example.com/"))
 
         testee.handleAfterInactivityOption(wasIdle = true)


### PR DESCRIPTION
  Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214502660427550

  ### Description

  Moves the new-user default logic out of `ShowOnAppLaunchOptionHandlerImpl` and into `FirstScreenHandlerImpl`, where it belongs. The option handler is now strictly about applying a
  stored option; the first-screen handler owns the "new user → persist NewTabPage" decision.

  **Changes:**

  - `FirstScreenHandlerImpl` now injects `ShowOnAppLaunchOptionDataStore` and `AppBuildConfig`, and has a private `suspend fun ensureNewUserDefault()` that runs on every `onOpen`. The
  gate is unchanged: `androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() && appBuildConfig.isNewInstall() && !showOnAppLaunchOptionDataStore.hasOptionSelected()`. When
  all three hold, it persists `NewTabPage`.
  - `ShowOnAppLaunchOptionHandler` no longer exposes `ensureNewUserDefault()`. The impl drops `appBuildConfig` and `androidBrowserConfigFeature` (both were only used by the moved
  method).
  - Tests rewritten on both sides: option-handler tests now verify only that the handler applies the persisted option (the new-user behaviour is tested at the `FirstScreenHandlerImpl`
  layer via assertions on the data store).

  ### Steps to test this PR

  _New-user default persistence (driven by `FirstScreenHandlerImpl.onOpen`)_                                                                                                            
  - [x] Uninstall and install a fresh build with `androidBrowserConfigFeature.showNTPAfterIdleReturn` enabled
  - [x] Open the app — confirm `NewTabPage` is persisted (e.g. open Settings → General and verify the "Show on app launch" row reads "New Tab Page")                                    
  - [x] Confirm that opening `ShowOnAppLaunchActivity` shows the **New Tab Page** radio selected                                                                                        
                                                                                                                                                                                        
  _Existing-user / non-new-install (regression)_                                                                                                                                        
  - [x] On an existing install with no stored option, open the app — confirm no option is auto-persisted (the row keeps the current "Last Opened Tab" fallback)                         
  - [x] On an install that already had an option chosen (e.g. "Specific Page"), open the app — confirm the option is preserved, not overwritten                                         
                                                                                                                                                                                        
  _Feature flag off (regression)_                                                                                                                                                       
  - [x] Disable `androidBrowserConfigFeature.showNTPAfterIdleReturn` (e.g. via remote config / internal settings) on a fresh install — confirm no option is auto-persisted              
                                                                                                                                                                                        
  _Inactivity flow (regression)_                                                                                                                                                        
  - [x] With NTP-after-idle enabled, set a short timeout, background the app past the timeout, and foreground it. Confirm `handleAfterInactivityOption` still applies the persisted     
  option (NTP / Last Opened Tab / Specific Page) the same way as before                                                                                                                 
                                                                    
  _Automated_                                                                                                                                                                           
  - [x] `./gradlew :app:testPlayDebugUnitTest --tests "com.duckduckgo.app.generalsettings.showonapplaunch.*"` passes
  - [x] Coverage in `FirstScreenHandlerImplTest`: new install + flag on + no option → persists `NewTabPage`; flag off → no persist; not new install → no persist; option already        
  selected → no overwrite                                                                                                                                                               
                                                                                                                                                                                        
  ### UI changes                                                                                                                                                                        
  No UI changes — only the location of the new-user default logic changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes when/where the default `Show on app launch` option is persisted for new installs, which could affect first-launch and after-idle behavior if gating conditions are wrong.
> 
> **Overview**
> Moves the *new-user default persistence* for “Show on app launch” out of `ShowOnAppLaunchOptionHandler` and into `FirstScreenHandlerImpl.onOpen`, so new installs eagerly store `NewTabPage` only when the NTP-after-idle feature is enabled and no option is already selected.
> 
> Simplifies `ShowOnAppLaunchOptionHandler` to only apply the stored option (drops `ensureNewUserDefault` and its `AppBuildConfig` dependency), and updates unit tests to assert default persistence at the first-screen layer while removing new-install coverage from the option-handler tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc9be6a7082a26f0b78c6006290e7c59980f480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->