### PR TITLE
Duck.Ai/Voice chat: Add support for endVoiceSession

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -82,6 +82,7 @@ enum class NativeAction {
     NEW_CHAT,
     SIDEBAR,
     DUCK_AI_SETTINGS,
+    END_VOICE_SESSION,
 }
 
 @ContributesBinding(AppScope::class)
@@ -247,6 +248,7 @@ class RealDuckChatJSHelper @Inject constructor(
             NativeAction.NEW_CHAT -> SUBSCRIPTION_NEW_CHAT
             NativeAction.SIDEBAR -> SUBSCRIPTION_TOGGLE_SIDEBAR
             NativeAction.DUCK_AI_SETTINGS -> SUBSCRIPTION_DUCK_AI_SETTINGS
+            NativeAction.END_VOICE_SESSION -> SUBSCRIPTION_END_VOICE_SESSION
         }
 
         return SubscriptionEventData(
@@ -500,5 +502,6 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUBSCRIPTION_TOGGLE_SIDEBAR = "submitToggleSidebarAction"
         private const val SUBSCRIPTION_DUCK_AI_SETTINGS = "submitOpenSettingsAction"
         private const val SUBSCRIPTION_SUBMIT_NATIVE_PROMPT = "submitAIChatNativePrompt"
+        private const val SUBSCRIPTION_END_VOICE_SESSION = "endVoiceSession"
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1400,6 +1400,14 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenNativeActionEndVoiceSessionRequestedThenSubscriptionDataSent() = runTest {
+        val result = testee.onNativeAction(NativeAction.END_VOICE_SESSION)
+
+        assertEquals("endVoiceSession", result.subscriptionName)
+        assertEquals(DUCK_CHAT_FEATURE_NAME, result.featureName)
+    }
+
+    @Test
     fun whenGetAIChatNativeHandoffDataThenReportOpenIsCalled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeHandoffData"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214524126170684?focus=true

### Description
Adds the ability to end voice session via sending a subscription event endVoiceSession to the js layer

### Steps to test this PR
QA_ optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `NativeAction` mapped to a JS subscription event and a small unit test, without changing existing voice-session state handling or data flows.
> 
> **Overview**
> Adds support for ending a voice chat session by introducing `NativeAction.END_VOICE_SESSION` and mapping it to a new JS subscription event (`endVoiceSession`) in `RealDuckChatJSHelper.onNativeAction`.
> 
> Extends `RealDuckChatJSHelperTest` to assert the new native action emits the expected subscription name and feature name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267f0fc40089ed83536cd23c709910bb5556eb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->