### PR TITLE
Adjust browser menu items in PDF mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -148,7 +148,7 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
             showFireMenuItem = browserViewState.fireButton is HighlightableButton.Visible,
             showDownloadDot = downloadMenuStateProvider.hasNewDownload(),
             isEmailSignedIn = browserViewState.isEmailSignedIn,
-            canChangeBrowsingMode = browserViewState.canChangeBrowsingMode,
+            canChangeBrowsingMode = browserViewState.canChangeBrowsingMode && browserViewState.currentPdfCachedUri == null,
             isDesktopBrowsingMode = browserViewState.isDesktopBrowsingMode,
             hasPreviousAppLink = browserViewState.previousAppLink != null,
             canFindInPage = browserViewState.canFindInPage && browserViewState.currentPdfCachedUri == null,

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
@@ -396,6 +396,46 @@ class RealBrowserMenuViewStateFactoryTest {
     }
 
     @Test
+    fun `when an inline PDF is showing then canChangeBrowsingMode is hidden even if the underlying state allows it`() = runTest {
+        val browserViewState = BrowserViewState(
+            canChangeBrowsingMode = true,
+            currentPdfCachedUri = mock(),
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser("https://example.com/doc.pdf"),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+        )
+
+        assertFalse((result as BrowserMenuViewState.Browser).canChangeBrowsingMode)
+    }
+
+    @Test
+    fun `when no inline PDF is showing then canChangeBrowsingMode propagates from the underlying state`() = runTest {
+        val browserViewState = BrowserViewState(
+            canChangeBrowsingMode = true,
+            currentPdfCachedUri = null,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser("https://example.com/page"),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+        )
+
+        assertTrue((result as BrowserMenuViewState.Browser).canChangeBrowsingMode)
+    }
+
+    @Test
     fun `when site has url and title then page context header is Visible`() = runTest {
         val result = testee.create(
             omnibarViewMode = ViewMode.Browser("https://www.example.com/"),

--- a/browser/browser-ui/src/main/res/layout/bottom_sheet_browser_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/bottom_sheet_browser_menu.xml
@@ -140,6 +140,14 @@
                 layout="@layout/view_menu_item_default_browser_medium" />
 
             <com.duckduckgo.common.ui.view.MenuItemView
+                android:id="@+id/downloadPdfMenuItem"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:iconDrawable="@drawable/ic_document_download_24"
+                app:menuSize="medium"
+                app:primaryText="@string/browserMenuDownloadPdf" />
+
+            <com.duckduckgo.common.ui.view.MenuItemView
                 android:id="@+id/refreshMenuItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -170,14 +178,6 @@
                 app:iconDrawable="@drawable/ic_add_to_home_24"
                 app:menuSize="medium"
                 app:primaryText="@string/browserMenuAddToHome" />
-
-            <com.duckduckgo.common.ui.view.MenuItemView
-                android:id="@+id/downloadPdfMenuItem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:iconDrawable="@drawable/ic_document_download_24"
-                app:menuSize="medium"
-                app:primaryText="@string/browserMenuDownloadPdf" />
 
             <com.duckduckgo.common.ui.view.MenuItemView
                 android:id="@+id/findInPageMenuItem"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214526299425585

### Description

* `Download PDF` is now the first item in the menu (above `Refresh`), instead of being buried below `Add to Home`. This better reflects its importance when the user is viewing a PDF inline.
* `Desktop Site` / `Mobile Site` is now hidden when an inline PDF is being shown. Toggling browsing mode has no effect on the inline PDF viewer, so the option was misleading.

### Steps to test this PR

_Download PDF moved to top_
- [x] Open the app and navigate to a URL that points to a PDF
- [x] Wait for the inline PDF viewer to render the document.
- [x] Open the browser menu and confirm that `Download PDF` is the first row, immediately above `Refresh` and "Desktop/Mobile Site" isn't displayed.
- [x] Back to the website, "Desktop/Mobile Site" menu item appears again

### UI changes

Download PDF menu item displayed at the top

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/4c81d05e-75ed-40b8-a375-f4fe16535cf3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/view-state changes that only affect browser menu item ordering and visibility when an inline PDF is displayed; limited to menu state computation and layout ordering.
> 
> **Overview**
> Improves the browser menu behavior when viewing an inline PDF by **moving `Download PDF` to the top of the menu** (above `Refresh`) in `bottom_sheet_browser_menu.xml`.
> 
> Updates `RealBrowserMenuViewStateFactory` to **hide `canChangeBrowsingMode` (Desktop/Mobile Site toggle)** when `currentPdfCachedUri` is present, and adds unit tests to verify the new PDF vs non-PDF behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5b0e84cb5f5d008ef157801e5365f06f3959cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->