### PR TITLE
Add Duck.ai chat history shortcut to the NTP browser menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1737,7 +1737,7 @@ class BrowserTabFragment :
             }
             onMenuItemClicked(duckChatHistoryMenuItem) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
-                viewModel.openDuckChatSidebar()
+                viewModel.openDuckChatSidebar(omnibar.viewMode)
             }
             onMenuItemClicked(duckChatSettingsMenuItem) {
                 viewModel.openDuckChatSettings()
@@ -1868,7 +1868,7 @@ class BrowserTabFragment :
             }
             onMenuItemClicked(duckChatHistoryMenuItem) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
-                viewModel.openDuckChatSidebar()
+                viewModel.openDuckChatSidebar(omnibar.viewMode)
             }
             onMenuItemClicked(duckChatSettingsMenuItem) {
                 viewModel.openDuckChatSettings()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4525,6 +4525,12 @@ class BrowserTabViewModel @Inject constructor(
                             _subscriptionEventDataChannel.send(event)
                         }
                     }
+                    duckChatJSHelper.consumeOpenSidebarOnHandoff(method)?.let { event ->
+                        // The user requested chat history before this Duck.ai tab was opened — toggle sidebar now
+                        withContext(dispatchers.main()) {
+                            _subscriptionEventDataChannel.send(event)
+                        }
+                    }
                 }
             }
 
@@ -5046,10 +5052,14 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun openDuckChatSidebar() {
-        viewModelScope.launch {
-            val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.SIDEBAR)
-            _subscriptionEventDataChannel.send(subscriptionEvent)
+    fun openDuckChatSidebar(viewMode: ViewMode = ViewMode.DuckAI) {
+        if (viewMode == ViewMode.DuckAI) {
+            viewModelScope.launch {
+                val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.SIDEBAR)
+                _subscriptionEventDataChannel.send(subscriptionEvent)
+            }
+        } else {
+            duckChat.openDuckChatHistory()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -101,6 +101,7 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
     ): BrowserMenuViewState.NewTabPage {
         return BrowserMenuViewState.NewTabPage(
             showDuckChatOption = browserViewState.showDuckChatOption,
+            showDuckChatHistoryOption = browserViewState.showDuckChatOption,
             vpnMenuState = browserViewState.vpnMenuState,
             isEmailSignedIn = browserViewState.isEmailSignedIn,
             showAutofill = browserViewState.showAutofill,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -9546,6 +9546,13 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOpenDuckChatSidebarFromNewTabPageThenOpenDuckChatHistoryIsCalled() = runTest {
+        testee.openDuckChatSidebar(ViewMode.NewTab)
+
+        verify(mockDuckChat).openDuckChatHistory()
+    }
+
+    @Test
     fun whenDuckChatNativeSettingsRequested() = runTest {
         val expectedEvent = SubscriptionEventData(
             featureName = "event1",

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
@@ -193,8 +193,30 @@ class RealBrowserMenuViewStateFactoryTest {
         val viewState = result as BrowserMenuViewState.NewTabPage
 
         assertTrue(viewState.showDuckChatOption)
+        assertTrue(viewState.showDuckChatHistoryOption)
         assertTrue(viewState.showAutofill)
         assertTrue(viewState.vpnMenuState == VpnMenuState.Hidden)
+    }
+
+    @Test
+    fun `when creating menu in new tab mode with duck chat disabled then chat history option is hidden`() = runTest {
+        val browserViewState = BrowserViewState(
+            showDuckChatOption = false,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.NewTab,
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+        )
+        val viewState = result as BrowserMenuViewState.NewTabPage
+
+        assertFalse(viewState.showDuckChatOption)
+        assertFalse(viewState.showDuckChatHistoryOption)
     }
 
     @Test

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -310,7 +310,7 @@ class BrowserMenuBottomSheet(
         autofillMenuItem.isVisible = viewState.showAutofill
         downloadsMenuItem.isVisible = true
         downloadsMenuItem.showDotIndicator = viewState.showDownloadDot
-        duckChatHistoryMenuItem.isVisible = false
+        duckChatHistoryMenuItem.isVisible = viewState.showDuckChatHistoryOption
         renderVpnMenu(viewState.vpnMenuState)
         createAliasMenuItem.isVisible = viewState.isEmailSignedIn
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuViewState.kt
@@ -64,6 +64,7 @@ sealed class BrowserMenuViewState {
     data class NewTabPage(
         val canGoForward: Boolean = false,
         val showDuckChatOption: Boolean = false,
+        val showDuckChatHistoryOption: Boolean = false,
         val isEmailSignedIn: Boolean = false,
         val vpnMenuState: VpnMenuState = VpnMenuState.Hidden,
         val showAutofill: Boolean = false,

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserPopupMenu.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserPopupMenu.kt
@@ -436,6 +436,7 @@ class BrowserPopupMenu(
 
         forwardMenuItem.isEnabled = viewState.canGoForward
         duckChatMenuItem.isVisible = viewState.showDuckChatOption
+        duckChatHistoryMenuItem.isVisible = viewState.showDuckChatHistoryOption
         autofillMenuItem.isVisible = viewState.showAutofill
 
         when (viewState.vpnMenuState) {

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
@@ -188,6 +188,24 @@ class BrowserMenuBottomSheetTest {
     }
 
     @Test
+    fun whenRenderNewTabPageMenuWithDuckChatHistoryOptionEnabledThenChatHistoryMenuItemIsVisible() {
+        val viewState = BrowserMenuViewState.NewTabPage(showDuckChatHistoryOption = true)
+
+        dialog.render(viewState)
+
+        assertTrue(dialog.duckChatHistoryMenuItem.isVisible)
+    }
+
+    @Test
+    fun whenRenderNewTabPageMenuWithDuckChatHistoryOptionDisabledThenChatHistoryMenuItemIsHidden() {
+        val viewState = BrowserMenuViewState.NewTabPage(showDuckChatHistoryOption = false)
+
+        dialog.render(viewState)
+
+        assertFalse(dialog.duckChatHistoryMenuItem.isVisible)
+    }
+
+    @Test
     fun whenRenderCustomTabsModeThenMenuActionItemsShouldBeUpdated() {
         val viewState = BrowserMenuViewState.CustomTabs()
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -38,6 +38,12 @@ interface DuckChat {
     fun openDuckChat()
 
     /**
+     * Opens DuckChat with the chat history sidebar visible. The sidebar is toggled open as soon
+     * as the Duck.ai frontend completes its native handshake.
+     */
+    fun openDuckChatHistory()
+
+    /**
      * Auto-prompts the DuckChat WebView with the provided [String] query.
      */
     fun openDuckChatWithAutoPrompt(query: String)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.helper.PendingDuckChatOpenActionStore
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection
@@ -368,6 +369,7 @@ class RealDuckChat @Inject constructor(
     private val duckAiHostProvider: DuckAiHostProvider,
     private val appBuildConfig: AppBuildConfig,
     private val voiceSessionStateManager: VoiceSessionStateManager,
+    private val pendingDuckChatOpenActionStore: PendingDuckChatOpenActionStore,
 ) : DuckChatInternal,
     DuckAiFeatureState,
     DuckChatInputModeState,
@@ -610,6 +612,12 @@ class RealDuckChat @Inject constructor(
 
     override fun openDuckChat() {
         logcat { "Duck.ai: openDuckChat" }
+        openDuckChat(emptyMap())
+    }
+
+    override fun openDuckChatHistory() {
+        logcat { "Duck.ai: openDuckChatHistory" }
+        pendingDuckChatOpenActionStore.markOpenSidebar()
         openDuckChat(emptyMap())
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -71,6 +71,8 @@ interface DuckChatJSHelper {
     fun clearTabContextPromptEvent()
 
     fun consumeTabContextPromptOnHandoff(method: String): SubscriptionEventData?
+
+    fun consumeOpenSidebarOnHandoff(method: String): SubscriptionEventData?
 }
 
 enum class Mode {
@@ -93,6 +95,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val pendingTabContextStore: PendingTabContextStore,
     private val pendingNativePromptStore: PendingNativePromptStore,
+    private val pendingDuckChatOpenActionStore: PendingDuckChatOpenActionStore,
     private val faviconManager: FaviconManager,
     private val duckChatFeature: DuckChatFeature,
     private val voiceSessionStateManager: VoiceSessionStateManager,
@@ -291,6 +294,16 @@ class RealDuckChatJSHelper @Inject constructor(
     override fun clearTabContextPromptEvent() {
         if (!duckChatFeature.chatTabAttachments().isEnabled()) return
         pendingTabContextStore.clear()
+    }
+
+    override fun consumeOpenSidebarOnHandoff(method: String): SubscriptionEventData? {
+        if (method != METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA) return null
+        if (!pendingDuckChatOpenActionStore.consumeOpenSidebar()) return null
+        return SubscriptionEventData(
+            featureName = DUCK_CHAT_FEATURE_NAME,
+            subscriptionName = SUBSCRIPTION_TOGGLE_SIDEBAR,
+            params = JSONObject(),
+        )
     }
 
     override fun consumeTabContextPromptOnHandoff(method: String): SubscriptionEventData? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/PendingDuckChatOpenActionStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/PendingDuckChatOpenActionStore.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.helper
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+interface PendingDuckChatOpenActionStore {
+    fun markOpenSidebar()
+    fun consumeOpenSidebar(): Boolean
+    fun clear()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealPendingDuckChatOpenActionStore @Inject constructor() : PendingDuckChatOpenActionStore {
+
+    private val openSidebarPending = AtomicBoolean(false)
+
+    override fun markOpenSidebar() {
+        openSidebarPending.set(true)
+    }
+
+    override fun consumeOpenSidebar(): Boolean = openSidebarPending.getAndSet(false)
+
+    override fun clear() {
+        openSidebarPending.set(false)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.duckchat.impl.helper.PendingDuckChatOpenActionStore
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialog
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
@@ -107,6 +108,7 @@ class RealDuckChatTest {
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
+    private val mockPendingDuckChatOpenActionStore: PendingDuckChatOpenActionStore = mock()
 
     private lateinit var testee: RealDuckChat
 
@@ -149,6 +151,7 @@ class RealDuckChatTest {
                 mockDuckAiHostProvider,
                 mockAppBuildConfig,
                 mockVoiceSessionStateManager,
+                mockPendingDuckChatOpenActionStore,
             ),
         )
         coroutineRule.testScope.advanceUntilIdle()
@@ -481,6 +484,19 @@ class RealDuckChatTest {
     fun whenOpenDuckChatCalledThenOpenDuckChat() = runTest {
         testee.openDuckChat()
 
+        verify(mockBrowserNav).openDuckChat(
+            mockContext,
+            hasSessionActive = false,
+            duckChatUrl = "https://duck.ai/chat?duckai=5",
+        )
+        verify(mockContext).startActivity(mockIntent)
+    }
+
+    @Test
+    fun whenOpenDuckChatHistoryCalledThenOpenDuckChatAndMarkSidebarPending() = runTest {
+        testee.openDuckChatHistory()
+
+        verify(mockPendingDuckChatOpenActionStore).markOpenSidebar()
         verify(mockBrowserNav).openDuckChat(
             mockContext,
             hasSessionActive = false,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1411,6 +1411,7 @@ class DuckChatContextualViewModelTest {
 
         override fun isEnabled(): Boolean = true
         override fun openDuckChat() = Unit
+        override fun openDuckChatHistory() = Unit
         override fun openDuckChatWithAutoPrompt(query: String) = Unit
         override fun openDuckChatWithPrefill(query: String) = Unit
         override fun getDuckChatUrl(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -70,6 +70,7 @@ class RealDuckChatJSHelperTest {
     private val mockDuckChatPixels: DuckChatPixels = mock()
     private val mockPendingTabContextStore: PendingTabContextStore = mock()
     private val mockPendingNativePromptStore: PendingNativePromptStore = mock()
+    private val mockPendingDuckChatOpenActionStore: PendingDuckChatOpenActionStore = mock()
     private val mockFaviconManager: FaviconManager = mock()
     private val mockDuckChatFeature: DuckChatFeature =
         FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
@@ -82,6 +83,7 @@ class RealDuckChatJSHelperTest {
         dispatcherProvider = coroutineRule.testDispatcherProvider,
         pendingTabContextStore = mockPendingTabContextStore,
         pendingNativePromptStore = mockPendingNativePromptStore,
+        pendingDuckChatOpenActionStore = mockPendingDuckChatOpenActionStore,
         faviconManager = mockFaviconManager,
         duckChatFeature = mockDuckChatFeature,
         voiceSessionStateManager = mockVoiceSessionStateManager,
@@ -1565,6 +1567,38 @@ class RealDuckChatJSHelperTest {
 
         assertNull(result)
         verify(mockPendingTabContextStore, never()).consume()
+    }
+
+    // endregion
+
+    // region open sidebar on handoff
+
+    @Test
+    fun whenConsumeOpenSidebarOnHandoffWithHandoffMethodAndPendingActionThenReturnsToggleSidebarEvent() {
+        whenever(mockPendingDuckChatOpenActionStore.consumeOpenSidebar()).thenReturn(true)
+
+        val result = testee.consumeOpenSidebarOnHandoff("getAIChatNativeHandoffData")
+
+        assertNotNull(result)
+        assertEquals(DUCK_CHAT_FEATURE_NAME, result!!.featureName)
+        assertEquals("submitToggleSidebarAction", result.subscriptionName)
+    }
+
+    @Test
+    fun whenConsumeOpenSidebarOnHandoffWithNoPendingActionThenReturnsNull() {
+        whenever(mockPendingDuckChatOpenActionStore.consumeOpenSidebar()).thenReturn(false)
+
+        val result = testee.consumeOpenSidebarOnHandoff("getAIChatNativeHandoffData")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenConsumeOpenSidebarOnHandoffWithOtherMethodThenReturnsNullAndDoesNotConsume() {
+        val result = testee.consumeOpenSidebarOnHandoff("getAIChatNativeConfigValues")
+
+        assertNull(result)
+        verify(mockPendingDuckChatOpenActionStore, never()).consumeOpenSidebar()
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealPendingDuckChatOpenActionStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealPendingDuckChatOpenActionStoreTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.helper
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealPendingDuckChatOpenActionStoreTest {
+
+    private val testee = RealPendingDuckChatOpenActionStore()
+
+    @Test
+    fun whenInitialThenConsumeReturnsFalse() {
+        assertFalse(testee.consumeOpenSidebar())
+    }
+
+    @Test
+    fun whenMarkedThenConsumeReturnsTrueOnce() {
+        testee.markOpenSidebar()
+
+        assertTrue(testee.consumeOpenSidebar())
+        assertFalse(testee.consumeOpenSidebar())
+    }
+
+    @Test
+    fun whenClearedThenConsumeReturnsFalse() {
+        testee.markOpenSidebar()
+        testee.clear()
+
+        assertFalse(testee.consumeOpenSidebar())
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -30,6 +30,7 @@ class FakeDuckChat(
 ) : DuckChat {
 
     private val openDuckChatCalls = mutableListOf<Unit>()
+    private val openDuckChatHistoryCalls = mutableListOf<Unit>()
     private val openDuckChatWithAutoPromptCalls = mutableListOf<String>()
     private val openDuckChatWithPrefillCalls = mutableListOf<String>()
     private var wasOpenedBeforeValue: Boolean = false
@@ -44,6 +45,10 @@ class FakeDuckChat(
 
     override fun openDuckChat() {
         openDuckChatCalls.add(Unit)
+    }
+
+    override fun openDuckChatHistory() {
+        openDuckChatHistoryCalls.add(Unit)
     }
 
     override fun openDuckChatWithAutoPrompt(query: String) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -58,6 +58,8 @@ class FakeDuckChatInternal(
 
     override fun openDuckChat() { }
 
+    override fun openDuckChatHistory() { }
+
     override fun openDuckChatWithAutoPrompt(query: String) { }
 
     override fun openDuckChatWithPrefill(query: String) { }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1214515000838573?focus=true 

### Description

Adds a **Chat history** entry to the browser overflow menu when the user is on the New Tab Page.
Tapping it opens Duck.ai with the history sidebar already visible in a single click.

### Steps to test this PR

_Open chat history from NTP_
- [ ] Install Internal Debug, ensure Duck.ai is enabled.
- [ ] On the New Tab Page, open the browser overflow menu.
- [ ] Verify a **Chat history** entry is present.
- [ ] Tap it — verify a new Duck.ai tab opens **with the chat history sidebar already visible**.

_Existing in-Duck.ai sidebar still works_
- [ ] Open Duck.ai
- [ ] Once Duck.ai has loaded, open the browser overflow menu and tap **Chat history**.
- [ ] Verify the in-page sidebar toggles open as before — no regression on the existing path.

_Chat history is NTP-only_
- [ ] Browse to any web page.
- [ ] Open the browser overflow menu.
- [ ] Verify the **Chat history** entry is **not** in the list — it appears only on the NTP.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
