### PR TITLE
Maestro: Fix app restart journey

### DIFF
--- a/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
@@ -1,4 +1,4 @@
-appId: com.duckduckgo.mobile.android.debug
+appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---

--- a/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
@@ -1,4 +1,4 @@
-appId: com.duckduckgo.mobile.android
+appId: com.duckduckgo.mobile.android.debug
 tags:
     - privacyTest
 ---
@@ -88,8 +88,7 @@ tags:
                 text: ".*Ad Company"
             - assertVisible:
                 text: "convert.ad-company.site"
-            - action: back
-            - action: back
+            - pressKey: "home"
             - killApp
             - launchApp:
                 clearState: false

--- a/.maestro/shared/browser_screen/click_on_privacy_shield.yaml
+++ b/.maestro/shared/browser_screen/click_on_privacy_shield.yaml
@@ -14,9 +14,9 @@ appId: com.duckduckgo.mobile.android
 - runFlow:
       when:
           visible:
-              id: "com.duckduckgo.mobile.android:id/shieldIconPulseAnimationContainer"
+              id: "shieldIconPulseAnimationContainer"
       commands:
           - assertVisible:
-                id: "com.duckduckgo.mobile.android:id/shieldIcon"
+                id: "shieldIcon"
           - tapOn:
-                id: "com.duckduckgo.mobile.android:id/shieldIconPulseAnimationContainer"
+                id: "shieldIconPulseAnimationContainer"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214554675344904?focus=true

### Description
Background the app before killing it so that the timestamps are stored properly.

### Steps to test this PR
Run remote

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Maestro UI test flows and view selectors, with no production code or data-handling changes.
> 
> **Overview**
> Adjusts the `Browser_restart_mid-session` Maestro journey to **background the app** (`pressKey: "home"`) before `killApp`/`launchApp`, instead of navigating back twice, to better simulate a mid-session restart.
> 
> Updates the shared `click_on_privacy_shield` flow to use **unqualified view ids** (e.g., `shieldIconPulseAnimationContainer`, `shieldIcon`) rather than fully qualified `com.duckduckgo.mobile.android:id/...` selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a746fa35475e8b861674629ed3ab263551546c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->