### PR TITLE
Prevent keyboard dismissal from hiding the native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -675,7 +675,11 @@ class BrowserTabFragment :
         object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
-                    hideKeyboardRetainFocus()
+                    if (nativeInputManager.isNativeInputEnabled()) {
+                        hideKeyboardImmediatelyRetainFocus()
+                    } else {
+                        hideKeyboardRetainFocus()
+                    }
                 }
             }
         }
@@ -4799,6 +4803,13 @@ class BrowserTabFragment :
         if (!isHidden) {
             logcat(VERBOSE) { "Keyboard now hiding" }
             omnibar.omnibarTextInput.postDelayed(KEYBOARD_DELAY) { omnibar.omnibarTextInput.hideKeyboard() }
+        }
+    }
+
+    private fun hideKeyboardImmediatelyRetainFocus() {
+        if (!isHidden) {
+            logcat(VERBOSE) { "Keyboard now hiding" }
+            omnibar.omnibarTextInput.hideKeyboard()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -216,7 +216,7 @@ class RealNativeInputManager @Inject constructor(
         if (isVisible) {
             onKeyboardShown(widgetRoot)
         } else {
-            onKeyboardHidden(widget, widgetRoot)
+            onKeyboardHidden(widget)
         }
     }
 
@@ -226,19 +226,9 @@ class RealNativeInputManager @Inject constructor(
         widgetRoot?.translationZ = 0f
     }
 
-    private fun onKeyboardHidden(
-        widget: NativeInputWidget,
-        widgetRoot: View?,
-    ) {
+    private fun onKeyboardHidden(widget: NativeInputWidget) {
         if (omnibarController.isDuckAiMode()) {
             updateWidgetFocus(widget)
-        } else {
-            omnibarController.showTransparentOmnibar()
-            widgetRoot?.let {
-                it.bringToFront()
-                it.translationZ = WIDGET_ELEVATION_DP.toPx()
-            }
-            rootView.post { hideNativeInput() }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -55,7 +55,6 @@ interface NativeInputOmnibarController : OmnibarState {
     fun hide()
     fun getText(): String
     fun hideBackground()
-    fun showTransparentOmnibar()
     fun getCardView(): View?
     fun restore()
     fun forceToTop()
@@ -107,22 +106,6 @@ class RealNativeInputOmnibarController(
         omnibarView.findViewById<View?>(R.id.fireIconMenu)?.gone()
         omnibarView.findViewById<View?>(R.id.tabsMenu)?.gone()
         omnibarView.findViewById<View?>(R.id.browserMenu)?.gone()
-    }
-
-    override fun showTransparentOmnibar() {
-        val omnibarView = omnibar.omnibarView as? View ?: return
-        if (rootView.findViewById<View?>(R.id.inputModeWidget) == null) return
-        omnibar.show()
-        omnibar.isScrollingEnabled = false
-        omnibar.setExpanded(true)
-        applyOnLayout(omnibarView) {
-            makeOmnibarTransparent(omnibarView)
-            hideOmnibarContent(omnibarView)
-            omnibarView.findViewById<View?>(R.id.duckAIHeader)?.gone()
-            omnibarView.findViewById<View?>(R.id.duckAIFreePill)?.gone()
-            omnibarView.findViewById<View?>(R.id.endIconsContainer)?.gone()
-            omnibarView.findViewById<View?>(R.id.duckAiSidebar)?.gone()
-        }
     }
 
     private fun makeOmnibarTransparent(omnibarView: View) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214430974597237?focus=true 

### Description

Scrolling the autocomplete or chat suggestions list inside the native input widget would dismiss the widget. 

The root cause are 2 independent behaviours that are creating this side effect:
(1) We have an existing logic where hiding the keyboard would dismiss the widget and go back to the single line omnibar. 
(2) in PR #8280 a logic was added to dismiss the keyboard when the user scrolls in the list to create more space for it.

Those 2 behaviours are causing an unintentional side effect where: User scrolls —> Keyboard dismiss (2) —> Native input widget closed (1)

Until we find the final design requirement, we decided to revert the change from (1). So scrolling the list dismissed the keyboard but do not close the widget.

### Changes

- **`NativeInputManager.onKeyboardHidden`** no longer dismisses the widget. The widget now closes only via explicit actions: tapping a suggestion, pressing back, or submitting.
- **`NativeInputOmnibarController.showTransparentOmnibar()`** removed — it was only used by the removed dismissal flow.
- **`BrowserTabFragment`**:
  - Added `hideKeyboardImmediatelyRetainFocus()` next to `hideKeyboardRetainFocus()`: same semantics, without the 200 ms `postDelayed` carried over from the legacy omnibar. The autocomplete scroll listener uses it only when native input is enabled, so the keyboard collapses in the same frame the drag begins for a better experience. Legacy mode still uses `hideKeyboardRetainFocus()` and is unchanged.

## Steps to test this PR

Enable the native input field setting.

### 1. Scrolling the suggestions list keeps the widget open
- [x] Open a tab and tap the address bar —> the native input widget appears.
- [x] Type a query so autocomplete suggestions appear.
- [x] Scroll the suggestions list.
- [x] **Expected:** the widget stays open, the keyboard hides immediately (no visible lag or glitch)

### 2. Same behavior for chat suggestions
- [x] In the widget, switch to the Duck.ai (chat) tab.
- [x] Scroll the chat suggestions list.
- [x] **Expected:** widget stays open, keyboard hides immediately.

### 3. Explicit dismissal still works
- [x] Tap a suggestion row → widget dismisses and navigates.
- [x] Press back while widget is open (with keyboard up) → keyboard hides; press back again → widget dismisses.
- [x] Submit a query (search or chat) → widget dismisses.

### 4. Legacy mode regression check
- [x] Disable the native input field setting and restart the app.
- [x] Tap the address bar, type a query, scroll the autocomplete list.
- [x] **Expected:** existing behaviour unchanged keyboard dismisses on scroll, list still works as before.

### UI changes

https://github.com/user-attachments/assets/8846823a-a5c9-4a32-be28-15e9b3c3e79a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard-visibility handling for the native input widget and adjusts omnibar behavior, which could affect focus/visibility transitions across browse and Duck.ai modes. Risk is moderate due to UI state edge cases around keyboard, scrolling, and widget dismissal.
> 
> **Overview**
> Prevents native input from being dismissed as a side effect of keyboard hiding: `NativeInputManager` no longer triggers widget/omnibar transition logic on keyboard hidden (except for Duck.ai focus handling).
> 
> Updates autocomplete scroll behavior so keyboard dismissal happens **immediately** when native input is enabled (new `hideKeyboardImmediatelyRetainFocus()`), while legacy omnibar keeps the existing delayed hide.
> 
> Removes the unused `NativeInputOmnibarController.showTransparentOmnibar()` API and its implementation after the dismissal flow is eliminated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdeca760a4819ec958adee69f2858ff4ff6b13a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->