### PR TITLE
Move PRs merged to the default branch to Waiting for release

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -1,17 +1,27 @@
-name: Mark task as complete on merge
+name: Mark task as complete and move PRs merged to develop to Waiting for release
 
 on:
   pull_request:
     types: [closed]
 
 jobs:
-  add-pr-merged-comment:
+  add-pr-comment-and-move-to-section:
     runs-on: ubuntu-latest
     steps:
-      - uses: duckduckgo/native-github-asana-sync@v2.0
+      - name: Add PR merged comment
+        uses: duckduckgo/native-github-asana-sync@v2.0
         if: github.event.pull_request.merged
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: "Task/Issue URL:"
           action: 'notify-pr-merged'
           is-complete: true
+      - name: If merged to develop, add to Waiting for release
+        if: github.event.pull_request.merged && github.event.pull_request.base.ref == 'develop'
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_WAITING_FOR_RELEASE_SECTION_ID }}
+          trigger-phrase: "Task/Issue URL:"
+          action: 'add-task-asana-project'

--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -1,4 +1,4 @@
-name: Mark task as complete and move PRs merged to develop to Waiting for release
+name: Mark task as complete and move PRs merged to the default branch to Waiting for release
 
 on:
   pull_request:
@@ -16,8 +16,8 @@ jobs:
           trigger-phrase: "Task/Issue URL:"
           action: 'notify-pr-merged'
           is-complete: true
-      - name: If merged to develop, add to Waiting for release
-        if: github.event.pull_request.merged && github.event.pull_request.base.ref == 'develop'
+      - name: If merged to the default branch, add to Waiting for release
+        if: github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1213760316430332?focus=true

### Description
When a PR is merged, keep adding a comment as before, and then, if merged to develop, also move to "Waiting for release" column

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds an extra Asana update step gated on merges to the repository default branch; impact is limited to PR-close automation.
> 
> **Overview**
> Updates `.github/workflows/action-pr-merged.yaml` so the PR-close workflow still marks the linked Asana task complete, and **additionally** (only when merged into the repository’s default branch) adds the task to the Asana release board’s *Waiting for release* section via `duckduckgo/native-github-asana-sync@v2.0` using new `vars` for project/section IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b91b326fda163472a663871398a601c90432c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->