### PR TITLE
Duck.ai: add back button to non-toggle Duck.ai

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3662,6 +3662,10 @@ class BrowserTabFragment :
                     pixel.fire(DuckChatPixelName.DUCK_CHAT_OMNIBAR_SIDEBAR_TAPPED)
                     viewModel.openDuckChatSidebar()
                 }
+
+                override fun onDuckAIBackButtonPressed() {
+                    onBackPressed()
+                }
             },
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -84,6 +84,8 @@ class Omnibar(
         fun onBackButtonPressed()
 
         fun onDuckAISidebarButtonPressed()
+
+        fun onDuckAIBackButtonPressed()
     }
 
     interface FindInPageListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -164,6 +164,7 @@ class OmnibarLayout @JvmOverloads constructor(
         val showChatMenu: Boolean,
         val showSpacer: Boolean,
         val showDuckSidebar: Boolean,
+        val showDuckBack: Boolean,
     )
 
     @Inject
@@ -236,6 +237,7 @@ class OmnibarLayout @JvmOverloads constructor(
     private val leadingIconContainer: View by lazy { findViewById(R.id.omnibarIconContainer) }
     private val duckAIHeader: View by lazy { findViewById(R.id.duckAIHeader) }
     private val duckAISidebar: View by lazy { findViewById(R.id.duckAiSidebar) }
+    private val duckAIBack: View by lazy { findViewById(R.id.dackAiBack) }
 
     private var isFindInPageVisible = false
     private val findInPageLayoutVisibilityChangeListener =
@@ -334,6 +336,7 @@ class OmnibarLayout @JvmOverloads constructor(
                     addTarget(aiChatMenu)
                     addTarget(browserMenu)
                     addTarget(duckAISidebar)
+                    addTarget(duckAIBack)
                 },
             )
         }
@@ -592,6 +595,9 @@ class OmnibarLayout @JvmOverloads constructor(
         duckAISidebar.setOnClickListener {
             omnibarItemPressedListener?.onDuckAISidebarButtonPressed()
         }
+        duckAIBack.setOnClickListener {
+            omnibarItemPressedListener?.onDuckAIBackButtonPressed()
+        }
     }
 
     override fun setLogoClickListener(logoClickListener: LogoClickListener) {
@@ -655,6 +661,13 @@ class OmnibarLayout @JvmOverloads constructor(
             }
 
             duckAISidebar.updateLayoutParams {
+                (this as MarginLayoutParams).apply {
+                    topMargin = omnibarCardMarginBottom
+                    bottomMargin = omnibarCardMarginTop
+                }
+            }
+
+            duckAIBack.updateLayoutParams {
                 (this as MarginLayoutParams).apply {
                     topMargin = omnibarCardMarginBottom
                     bottomMargin = omnibarCardMarginTop
@@ -822,6 +835,7 @@ class OmnibarLayout @JvmOverloads constructor(
                 showChatMenu = viewState.showChatMenu,
                 showSpacer = viewState.showClearButton || viewState.showVoiceSearch,
                 showDuckSidebar = viewState.showDuckAISidebar,
+                showDuckBack = viewState.showDuckAISidebar && viewState.isDuckAiBackAvailable,
             )
 
         if (omnibarAnimationManager.isFeatureEnabled() && previousTransitionState != null &&
@@ -844,6 +858,7 @@ class OmnibarLayout @JvmOverloads constructor(
         aiChatMenu?.isVisible = newTransitionState.showChatMenu
         aiChatDivider.isVisible = (viewState.showVoiceSearch || viewState.showClearButton) && viewState.showChatMenu
         duckAISidebar.isVisible = newTransitionState.showDuckSidebar
+        duckAIBack.isVisible = newTransitionState.showDuckBack
 
         if (omnibarAnimationManager.isFeatureEnabled()) {
             toolbarContainer.requestLayout()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -237,7 +237,7 @@ class OmnibarLayout @JvmOverloads constructor(
     private val leadingIconContainer: View by lazy { findViewById(R.id.omnibarIconContainer) }
     private val duckAIHeader: View by lazy { findViewById(R.id.duckAIHeader) }
     private val duckAISidebar: View by lazy { findViewById(R.id.duckAiSidebar) }
-    private val duckAIBack: View by lazy { findViewById(R.id.dackAiBack) }
+    private val duckAIBack: View by lazy { findViewById(R.id.duckAiBack) }
 
     private var isFindInPageVisible = false
     private val findInPageLayoutVisibilityChangeListener =

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -563,12 +563,6 @@ class OmnibarLayoutViewModel @Inject constructor(
         }
     }
 
-    private fun shouldShowDuckAiBack(
-        isEnabled: Boolean,
-        isInputScreenUserSettingEnabled: Boolean,
-    ): Boolean =
-        !(isEnabled && isInputScreenUserSettingEnabled)
-
     fun onViewModeChanged(viewMode: ViewMode) {
         val currentViewMode = _viewState.value.viewMode
         val hasFocus = _viewState.value.hasFocus

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -67,6 +67,7 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.ui.NativeInputState
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.serp.logos.api.SerpEasterEggLogosToggles
@@ -77,6 +78,7 @@ import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -88,6 +90,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -241,6 +244,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val showFindInPage: Boolean = false,
         val showDuckAIHeader: Boolean = false,
         val showDuckAISidebar: Boolean = false,
+        val isDuckAiBackAvailable: Boolean = false,
         val isAddressBarTrackersAnimationEnabled: Boolean = false,
         val isProgressBarUpgradeEnabled: Boolean = false,
     ) {
@@ -287,12 +291,12 @@ class OmnibarLayoutViewModel @Inject constructor(
         combine(
             duckAiFeatureState.showInputScreen,
             duckChat.observeNativeInputFieldUserSettingEnabled(),
-        ) { inputScreenEnabled, nativeInputEnabled ->
-            inputScreenEnabled || nativeInputEnabled
-        }.onEach { showClickCatcher ->
+            duckChat.observeInputScreenUserSettingEnabled(),
+        ) { inputScreenEnabled, nativeInputEnabled, aiToggleEnabled ->
             _viewState.update {
                 it.copy(
-                    showTextInputClickCatcher = showClickCatcher,
+                    showTextInputClickCatcher = inputScreenEnabled || nativeInputEnabled,
+                    isDuckAiBackAvailable = nativeInputEnabled && !aiToggleEnabled
                 )
             }
         }.launchIn(viewModelScope)
@@ -561,6 +565,12 @@ class OmnibarLayoutViewModel @Inject constructor(
             false
         }
     }
+
+    private fun shouldShowDuckAiBack(
+        isEnabled: Boolean,
+        isInputScreenUserSettingEnabled: Boolean,
+    ): Boolean =
+        !(isEnabled && isInputScreenUserSettingEnabled)
 
     fun onViewModeChanged(viewMode: ViewMode) {
         val currentViewMode = _viewState.value.viewMode

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -67,7 +67,6 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
-import com.duckduckgo.duckchat.impl.ui.NativeInputState
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.serp.logos.api.SerpEasterEggLogosToggles
@@ -78,7 +77,6 @@ import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -90,7 +88,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -296,7 +293,7 @@ class OmnibarLayoutViewModel @Inject constructor(
             _viewState.update {
                 it.copy(
                     showTextInputClickCatcher = inputScreenEnabled || nativeInputEnabled,
-                    isDuckAiBackAvailable = nativeInputEnabled && !aiToggleEnabled
+                    isDuckAiBackAvailable = nativeInputEnabled && !aiToggleEnabled,
                 )
             }
         }.launchIn(viewModelScope)

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -39,7 +39,7 @@
             android:background="?attr/daxColorToolbar">
 
             <ImageView
-                android:id="@+id/duckAiSidebar"
+                android:id="@+id/dackAiBack"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="@dimen/keyline_3"
@@ -50,6 +50,21 @@
                 android:padding="@dimen/keyline_1"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_arrow_left_24" />
+
+            <ImageView
+                android:id="@+id/duckAiSidebar"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/keyline_3"
+                android:layout_marginTop="@dimen/omnibarCardMarginTop"
+                android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
+                android:background="@drawable/selectable_item_rounded_corner_background"
+                android:contentDescription="@string/browserMenuChatHistory"
+                android:padding="@dimen/keyline_1"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/dackAiBack"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_chats_24" />
 

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -39,14 +39,14 @@
             android:background="?attr/daxColorToolbar">
 
             <ImageView
-                android:id="@+id/dackAiBack"
+                android:id="@+id/duckAiBack"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="@dimen/keyline_3"
                 android:layout_marginTop="@dimen/omnibarCardMarginTop"
                 android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
                 android:background="@drawable/selectable_item_rounded_corner_background"
-                android:contentDescription="@string/browserMenuChatHistory"
+                android:contentDescription="@string/back"
                 android:padding="@dimen/keyline_1"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -64,7 +64,7 @@
                 android:contentDescription="@string/browserMenuChatHistory"
                 android:padding="@dimen/keyline_1"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/dackAiBack"
+                app:layout_constraintStart_toEndOf="@id/duckAiBack"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_chats_24" />
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -97,6 +97,7 @@ class OmnibarLayoutViewModelTest {
     private val duckAiShowOmnibarShortcutInAllStatesFlow = MutableStateFlow(true)
     private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val nativeInputFieldSettingFlow = MutableStateFlow(false)
+    private val inputScreenUserSettingFlow = MutableStateFlow(false)
     private val isFullUrlEnabledFlow = MutableStateFlow(true)
     private val settingsDataStore: SettingsDataStore = mock()
     private val urlDisplayRepository: UrlDisplayRepository = mock()
@@ -135,6 +136,7 @@ class OmnibarLayoutViewModelTest {
         whenever(urlDisplayRepository.isFullUrlEnabled).then { isFullUrlEnabledFlow }
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
+        whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(serpEasterEggLogosToggles.setFavourite()).thenReturn(mock())
         whenever(serpEasterEggLogosToggles.setFavourite().isEnabled()).thenReturn(false)
         whenever(serpEasterEggLogosToggles.setFavourite().enabled()).thenReturn(setFavouriteFeatureEnabledFlow)
@@ -1520,6 +1522,69 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertTrue(viewState.showTextInputClickCatcher)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNativeInputEnabledAndAiToggleDisabledThenIsDuckAiBackAvailableTrue() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        inputScreenUserSettingFlow.value = false
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.isDuckAiBackAvailable)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNativeInputEnabledAndAiToggleEnabledThenIsDuckAiBackAvailableFalse() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        inputScreenUserSettingFlow.value = true
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.isDuckAiBackAvailable)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNativeInputDisabledAndAiToggleDisabledThenIsDuckAiBackAvailableFalse() = runTest {
+        nativeInputFieldSettingFlow.value = false
+        inputScreenUserSettingFlow.value = false
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.isDuckAiBackAvailable)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNativeInputDisabledAndAiToggleEnabledThenIsDuckAiBackAvailableFalse() = runTest {
+        nativeInputFieldSettingFlow.value = false
+        inputScreenUserSettingFlow.value = true
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.isDuckAiBackAvailable)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAiToggleFlipsOffWhileNativeInputEnabledThenIsDuckAiBackAvailableBecomesTrue() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        inputScreenUserSettingFlow.value = true
+
+        testee.viewState.test {
+            assertFalse(expectMostRecentItem().isDuckAiBackAvailable)
+
+            inputScreenUserSettingFlow.value = false
+
+            assertTrue(expectMostRecentItem().isDuckAiBackAvailable)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214289349539844?focus=true

### Description

Adds a back button next to the address bar for users on the non-toggle Duck.ai variant (native input field enabled, AI toggle / input screen user setting disabled). Drives a new `isDuckAiBackAvailable` view-state flag from the combine of `duckAiFeatureState.showInputScreen`, `duckChat.observeNativeInputFieldUserSettingEnabled()` and `duckChat.observeInputScreenUserSettingEnabled()`, so the button is shown only when `nativeInputEnabled && !aiToggleEnabled`.

Also wires the button visibility through `Omnibar` / `OmnibarLayout` and the omnibar XML, hooks the click into `BrowserTabFragment` to navigate back, and adds unit tests covering the four boolean combinations plus the transition that flips `isDuckAiBackAvailable` to true when the AI toggle is disabled while native input is on.

### Steps to test this PR

_Back button visibility (non-toggle Duck.ai)_
- [ ] Enable the native input field user setting
- [ ] Disable the input screen / AI toggle user setting
- [ ] Open the browser and confirm the back button is visible in the omnibar area
- [ ] Tap the back button and confirm it triggers back navigation in the browser tab

_Back button hidden (toggle Duck.ai)_
- [ ] Enable both the native input field user setting and the input screen / AI toggle user setting
- [ ] Confirm the back button is NOT visible in the omnibar

_Back button hidden (native input disabled)_
- [ ] Disable the native input field user setting (with AI toggle either on or off)
- [ ] Confirm the back button is NOT visible in the omnibar

_Live toggle_
- [ ] With native input enabled and the AI toggle on, disable the AI toggle and confirm the back button appears without restarting the app

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that adds a new omnibar button and visibility logic; main risk is unintended icon visibility/layout issues across different omnibar modes.
> 
> **Overview**
> Adds a new **Duck.ai back button** next to the omnibar for the non-toggle Duck.ai variant, wired to trigger normal tab back navigation.
> 
> Introduces an `isDuckAiBackAvailable` view-state flag derived from Duck.ai feature/user-setting flows, and updates `Omnibar`/`OmnibarLayout` plus `view_omnibar.xml` to render/animate the new `duckAiBack` icon only when `nativeInputEnabled && !aiToggleEnabled`, with unit tests covering the relevant combinations and live toggling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bfd4b29f77e6223d5ebdd6c88aaa87e5d11c016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->