### PR TITLE
Unified Input: Hide Start Chat in Duck.ai with no toggle

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.impl.DuckChatInternal
-import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
@@ -46,7 +45,7 @@ class StartChatViewModel @Inject constructor(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
-        duckChatInputModeState.displayedMode
+        duckChatInputModeState.displayedMode,
     ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, displayedMode ->
         isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled && displayedMode == InputMode.SEARCH
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -20,7 +20,10 @@ import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
@@ -29,6 +32,7 @@ import javax.inject.Inject
 class StartChatViewModel @Inject constructor(
     duckAiFeatureState: DuckAiFeatureState,
     private val duckChatInternal: DuckChatInternal,
+    private val duckChatInputModeState: DuckChatInputModeState,
 ) : ViewModel() {
 
     /**
@@ -42,8 +46,9 @@ class StartChatViewModel @Inject constructor(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled ->
-        isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled
+        duckChatInputModeState.displayedMode
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, displayedMode ->
+        isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled && displayedMode == InputMode.SEARCH
     }
 
     fun openNewChat() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214502660427567?focus=true

### Description
Ensure Start Chat button is not available in Duck.ai non-toggle

### Steps to test this PR

_Non-Toggle_
- [x] Enable Native Input
- [x] Enable Search Only toggle
- [x] Focus on the Omnibar
- [x] Verify Duck.ai button is visible
- [x] Open Duck.ai
- [x] Verify Duck.ai button is not visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that only adjusts when the Start Chat entry point is shown based on the current `InputMode`.
> 
> **Overview**
> Updates `StartChatViewModel.isVisible` to also depend on `DuckChatInputModeState.displayedMode`, hiding the Start Chat icon unless Duck.ai is enabled, the user setting is on, the input-screen toggle is off, **and** the currently displayed mode is `InputMode.SEARCH` (prevents showing the button within Duck.ai’s non-toggle/native input context).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afab2e865c9c0151517c7e80e93ce8db48d565d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->