### PR TITLE
Wire refresh menu item to re-download inline PDFs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1617,6 +1617,18 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onRefreshRequested(triggeredByUser: Boolean) {
+        if (currentBrowserViewState().currentPdfCachedUri != null) {
+            url?.let {
+                handlePdfUrl(
+                    it,
+                    contentDisposition = null,
+                    mimeType = "application/pdf",
+                    requestUserConfirmation = false,
+                    forceRefresh = true,
+                )
+            }
+            return
+        }
         val omnibarContent = currentOmnibarViewState().queryOrFullUrl
         if (!Patterns.WEB_URL.matcher(omnibarContent).matches()) {
             fireQueryChangedPixel(omnibarContent)
@@ -3695,21 +3707,29 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    private fun handlePdfUrl(url: String, contentDisposition: String?, mimeType: String, requestUserConfirmation: Boolean) {
-        command.value = Command.ExpandOmnibar
+    private fun handlePdfUrl(
+        url: String,
+        contentDisposition: String?,
+        mimeType: String,
+        requestUserConfirmation: Boolean,
+        forceRefresh: Boolean = false,
+    ) {
+        if (!forceRefresh) command.value = Command.ExpandOmnibar
         loadingViewState.value = currentLoadingViewState().copy(isLoading = true, progress = FIXED_PROGRESS)
         pdfDownloadJob += viewModelScope.launch {
             // downloadToCache wraps its own work in withContext(io); viewModelScope.launch
             // defaults to Main, so we stay on Main for the LiveData updates below.
-            val result = inlinePdfHandler.downloadToCache(url)
+            val result = inlinePdfHandler.downloadToCache(url, forceRefresh = forceRefresh)
             loadingViewState.value = currentLoadingViewState().copy(isLoading = false, progress = 100)
             when (result) {
                 is PdfDownloadResult.Success -> {
-                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED)
-                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_DAILY, type = Daily())
-                    pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_UNIQUE, type = Unique())
                     val pdfTitle = inlinePdfHandler.extractFileName(url)
-                    pageChanged(url, pdfTitle)
+                    if (!forceRefresh) {
+                        pixel.fire(PdfPixelName.PDF_VIEWER_OPENED)
+                        pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_DAILY, type = Daily())
+                        pixel.fire(PdfPixelName.PDF_VIEWER_OPENED_UNIQUE, type = Unique())
+                        pageChanged(url, pdfTitle)
+                    }
                     browserViewState.value = currentBrowserViewState().copy(
                         currentPdfCachedUri = result.uri,
                         currentPdfFileName = pdfTitle,

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -192,6 +192,7 @@ class RealInlinePdfHandler @Inject constructor(
             throw e
         } catch (e: IOException) {
             logcat { "PDF download failed: ${e.message}" }
+            targetFile.delete()
             PdfDownloadResult.Failure(PdfErrorType.IO_ERROR)
         } catch (e: SecurityException) {
             logcat { "PDF download denied: ${e.message}" }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -77,8 +77,11 @@ interface InlinePdfHandler {
      * file is deleted.
      *
      * @param url the URL of the PDF to download
+     * @param forceRefresh when true, ignore any existing cache entry and re-fetch from the network.
+     *   Used by the user-triggered refresh action so an updated server-side document replaces the
+     *   stale cached copy.
      */
-    suspend fun downloadToCache(url: String): PdfDownloadResult
+    suspend fun downloadToCache(url: String, forceRefresh: Boolean = false): PdfDownloadResult
 
     /**
      * Extracts a sanitized filename from the PDF [url]'s last path segment.
@@ -131,13 +134,13 @@ class RealInlinePdfHandler @Inject constructor(
     private val cacheDir: File
         get() = File(context.cacheDir, PDF_CACHE_DIR).also { it.mkdirs() }
 
-    override suspend fun downloadToCache(url: String): PdfDownloadResult = withContext(dispatcherProvider.io()) {
+    override suspend fun downloadToCache(url: String, forceRefresh: Boolean): PdfDownloadResult = withContext(dispatcherProvider.io()) {
         val fileName = extractFileName(url)
         // Prefix the cache filename with the URL hash so two URLs sharing a last path segment
         // (e.g. report.pdf at site A and site B) don't collide and serve stale content.
         val targetFile = File(cacheDir, "${url.hashCode()}-$fileName")
         try {
-            if (targetFile.exists() && hasPdfMagicBytes(targetFile)) {
+            if (!forceRefresh && targetFile.exists() && hasPdfMagicBytes(targetFile)) {
                 // Bump mtime so LRU eviction treats this file as recently *used*,
                 // not just recently *written*.
                 targetFile.setLastModified(System.currentTimeMillis())

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10332,6 +10332,62 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenRefreshRequestedWhilePdfShownThenForceRefreshDownloadAndEmitNewShowPdfCommand() = runTest {
+        val pdfUrl = "https://example.com/doc.pdf"
+        val refreshedUri = Uri.parse("file:///cache/doc-refreshed.pdf")
+        loadUrl(pdfUrl)
+        testee.browserViewState.value = browserViewState().copy(
+            currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),
+            currentPdfFileName = "doc.pdf",
+        )
+        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true)).thenReturn(PdfDownloadResult.Success(refreshedUri))
+
+        testee.onRefreshRequested(triggeredByUser = true)
+        advanceUntilIdle()
+
+        verify(mockInlinePdfHandler).downloadToCache(pdfUrl, forceRefresh = true)
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val lastShowPdf = commandCaptor.allValues.filterIsInstance<Command.ShowPdfInTab>().last()
+        assertEquals(pdfUrl, lastShowPdf.url)
+        assertEquals(refreshedUri, lastShowPdf.cachedFileUri)
+        assertEquals(refreshedUri, browserViewState().currentPdfCachedUri)
+    }
+
+    @Test
+    fun whenRefreshRequestedAndNoPdfShownThenNavigationRefreshEmittedAndPdfHandlerNotCalled() = runTest {
+        setBrowserShowing(true)
+        loadUrl("https://example.com")
+
+        testee.onRefreshRequested(triggeredByUser = true)
+        advanceUntilIdle()
+
+        assertCommandIssued<NavigationCommand.Refresh>()
+        verify(mockInlinePdfHandler, never()).downloadToCache(any(), eq(true))
+    }
+
+    @Test
+    fun whenPdfRefreshFailsThenRenderFailurePixelFiresAndStandardDownloadCommandEmitted() = runTest {
+        val pdfUrl = "https://example.com/doc.pdf"
+        val originalUri = Uri.parse("file:///cache/doc.pdf")
+        loadUrl(pdfUrl)
+        testee.browserViewState.value = browserViewState().copy(
+            currentPdfCachedUri = originalUri,
+            currentPdfFileName = "doc.pdf",
+        )
+        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true)).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
+
+        testee.onRefreshRequested(triggeredByUser = true)
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(PdfPixelName.PDF_RENDER_FAILURE, parameters = mapOf("error_type" to "io_error"))
+        assertEquals(originalUri, browserViewState().currentPdfCachedUri)
+        assertCommandIssued<Command.RequestFileDownload> {
+            assertEquals(pdfUrl, this.url)
+            assertEquals("application/pdf", this.mimeType)
+        }
+    }
+
+    @Test
     fun whenDownloadPdfClickedAndPdfShownThenCachedFileDownloaderInvoked() = runTest {
         val cachedUri = Uri.parse("file:///cache/doc.pdf")
         testee.browserViewState.value = browserViewState().copy(

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -238,6 +238,26 @@ class InlinePdfHandlerTest {
     }
 
     @Test
+    fun whenForceRefreshThenCacheBypassedAndNewContentReplacesOld() = runTest {
+        val firstBytes = "%PDF-1.4 first version".toByteArray()
+        val secondBytes = "%PDF-1.4 second version after refresh".toByteArray()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(firstBytes)))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(secondBytes)))
+        val url = server.url("/refreshable.pdf").toString()
+
+        val firstResult = inlinePdfHandler.downloadToCache(url)
+        assertTrue(firstResult is PdfDownloadResult.Success)
+        assertEquals(1, server.requestCount)
+
+        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true)
+        assertTrue(refreshResult is PdfDownloadResult.Success)
+        assertEquals(2, server.requestCount)
+
+        val refreshedFile = File((refreshResult as PdfDownloadResult.Success).uri.path!!)
+        assertTrue(refreshedFile.readBytes().contentEquals(secondBytes))
+    }
+
+    @Test
     fun whenTwoUrlsShareLastPathSegmentThenCacheFilesDontCollide() = runTest {
         val pdfBytesA = "%PDF-1.4 content A".toByteArray()
         val pdfBytesB = "%PDF-1.4 content B".toByteArray()

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -258,6 +258,35 @@ class InlinePdfHandlerTest {
     }
 
     @Test
+    fun whenForceRefreshFailsMidStreamThenPartialFileDeletedAndNextLoadRefetches() = runTest {
+        val originalBytes = "%PDF-1.4 original".toByteArray()
+        val replacementBytes = "%PDF-1.4 replacement after recovery".toByteArray()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(originalBytes)))
+        // The truncated body still starts with %PDF-, so without cleanup the cached file would
+        // pass hasPdfMagicBytes on the next load and serve the corrupt partial.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(("%PDF-1.4 " + "x".repeat(8192)).toByteArray()))
+                .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(replacementBytes)))
+        val url = server.url("/refresh-fails.pdf").toString()
+
+        assertTrue(inlinePdfHandler.downloadToCache(url) is PdfDownloadResult.Success)
+        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true)
+        assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), refreshResult)
+
+        // A subsequent non-force-refresh load must not pick up a corrupt partial: it should
+        // re-fetch from the server (3rd request) and return the replacement bytes.
+        val recovered = inlinePdfHandler.downloadToCache(url)
+        assertTrue(recovered is PdfDownloadResult.Success)
+        assertEquals(3, server.requestCount)
+        val recoveredFile = File((recovered as PdfDownloadResult.Success).uri.path!!)
+        assertTrue(recoveredFile.readBytes().contentEquals(replacementBytes))
+    }
+
+    @Test
     fun whenTwoUrlsShareLastPathSegmentThenCacheFilesDontCollide() = runTest {
         val pdfBytesA = "%PDF-1.4 content A".toByteArray()
         val pdfBytesB = "%PDF-1.4 content B".toByteArray()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214526299425584?focus=true 

### Description

Display refresh menu item to refresh the pdf file in the current tab.

Pull-to-refresh is intentionally out of scope for this change: enabling it would require both teaching `SwipeBlockingFrameLayout` to differentiate vertical from horizontal motion

### Steps to test this PR

- [x] Open DuckDuckGo Internal app, navigate to a PDF file
- [x] Open the browser menu and tap **Refresh** — the loading bar runs and the PDF is re-rendered

### UI changes

Refresh menu item displayed in the browser menu with PDF file

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/35014741-f136-4a50-87ea-908d8fb8ef32" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies refresh behavior in `BrowserTabViewModel` and PDF caching logic to force network re-downloads, which could affect navigation/telemetry flow and cached file integrity if edge cases are missed.
> 
> **Overview**
> Wires the browser **Refresh** action to re-download inline PDFs when a PDF is currently shown, bypassing the cached copy and emitting a new `ShowPdfInTab` with the refreshed cached URI.
> 
> Extends `InlinePdfHandler.downloadToCache` with a `forceRefresh` option that skips cache hits and deletes partial files on `IOException` to avoid serving corrupt/stale PDFs; updates PDF open pixels/page-change behavior to not re-fire on refresh. Adds targeted unit tests covering PDF refresh success, failure fallback to download, cache bypass, and partial-download cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 639b13218695bd7dc53853d0b99594115055a502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->