### PR TITLE
[Quick Win] Reduce runBlocking overhead in WebView request interception

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -673,8 +673,10 @@ class BrowserWebViewClient @Inject constructor(
     ): WebResourceResponse? =
         runBlocking {
             val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
-            withContext(dispatcherProvider.main()) {
-                loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
+            if (request.method == "POST") {
+                withContext(dispatcherProvider.main()) {
+                    loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
+                }
             }
             logcat(VERBOSE) { "Intercepting resource ${request.url} type:${request.method} on page $documentUrl" }
             requestInterceptor.shouldIntercept(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -672,11 +672,11 @@ class BrowserWebViewClient @Inject constructor(
         request: WebResourceRequest,
     ): WebResourceResponse? =
         runBlocking {
-            val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
-            if (request.method == "POST") {
-                withContext(dispatcherProvider.main()) {
+            val documentUrl = withContext(dispatcherProvider.main()) {
+                if (request.method == "POST") {
                     loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
                 }
+                webView.url
             }
             logcat(VERBOSE) { "Intercepting resource ${request.url} type:${request.method} on page $documentUrl" }
             requestInterceptor.shouldIntercept(

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -359,10 +359,19 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenShouldInterceptRequestThenEventSentToLoginDetector() {
+    fun whenShouldInterceptRequestForPostThenEventSentToLoginDetector() {
         val webResourceRequest = mock<WebResourceRequest>()
+        whenever(webResourceRequest.method).thenReturn("POST")
         testee.shouldInterceptRequest(webView, webResourceRequest)
         verify(loginDetector).onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, webResourceRequest))
+    }
+
+    @Test
+    fun whenShouldInterceptRequestForNonPostThenEventNotSentToLoginDetector() {
+        val webResourceRequest = mock<WebResourceRequest>()
+        whenever(webResourceRequest.method).thenReturn("GET")
+        testee.shouldInterceptRequest(webView, webResourceRequest)
+        verify(loginDetector, never()).onEvent(any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1213813247257900?focus=true

### Description

1/ BrowserWebViewClient.kt — shouldInterceptRequest:

- Gated loginDetector.onEvent(...) behind request.method == "POST". The login detector's only ShouldInterceptRequest handler already short-circuited on non-POST internally, so behavior is unchanged, but we now skip the work (and the main-thread dispatch) for every non-POST request.
- Collapsed the two withContext(dispatcherProvider.main()) blocks (one for webView.url, one for the login-detector event) into a single main-thread hop. On POST requests both happen in the same UI-thread tick; cuts dispatch overhead in half.

2/ BrowserWebViewClientTest.kt:

- Renamed whenShouldInterceptRequestThenEventSentToLoginDetector → whenShouldInterceptRequestForPostThenEventSentToLoginDetector and stubbed request.method = "POST".
- Added whenShouldInterceptRequestForNonPostThenEventNotSentToLoginDetector to lock in the new short-circuit (verifies loginDetector.onEvent is never called for GET).

### Steps to test this PR

- Tests pass.
- Code review only.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that only gates a login-detection event on `POST` requests and updates unit tests accordingly. Main risk is missing login-detection signals if any relied on non-`POST` methods unexpectedly.
> 
> **Overview**
> Reduces overhead in `BrowserWebViewClient.shouldInterceptRequest` by **only sending `WebNavigationEvent.ShouldInterceptRequest` to `loginDetector` for `POST` requests**, and by combining the event + `webView.url` fetch into a single main-thread `withContext`.
> 
> Updates `BrowserWebViewClientTest` to stub request methods, rename the `POST`-specific test, and add coverage asserting the login detector is *not* invoked for non-`POST` (e.g., `GET`) requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1867d9c828eaf6b26e4dc3fd878aa401b64df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->