### PR TITLE
Add dual DI build logic for CI

### DIFF
--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -15,8 +15,11 @@ concurrency:
 
 jobs:
   build_debug_apk:
-    name: Build debug apk
+    name: Build debug apk (${{ matrix.di }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        di: [AnvilDagger, Metro]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
@@ -63,18 +66,18 @@ jobs:
           MALICIOUS_SITE_PROTECTION_AUTH_TOKEN: ${{ secrets.MALICIOUS_SITE_PROTECTION_AUTH_TOKEN }}
           DUCKSANS_PACKAGE_AUTH_USER: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION_USER }}
           DUCKSANS_PACKAGE_AUTH_TOKEN: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
-        run: ./gradlew assembleInternalDebug -Pforce-default-variant
+        run: ./gradlew assembleInternalDebug -Pforce-default-variant -Pddg.di=${{ matrix.di }}
 
       - name: Obtain debug apk
         if: always()
-        run: cp "$(find . -regex '.*outputs/apk/.*internal-debug.apk')" pr-ddg-debug.apk
+        run: cp "$(find . -regex '.*outputs/apk/.*internal-debug.apk')" pr-ddg-debug-${{ matrix.di }}.apk
 
       - name: Upload debug apk
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pr-ddg-debug
-          path: pr-ddg-debug.apk
+          name: pr-ddg-debug-${{ matrix.di }}
+          path: pr-ddg-debug-${{ matrix.di }}.apk
 
       - name: Cleanup secrets
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,13 @@ jobs:
         run: ./gradlew spotlessCheck
 
   unit_tests:
-    name: Unit tests
+    name: ${{ matrix.di == 'AnvilDagger' && 'Unit tests' || format('Unit tests ({0})', matrix.di) }}
     needs: [check_changes]
     if: needs.check_changes.outputs.should_run == 'true'
     runs-on: android-large-runner
+    strategy:
+      matrix:
+        di: [AnvilDagger, Metro]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -103,18 +106,18 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
-        run: ./gradlew jvm_tests ${{ github.event_name != 'pull_request' && '-Dpts.enabled=false' || '' }}
+        run: ./gradlew jvm_tests -Pddg.di=${{ matrix.di }} ${{ github.event_name != 'pull_request' && '-Dpts.enabled=false' || '' }}
 
       - name: Bundle the JVM checks report
         if: always()
-        run: find . -type d -name 'reports' | zip -@ -r unit-tests-report.zip
+        run: find . -type d -name 'reports' | zip -@ -r unit-tests-report-${{ matrix.di }}.zip
 
       - name: Upload the JVM checks report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-report
-          path: unit-tests-report.zip
+          name: unit-tests-report-${{ matrix.di }}
+          path: unit-tests-report-${{ matrix.di }}.zip
 
   lint:
     name: Lint

--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -1,5 +1,7 @@
 name: 'End to End Tests - Full Suite (Nightly)'
 
+run-name: 'End to End Tests - Full Suite (${{ inputs.ddg_di || ''AnvilDagger'' }} Nightly)'
+
 on:
   workflow_call:
     inputs:
@@ -12,6 +14,11 @@ on:
         required: false
         type: boolean
         default: true
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
   workflow_dispatch:
     inputs:
       commit:
@@ -23,10 +30,25 @@ on:
         required: false
         type: boolean
         default: true
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
 
 concurrency:
   group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
+
+# Workflow-level env: compute DI-variant suffixes once. Empty when AnvilDagger
+# (or input missing) so maestro test names and Asana task names stay
+# byte-identical to pre-change for the default Anvil path. Pattern uses
+# truthy-first ternary because `A && '' || X` is broken in GHA expressions
+# (empty string is falsy).
+env:
+  DDG_DI: ${{ inputs.ddg_di || 'AnvilDagger' }}
+  DI_UNDERSCORE_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format('_{0}', inputs.ddg_di) || '' }}
+  DI_PAREN_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format(' ({0})', inputs.ddg_di) || '' }}
 
 jobs:
   instrumentation_tests:
@@ -47,6 +69,7 @@ jobs:
           release_properties: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
           release_key: ${{ secrets.FAKE_RELEASE_KEY }}
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          gradle_flags: '-Pddg.di=${{ env.DDG_DI }}'
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           ducksans_package_auth_user: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION_USER }}
           ducksans_package_auth_token: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
@@ -58,7 +81,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: binary_internal_upload_${{ github.sha }}
+          maestro_test_name: binary_internal_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
           maestro_api_level: 30
@@ -66,7 +89,7 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Internal Binary Upload
+          test_suite_name: Internal Binary Upload${{ env.DI_PAREN_SUFFIX }}
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
 
       - name: Upload Release Binary to Maestro
@@ -76,7 +99,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: binary_release_upload_${{ github.sha }}
+          maestro_test_name: binary_release_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
           maestro_api_level: 30
@@ -84,7 +107,7 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Release Binary Upload
+          test_suite_name: Release Binary Upload${{ env.DI_PAREN_SUFFIX }}
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
 
       - name: Custom tabs flows
@@ -94,7 +117,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: customTabs_${{ github.sha }}
+          maestro_test_name: customTabs${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -102,9 +125,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Custom Tabs
+          test_suite_name: Custom Tabs${{ env.DI_PAREN_SUFFIX }}
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -115,7 +139,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: internalPrivacyTest_${{ github.sha }}
+          maestro_test_name: internalPrivacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 34
@@ -123,9 +147,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Internal Privacy (Nightly)
+          test_suite_name: Internal Privacy (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -136,7 +161,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: onboardingTest_${{ github.sha }}
+          maestro_test_name: onboardingTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -144,9 +169,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Onboarding (Nightly)
+          test_suite_name: Onboarding (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -157,7 +183,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: navigationTest_${{ github.sha }}
+          maestro_test_name: navigationTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -165,9 +191,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Deeplink (Nightly)
+          test_suite_name: Deeplink (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -178,7 +205,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: adClickTest_${{ github.sha }}
+          maestro_test_name: adClickTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -186,9 +213,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Ad Click (Nightly)
+          test_suite_name: Ad Click (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -199,7 +227,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: privacyTest_${{ github.sha }}
+          maestro_test_name: privacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -207,9 +235,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Privacy (Nightly)
+          test_suite_name: Privacy (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -220,7 +249,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: securityTest_${{ github.sha }}
+          maestro_test_name: securityTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -228,9 +257,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Security (Nightly)
+          test_suite_name: Security (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -241,7 +271,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: releaseTest_${{ github.sha }}
+          maestro_test_name: releaseTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 30
@@ -249,9 +279,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Release Tests (Nightly)
+          test_suite_name: Release Tests (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -262,7 +293,7 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: notificationPermissionTest_${{ github.sha }}
+          maestro_test_name: notificationPermissionTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_api_level: 33
@@ -270,9 +301,10 @@ jobs:
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Notification Permissions (Nightly)
+          test_suite_name: Notification Permissions (${{ env.DDG_DI == 'AnvilDagger' && 'Nightly' || format('{0} Nightly', env.DDG_DI) }})
           create_asana_error_task: ${{ inputs.create_asana_tasks }}
-          is_release_blocker: 'true'
+          # Only block releases for the default Anvil path. Metro is informational.
+          is_release_blocker: ${{ env.DDG_DI == 'AnvilDagger' }}
           asana_releases_project_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
@@ -284,6 +316,6 @@ jobs:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
           asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
-          asana-task-name: GH Workflow Failure - End to End tests (Release Blockers)
-          asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          asana-task-name: GH Workflow Failure - End to End tests${{ env.DDG_DI == 'AnvilDagger' && ' (Release Blockers)' || format(' ({0}, Release Blockers)', env.DDG_DI) }}
+          asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/nightly-metro.yml
+++ b/.github/workflows/nightly-metro.yml
@@ -1,0 +1,112 @@
+name: Nightly (Metro)
+
+# Runs the full nightly suite under the Metro DI framework. Scheduled at 04:30 UTC,
+# 2h30m after nightly-orchestrator.yml (02:00 UTC) — that orchestrator typically
+# completes in ~2h, so the gap absorbs cron-drift and avoids contention for runners
+# and Maestro/Robin quota without blocking the Anvil release flow. Metro is still
+# the non-default DI path, so this nightly is intentionally informational and does
+# not gate LGC tagging.
+
+on:
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_call:
+    inputs:
+      commit:
+        description: 'Specific commit SHA to checkout'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Specific commit SHA to checkout (optional, defaults to latest)'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-nightly:
+    uses: ./.github/workflows/nightly.yml
+    with:
+      commit: ${{ inputs.commit || github.sha }}
+      ddg_di: Metro
+    secrets: inherit
+
+  call-end-to-end:
+    needs: [call-nightly]
+    uses: ./.github/workflows/e2e-nightly-full-suite.yml
+    with:
+      commit: ${{ inputs.commit || github.sha }}
+      ddg_di: Metro
+    secrets: inherit
+
+  call-privacy:
+    needs: [call-end-to-end]
+    uses: ./.github/workflows/privacy.yml
+    with:
+      commit: ${{ inputs.commit || github.sha }}
+      ddg_di: Metro
+    secrets: inherit
+
+  build_variants:
+    name: Assemble ${{ matrix.variant }} (Metro)
+    runs-on: android-large-runner
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [internalRelease, playRelease, fdroidRelease]
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+          submodules: recursive
+
+      - name: Decode release properties
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
+          fileName: ddg_android_build.properties
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Decode release key
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_KEY }}
+          fileName: android
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Set up JDK version
+        uses: actions/setup-java@v4
+        with:
+          java-version-file: .github/.java-version
+          distribution: 'adopt'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Assemble ${{ matrix.variant }}
+        env:
+          MALICIOUS_SITE_PROTECTION_AUTH_TOKEN: ${{ secrets.MALICIOUS_SITE_PROTECTION_AUTH_TOKEN }}
+          DUCKSANS_PACKAGE_AUTH_USER: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION_USER }}
+          DUCKSANS_PACKAGE_AUTH_TOKEN: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
+        run: ./gradlew assemble${{ matrix.variant }} -Pforce-default-variant -Pskip-onboarding -Pddg.di=Metro -x lint
+
+      - name: Create Asana task on failure
+        if: ${{ failure() }}
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - Assemble ${{ matrix.variant }} (Metro)
+          asana-task-description: The Metro assemble ${{ matrix.variant }} build has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,7 @@
 name: Nightly
 
+run-name: 'Nightly (${{ inputs.ddg_di || ''AnvilDagger'' }})'
+
 on:
   workflow_call:
     inputs:
@@ -7,16 +9,35 @@ on:
         description: 'Specific commit SHA to checkout (optional, defaults to latest)'
         required: true
         type: string
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
   workflow_dispatch:
     inputs:
       commit:
         description: 'Specific commit SHA to checkout (optional, defaults to latest)'
         required: false
         type: string
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
 
 concurrency:
   group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
+
+# Workflow-level env: compute DI-variant suffixes once. Empty when AnvilDagger
+# (or input missing) so artifact/task names stay byte-identical to pre-change
+# for the default Anvil path. Pattern uses truthy-first ternary because
+# `A && '' || X` is broken in GHA expressions (empty string is falsy).
+env:
+  DDG_DI: ${{ inputs.ddg_di || 'AnvilDagger' }}
+  DI_HYPHEN_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format('-{0}', inputs.ddg_di) || '' }}
+  DI_PAREN_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format(' ({0})', inputs.ddg_di) || '' }}
 
 jobs:
   code_formatting:
@@ -45,7 +66,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run Code Formatting Checks
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck -Pddg.di=${{ env.DDG_DI }}
 
   unit_tests:
     name: Unit tests
@@ -72,18 +93,18 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
-        run: ./gradlew jvm_tests -Dpts.enabled=false
+        run: ./gradlew jvm_tests -Dpts.enabled=false -Pddg.di=${{ env.DDG_DI }}
 
       - name: Bundle the JVM checks report
         if: always()
-        run: find . -type d -name 'reports' | zip -@ -r unit-tests-report-nightly.zip
+        run: find . -type d -name 'reports' | zip -@ -r unit-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Upload the JVM checks report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-tests-report-nightly
-          path: unit-tests-report-nightly.zip
+          name: unit-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}
+          path: unit-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
   lint:
     name: Lint
@@ -115,18 +136,18 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Lint
-        run: ./gradlew lint
+        run: ./gradlew lint -Pddg.di=${{ env.DDG_DI }}
 
       - name: Bundle the lint report
         if: always()
-        run: find . -name lint-results\* | zip -@ -r lint-report-nightly.zip
+        run: find . -name lint-results\* | zip -@ -r lint-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Upload the JVM lint report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: lint-report-nightly
-          path: lint-report-nightly.zip
+          name: lint-report-nightly${{ env.DI_HYPHEN_SUFFIX }}
+          path: lint-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
   android_tests:
     runs-on: android-large-runner
@@ -168,14 +189,14 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
-        run: ./gradlew androidTestsBuild
+        run: ./gradlew androidTestsBuild -Pddg.di=${{ env.DDG_DI }}
 
       - name: Run Android Tests
-        run: ./gradlew runFlankAndroidTests --no-configuration-cache
+        run: ./gradlew runFlankAndroidTests --no-configuration-cache -Pddg.di=${{ env.DDG_DI }}
 
       - name: Bundle the Android CI tests report
         if: always()
-        run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report-nightly.zip
+        run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Generate json file with failures
         if: ${{ failure() }}
@@ -190,8 +211,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: android-tests-report-nightly
-          path: android-tests-report-nightly.zip
+          name: android-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}
+          path: android-tests-report-nightly${{ env.DI_HYPHEN_SUFFIX }}.zip
 
   create_task_when_failed:
     name: Create Asana task when workflow failed
@@ -206,12 +227,13 @@ jobs:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
           asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
-          asana-task-name: GH Workflow Failure - Nightly
-          asana-task-description: The nightly workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          asana-task-name: GH Workflow Failure - Nightly${{ env.DI_PAREN_SUFFIX }}
+          asana-task-description: The nightly workflow${{ env.DI_PAREN_SUFFIX }} has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ steps.create-failure-task.outputs.taskId != '' }}
+        # Only block releases for the default Anvil path. Metro is informational.
+        if: ${{ env.DDG_DI == 'AnvilDagger' && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,7 @@ env:
 jobs:
   code_formatting:
     name: Code Formatting
+    if: ${{ (inputs.ddg_di || 'AnvilDagger') == 'AnvilDagger' }}
     runs-on: android-large-runner
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -66,7 +67,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run Code Formatting Checks
-        run: ./gradlew spotlessCheck -Pddg.di=${{ env.DDG_DI }}
+        run: ./gradlew spotlessCheck
 
   unit_tests:
     name: Unit tests

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -1,5 +1,7 @@
 name: Privacy Tests
 
+run-name: 'Privacy Tests (${{ inputs.ddg_di || ''AnvilDagger'' }})'
+
 on:
   pull_request:
     types:
@@ -14,16 +16,36 @@ on:
         description: 'Specific commit SHA to checkout (optional, defaults to latest)'
         required: true
         type: string
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
   workflow_dispatch:
     inputs:
       commit:
         description: 'Specific commit SHA to checkout (optional, defaults to latest)'
         required: false
         type: string
+      ddg_di:
+        description: 'DI framework to build with (AnvilDagger or Metro)'
+        required: false
+        type: string
+        default: 'AnvilDagger'
 
 concurrency:
   group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
+
+# Workflow-level env: compute DI-variant suffixes once. Empty when AnvilDagger
+# (or input missing — pull_request triggers don't populate inputs) so
+# artifact/task names stay byte-identical to pre-change for the default Anvil path.
+# Pattern uses truthy-first ternary because `A && '' || X` is broken in GHA
+# expressions (empty string is falsy).
+env:
+  DDG_DI: ${{ inputs.ddg_di || 'AnvilDagger' }}
+  DI_HYPHEN_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format('-{0}', inputs.ddg_di) || '' }}
+  DI_PAREN_SUFFIX: ${{ (inputs.ddg_di || 'AnvilDagger') != 'AnvilDagger' && format(' ({0})', inputs.ddg_di) || '' }}
 
 jobs:
   privacy_tests:
@@ -81,14 +103,14 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
-        run: ./gradlew ${{ matrix.build-task }}
+        run: ./gradlew ${{ matrix.build-task }} -Pddg.di=${{ env.DDG_DI }}
 
       - name: Run Android Tests
-        run: ./gradlew ${{ matrix.flank-task }} --no-configuration-cache
+        run: ./gradlew ${{ matrix.flank-task }} --no-configuration-cache -Pddg.di=${{ env.DDG_DI }}
 
       - name: Bundle the Android CI tests report
         if: always()
-        run: find . -type d -name 'fladleResults' | zip -@ -r ${{ matrix.artifact-name }}.zip
+        run: find . -type d -name 'fladleResults' | zip -@ -r ${{ matrix.artifact-name }}${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Generate json file with failures
         if: ${{ failure() }}
@@ -103,8 +125,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact-name }}
-          path: ${{ matrix.artifact-name }}.zip
+          name: ${{ matrix.artifact-name }}${{ env.DI_HYPHEN_SUFFIX }}
+          path: ${{ matrix.artifact-name }}${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
@@ -114,12 +136,13 @@ jobs:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
           asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
-          asana-task-name: ${{ matrix.asana-task-name }}
-          asana-task-description: The ${{ matrix.name }} workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          asana-task-name: ${{ matrix.asana-task-name }}${{ env.DI_PAREN_SUFFIX }}
+          asana-task-description: The ${{ matrix.name }}${{ env.DI_PAREN_SUFFIX }} workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'
 
       - name: Adding as a release blocker
-        if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
+        # Only block releases for the default Anvil path. Metro is informational.
+        if: ${{ failure() && env.DDG_DI == 'AnvilDagger' && steps.create-failure-task.outputs.taskId != '' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8347,7 +8347,7 @@ class BrowserTabViewModelTest {
 
         val viewState = testee.browserViewState.value
         assertNotNull(viewState)
-        assertFalse((viewState.fireButton as HighlightableButton.Visible).highlighted)
+        assertFalse((viewState!!.fireButton as HighlightableButton.Visible).highlighted)
     }
 
     @Test
@@ -8358,7 +8358,7 @@ class BrowserTabViewModelTest {
 
         val viewState = testee.browserViewState.value
         assertNotNull(viewState)
-        assertFalse((viewState.fireButton as HighlightableButton.Visible).highlighted)
+        assertFalse((viewState!!.fireButton as HighlightableButton.Visible).highlighted)
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -309,6 +309,9 @@ def isCI = System.getenv('CI') != null
 subprojects {
     tasks.withType(Test).configureEach {
         useJUnitPlatform()
+        // Expose the active DI framework to tests so Anvil/Dagger-specific
+        // assertions can be skipped under Metro
+        systemProperty 'ddg.di', findProperty('ddg.di') ?: 'AnvilDagger'
         develocity.testRetry {
             maxRetries = isCI ? 1 : 0
             maxFailures = 5

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         // in the individual module build.gradle files
 
         // Metro DI plugin (requires JVM 21+ to load)
-        classpath "dev.zacsweers.metro:gradle-plugin:1.1.0-SNAPSHOT"
+        classpath "dev.zacsweers.metro:gradle-plugin:_"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         google()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     }
     dependencies {
         classpath(Android.tools.build.gradlePlugin)
@@ -28,7 +29,7 @@ buildscript {
         // in the individual module build.gradle files
 
         // Metro DI plugin (requires JVM 21+ to load)
-        classpath "dev.zacsweers.metro:gradle-plugin:1.0.0"
+        classpath "dev.zacsweers.metro:gradle-plugin:1.1.0-SNAPSHOT"
     }
 }
 
@@ -63,6 +64,7 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
         if (rootProject.ext.proprietaryFontAvailable) {
             maven {
                 url = uri("https://maven.pkg.github.com/duckduckgo/native-apps-ducksans")

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -50,6 +50,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeFalse
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -117,6 +118,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
 
     @Test
     fun `the class factory is generated`() = runTest {
+        // Metro replaces Dagger/Anvil codegen and does not emit standalone `_Factory` classes.
+        assumeFalse("Dagger `_Factory` codegen does not apply under Metro", System.getProperty("ddg.di") == "Metro")
         val generatedClass = Class
             .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature_Factory")
         assertNotNull(generatedClass)

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,11 @@ develocity {
             username { name -> "dax" }
             externalProcessName { processName -> 'non-build-process' }
         }
+        // Tag scans with the active DI framework so cache hits are queryable per-variant
+        // and Anvil/Metro builds remain visibly distinct on Develocity.
+        def diFrameworkTag = settings.startParameter.projectProperties.get('ddg.di') ?: 'AnvilDagger'
+        tag(diFrameworkTag)
+        value('ddg.di', diFrameworkTag)
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionViewModelTest.kt
@@ -111,6 +111,10 @@ class RestoreSubscriptionViewModelTest {
 
     @Test
     fun whenRestoreFromStoreClickThenPixelIsSent() = runTest {
+        whenever(subscriptionsManager.recoverSubscriptionFromStore()).thenReturn(
+            RecoverSubscriptionResult.Failure("error"),
+        )
+
         viewModel.restoreFromStore(isOriginWeb = false)
         verify(pixelSender).reportActivateSubscriptionRestorePurchaseClick()
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -95,6 +95,11 @@ internal class EnterCodeViewModelTest {
     fun whenUserClicksOnPasteCodeThenClipboardIsPasted() = runTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+        // `parseSyncAuthCode` returns the sealed `SyncAuthCode`; without a stub Mockito returns
+        // null, then `any()` in the `processCode` matcher won't match null, and the unstubbed
+        // `processCode` falls back to null → `NoWhenBranchMatchedException` under K2 (Metro).
+        whenever(syncAccountRepository.parseSyncAuthCode(jsonRecoveryKeyEncoded)).thenReturn(Unknown(jsonRecoveryKeyEncoded))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Error(code = INVALID_CODE.code))
 
         testee.onPasteCodeClicked()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -471,6 +471,7 @@ class SyncActivityViewModelTest {
     fun whenDeleteAccountConfirmedThenDeleteAccount() = runTest {
         whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(connectedDevice)
         whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Success(true))
+        whenever(syncAccountRepository.deleteAccount()).thenReturn(Result.Success(true))
 
         testee.onDeleteAccountConfirmed()
 

--- a/versions.properties
+++ b/versions.properties
@@ -11,8 +11,6 @@ plugin.android=8.13.2
 
 plugin.com.squareup.anvil=2.7.0
 
-version.dev.zacsweers.metro=1.1.0-SNAPSHOT
-
 plugin.org.jetbrains.dokka=1.8.20
 
 plugin.com.osacky.fulladle=0.17.4
@@ -112,7 +110,9 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.com.slack.lint.compose..compose-lint-checks=1.4.2
 
-version.dev.zacsweers.metro..runtime=1.0.0
+version.dev.zacsweers.metro..gradle-plugin=1.1.0-SNAPSHOT
+
+version.dev.zacsweers.metro..runtime=1.1.0-SNAPSHOT
 
 version.google.android.flexbox=3.0.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.android=8.13.2
 
 plugin.com.squareup.anvil=2.7.0
 
-version.dev.zacsweers.metro=1.0.0
+version.dev.zacsweers.metro=1.1.0-SNAPSHOT
 
 plugin.org.jetbrains.dokka=1.8.20
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214119362406643/task/1214482475565228?focus=true

### Description
Sets up the CI workflows to also build the Metro variant of the app:

- CI checks on every PR run unit tests for both Anvil and Metro (blocking in case of failure)
- every PR also builds the internalDebug version of the app with Metro
- nightly orchestrator that builds internalRelease, playRelease and fdroidRelease variants with Metro and runs the full suite of e2e tests (separate from the regular nightly orchestrator to not be a release blocked)

### Steps to test this PR

- [ ] Verify new CI checks pass
- [ ] Trigger the new nightly metro workflow on this branch and make sure it passes

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes multiple GitHub Actions workflows and Gradle configuration; misconfigured matrix/flags or artifact naming could break CI/nightly pipelines, though runtime app logic is largely untouched.
> 
> **Overview**
> CI/workflows now **build and run unit tests for both DI frameworks** by adding `Metro` alongside `AnvilDagger` via matrix jobs and passing `-Pddg.di=...` (including debug APK artifacts).
> 
> Nightly/e2e/privacy workflows accept a `ddg_di` input, apply consistent DI-specific suffixes to artifact/Maestro/Asana names, and ensure **Metro runs are informational** (no release-blocker tasks); a new scheduled `nightly-metro.yml` orchestrates Metro nightly + e2e + privacy plus Metro release-variant assembles.
> 
> Gradle config is updated to support this split: adds Sonatype snapshots repo, moves Metro plugin/runtime to `1.1.0-SNAPSHOT` (plugin classpath now via refreshVersions), tags Develocity scans with `ddg.di`, and exposes `ddg.di` as a test system property; a few tests are adjusted to be Metro-compatible (skip Dagger `_Factory` assertion and add missing stubs/null-safety fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75265189cede473dca8d5a78e25a3b499c5ff029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->