### PR TITLE
Add chat url suggestions in Duck.ai mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1346,6 +1346,7 @@ class BrowserTabFragment :
                     )
                 },
                 onChatSuggestionSelected = { query -> userEnteredQuery(query) },
+                onChatUrlSuggestionClicked = { suggestion -> viewModel.userSelectedAutocomplete(suggestion, firePixel = false) },
                 onStopTapped = {
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(
@@ -5497,6 +5498,11 @@ class BrowserTabFragment :
         }
 
         fun renderAutocomplete(viewState: AutoCompleteViewState) {
+            // Chat tab owns rendering its autoCompleteSuggestionsList.
+            if (nativeInputManager.isChatTabSelected()) {
+                lastSeenAutoCompleteViewState = null
+                return
+            }
             renderIfChanged(viewState, lastSeenAutoCompleteViewState) {
                 lastSeenAutoCompleteViewState = viewState
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1198,7 +1198,10 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun userSelectedAutocomplete(suggestion: AutoCompleteSuggestion) {
+    fun userSelectedAutocomplete(
+        suggestion: AutoCompleteSuggestion,
+        firePixel: Boolean = true,
+    ) {
         // send pixel before submitting the query and changing the autocomplete state to empty; otherwise will send the wrong params
         appCoroutineScope.launch(dispatchers.io()) {
             val autoCompleteViewState = currentAutoCompleteViewState()
@@ -1216,7 +1219,9 @@ class BrowserTabViewModel @Inject constructor(
                     }
                 }
             }
-            autoComplete.fireAutocompletePixel(autoCompleteViewState.searchResults.suggestions, suggestion)
+            if (firePixel) {
+                autoComplete.fireAutocompletePixel(autoCompleteViewState.searchResults.suggestions, suggestion)
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
 import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
@@ -52,6 +53,7 @@ class NativeInputCallbacks(
     val onSearchSubmitted: (String) -> Unit,
     val onDuckAiChatSubmitted: (query: String, modelId: String?) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
+    val onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit = {},
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
@@ -67,6 +69,10 @@ interface NativeInputManager {
     )
 
     fun isNativeInputEnabled(): Boolean
+
+    /** True when the widget is shown with the chat tab selected. */
+    fun isChatTabSelected(): Boolean
+
     fun showNativeInput(
         layoutInflater: LayoutInflater,
         lifecycleOwner: LifecycleOwner,
@@ -118,6 +124,12 @@ class RealNativeInputManager @Inject constructor(
     }
 
     override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
+
+    override fun isChatTabSelected(): Boolean {
+        if (!::rootView.isInitialized) return false
+        val widget = widgetFrom(rootView) ?: return false
+        return widget.isChatTabSelected()
+    }
 
     override fun handleDuckAiVoiceResult(query: String) {
         val widget = widgetFrom(rootView)
@@ -418,7 +430,7 @@ class RealNativeInputManager @Inject constructor(
         }
         bindSearchCallbacks(widgetView, callbacks)
         bindAutocompleteVisibility(widgetView)
-        bindChatSuggestions(widgetView, lifecycleOwner, callbacks.onChatSuggestionSelected)
+        bindChatSuggestions(widgetView, lifecycleOwner, callbacks)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         bindVoiceButtons(widgetView, callbacks)
         layoutCoordinator.applyBottomCardShape(widgetView, isBottom)
@@ -557,7 +569,7 @@ class RealNativeInputManager @Inject constructor(
     private fun bindChatSuggestions(
         widgetView: View,
         lifecycleOwner: LifecycleOwner,
-        onChatSuggestionSelected: (String) -> Unit,
+        callbacks: NativeInputCallbacks,
     ) {
         if (omnibarController.isDuckAiMode()) return
         val widget = widgetFrom(widgetView) ?: return
@@ -569,12 +581,27 @@ class RealNativeInputManager @Inject constructor(
             lifecycleOwner = lifecycleOwner,
             onChatSuggestionSelected = { query ->
                 hideNativeInput(animate = false, isNavigation = true)
-                onChatSuggestionSelected(query)
+                callbacks.onChatSuggestionSelected(query)
+            },
+            onChatUrlSuggestionClicked = { suggestion ->
+                hideNativeInput(isNavigation = true)
+                callbacks.onChatUrlSuggestionClicked(suggestion)
+            },
+            onSearchForQuerySubmitted = { query ->
+                hideNativeInput(isNavigation = true)
+                callbacks.onSearchSubmitted(query)
             },
             onShowSuggestions = { chatAdapter ->
-                adapter = adapter ?: autoCompleteList.adapter
-                autoCompleteList.adapter = chatAdapter
-                autoCompleteList.itemAnimator = null
+                if (autoCompleteList.adapter === chatAdapter) {
+                    // Force a fresh layout pass so the adapter behaviour
+                    // doesn't leave the user scrolled to a stale position when
+                    // URL items appear at position 0.
+                    autoCompleteList.swapAdapter(chatAdapter, true)
+                } else {
+                    adapter = adapter ?: autoCompleteList.adapter
+                    autoCompleteList.adapter = chatAdapter
+                    autoCompleteList.itemAnimator = null
+                }
                 autoCompleteList.show()
                 focusedView?.gone()
             },

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeatureExt.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeatureExt.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.feature
+
+import org.json.JSONObject
+
+private const val MAX_URL_SUGGESTIONS_KEY = "maxUrlSuggestions"
+private const val DEFAULT_MAX_URL_SUGGESTIONS = 3
+private const val MAX_HISTORY_COUNT_KEY = "maxHistoryCount"
+private const val DEFAULT_MAX_HISTORY_COUNT = 10
+
+fun DuckAiChatHistoryFeature.maxUrlSuggestions(): Int = readIntSetting(MAX_URL_SUGGESTIONS_KEY, DEFAULT_MAX_URL_SUGGESTIONS)
+
+fun DuckAiChatHistoryFeature.maxHistoryCount(): Int = readIntSetting(MAX_HISTORY_COUNT_KEY, DEFAULT_MAX_HISTORY_COUNT)
+
+private fun DuckAiChatHistoryFeature.readIntSetting(key: String, default: Int): Int =
+    runCatching {
+        self().getSettings()?.let { JSONObject(it).optInt(key, default) }
+    }.getOrNull() ?: default

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
@@ -17,10 +17,10 @@
 package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader
 
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.maxHistoryCount
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
-import org.json.JSONObject
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -33,7 +33,7 @@ class ChatSuggestionsNativeReader @Inject constructor(
 ) : ChatSuggestionsReader {
 
     override suspend fun fetchSuggestions(query: String): List<ChatSuggestion> {
-        val maxSuggestions = getMaxHistoryCount()
+        val maxSuggestions = feature.maxHistoryCount()
         val recentCutoff = LocalDateTime.now().minusDays(RECENT_DAYS_CUTOFF).toLocalDate().atStartOfDay()
 
         return store.getChats()
@@ -58,10 +58,6 @@ class ChatSuggestionsNativeReader @Inject constructor(
 
     override fun tearDown() = Unit // no WebView to clean up
 
-    private fun getMaxHistoryCount(): Int = runCatching {
-        feature.self().getSettings()?.let { JSONObject(it).optInt("maxHistoryCount", DEFAULT_MAX_SUGGESTIONS) }
-    }.getOrNull() ?: DEFAULT_MAX_SUGGESTIONS
-
     private fun parseLastEdit(lastEditStr: String): LocalDateTime {
         if (lastEditStr.isEmpty()) return LocalDateTime.MIN
         return try {
@@ -72,7 +68,6 @@ class ChatSuggestionsNativeReader @Inject constructor(
     }
 
     companion object {
-        private const val DEFAULT_MAX_SUGGESTIONS = 10
         private const val RECENT_DAYS_CUTOFF = 7L
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsReader.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.maxHistoryCount
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
@@ -73,7 +74,7 @@ class RealChatSuggestionsReader @Inject constructor(
     @SuppressLint("SetJavaScriptEnabled")
     override suspend fun fetchSuggestions(query: String): List<ChatSuggestion> {
         return withContext(dispatchers.main()) {
-            val maxSuggestions = getMaxHistoryCount()
+            val maxSuggestions = duckAiChatHistoryFeature.maxHistoryCount()
             val script = getScript()
             val wv = getOrCreateWebView(script)
 
@@ -133,15 +134,6 @@ class RealChatSuggestionsReader @Inject constructor(
             }
         }
         return """{"features":{"duckAiChatHistory":{"state":"$state","exceptions":$exceptions,"settings":$settings}},"unprotectedTemporary":[]}"""
-    }
-
-    @VisibleForTesting
-    internal fun getMaxHistoryCount(): Int {
-        return runCatching {
-            duckAiChatHistoryFeature.self().getSettings()?.let {
-                JSONObject(it).optInt(MAX_HISTORY_COUNT_KEY, DEFAULT_MAX_SUGGESTIONS)
-            }
-        }.getOrNull() ?: DEFAULT_MAX_SUGGESTIONS
     }
 
     private fun getUserPreferencesJson(): String {
@@ -315,7 +307,6 @@ class RealChatSuggestionsReader @Inject constructor(
         private const val FEATURE_NAME = "duckAiChatHistory"
         private const val SUBSCRIPTION_GET_CHATS = "getDuckAiChats"
         private const val METHOD_CHATS_RESULT = "duckAiChatsResult"
-        private const val MAX_HISTORY_COUNT_KEY = "maxHistoryCount"
         private const val DEFAULT_MAX_SUGGESTIONS = 10
         private const val FETCH_TIMEOUT_MS = 3000L
         private const val SEVEN_DAYS_MS = 7L * 24 * 60 * 60 * 1000

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.feature.maxUrlSuggestions
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
@@ -86,6 +87,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
 import com.duckduckgo.duckchat.impl.pixel.fireCountAndDaily
 import com.duckduckgo.duckchat.impl.pixel.inputScreenPixelsModeParam
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.duckchat.impl.ui.internal.debounceExceptFirst
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import dagger.assisted.Assisted
@@ -293,7 +295,7 @@ class InputScreenViewModel @AssistedInject constructor(
                                         it is AutoCompleteSwitchToTabSuggestion ||
                                         it is AutoCompleteHistorySuggestion ||
                                         (it is AutoCompleteSearchSuggestion && it.isUrl)
-                                }.take(getMaxUrlSuggestionsCount()),
+                                }.take(duckAiChatHistoryFeature.maxUrlSuggestions()),
                             )
                         }
                     } else {
@@ -1035,29 +1037,12 @@ class InputScreenViewModel @AssistedInject constructor(
         fun create(currentOmnibarText: String): InputScreenViewModel
     }
 
-    private fun getMaxUrlSuggestionsCount(): Int {
-        return runCatching {
-            duckAiChatHistoryFeature.self().getSettings()?.let {
-                JSONObject(it).optInt(MAX_URL_SUGGESTIONS_KEY, DEFAULT_MAX_URL_SUGGESTIONS)
-            }
-        }.getOrNull() ?: DEFAULT_MAX_URL_SUGGESTIONS
-    }
-
     companion object {
         const val DUCK_SCHEME = "duck"
         private const val CHAT_SUGGESTIONS_DEBOUNCE_MS = 150L
         private const val MAX_TAG_TITLE_LENGTH = 20
-        private const val MAX_URL_SUGGESTIONS_KEY = "maxUrlSuggestions"
-        private const val DEFAULT_MAX_URL_SUGGESTIONS = 3
 
         // TODO Read this from the privacy configs once the frontend defines it
         private const val MAX_POPUP_TABS = 5
     }
 }
-
-@OptIn(FlowPreview::class)
-private fun <T> Flow<T>.debounceExceptFirst(timeoutMillis: Long): Flow<T> =
-    merge(
-        take(1),
-        drop(1).debounce(timeoutMillis),
-    )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -20,22 +20,42 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.browser.api.autocomplete.AutoComplete
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
+import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.maxUrlSuggestions
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -43,12 +63,18 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+data class ChatTabSuggestions(
+    val chatHistory: List<ChatSuggestion>,
+    val urlSuggestions: AutoCompleteResult,
+)
 
 @ContributesViewModel(ViewScope::class)
 class NativeInputModeWidgetViewModel @Inject constructor(
@@ -58,7 +84,23 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val pendingNativePromptStore: PendingNativePromptStore,
     private val chatSuggestionsReader: ChatSuggestionsReader,
     private val nativeInputPlugins: ActivePluginPoint<NativeInputPlugin>,
+    autoCompleteFactory: AutoCompleteFactory,
+    private val autoCompleteSettings: AutoCompleteSettings,
+    private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature,
+    private val dispatchers: DispatcherProvider,
+    private val inputScreenConfigResolver: InputScreenConfigResolver,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
+
+    private val autoComplete: AutoComplete = autoCompleteFactory.create(
+        AutoComplete.Config(showInstalledApps = inputScreenConfigResolver.shouldShowInstalledApps()),
+    )
+
+    // Captures the URL list returned from the most recent fetchChatTabSuggestions so that
+    // fireChatUrlSuggestionPixel can credit the right suggestions when the user clicks one.
+    @Volatile
+    private var lastChatUrlSuggestions: List<AutoCompleteSuggestion> = emptyList()
 
     sealed class Command {
         data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
@@ -152,11 +194,64 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
     }
 
-    suspend fun fetchChatSuggestions(query: String): List<ChatSuggestion> =
-        runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
-
     fun cancelChatSuggestions() {
         chatSuggestionsReader.tearDown()
+        lastChatUrlSuggestions = emptyList()
+    }
+
+    suspend fun fetchChatTabSuggestions(
+        query: String,
+        chatSuggestionsEnabled: Boolean,
+    ): ChatTabSuggestions = coroutineScope {
+        val chatHistoryDeferred = async {
+            if (chatSuggestionsEnabled) {
+                runCatching { chatSuggestionsReader.fetchSuggestions(query) }.getOrDefault(emptyList())
+            } else {
+                emptyList()
+            }
+        }
+        val urlSuggestionsDeferred = async(dispatchers.io()) {
+            if (autoCompleteSettings.autoCompleteSuggestionsEnabled && query.isNotEmpty()) {
+                runCatching {
+                    val raw = autoComplete.autoComplete(query).firstOrNull()
+                        ?: return@runCatching AutoCompleteResult(query, emptyList())
+                    raw.copy(
+                        suggestions = raw.suggestions.filter {
+                            it is AutoCompleteBookmarkSuggestion ||
+                                it is AutoCompleteSwitchToTabSuggestion ||
+                                it is AutoCompleteHistorySuggestion ||
+                                (it is AutoCompleteSearchSuggestion && it.isUrl)
+                        }.take(duckAiChatHistoryFeature.maxUrlSuggestions()),
+                    )
+                }.getOrDefault(AutoCompleteResult(query, emptyList()))
+            } else {
+                AutoCompleteResult(query, emptyList())
+            }
+        }
+        val result = ChatTabSuggestions(
+            chatHistory = chatHistoryDeferred.await(),
+            urlSuggestions = urlSuggestionsDeferred.await(),
+        )
+        lastChatUrlSuggestions = result.urlSuggestions.suggestions
+        result
+    }
+
+    fun fireChatUrlSuggestionPixel(suggestion: AutoCompleteSuggestion) {
+        val suggestionsShown = lastChatUrlSuggestions
+        // Use appCoroutineScope so the pixel fire survives the widget detach
+        appCoroutineScope.launch(dispatchers.io()) {
+            autoComplete.fireAutocompletePixel(suggestionsShown, suggestion, experimentalInputScreen = true)
+        }
+    }
+
+    fun fireChatHistorySelectedPixel(pinned: Boolean) {
+        if (pinned) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY, type = Daily())
+        } else {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
+        }
     }
 
     fun buildChatSuggestionUrl(suggestion: ChatSuggestion): String =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/internal/Flows.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/internal/Flows.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.internal
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.take
+
+@OptIn(FlowPreview::class)
+internal fun <T> Flow<T>.debounceExceptFirst(timeoutMillis: Long): Flow<T> =
+    merge(
+        take(1),
+        drop(1).debounce(timeoutMillis),
+    )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSearchSuggestionAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAdapter
+import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
+import javax.inject.Inject
+
+/** Builds the chat-tab ConcatAdapter: chat history → divider → URL suggestions → divider → "Search for [query]". */
+class NativeInputChatSuggestionsBinder @Inject constructor(
+    private val inputScreenConfigResolver: InputScreenConfigResolver,
+) {
+
+    class Binding internal constructor(
+        val adapter: RecyclerView.Adapter<*>,
+        private val chatSuggestionsAdapter: ChatSuggestionsAdapter,
+        private val urlAdapter: BrowserAutoCompleteSuggestionsAdapter,
+        private val urlDivider: SectionDividerAdapter,
+        private val searchDivider: SectionDividerAdapter,
+        private val searchForAdapter: ChatSearchSuggestionAdapter,
+    ) {
+        /**
+         * Applies content to all sub-adapters; [onCommit] fires after the async chat history
+         * arrives. Callers must defer attaching the ConcatAdapter to the RecyclerView until then,
+         * otherwise the late insert at position 0 leaves the list scrolled to the first rows that arrived.
+         * [onCommit]'s `hasContent` reports whether the final list is non-empty.
+         */
+        fun submit(
+            suggestions: ChatTabSuggestions,
+            query: String,
+            onCommit: (hasContent: Boolean) -> Unit,
+        ) {
+            val isTyping = query.isNotEmpty()
+            val hasChat = suggestions.chatHistory.isNotEmpty()
+            val hasUrl = suggestions.urlSuggestions.suggestions.isNotEmpty()
+            val showUrl = isTyping && hasUrl
+            val hasContent = hasChat || isTyping
+
+            chatSuggestionsAdapter.submitList(suggestions.chatHistory) {
+                onCommit(hasContent)
+            }
+            if (showUrl) {
+                urlAdapter.updateData(suggestions.urlSuggestions.query, suggestions.urlSuggestions.suggestions)
+            } else {
+                urlAdapter.updateData("", emptyList())
+            }
+            searchForAdapter.update(query, visible = isTyping)
+            urlDivider.setVisible(hasChat && showUrl)
+            searchDivider.setVisible((hasChat || showUrl) && isTyping)
+        }
+
+        fun clear() {
+            chatSuggestionsAdapter.submitList(emptyList())
+            urlAdapter.updateData("", emptyList())
+            searchForAdapter.update("", visible = false)
+            urlDivider.setVisible(false)
+            searchDivider.setVisible(false)
+        }
+    }
+
+    fun create(
+        onChatSuggestionSelected: (ChatSuggestion) -> Unit,
+        onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
+        onSearchForQuerySubmitted: (String) -> Unit,
+    ): Binding {
+        val chatSuggestionsAdapter = ChatSuggestionsAdapter { onChatSuggestionSelected(it) }
+        val urlAdapter = BrowserAutoCompleteSuggestionsAdapter(
+            immediateSearchClickListener = { onChatUrlSuggestionClicked(it) },
+            editableSearchClickListener = { },
+            autoCompleteLongPressClickListener = { },
+            omnibarType = if (inputScreenConfigResolver.useTopBar()) OmnibarType.SINGLE_TOP else OmnibarType.SINGLE_BOTTOM,
+            hideEditQueryArrow = true,
+            hideSectionDividers = true,
+        )
+        val urlDivider = SectionDividerAdapter()
+        val searchDivider = SectionDividerAdapter()
+        val searchForAdapter = ChatSearchSuggestionAdapter { onSearchForQuerySubmitted(it) }
+
+        val concat = ConcatAdapter(
+            chatSuggestionsAdapter,
+            urlDivider,
+            urlAdapter,
+            searchDivider,
+            searchForAdapter,
+        )
+
+        return Binding(
+            adapter = concat,
+            chatSuggestionsAdapter = chatSuggestionsAdapter,
+            urlAdapter = urlAdapter,
+            urlDivider = urlDivider,
+            searchDivider = searchDivider,
+            searchForAdapter = searchForAdapter,
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -40,7 +40,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
@@ -49,7 +51,6 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -119,7 +120,9 @@ interface NativeInputWidget {
     fun bindChatSuggestions(
         lifecycleOwner: LifecycleOwner,
         onChatSuggestionSelected: (String) -> Unit,
-        onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
+        onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
+        onSearchForQuerySubmitted: (String) -> Unit,
+        onShowSuggestions: (RecyclerView.Adapter<*>) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     )
 
@@ -146,6 +149,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     @Inject
     lateinit var dispatchers: DispatcherProvider
 
+    @Inject
+    lateinit var chatSuggestionsBinder: NativeInputChatSuggestionsBinder
+
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
     private var submitButtons: InputScreenButtons? = null
@@ -162,8 +168,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         inputMode = NativeInputState.InputMode.SEARCH_ONLY,
         inputContext = NativeInputState.InputContext.BROWSER,
     )
-    private var chatSuggestionsAdapter: ChatSuggestionsAdapter? = null
-    private var onShowSuggestions: ((ChatSuggestionsAdapter) -> Unit)? = null
+    private var chatSuggestionsBinding: NativeInputChatSuggestionsBinder.Binding? = null
+    private var onShowSuggestions: ((RecyclerView.Adapter<*>) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     private var voiceSearchAvailable: Boolean = false
     private var voiceChatAvailable: Boolean = false
@@ -595,22 +601,32 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun bindChatSuggestions(
         lifecycleOwner: LifecycleOwner,
         onChatSuggestionSelected: (String) -> Unit,
-        onShowSuggestions: (ChatSuggestionsAdapter) -> Unit,
+        onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
+        onSearchForQuerySubmitted: (String) -> Unit,
+        onShowSuggestions: (RecyclerView.Adapter<*>) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     ) {
         this.onShowSuggestions = onShowSuggestions
         this.onClearSuggestions = onClearSuggestions
 
-        val adapter = ChatSuggestionsAdapter { suggestion ->
-            onChatSuggestionSelected(viewModel.buildChatSuggestionUrl(suggestion))
-        }.also { chatSuggestionsAdapter = it }
+        // Lazy: bindChatSuggestions runs before attach, so @Inject fields and the ViewModel
+        // aren't ready yet. showSuggestions() only fires post-attach.
+        fun ensureBinding(): NativeInputChatSuggestionsBinder.Binding {
+            return chatSuggestionsBinding ?: chatSuggestionsBinder.create(
+                onChatSuggestionSelected = { suggestion ->
+                    viewModel.fireChatHistorySelectedPixel(suggestion.pinned)
+                    onChatSuggestionSelected(viewModel.buildChatSuggestionUrl(suggestion))
+                },
+                onChatUrlSuggestionClicked = { suggestion ->
+                    viewModel.fireChatUrlSuggestionPixel(suggestion)
+                    onChatUrlSuggestionClicked(suggestion)
+                },
+                onSearchForQuerySubmitted = onSearchForQuerySubmitted,
+            ).also { chatSuggestionsBinding = it }
+        }
 
         fun showSuggestions(query: String) {
-            if (!chatSuggestionsUserEnabled) {
-                hideChatSuggestions(hideList = true)
-                return
-            }
-            fetchChatSuggestions(lifecycleOwner, query, adapter)
+            fetchChatTabSuggestions(lifecycleOwner, query, ensureBinding())
         }
 
         val previousOnSearchSelected = this.onSearchSelected
@@ -632,7 +648,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun tearDownChatSuggestions() {
         hideChatSuggestions(hideList = true)
-        chatSuggestionsAdapter = null
+        chatSuggestionsBinding = null
         onShowSuggestions = null
         onClearSuggestions = null
     }
@@ -665,27 +681,29 @@ class NativeInputModeWidget @JvmOverloads constructor(
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 
-    private fun fetchChatSuggestions(
+    private fun fetchChatTabSuggestions(
         lifecycleOwner: LifecycleOwner,
         query: String,
-        adapter: ChatSuggestionsAdapter,
+        binding: NativeInputChatSuggestionsBinder.Binding,
     ) {
         chatSuggestionsJob?.cancel()
         chatSuggestionsJob = lifecycleOwner.lifecycleScope.launch {
-            val suggestions = viewModel.fetchChatSuggestions(query)
-            if (suggestions.isNotEmpty()) {
-                onShowSuggestions?.invoke(adapter)
-            }
-            adapter.submitList(suggestions)
-            if (suggestions.isEmpty()) {
-                onClearSuggestions?.invoke(true)
+            val result = viewModel.fetchChatTabSuggestions(query, chatSuggestionsUserEnabled)
+            // Defer the adapter swap until the chat history arrives, so the RecyclerView
+            // lays out from position 0 with chat history on top and avoids repositioning.
+            binding.submit(result, query) { hasContent ->
+                if (hasContent) {
+                    onShowSuggestions?.invoke(binding.adapter)
+                } else {
+                    onClearSuggestions?.invoke(true)
+                }
             }
         }
     }
 
     private fun hideChatSuggestions(hideList: Boolean) {
         chatSuggestionsJob?.cancel()
-        chatSuggestionsAdapter?.submitList(emptyList())
+        chatSuggestionsBinding?.clear()
         viewModel.cancelChatSuggestions()
         onClearSuggestions?.invoke(hideList)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeatureExtTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeatureExtTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.feature
+
+import com.duckduckgo.feature.toggles.api.Toggle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class DuckAiChatHistoryFeatureExtTest {
+
+    private val toggle: Toggle = mock()
+    private val feature: DuckAiChatHistoryFeature = mock<DuckAiChatHistoryFeature>().also {
+        whenever(it.self()).thenReturn(toggle)
+    }
+
+    @Test
+    fun `maxUrlSuggestions returns parsed value when settings present`() {
+        whenever(toggle.getSettings()).thenReturn("""{"maxUrlSuggestions": 7}""")
+        assertEquals(7, feature.maxUrlSuggestions())
+    }
+
+    @Test
+    fun `maxUrlSuggestions returns default when key missing`() {
+        whenever(toggle.getSettings()).thenReturn("""{"other":1}""")
+        assertEquals(3, feature.maxUrlSuggestions())
+    }
+
+    @Test
+    fun `maxUrlSuggestions returns default when settings null`() {
+        whenever(toggle.getSettings()).thenReturn(null)
+        assertEquals(3, feature.maxUrlSuggestions())
+    }
+
+    @Test
+    fun `maxUrlSuggestions returns default when settings malformed`() {
+        whenever(toggle.getSettings()).thenReturn("not-json")
+        assertEquals(3, feature.maxUrlSuggestions())
+    }
+
+    @Test
+    fun `maxHistoryCount returns parsed value when settings present`() {
+        whenever(toggle.getSettings()).thenReturn("""{"maxHistoryCount": 25}""")
+        assertEquals(25, feature.maxHistoryCount())
+    }
+
+    @Test
+    fun `maxHistoryCount returns default when key missing`() {
+        whenever(toggle.getSettings()).thenReturn("""{"other":1}""")
+        assertEquals(10, feature.maxHistoryCount())
+    }
+
+    @Test
+    fun `maxHistoryCount returns default when settings null`() {
+        whenever(toggle.getSettings()).thenReturn(null)
+        assertEquals(10, feature.maxHistoryCount())
+    }
+
+    @Test
+    fun `maxHistoryCount returns default when settings malformed`() {
+        whenever(toggle.getSettings()).thenReturn("{nope")
+        assertEquals(10, feature.maxHistoryCount())
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -19,21 +19,37 @@ package com.duckduckgo.duckchat.impl.ui
 import android.content.Context
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.browser.api.autocomplete.AutoComplete
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
+import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
+import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -44,10 +60,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.io.IOException
 import java.time.LocalDateTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -63,6 +80,12 @@ class NativeInputModeWidgetViewModelTest {
     private val subscriptions: Subscriptions = mock()
     private val pendingNativePromptStore: PendingNativePromptStore = mock()
     private val chatSuggestionsReader: ChatSuggestionsReader = mock()
+    private val autoCompleteFactory: AutoCompleteFactory = mock()
+    private val autoComplete: AutoComplete = mock()
+    private val autoCompleteSettings: AutoCompleteSettings = mock()
+    private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
+    private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
+    private val pixel: Pixel = mock()
 
     private val showSettingsFlow = MutableStateFlow(false)
     private val duckChatUserEnabledFlow = MutableStateFlow(false)
@@ -86,6 +109,9 @@ class NativeInputModeWidgetViewModelTest {
         whenever(duckChatInternal.observeChatSuggestionsUserSettingEnabled()).thenReturn(chatSuggestionsUserEnabledFlow)
         whenever(duckChatInternal.chatState).thenReturn(chatStateFlow)
         whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementsFlow)
+        whenever(autoCompleteFactory.create(any())).thenReturn(autoComplete)
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
+        whenever(inputScreenConfigResolver.shouldShowInstalledApps()).thenReturn(false)
 
         testee = createViewModel()
     }
@@ -99,6 +125,13 @@ class NativeInputModeWidgetViewModelTest {
             pendingNativePromptStore = pendingNativePromptStore,
             chatSuggestionsReader = chatSuggestionsReader,
             nativeInputPlugins = fakePluginPoint,
+            autoCompleteFactory = autoCompleteFactory,
+            autoCompleteSettings = autoCompleteSettings,
+            duckAiChatHistoryFeature = duckAiChatHistoryFeature,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            inputScreenConfigResolver = inputScreenConfigResolver,
+            pixel = pixel,
+            appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
 
@@ -325,27 +358,6 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenFetchChatSuggestionsThenReturnsReaderSuggestions() = runTest {
-        val suggestions = listOf(
-            ChatSuggestion(chatId = "id-1", title = "Title", lastEdit = LocalDateTime.now(), pinned = false),
-        )
-        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(suggestions)
-
-        val result = testee.fetchChatSuggestions("query")
-
-        assertEquals(suggestions, result)
-    }
-
-    @Test
-    fun whenFetchChatSuggestionsFailsThenReturnsEmptyList() = runTest {
-        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenAnswer { throw IOException("boom") }
-
-        val result = testee.fetchChatSuggestions("query")
-
-        assertTrue(result.isEmpty())
-    }
-
-    @Test
     fun whenBuildChatSuggestionUrlThenAppendsChatIdParam() {
         whenever(duckChatInternal.getDuckChatUrl("", false)).thenReturn("https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5")
         val suggestion = ChatSuggestion(
@@ -420,15 +432,6 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenFetchChatSuggestionsThenDelegatesQueryToReader() = runTest {
-        whenever(chatSuggestionsReader.fetchSuggestions("hello world")).thenReturn(emptyList())
-
-        testee.fetchChatSuggestions("hello world")
-
-        verify(chatSuggestionsReader).fetchSuggestions("hello world")
-    }
-
-    @Test
     fun whenNoPluginsThenPluginsStateIsEmpty() = runTest {
         val viewModel = createViewModel(plugins = emptyList())
 
@@ -490,4 +493,187 @@ class NativeInputModeWidgetViewModelTest {
                 modelId?.let { PromptContribution.ModelSelection(it) }
         }
     }
+
+    // region fetchChatTabSuggestions
+
+    @Test
+    fun whenFetchChatTabSuggestionsThenReturnsBothFetchResults() = runTest {
+        val chat = ChatSuggestion(chatId = "id", title = "t", lastEdit = LocalDateTime.now(), pinned = false)
+        val url = AutoCompleteBookmarkSuggestion(phrase = "ddg", title = "DDG", url = "https://duckduckgo.com")
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions("query")).thenReturn(listOf(chat))
+        whenever(autoComplete.autoComplete("query")).thenReturn(flowOf(AutoCompleteResult("query", listOf(url))))
+
+        val result = testee.fetchChatTabSuggestions(query = "query", chatSuggestionsEnabled = true)
+
+        assertEquals(listOf(chat), result.chatHistory)
+        assertEquals(listOf(url), result.urlSuggestions.suggestions)
+    }
+
+    @Test
+    fun whenChatSuggestionsDisabledThenChatHistoryEmpty() = runTest {
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(autoComplete.autoComplete(any())).thenReturn(flowOf(AutoCompleteResult("q", emptyList())))
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = false)
+
+        assertTrue(result.chatHistory.isEmpty())
+    }
+
+    @Test
+    fun whenAutoCompleteSettingDisabledThenUrlSuggestionsEmpty() = runTest {
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        assertTrue(result.urlSuggestions.suggestions.isEmpty())
+    }
+
+    @Test
+    fun whenQueryEmptyThenUrlSuggestionsEmpty() = runTest {
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+
+        val result = testee.fetchChatTabSuggestions(query = "", chatSuggestionsEnabled = true)
+
+        assertTrue(result.urlSuggestions.suggestions.isEmpty())
+    }
+
+    @Test
+    fun whenAutoCompleteFetchFailsThenUrlSuggestionsEmpty() = runTest {
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenThrow(RuntimeException("boom"))
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        assertTrue(result.urlSuggestions.suggestions.isEmpty())
+    }
+
+    @Test
+    fun whenChatHistoryFetchFailsThenChatHistoryEmpty() = runTest {
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenAnswer { throw RuntimeException("boom") }
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        assertTrue(result.chatHistory.isEmpty())
+    }
+
+    @Test
+    fun whenFetchChatTabSuggestionsThenFiltersOutDisallowedTypes() = runTest {
+        // Three allowed types kept under the default maxUrlSuggestions cap (3) so this test
+        // exercises the filter without conflating with the cap (covered separately below).
+        val bookmark = AutoCompleteBookmarkSuggestion(phrase = "b", title = "B", url = "https://b")
+        val switchToTab = AutoCompleteSwitchToTabSuggestion(phrase = "s", title = "S", url = "https://s", tabId = "1")
+        val historyUrl = AutoCompleteHistorySuggestion(phrase = "h", title = "H", url = "https://h", isAllowedInTopHits = true)
+        val phraseSearchSuggestion = AutoCompleteSearchSuggestion(phrase = "phrase", isUrl = false, isAllowedInTopHits = true)
+        val historySearchSuggestion = AutoCompleteHistorySearchSuggestion(phrase = "hs", isAllowedInTopHits = true)
+        val rawSuggestions = listOf(bookmark, switchToTab, historyUrl, phraseSearchSuggestion, historySearchSuggestion)
+
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenReturn(flowOf(AutoCompleteResult("q", rawSuggestions)))
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        // search-phrase and history-search are filtered out; bookmark, switch-to-tab, and history-url remain.
+        assertEquals(listOf(bookmark, switchToTab, historyUrl), result.urlSuggestions.suggestions)
+    }
+
+    @Test
+    fun whenFetchChatTabSuggestionsThenSearchSuggestionMarkedAsUrlIsAllowed() = runTest {
+        val searchAsUrl = AutoCompleteSearchSuggestion(phrase = "https://x", isUrl = true, isAllowedInTopHits = true)
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenReturn(flowOf(AutoCompleteResult("q", listOf(searchAsUrl))))
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        assertEquals(listOf(searchAsUrl), result.urlSuggestions.suggestions)
+    }
+
+    @Test
+    fun whenFetchChatTabSuggestionsThenAppliesMaxUrlSuggestionsCap() = runTest {
+        // Default cap from DuckAiChatHistoryFeature is 3.
+        val urls = (1..10).map {
+            AutoCompleteBookmarkSuggestion(phrase = "p$it", title = "t$it", url = "https://x$it")
+        }
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenReturn(flowOf(AutoCompleteResult("q", urls)))
+
+        val result = testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        assertEquals(3, result.urlSuggestions.suggestions.size)
+        assertEquals(urls.take(3), result.urlSuggestions.suggestions)
+    }
+
+    // endregion
+
+    // region fireChatUrlSuggestionPixel
+
+    @Test
+    fun whenFireChatUrlSuggestionPixelThenFiresWithLastChatUrlListAndExperimentalFlag() = runTest {
+        val url = AutoCompleteBookmarkSuggestion(phrase = "u", title = "U", url = "https://u")
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenReturn(flowOf(AutoCompleteResult("q", listOf(url))))
+        // Drive a fetch first so lastChatUrlSuggestions is populated.
+        testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        testee.fireChatUrlSuggestionPixel(url)
+
+        verify(autoComplete).fireAutocompletePixel(eq(listOf(url)), eq(url), eq(true))
+    }
+
+    @Test
+    fun whenFireChatUrlSuggestionPixelWithoutPriorFetchThenFiresWithEmptyList() = runTest {
+        val url = AutoCompleteBookmarkSuggestion(phrase = "u", title = "U", url = "https://u")
+
+        testee.fireChatUrlSuggestionPixel(url)
+
+        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), eq(true))
+    }
+
+    @Test
+    fun whenCancelChatSuggestionsThenLastChatUrlListIsReset() = runTest {
+        val url = AutoCompleteBookmarkSuggestion(phrase = "u", title = "U", url = "https://u")
+        whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(true)
+        whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
+        whenever(autoComplete.autoComplete("q")).thenReturn(flowOf(AutoCompleteResult("q", listOf(url))))
+        testee.fetchChatTabSuggestions(query = "q", chatSuggestionsEnabled = true)
+
+        testee.cancelChatSuggestions()
+        testee.fireChatUrlSuggestionPixel(url)
+
+        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), eq(true))
+    }
+
+    // endregion
+
+    // region fireChatHistorySelectedPixel
+
+    @Test
+    fun whenFireChatHistorySelectedPixelPinnedThenFiresPinnedPixels() {
+        testee.fireChatHistorySelectedPixel(pinned = true)
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT)
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY, type = Daily())
+        verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_COUNT)
+        verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenFireChatHistorySelectedPixelNotPinnedThenFiresRegularPixels() {
+        testee.fireChatHistorySelectedPixel(pinned = false)
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_COUNT)
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
+        verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT)
+        verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY, type = Daily())
+    }
+
+    // endregion
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/RealChatSuggestionsReaderTest.kt
@@ -512,40 +512,4 @@ class RealChatSuggestionsReaderTest {
     }
 
     // endregion
-
-    // region getMaxHistoryCount
-
-    @Test
-    fun `when settings has maxHistoryCount then returns that value`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = """{"maxHistoryCount":5}"""),
-        )
-
-        assertEquals(5, reader.getMaxHistoryCount())
-    }
-
-    @Test
-    fun `when settings has no maxHistoryCount then returns default`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = """{}"""),
-        )
-
-        assertEquals(10, reader.getMaxHistoryCount())
-    }
-
-    @Test
-    fun `when settings is null then returns default`() {
-        assertEquals(10, reader.getMaxHistoryCount())
-    }
-
-    @Test
-    fun `when settings has invalid json then returns default`() {
-        duckAiChatHistoryFeature.self().setRawStoredState(
-            State(enable = true, settings = "invalid"),
-        )
-
-        assertEquals(10, reader.getMaxHistoryCount())
-    }
-
-    // endregion
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214560893964014?focus=true 

### Description

#### Context

The DuckDuckGo input screen already shows URL autocomplete suggestions on the chat tab when the. The native input field only showed chat history. This PR brings the same chat-tab URL suggestions experience to the native input field.

The work is split into two commits:

1. **Extract settings and flows from chat suggestion reader**: moves shared utilities out of the input-screen-specific code so the native input can reuse them.
2. **Add chat URL suggestions**: wires up the actual feature on the native input chat tab.

#### Description of changes

**1. Shared utilities extracted (commit 1)**

- `DuckAiChatHistoryFeature` settings accessors (`maxUrlSuggestions()`, `maxHistoryCount()`) lifted into a new `DuckAiChatHistoryFeatureExt.kt` so both surfaces can read the same toggle config.
- The `debounceExceptFirst` flow operator pulled out of `InputScreenViewModel` into `Flows.kt` for reuse.
- `ChatSuggestionsReader` / `ChatSuggestionsNativeReader` updated to consume the new ext functions instead of inlining the settings parse.

**2. Native input chat-tab URL suggestions (commit 2)**

- `NativeInputModeWidgetViewModel` gains `fetchChatTabSuggestions(query, chatSuggestionsEnabled)`, which fetches chat history and URL suggestions in parallel and applies the same filter set + cap as the input screen.
- New `NativeInputChatSuggestionsBinder` builds the chat-tab `ConcatAdapter` (chat history → divider → URL suggestions → divider → "Search for [query]") and exposes a `submit()` that updates all sub-adapters, plus a commit callback fired once the chat-history `ListAdapter` diff has been dispatched.
- `NativeInputModeWidget.bindChatSuggestions` is rebuilt around the binder. 
- `NativeInputManager` propagates the new click hooks up to `BrowserTabFragment` via `NativeInputCallbacks.onChatUrlSuggestionClicked`.
- Pixel parity with the input screen for both selection paths:
  - Chat URL suggestion → `fireAutocompletePixel`.
  - Chat history → `DUCK_CHAT_RECENT_CHAT_SELECTED_(PINNED_)?(COUNT|DAILY)`.
- Unit tests added/updated in `NativeInputModeWidgetViewModelTest` and `BrowserTabViewModelTest`.

### Steps to test this PR

#### 1. First-time entry into chat tab on a new tab

- [ ] Open a new tab. Tap the omnibar to open the native input.
- [ ] Switch to the **Chat** tab.
- [ ] Confirm that the suggestions list shows recent chat history at the top (if any chat history exists). Empty otherwise.
- [ ] Confirm there are no URL suggestions and no "Search for …" row when the input is empty.

#### 2. Typing on the chat tab

- [ ] Open the native input on a new tab and switch to **Chat**.
- [ ] Type in the input field
- [ ] Confirm the list contains: chat history (if any) → divider → URL suggestions (max 3, only bookmarks / history / switch-to-tab / URL search results) → divider → "Search for” row.

#### 3. Selecting a chat-tab URL suggestion

- [ ] On the chat tab, type until URL suggestions appear, then tap one (bookmark / history / switch-to-tab).
- [ ] Confirm the native input dismisses and the URL loads (or tab switches for switch-to-tab suggestions).
- [ ] Confirm `m_autocomplete_click_*` pixel fires with parameters reflecting the selected item

#### 4. Selecting "Search for [query]" on the chat tab

- [ ] On the chat tab, type a query that doesn't match a URL.
- [ ] Tap the "Search for [query]" row at the bottom.
- [ ] Confirm the native input dismisses and the query is submitted as a search.

#### 5. Tab switch interactions

- [ ] On the chat tab with suggestions visible, switch to the **Search** tab. Confirm the chat suggestions list is replaced by the standard search-tab autocomplete (or hidden if there's nothing to show).
- [ ] Switch back to **Chat**. Confirm chat suggestions reappear and are not affected by stale search-tab state.

#### 6. Settings gates

- [ ] Disable "Show chat suggestions" in DuckChat settings.
- [ ] Open native input, switch to **Chat**, type a query.
- [ ] Confirm chat history is **not** shown, but URL suggestions and "Search for [query]" still appear.
- [ ] Re-enable "Show chat suggestions" and confirm chat history reappears.

#### 7. Closing the native input

- [ ] With chat suggestions visible, tap the back button / dismiss the native input.
- [ ] Confirm the suggestions list is hidden cleanly and no leftover content is visible behind the omnibar.
- [ ] Re-open the native input. Confirm the suggestions list starts fresh (no stale items from the previous session).

### UI changes

https://github.com/user-attachments/assets/65d61a28-24b3-498a-8ce6-e7631070973d




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how autocomplete/suggestions are rendered and handled in the omnibar/native input, including new adapter composition and new click flows/pixel firing; regressions could affect navigation and suggestion list behavior across chat/search tabs.
> 
> **Overview**
> Adds chat-tab URL autocomplete suggestions to the **native input** Duck.ai experience, matching the input-screen behavior: chat history plus filtered/capped URL suggestions and a "Search for query" action, with updated navigation callbacks.
> 
> Centralizes Duck.ai chat-history feature settings via new `DuckAiChatHistoryFeature` extension helpers (`maxUrlSuggestions`, `maxHistoryCount`) and moves `debounceExceptFirst` to a shared `Flows.kt` utility.
> 
> Refactors native input chat suggestions rendering to a new `NativeInputChatSuggestionsBinder` (ConcatAdapter) and updates `NativeInputModeWidgetViewModel` to fetch chat history + URL suggestions in parallel and fire selection pixels; `BrowserTabViewModel.userSelectedAutocomplete` now supports suppressing pixel fire for chat URL clicks, and `BrowserTabFragment` skips rendering standard autocomplete while the chat tab owns the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d81bf44d5cf6dfd4abb50bdc9574dcb7f4dabd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->