### PR TITLE
Revert "Move PRs merged to the default branch to Waiting for release"

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -1,27 +1,17 @@
-name: Mark task as complete and move PRs merged to the default branch to Waiting for release
+name: Mark task as complete on merge
 
 on:
   pull_request:
     types: [closed]
 
 jobs:
-  add-pr-comment-and-move-to-section:
+  add-pr-merged-comment:
     runs-on: ubuntu-latest
     steps:
-      - name: Add PR merged comment
-        uses: duckduckgo/native-github-asana-sync@v2.0
+      - uses: duckduckgo/native-github-asana-sync@v2.0
         if: github.event.pull_request.merged
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: "Task/Issue URL:"
           action: 'notify-pr-merged'
           is-complete: true
-      - name: If merged to the default branch, add to Waiting for release
-        if: github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_WAITING_FOR_RELEASE_SECTION_ID }}
-          trigger-phrase: "Task/Issue URL:"
-          action: 'add-task-asana-project'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214535782475870?focus=true

Reverts duckduckgo/Android#8442

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that removes the Asana project/section move step; impact is limited to release-board automation behavior.
> 
> **Overview**
> Simplifies the `.github/workflows/action-pr-merged.yaml` workflow to only notify Asana and mark the linked task complete when a PR is merged.
> 
> Removes the conditional step that, on merges to the default branch, added the task to the "Waiting for release" section of the release board.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc0f9b82f11e16f70e0e0782581439b67893209. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->