### PR TITLE
Fix browser overlay on subscription screen from AppTP banner

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.message
 
 import android.content.Context
 import android.view.View
+import androidx.core.net.toUri
 import androidx.core.view.doOnAttach
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
-import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.view.MessageCta
 import com.duckduckgo.common.ui.view.MessageCta.Message
 import com.duckduckgo.common.ui.view.MessageCta.MessageType.REMOTE_MESSAGE
@@ -46,7 +46,6 @@ import javax.inject.Inject
 )
 class PProUpsellBannerPlugin @Inject constructor(
     private val subscriptions: Subscriptions,
-    private val browserNav: BrowserNav,
     private val vpnStore: VpnStore,
     private val deviceShieldPixels: DeviceShieldPixels,
     private val appTPStateMessageToggle: AppTPStateMessageToggle,
@@ -97,7 +96,7 @@ class PProUpsellBannerPlugin @Inject constructor(
     }
 
     private fun Context.launchPPro() {
-        startActivity(browserNav.openInNewTab(this, PPRO_UPSELL_URL))
+        subscriptions.launchSubscription(this, PPRO_UPSELL_URL.toUri())
     }
 
     companion object {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPluginTest.kt
@@ -3,7 +3,6 @@ package com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.message
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnRunningState.DISABLED
@@ -22,7 +21,6 @@ import org.mockito.kotlin.whenever
 @RunWith(AndroidJUnit4::class)
 class PProUpsellBannerPluginTest {
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val browserNav: BrowserNav = mock()
     private val subscriptions: Subscriptions = mock()
     private val deviceShieldPixels: DeviceShieldPixels = mock()
     private val appTPStateMessageToggle: AppTPStateMessageToggle = mock()
@@ -36,7 +34,7 @@ class PProUpsellBannerPluginTest {
         vpnStore = FakeVPNStore(pproUpsellBannerDismissed = false)
         whenever(subscriptions.isFreeTrialEligible()).thenReturn(false)
         whenever(appTPStateMessageToggle.freeTrialCopy()).thenReturn(mockDisabledToggle)
-        plugin = PProUpsellBannerPlugin(subscriptions, browserNav, vpnStore, deviceShieldPixels, appTPStateMessageToggle)
+        plugin = PProUpsellBannerPlugin(subscriptions, vpnStore, deviceShieldPixels, appTPStateMessageToggle)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214075204576671?focus=true

### Description
Launch subscription paywall from subscriptions API instead launching the browser which causes a bug

### Steps to test this PR
_Pre steps_

- [x] Apply patch pinned on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Fix_
- [x] Install from branch
- [x] Go to Settings > Subscriptions Paywall
- [x] Go back and open App Tracking Protection
- [x] Do AppTP onboarding if not done before
- [x] A subscription banner will show on the top of the screen
<img width="275" alt="Screenshot 2026-05-06 at 21 36 22" src="https://github.com/user-attachments/assets/66a95377-c4bf-4963-b26a-4e6f44dbcb08" />

- [x] Tap on Learn More
- [x] Verify that the subscription paywall is shown and the browser does not overlay on top of it.

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the navigation path for the AppTP Privacy Pro upsell CTA to use the subscriptions paywall launcher instead of opening a browser tab, which could impact the upgrade flow if the new API call behaves differently across devices/builds.
> 
> **Overview**
> Updates the AppTP Privacy Pro upsell banner so the *Learn more* CTA opens the subscriptions paywall via `Subscriptions.launchSubscription(...)` (using a URI) instead of navigating to `duckduckgo.com/pro` in a new browser tab.
> 
> Removes the `BrowserNav` dependency from `PProUpsellBannerPlugin` and updates the corresponding test setup to match the new constructor signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907813391f722217ac52bdd1cc8f07912331d664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->