### PR TITLE
PDF inline: show shield icon and Privacy Dashboard for PDFs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2343,7 +2343,11 @@ class BrowserTabFragment :
             .commitAllowingStateLoss()
         binding.pdfViewerContainer.gone()
         binding.swipeRefreshContainer.isEnabled = true
-        viewModel.onPdfHidden(currentWebViewUrl = webView?.url, currentWebViewTitle = webView?.title)
+        viewModel.onPdfHidden(
+            currentWebViewUrl = webView?.url,
+            currentWebViewTitle = webView?.title,
+            currentWebViewCertificate = webView?.certificate,
+        )
         // PdfViewerFragmentV2 dispatches window insets to handle edge-to-edge, which can
         // leave a bottom padding on the WebView. Re-dispatch so siblings recompute insets.
         ViewCompat.requestApplyInsets(binding.root)
@@ -2681,20 +2685,24 @@ class BrowserTabFragment :
             is Command.ShowFireproofWebSiteConfirmation -> fireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.DeleteFireproofConfirmation -> removeFireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.RefreshAndShowPrivacyProtectionEnabledConfirmation -> {
-                webView?.let { safeWebView ->
-                    lifecycleScope.launch {
-                        refresh()
-                        privacyProtectionEnabledConfirmation(it.domain)
+                lifecycleScope.launch {
+                    if (isPdfVisible()) {
+                        viewModel.onPrivacyProtectionToggledForPdf()
+                    } else {
+                        webView?.let { refresh() }
                     }
+                    privacyProtectionEnabledConfirmation(it.domain)
                 }
             }
 
             is Command.RefreshAndShowPrivacyProtectionDisabledConfirmation -> {
-                webView?.let { safeWebView ->
-                    lifecycleScope.launch {
-                        refresh()
-                        privacyProtectionDisabledConfirmation(it.domain)
+                lifecycleScope.launch {
+                    if (isPdfVisible()) {
+                        viewModel.onPrivacyProtectionToggledForPdf()
+                    } else {
+                        webView?.let { refresh() }
                     }
+                    privacyProtectionDisabledConfirmation(it.domain)
                 }
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3732,6 +3732,7 @@ class BrowserTabViewModel @Inject constructor(
                         pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_UNIQUE, type = Unique())
                         pageChanged(url, pdfTitle)
                     }
+                    onCertificateReceived(result.certificate)
                     browserViewState.value = currentBrowserViewState().copy(
                         currentPdfCachedUri = result.uri,
                         currentPdfFileName = pdfTitle,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3733,6 +3733,7 @@ class BrowserTabViewModel @Inject constructor(
                         pageChanged(url, pdfTitle)
                     }
                     onCertificateReceived(result.certificate)
+                    onSiteChanged()
                     browserViewState.value = currentBrowserViewState().copy(
                         currentPdfCachedUri = result.uri,
                         currentPdfFileName = pdfTitle,
@@ -3764,13 +3765,29 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     /**
+     * Re-publishes the current site's privacy state when the user toggles protections
+     * while a PDF is showing. The WebView path relies on `webView.reload()` re-firing
+     * `pageChanged`, which doesn't work for PDFs (the WebView is hidden + paused and
+     * the cached PDF doesn't need to be re-fetched). [Site.privacyProtection] re-reads
+     * the user allow list on every call, so [onSiteChanged] alone is enough to refresh
+     * the shield variant.
+     */
+    fun onPrivacyProtectionToggledForPdf() {
+        onSiteChanged()
+    }
+
+    /**
      * Called by the fragment when the inline PDF is hidden (back press, navigation).
      * Clears the cached PDF state so the "Download PDF" menu item disappears, and
      * re-runs [pageChanged] for the WebView's actual URL/title so the omnibar,
      * page header, and tab title revert from the PDF entry to the underlying page —
      * the same path that fires when the WebView itself navigates back.
      */
-    fun onPdfHidden(currentWebViewUrl: String?, currentWebViewTitle: String?) {
+    fun onPdfHidden(
+        currentWebViewUrl: String?,
+        currentWebViewTitle: String?,
+        currentWebViewCertificate: SslCertificate? = null,
+    ) {
         if (currentBrowserViewState().currentPdfCachedUri == null) return
         browserViewState.value = currentBrowserViewState().copy(
             currentPdfCachedUri = null,
@@ -3778,6 +3795,7 @@ class BrowserTabViewModel @Inject constructor(
         )
         if (!currentWebViewUrl.isNullOrBlank() && currentWebViewUrl != ABOUT_BLANK) {
             pageChanged(currentWebViewUrl, currentWebViewTitle)
+            onCertificateReceived(currentWebViewCertificate)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -1126,7 +1126,7 @@ class OmnibarLayout @JvmOverloads constructor(
         renderIfChanged(privacyShieldState, lastSeenPrivacyShield) {
             lastSeenPrivacyShield = privacyShieldState
             val shieldIconView =
-                if (viewMode is ViewMode.Browser) {
+                if (viewMode is ViewMode.Browser || viewMode is ViewMode.Pdf) {
                     shieldIcon
                 } else if (omnibarRepository.isNewCustomTabEnabled) {
                     newCustomTabToolbarContainer.customTabShieldIcon

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -486,6 +486,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         return when (viewMode) {
             Error, SSLWarning, MaliciousSiteWarning -> Globe
             NewTab -> Search
+            is ViewMode.Pdf -> if (hasFocus) Search else PrivacyShield
             else -> {
                 when {
                     hasFocus -> Search

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.net.Uri
 import android.net.http.SslCertificate
 import android.os.Build
+import android.os.Parcel
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
@@ -146,7 +147,10 @@ class RealInlinePdfHandler @Inject constructor(
                 // Bump mtime so LRU eviction treats this file as recently *used*,
                 // not just recently *written*.
                 targetFile.setLastModified(System.currentTimeMillis())
-                return@withContext PdfDownloadResult.Success(Uri.fromFile(targetFile))
+                return@withContext PdfDownloadResult.Success(
+                    uri = Uri.fromFile(targetFile),
+                    certificate = readCertSidecar(targetFile),
+                )
             }
 
             val requestBuilder = Request.Builder().url(url)
@@ -191,6 +195,8 @@ class RealInlinePdfHandler @Inject constructor(
                 targetFile.delete()
                 return@withContext PdfDownloadResult.Failure(PdfErrorType.UNKNOWN)
             }
+
+            certificate?.let { saveCertSidecar(targetFile, it) }
 
             enforceCacheBudget(keepFile = targetFile, maxFiles = MAX_CACHED_FILES)
 
@@ -246,21 +252,71 @@ class RealInlinePdfHandler @Inject constructor(
     /**
      * Cap the PDF cache at [maxFiles] entries using LRU eviction.
      *
-     * Counts all files in the cache directory (including [keepFile]) and, if the
-     * total exceeds [maxFiles], deletes the oldest non-keep files until exactly
-     * [maxFiles] remain. [keepFile] is never evicted, so a freshly-written entry
-     * always survives even when it's the one that pushed the cache over the cap.
+     * Counts only PDF files (cert sidecars are paired data, not independent entries).
+     * If the total exceeds [maxFiles], deletes the oldest non-keep PDFs and their
+     * matching sidecars until exactly [maxFiles] remain. [keepFile] is never evicted,
+     * so a freshly-written entry always survives even when it's the one that pushed
+     * the cache over the cap.
      */
     @VisibleForTesting
     internal fun enforceCacheBudget(keepFile: File, maxFiles: Int) {
         val dir = cacheDir
         val keepName = keepFile.name
-        val candidates = dir.listFiles()?.filter { it.isFile && it.name != keepName } ?: return
+        val candidates = dir.listFiles()
+            ?.filter { it.isFile && !it.name.endsWith(CERT_SIDECAR_SUFFIX) && it.name != keepName }
+            ?: return
         val totalFiles = candidates.size + 1
         if (totalFiles <= maxFiles) return
 
         val toEvict = totalFiles - maxFiles
-        candidates.sortedBy { it.lastModified() }.take(toEvict).forEach { it.delete() }
+        candidates.sortedBy { it.lastModified() }.take(toEvict).forEach { evicted ->
+            evicted.delete()
+            certSidecarFile(evicted).delete()
+        }
+    }
+
+    private fun certSidecarFile(targetFile: File): File =
+        File(targetFile.parentFile, "${targetFile.name}$CERT_SIDECAR_SUFFIX")
+
+    /**
+     * Marshals the [certificate] via [SslCertificate.saveState] and writes the resulting
+     * Bundle's bytes to a sidecar next to [targetFile].
+     */
+    private fun saveCertSidecar(targetFile: File, certificate: SslCertificate) {
+        val bundle = SslCertificate.saveState(certificate) ?: return
+        val parcel = Parcel.obtain()
+        try {
+            parcel.writeBundle(bundle)
+            certSidecarFile(targetFile).writeBytes(parcel.marshall())
+        } catch (e: IOException) {
+            logcat { "PDF cert sidecar write failed: ${e.message}" }
+        } finally {
+            parcel.recycle()
+        }
+    }
+
+    /**
+     * Inverse of [saveCertSidecar]. Returns null if the sidecar is missing or unreadable
+     */
+    private fun readCertSidecar(targetFile: File): SslCertificate? {
+        val sidecar = certSidecarFile(targetFile)
+        if (!sidecar.exists()) return null
+        return try {
+            val bytes = sidecar.readBytes()
+            val parcel = Parcel.obtain()
+            try {
+                parcel.unmarshall(bytes, 0, bytes.size)
+                parcel.setDataPosition(0)
+                val bundle = parcel.readBundle(SslCertificate::class.java.classLoader)
+                bundle?.let { SslCertificate.restoreState(it) }
+            } finally {
+                parcel.recycle()
+            }
+        } catch (t: Throwable) {
+            logcat { "PDF cert sidecar read failed: ${t.message}" }
+            sidecar.delete()
+            null
+        }
     }
 
     override fun extractFileName(url: String): String {
@@ -277,5 +333,6 @@ class RealInlinePdfHandler @Inject constructor(
         private const val PDF_CACHE_DIR = "pdf_cache"
         private val PDF_MAGIC_BYTES = "%PDF-".toByteArray()
         private const val MAX_CACHED_FILES = 10
+        private const val CERT_SIDECAR_SUFFIX = ".cert"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.pdf
 
 import android.content.Context
 import android.net.Uri
+import android.net.http.SslCertificate
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
@@ -39,6 +40,7 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.File
 import java.io.IOException
+import java.security.cert.X509Certificate
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 
@@ -98,7 +100,7 @@ sealed class PdfRenderDecision {
 }
 
 sealed class PdfDownloadResult {
-    data class Success(val uri: Uri) : PdfDownloadResult()
+    data class Success(val uri: Uri, val certificate: SslCertificate? = null) : PdfDownloadResult()
     data class Failure(val errorType: PdfErrorType) : PdfDownloadResult()
 }
 
@@ -154,11 +156,18 @@ class RealInlinePdfHandler @Inject constructor(
                 requestBuilder.addHeader("Cookie", cookie)
             }
 
+            var certificate: SslCertificate? = null
             executeRequestCancellably(okHttpClient.newCall(requestBuilder.build())).use { response ->
                 if (!response.isSuccessful) {
                     logcat { "PDF download failed: HTTP ${response.code}" }
                     return@withContext PdfDownloadResult.Failure(PdfErrorType.UNKNOWN)
                 }
+
+                certificate = response.handshake
+                    ?.peerCertificates
+                    ?.firstOrNull()
+                    ?.let { it as? X509Certificate }
+                    ?.let { SslCertificate(it) }
 
                 response.body?.byteStream()?.use { input ->
                     targetFile.outputStream().use { output ->
@@ -185,7 +194,7 @@ class RealInlinePdfHandler @Inject constructor(
 
             enforceCacheBudget(keepFile = targetFile, maxFiles = MAX_CACHED_FILES)
 
-            PdfDownloadResult.Success(Uri.fromFile(targetFile))
+            PdfDownloadResult.Success(Uri.fromFile(targetFile), certificate)
         } catch (e: CancellationException) {
             logcat { "PDF download cancelled, cleaning up partial file" }
             targetFile.delete()

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.pdf
 import android.content.Context
 import android.net.Uri
 import android.net.http.SslCertificate
+import android.os.BadParcelableException
 import android.os.Build
 import android.os.Parcel
 import androidx.annotation.VisibleForTesting
@@ -290,6 +291,10 @@ class RealInlinePdfHandler @Inject constructor(
             certSidecarFile(targetFile).writeBytes(parcel.marshall())
         } catch (e: IOException) {
             logcat { "PDF cert sidecar write failed: ${e.message}" }
+        } catch (e: BadParcelableException) {
+            logcat { "PDF cert parcelable not conform: ${e.message}" }
+        } catch (e: Throwable) {
+            logcat { "PDF cert unexpected error: ${e.message}" }
         } finally {
             parcel.recycle()
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10338,6 +10338,33 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenPdfDownloadCarriesCertificateThenSiteCertificateIsPopulated() = runTest {
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val url = "https://example.com/doc.pdf"
+        val certificate: SslCertificate = mock()
+        whenever(mockInlinePdfHandler.downloadToCache(url))
+            .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf"), certificate))
+        whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
+
+        testee.requestFileDownload(mock(), url, null, "application/pdf", true, false)
+
+        assertEquals(certificate, testee.siteLiveData.value?.certificate)
+    }
+
+    @Test
+    fun whenPdfDownloadHasNoCertificateThenSiteCertificateRemainsNull() = runTest {
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val url = "https://example.com/doc.pdf"
+        whenever(mockInlinePdfHandler.downloadToCache(url))
+            .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf"), certificate = null))
+        whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
+
+        testee.requestFileDownload(mock(), url, null, "application/pdf", true, false)
+
+        assertNull(testee.siteLiveData.value?.certificate)
+    }
+
+    @Test
     fun whenOnPdfHiddenThenCurrentPdfStateClears() {
         testee.browserViewState.value = browserViewState().copy(
             currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -183,6 +183,7 @@ import com.duckduckgo.app.global.events.db.UserEventsStore
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.MaliciousSiteStatus.PHISHING
 import com.duckduckgo.app.global.model.PrivacyShield.PROTECTED
+import com.duckduckgo.app.global.model.PrivacyShield.UNPROTECTED
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactoryImpl
 import com.duckduckgo.app.location.data.LocationPermissionsDao
@@ -10365,6 +10366,40 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnPrivacyProtectionToggledForPdfThenPrivacyShieldReflectsAllowListChange() = runTest {
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("www.example.com")).thenReturn(false)
+        loadUrl("https://www.example.com/doc.pdf")
+
+        // Simulate the user adding the domain to the allow list (menu or dashboard toggle).
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("www.example.com")).thenReturn(true)
+        testee.onPrivacyProtectionToggledForPdf()
+
+        assertEquals(UNPROTECTED, privacyShieldState().privacyShield)
+    }
+
+    @Test
+    fun whenPdfReopenedAfterUserAllowListedThenShieldShowsUnprotected() = runTest {
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val pdfUrl = "https://www.example.com/doc.pdf"
+        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl))
+            .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
+        whenever(mockInlinePdfHandler.extractFileName(pdfUrl)).thenReturn("doc.pdf")
+        // Domain is already in the user allow list (user disabled protection in a previous session).
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("www.example.com")).thenReturn(true)
+
+        // First open: PDF should land with UNPROTECTED shield.
+        testee.requestFileDownload(mock(), pdfUrl, null, "application/pdf", true, false)
+        assertEquals(UNPROTECTED, privacyShieldState().privacyShield)
+
+        // User backs out of the PDF onto a different page.
+        testee.onPdfHidden(currentWebViewUrl = "https://other.com/", currentWebViewTitle = "other")
+
+        // Re-open the same PDF — site cache may evict, allow list state must still propagate.
+        testee.requestFileDownload(mock(), pdfUrl, null, "application/pdf", true, false)
+        assertEquals(UNPROTECTED, privacyShieldState().privacyShield)
+    }
+
+    @Test
     fun whenOnPdfHiddenThenCurrentPdfStateClears() {
         testee.browserViewState.value = browserViewState().copy(
             currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),
@@ -10431,6 +10466,23 @@ class BrowserTabViewModelTest {
             assertEquals(pdfUrl, this.url)
             assertEquals("application/pdf", this.mimeType)
         }
+    }
+
+    @Test
+    fun whenOnPdfHiddenWithUnderlyingPageCertificateThenSiteCertificatePopulated() {
+        testee.browserViewState.value = browserViewState().copy(
+            currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),
+            currentPdfFileName = "doc.pdf",
+        )
+        val certificate: SslCertificate = mock()
+
+        testee.onPdfHidden(
+            currentWebViewUrl = "https://www.example.com/",
+            currentWebViewTitle = "Example",
+            currentWebViewCertificate = certificate,
+        )
+
+        assertEquals(certificate, testee.siteLiveData.value?.certificate)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10323,6 +10323,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenPdfShownThenPrivacyShieldEnabled() = runTest {
+        whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
+        val url = "https://example.com/doc.pdf"
+        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
+        whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
+        testee.browserViewState.value = browserViewState().copy(
+            showPrivacyShield = HighlightableButton.Visible(enabled = false),
+        )
+
+        testee.requestFileDownload(mock(), url, null, "application/pdf", true, false)
+
+        assertTrue(browserViewState().showPrivacyShield.isEnabled())
+    }
+
+    @Test
     fun whenOnPdfHiddenThenCurrentPdfStateClears() {
         testee.browserViewState.value = browserViewState().copy(
             currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -697,6 +697,40 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
+    fun whenViewModeChangedToPdfThenLeadingIconIsPrivacyShield() = runTest {
+        testee.onViewModeChanged(ViewMode.Pdf(RANDOM_URL))
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.leadingIconState == LeadingIconState.PrivacyShield)
+            assertTrue(viewState.viewMode is ViewMode.Pdf)
+        }
+    }
+
+    @Test
+    fun whenViewModeChangedToPdfBeforeUrlPropagatedThenLeadingIconIsPrivacyShield() = runTest {
+        // No prior loading state means _viewState.value.url is empty — the shield must still appear.
+        testee.onViewModeChanged(ViewMode.Pdf(RANDOM_URL))
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.leadingIconState == LeadingIconState.PrivacyShield)
+        }
+    }
+
+    @Test
+    fun whenViewModeChangedToPdfAndFocusThenLeadingIconIsSearch() = runTest {
+        testee.onOmnibarFocusChanged(true, RANDOM_URL)
+        testee.onViewModeChanged(ViewMode.Pdf(RANDOM_URL))
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.leadingIconState == LeadingIconState.Search)
+            assertTrue(viewState.viewMode is ViewMode.Pdf)
+        }
+    }
+
+    @Test
     fun whenPrivacyShieldChangedToProtectedThenViewStateCorrect() = runTest {
         val privacyShield = PROTECTED
         testee.onPrivacyShieldChanged(privacyShield)

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -36,6 +36,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -100,6 +101,21 @@ class InlinePdfHandlerTest {
         val file = File((result as PdfDownloadResult.Success).uri.path!!)
         assertTrue(file.exists())
         assertEquals(pdfBytes.size.toLong(), file.length())
+    }
+
+    @Test
+    fun whenDownloadOverPlainHttpThenCertificateIsNull() = runTest {
+        val pdfBytes = "%PDF-1.4 test content".toByteArray()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(pdfBytes)),
+        )
+
+        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString())
+
+        assertTrue(result is PdfDownloadResult.Success)
+        assertNull((result as PdfDownloadResult.Success).certificate)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -539,4 +539,78 @@ class InlinePdfHandlerTest {
     }
 
     // endregion
+
+    @Test
+    fun whenPdfFileEvictedThenItsCertSidecarIsAlsoDeleted() {
+        val cacheDir = File(InstrumentationRegistry.getInstrumentation().targetContext.cacheDir, "pdf_cache").apply { mkdirs() }
+        val oldPdf = File(cacheDir, "1-old.pdf").apply {
+            writeBytes(ByteArray(10))
+            setLastModified(1_000L)
+        }
+        val oldSidecar = File(cacheDir, "1-old.pdf.cert").apply {
+            writeBytes(ByteArray(100))
+            setLastModified(1_000L)
+        }
+        val keep = File(cacheDir, "2-keep.pdf").apply {
+            writeBytes(ByteArray(10))
+            setLastModified(2_000L)
+        }
+
+        // only keep should remain. Old PDF is evicted, and so is its sidecar.
+        inlinePdfHandler.enforceCacheBudget(keepFile = keep, maxFiles = 1)
+
+        assertFalse("Evicted PDF should be gone", oldPdf.exists())
+        assertFalse("Evicted PDF's cert sidecar should be gone too", oldSidecar.exists())
+        assertTrue(keep.exists())
+    }
+
+    @Test
+    fun whenSidecarsPresentThenTheyDoNotCountTowardCacheCap() {
+        val cacheDir = File(InstrumentationRegistry.getInstrumentation().targetContext.cacheDir, "pdf_cache").apply { mkdirs() }
+        val pdfs = (1..3).map { i ->
+            File(cacheDir, "$i-file.pdf").apply {
+                writeBytes(ByteArray(10))
+                setLastModified(i.toLong() * 1_000L)
+            }
+        }
+        val sidecars = pdfs.map { File(cacheDir, "${it.name}.cert").apply { writeBytes(ByteArray(100)) } }
+        val keep = pdfs.last()
+
+        // 3 PDFs + 3 sidecars = 6 files on disk, but only 3 PDFs count. Cap at 3 → no eviction.
+        inlinePdfHandler.enforceCacheBudget(keepFile = keep, maxFiles = 3)
+
+        pdfs.forEach { assertTrue("PDF ${it.name} should survive a cap that ignores sidecars", it.exists()) }
+        sidecars.forEach { assertTrue("Sidecar ${it.name} should survive when its PDF survives", it.exists()) }
+    }
+
+    @Test
+    fun whenCertSidecarMalformedThenCacheHitReturnsNullCertWithoutCrashing() = runTest {
+        val cacheDir = File(InstrumentationRegistry.getInstrumentation().targetContext.cacheDir, "pdf_cache").apply { mkdirs() }
+        val url = "https://example.com/malformed.pdf"
+        val targetFile = File(cacheDir, "${url.hashCode()}-malformed.pdf").apply {
+            writeBytes("%PDF-1.4 cached content".toByteArray())
+        }
+        // Sidecar contains arbitrary bytes that aren't a valid marshaled Bundle.
+        File(cacheDir, "${targetFile.name}.cert").writeBytes("not a valid bundle".toByteArray())
+
+        val result = inlinePdfHandler.downloadToCache(url)
+
+        assertTrue(result is PdfDownloadResult.Success)
+        assertNull((result as PdfDownloadResult.Success).certificate)
+    }
+
+    @Test
+    fun whenCacheHitWithoutSidecarThenCertificateIsNull() = runTest {
+        val pdfBytes = "%PDF-1.4 cached".toByteArray()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
+        val url = server.url("/no-sidecar.pdf").toString()
+
+        val first = inlinePdfHandler.downloadToCache(url)
+        assertTrue(first is PdfDownloadResult.Success)
+        assertNull((first as PdfDownloadResult.Success).certificate)
+
+        val second = inlinePdfHandler.downloadToCache(url)
+        assertTrue(second is PdfDownloadResult.Success)
+        assertNull((second as PdfDownloadResult.Success).certificate)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214526299425582?focus=true 

### Description

Restores the Privacy Shield in the address bar while an inline PDF is rendered, so the Privacy Dashboard is reachable from the omnibar

### Steps to test this PR

_Inline PDF shield_
- [x] Open a PDF link from any HTTPS site
- [x] Confirm the shield icon appears in the address bar while the PDF is rendered inline.
- [x] Tap the shield and confirm the Privacy Dashboard opens with the PDF's origin and trackers populated.
- [x] Toggle "Disable Privacy Protection" from the dashboard and confirm the change is reflected in privacy dashboard screen and shield icon
- [x] Press back to leave the PDF and confirm the shield reflects the underlying page state

_inline PDF in cache_
- [x] Open a PDF link from any HTTPS site
- [x] Back and open it again, the load should be much more faster because you loaded from cache
- [x] Tap the shield and confirm the Privacy Dashboard opens with the PDF's origin and trackers populated.

### UI changes
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/13d3672b-a443-4323-b305-38ee50e832b0" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/cbcb744d-2f10-4593-96fb-042d4ebfa555" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/2056215f-4db9-45d3-8d1a-bc0f3f76432f" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/ee2e7cb6-9c3b-427b-8bfd-2596366cb0ec" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privacy/UI state propagation and introduces on-disk certificate sidecar persistence for cached PDFs; issues could cause incorrect shield/certificate display or cache cleanup edge cases.
> 
> **Overview**
> Restores the Privacy Shield/Privacy Dashboard affordance while viewing inline PDFs by treating `ViewMode.Pdf` like browser mode for shield rendering and adjusting the omnibar leading icon logic.
> 
> Updates privacy-protection toggling flows to work when a PDF is showing (no WebView reload), adds `onPrivacyProtectionToggledForPdf` to republish site state, and ensures leaving a PDF rehydrates underlying page state including the WebView certificate.
> 
> Enhances inline PDF caching to capture the TLS certificate from the download handshake, persist it in a `.cert` sidecar alongside the cached PDF, and evict sidecars with their PDFs; adds tests covering shield behavior, allowlist toggles, certificate propagation, and sidecar resilience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64838ccf25855c090a133ace38858b4b58d994e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->