### PR TITLE
Update copy for deleting server sync data

### DIFF
--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Изтриване на данните от сървъра?</string>
+    <string name="sync_delete_server_data_dialog_content">Резервното копие ще бъде изтрито от сървъра. Синхронизацията на всички устройства ще бъде изключена, но от устройствата няма да бъде изтрито нищо.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Изтриване на данните от сървъра</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Отмени</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Изтриване на данните от сървъра?</string>
-    <string name="sync_delete_server_data_dialog_content">Връзката на всички устройства ще бъде премахната, а синхронизираните данни ще бъдат изтрити от сървъра.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Изтриване на данни</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Отмени</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Smazat data ze serveru?</string>
-    <string name="sync_delete_server_data_dialog_content">Dojde k odpojení všech zařízení a smazání synchronizovaných dat ze serveru.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Smazat data</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Zrušit</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Smazat data ze serveru?</string>
+    <string name="sync_delete_server_data_dialog_content">Tvoje záloha bude ze serveru smazána. Všechna zařízení budou odpojena od synchronizace, ale z žádného zařízení nebude nic smazáno.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Smazat data ze serveru</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Zrušit</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Slet serverdata?</string>
-    <string name="sync_delete_server_data_dialog_content">Alle enheder vil blive afbrudt, og dine synkroniserede data vil blive slettet fra serveren.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Slet data</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuller</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Slet serverdata?</string>
+    <string name="sync_delete_server_data_dialog_content">Din backup vil blive slettet fra serveren. Alle enheder vil blive afbrudt fra synkronisering, men intet vil blive slettet fra nogen enhed.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Slet serverdata</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuller</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Serverdaten löschen?</string>
+    <string name="sync_delete_server_data_dialog_content">Dein Backup wird vom Server gelöscht. Alle Geräte werden von der Synchronisierung getrennt, es werden jedoch keine Daten von den Geräten gelöscht.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Serverdaten löschen</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Abbrechen</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Serverdaten löschen?</string>
-    <string name="sync_delete_server_data_dialog_content">Alle Geräte werden getrennt und deine synchronisierten Daten werden vom Server gelöscht.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Daten löschen</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Abbrechen</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Διαγραφή δεδομένων διακομιστή;</string>
+    <string name="sync_delete_server_data_dialog_content">Το αντίγραφο ασφαλείας σου θα διαγραφεί από τον διακομιστή. Όλες οι συσκευές θα αποσυνδεθούν από τον συγχρονισμό, αλλά τίποτα δεν θα διαγραφεί από καμία συσκευή.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Διαγραφή δεδομένων διακομιστή</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Ακύρωση</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Διαγραφή δεδομένων διακομιστή;</string>
-    <string name="sync_delete_server_data_dialog_content">Όλες οι συσκευές θα αποσυνδεθούν και τα συγχρονισμένα δεδομένα σας θα διαγραφούν από τον διακομιστή.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Διαγραφή δεδομένων</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Ακύρωση</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">¿Eliminar datos del servidor?</string>
+    <string name="sync_delete_server_data_dialog_content">Tu copia de seguridad se eliminará del servidor. Todos los dispositivos se desconectarán de la sincronización, pero no se eliminará nada de ningún dispositivo.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Eliminar datos del servidor</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Cancelar</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">¿Eliminar datos del servidor?</string>
-    <string name="sync_delete_server_data_dialog_content">Todos los dispositivos se desconectarán y tus datos sincronizados se eliminarán del servidor.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Eliminar datos</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Cancelar</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Kas kustutada serveri andmed?</string>
+    <string name="sync_delete_server_data_dialog_content">Sinu varukoopia kustutatakse serverist. Kõigi seadmete sünkroonimine katkestatakse, kuid ühestki seadmest ei kustutata midagi.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Kustuta serveri andmed</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Loobu</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Kas kustutada serveri andmed?</string>
-    <string name="sync_delete_server_data_dialog_content">Kõigi seadmete ühendus katkestatakse ja sinu sünkroonitud andmed kustutatakse serverist.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Andmete kustutamine</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Loobu</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Poista palvelimen tiedot?</string>
+    <string name="sync_delete_server_data_dialog_content">Varmuuskopiosi poistetaan palvelimelta. Kaikkien laitteiden synkronointi katkaistaan, mutta mitään ei poisteta mistään laitteesta.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Poista palvelimen tiedot</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Peruuta</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Poista palvelimen tiedot?</string>
-    <string name="sync_delete_server_data_dialog_content">Kaikkien laitteiden yhteys katkaistaan, ja synkronoidut tietosi poistetaan palvelimelta.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Poista tiedot</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Peruuta</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Supprimer les données du serveur ?</string>
+    <string name="sync_delete_server_data_dialog_content">Votre sauvegarde sera supprimée du serveur. Tous les appareils seront déconnectés de la synchronisation, mais rien ne sera supprimé sur aucun appareil.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Supprimer les données du serveur</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuler</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Supprimer les données du serveur ?</string>
-    <string name="sync_delete_server_data_dialog_content">Tous les appareils seront déconnectés et vos données synchronisées seront supprimées du serveur.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Supprimer les données</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuler</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Izbrisati podatke poslužitelja?</string>
+    <string name="sync_delete_server_data_dialog_content">Tvoja sigurnosna kopija bit će izbrisana s poslužitelja. Svi uređaji bit će isključeni iz sinkronizacije, ali ništa se neće izbrisati s bilo kojeg uređaja.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Brisanje podataka poslužitelja</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Odustani</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Izbrisati podatke poslužitelja?</string>
-    <string name="sync_delete_server_data_dialog_content">Svi uređaji bit će isključeni i tvoji sinkronizirani podaci bit će izbrisani s poslužitelja.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Izbriši podatke</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Odustani</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Szerveradatok törlése?</string>
-    <string name="sync_delete_server_data_dialog_content">A rendszer minden eszközt lecsatlakoztat, és a szinkronizált adatokat törli a szerverről.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Adatok törlése</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Mégsem</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Szerveradatok törlése?</string>
+    <string name="sync_delete_server_data_dialog_content">A biztonsági mentés törölve lesz a szerverről. A rendszer minden eszközt leválaszt a szinkronizálásról, de semmi sem lesz törölve az eszközökről.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Szerveradatok törlése</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Mégsem</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Eliminare i dati del server?</string>
-    <string name="sync_delete_server_data_dialog_content">Tutti i dispositivi saranno disconnessi e i dati sincronizzati verranno eliminati dal server.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Elimina dati</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annulla</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Eliminare i dati del server?</string>
+    <string name="sync_delete_server_data_dialog_content">Il tuo backup verrà eliminato dal server. Tutti i dispositivi verranno disconnessi dalla sincronizzazione, ma nessun dato verrà eliminato da alcun dispositivo.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Elimina i dati del server</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annulla</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Ištrinti serverio duomenis?</string>
-    <string name="sync_delete_server_data_dialog_content">Visi įrenginiai bus atjungti, o sinchronizuoti duomenys bus ištrinti iš serverio.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Ištrinti duomenis</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Atšaukti</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Ištrinti serverio duomenis?</string>
+    <string name="sync_delete_server_data_dialog_content">Jūsų atsarginė kopija bus ištrinta iš serverio. Visi įrenginiai bus atjungti nuo sinchronizavimo, bet iš nė vieno įrenginio niekas nebus ištrinta.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Ištrinti serverio duomenis</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Atšaukti</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Dzēst servera datus?</string>
+    <string name="sync_delete_server_data_dialog_content">Tavs dublējums tiks dzēsts no servera. Visas ierīces tiks atvienotas no sinhronizācijas, bet nekas netiks dzēsts ne no vienas ierīces.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Dzēst servera datus</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Atcelt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Dzēst servera datus?</string>
-    <string name="sync_delete_server_data_dialog_content">Visas ierīces tiks atvienotas un tavi sinhronizētie dati tiks dzēsti no servera.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Dzēst datus</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Atcelt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Vil du slette serverdata?</string>
-    <string name="sync_delete_server_data_dialog_content">Alle enheter blir frakoblet og dine synkroniserte data blir slettet fra serveren.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Slett data</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Avbryt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Vil du slette serverdata?</string>
+    <string name="sync_delete_server_data_dialog_content">Sikkerhetskopien din blir slettet fra serveren. Alle enheter blir koblet fra synkronisering, men ingenting blir slettet fra noen enhet.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Slett serverdata</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Avbryt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Wil je de servergegevens verwijderen?</string>
+    <string name="sync_delete_server_data_dialog_content">Je back-up wordt verwijderd van de server. Alle apparaten worden losgekoppeld van de synchronisatie, maar er wordt niets van de apparaten verwijderd.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Servergegevens verwijderen</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuleren</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Wil je de servergegevens verwijderen?</string>
-    <string name="sync_delete_server_data_dialog_content">De verbinding met alle apparaten wordt verbroken en je gesynchroniseerde gegevens worden van de server verwijderd.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Gegevens verwijderen</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Annuleren</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Usunąć dane serwera?</string>
-    <string name="sync_delete_server_data_dialog_content">Wszystkie urządzenia zostaną odłączone, a zsynchronizowane dane usunięte z serwera.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Usuń dane</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Anuluj</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Usunąć dane serwera?</string>
+    <string name="sync_delete_server_data_dialog_content">Twoja kopia zapasowa zostanie usunięta z serwera. Wszystkie urządzenia zostaną odłączone od synchronizacji, ale nic nie zostanie usunięte z żadnego urządzenia.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Usuń dane serwera</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Anuluj</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Eliminar dados do servidor?</string>
-    <string name="sync_delete_server_data_dialog_content">Todos os dispositivos serão desconectados e os dados sincronizados serão eliminados do servidor.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Eliminar dados</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Cancelar</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Eliminar dados do servidor?</string>
+    <string name="sync_delete_server_data_dialog_content">A tua cópia de segurança será eliminada do servidor. Todos os dispositivos serão desligados da sincronização, mas nada será eliminado dos dispositivos.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Eliminar dados do servidor</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Cancelar</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Ștergi datele serverului?</string>
+    <string name="sync_delete_server_data_dialog_content">Copia de rezervă va fi ștearsă de pe server. Toate dispozitivele vor fi deconectate de la sincronizare, dar nimic nu va fi șters de pe niciun dispozitiv.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Șterge datele serverului</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Anulare</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Ștergi datele serverului?</string>
-    <string name="sync_delete_server_data_dialog_content">Toate dispozitivele vor fi deconectate, iar datele tale sincronizate vor fi șterse de pe server.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Șterge datele</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Anulare</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Удалить данные с сервера?</string>
+    <string name="sync_delete_server_data_dialog_content">Ваша резервная копия будет удалена с сервера. Все устройства будут отключены от синхронизации, но никакие данные с устройств удалены не будут.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Удалить данные с сервера</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Отменить</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Удалить данные с сервера?</string>
-    <string name="sync_delete_server_data_dialog_content">Привязка устройств будет отключена, а синхронизированные данные — удалены с сервера.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Удалить данные</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Отменить</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Zmazať údaje servera?</string>
+    <string name="sync_delete_server_data_dialog_content">Tvoja záloha bude vymazaná zo servera. Všetky zariadenia budú odpojené od synchronizácie, ale zo žiadneho zariadenia sa nič neodstráni.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Zmazanie údajov servera</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Zrušiť</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Zmazať údaje servera?</string>
-    <string name="sync_delete_server_data_dialog_content">Všetky zariadenia budú odpojené a vaše synchronizované údaje budú zmazané zo servera.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Zmazať údaje</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Zrušiť</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Želite izbrisati podatke strežnika?</string>
-    <string name="sync_delete_server_data_dialog_content">Prekinjena bo povezava z vsemi napravami, sinhronizirani podatki pa bodo izbrisani iz strežnika.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Brisanje podatkov</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Prekliči</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Želite izbrisati podatke strežnika?</string>
+    <string name="sync_delete_server_data_dialog_content">Vaša varnostna kopija bo izbrisana s strežnika. Za vse naprave bo sinhronizacija prekinjena, vendar iz nobene naprave ne bo nič izbrisano.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Izbriši podatke strežnika</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Prekliči</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Radera serverdata?</string>
-    <string name="sync_delete_server_data_dialog_content">Alla enheter kopplas bort och dina synkroniserade data raderas från servern.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Radera data</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Avbryt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Radera serverdata?</string>
+    <string name="sync_delete_server_data_dialog_content">Din säkerhetskopia kommer att raderas från servern. Alla enheter kommer att kopplas bort från synkronisering, men inget kommer att raderas från någon enhet.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Radera serverdata</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Avbryt</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -175,6 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Sunucu Verileri Silinsin mi?</string>
+    <string name="sync_delete_server_data_dialog_content">Yedekleriniz sunucudan silinecektir. Tüm cihazların senkronizasyon bağlantısı kesilecek, ancak hiçbir cihazdan hiçbir şey silinmeyecektir.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Sunucu Verilerini Sil</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Vazgeç</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -175,8 +175,6 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Sunucu Verileri Silinsin mi?</string>
-    <string name="sync_delete_server_data_dialog_content">Tüm cihazların bağlantısı kesilecek ve senkronize edilen verileriniz sunucudan silinecektir.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Verileri Sil</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Vazgeç</string>
 
     <!-- Sync feature promo -->

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -175,8 +175,8 @@
 
     <!-- Sync Settings -->
     <string name="sync_delete_server_data_dialog_title">Delete server data?</string>
-    <string name="sync_delete_server_data_dialog_content">All devices will be disconnected and your synced data will be deleted from the server.</string>
-    <string name="sync_delete_server_data_dialog_primary_button">Delete Data</string>
+    <string name="sync_delete_server_data_dialog_content">Your backup will be deleted from the server. All devices will be disconnected from sync, but nothing will be deleted from any device.</string>
+    <string name="sync_delete_server_data_dialog_primary_button">Delete Server Data</string>
     <string name="sync_delete_server_data_dialog_secondary_button">Cancel</string>
 
     <!-- Sync feature promo -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214084105820969?focus=true

### Description
Update copy for deleting sync server data for better clarity

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: text-only localization updates with no changes to sync logic or data handling behavior.
> 
> **Overview**
> Clarifies the `sync_delete_server_data_dialog_*` strings across `strings-sync.xml` (default + multiple translations) so the confirmation dialog explicitly states that deleting server data removes the server backup and disconnects all devices from sync, **without deleting anything on-device**.
> 
> Updates the destructive CTA label to a more explicit “Delete Server Data” equivalent in each locale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cda9b5e71bfdae54d44b7e528db9c015105802. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->