### PR TITLE
PIR: Add jobs count to scheduled scan pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1566,6 +1566,16 @@
                 ]
             },
             {
+                "key": "total_scan",
+                "description": "The number of scan jobs executed during the run",
+                "type": "integer"
+            },
+            {
+                "key": "total_optout",
+                "description": "The number of opt-out jobs executed during the run",
+                "type": "integer"
+            },
+            {
                 "key": "profile_queries",
                 "description": "The number of profile queries used in the scan",
                 "type": "integer"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -167,11 +167,15 @@ interface PirPixelSender {
      * Emits a pixel to signal that a scheduled scan run has been completed.
      *
      * @param totalTimeInMillis - how long it took for the scan to complete
+     * @param totalScanJobs - the number of scan jobs executed during the run
+     * @param totalOptOutJobs - the number of opt-out jobs executed during the run
      * @param profileQueryCount - the number of profile queries used in the scan
      * @param brokerCount - the number of active brokers at the start of the scan
      */
     fun reportScheduledScanCompleted(
         totalTimeInMillis: Long,
+        totalScanJobs: Int,
+        totalOptOutJobs: Int,
         profileQueryCount: Int,
         brokerCount: Int,
     )
@@ -719,11 +723,15 @@ class RealPirPixelSender @Inject constructor(
 
     override fun reportScheduledScanCompleted(
         totalTimeInMillis: Long,
+        totalScanJobs: Int,
+        totalOptOutJobs: Int,
         profileQueryCount: Int,
         brokerCount: Int,
     ) {
         val params = mapOf(
             PARAM_KEY_TOTAL_TIME to totalTimeInMillis.toString(),
+            PARAM_KEY_TOTAL_SCAN to totalScanJobs.toString(),
+            PARAM_KEY_TOTAL_OPTOUT to totalOptOutJobs.toString(),
             PARAM_KEY_PROFILE_QUERY_COUNT to profileQueryCount.toString(),
             PARAM_KEY_BROKER_COUNT to brokerCount.toString(),
         )

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -253,7 +253,13 @@ class RealPirJobsRunner @Inject constructor(
                 notificationsPermissionGranted = context.areNotificationsPermissionGranted(),
             )
         } else {
-            pixelSender.reportScheduledScanCompleted(totalTimeMillis, profileQueryCount, brokerCount)
+            pixelSender.reportScheduledScanCompleted(
+                totalTimeInMillis = totalTimeMillis,
+                totalScanJobs = totalScanJobs,
+                totalOptOutJobs = totalOptOutJobs,
+                profileQueryCount = profileQueryCount,
+                brokerCount = brokerCount,
+            )
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -246,6 +246,8 @@ class RealPirPixelSenderTest {
 
         testee.reportScheduledScanCompleted(
             totalTimeInMillis = totalTimeInMillis,
+            totalScanJobs = 7,
+            totalOptOutJobs = 4,
             profileQueryCount = 3,
             brokerCount = 10,
         )
@@ -260,6 +262,10 @@ class RealPirPixelSenderTest {
 
         assert(paramsCaptor.firstValue.containsKey("totalTimeInMillis"))
         assert(paramsCaptor.firstValue["totalTimeInMillis"] == "54321")
+        assert(paramsCaptor.firstValue.containsKey("total_scan"))
+        assert(paramsCaptor.firstValue["total_scan"] == "7")
+        assert(paramsCaptor.firstValue.containsKey("total_optout"))
+        assert(paramsCaptor.firstValue["total_optout"] == "4")
         assert(paramsCaptor.firstValue.containsKey("profile_queries"))
         assert(paramsCaptor.firstValue["profile_queries"] == "3")
         assert(paramsCaptor.firstValue.containsKey("broker_count"))

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -399,7 +399,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportScheduledScanStarted(any(), any())
-        verify(mockPixelSender).reportScheduledScanCompleted(any(), any(), any())
+        verify(mockPixelSender).reportScheduledScanCompleted(any(), any(), any(), any(), any())
         verify(mockPirScan).executeScanForJobs(
             listOf(testScanJobRecord),
             mockContext,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214528441762766?focus=true

### Description
Add jobs count to scheduled scan pixel to see the impact of the number of jobs on scan completion

### Steps to test this PR
QA optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change: extends the scheduled scan completion pixel payload and updates call sites/tests to match the new method signature.
> 
> **Overview**
> Adds `total_scan` and `total_optout` parameters to the `m_dbp_scheduled-run_completed` pixel definition and includes them when firing the scheduled-run completion pixel.
> 
> Updates `PirPixelSender.reportScheduledScanCompleted` (and its callers in `PirJobsRunner`) to pass scan/opt-out job counts, and adjusts unit tests to validate the new parameters and signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5ff14abb5dc4aa3f73f6586cfda772e3ae2928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->