### PR TITLE
Fix property accesssed before dagger initalization race-condition

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -448,7 +448,7 @@ class DuckDuckGoWebView :
 
     internal fun setContentAllowsSwipeToRefresh(allowed: Boolean) {
         contentAllowsSwipeToRefresh = allowed
-        if (!allowed || browserUiLockFeature.self().isEnabled()) {
+        if (!allowed || (::browserUiLockFeature.isInitialized && browserUiLockFeature.self().isEnabled())) {
             enableSwipeRefresh(allowed)
         }
     }


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214568643454577?focus=true

### Description

### Steps to test this PR
This is a race-condition, make sure launching the browser multiple times doesn't crash.

### UI changes
bugfix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional change to avoid accessing an uninitialized injected dependency; main impact is limited to swipe-to-refresh enablement timing.
> 
> **Overview**
> Prevents a potential crash caused by reading `browserUiLockFeature` before Dagger injection completes.
> 
> `DuckDuckGoWebView.setContentAllowsSwipeToRefresh` now checks `::browserUiLockFeature.isInitialized` before consulting the UI-lock feature flag when deciding whether to toggle swipe-to-refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c354bab3af2651ae36c6887f76a0edd5ce3c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->