### PR TITLE
Duck.Ai/Voice chat: Implement notification for voice chat

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -548,6 +548,7 @@ class BrowserTabViewModel @Inject constructor(
     UrlExtractionListener,
     NavigationHistoryListener {
     private var buildingSiteFactoryJob: Job? = null
+    private var pendingVoiceSessionEndJob: Job? = null
     private var lastAutoCompleteState: AutoCompleteViewState? = null
 
     // Map<String, Map<String, JavaScriptReplyProxy>>() = Map<Origin, Map<location.href, JavaScriptReplyProxy>>()
@@ -885,12 +886,26 @@ class BrowserTabViewModel @Inject constructor(
         siteLiveData = tabRepository.retrieveSiteData(tabId)
         site = siteLiveData.value
 
+        observePendingVoiceSessionEnd(tabId)
+
         initialUrl?.let {
             // initialUrl is the previousUrl from previous session unless it's launched from an external app
             if (androidBrowserConfig.disableTrackerAnimationOnRestart().isEnabled() && !isExternal) {
                 previousUrl = it
             }
             buildSiteFactory(it, stillExternal = isExternal)
+        }
+    }
+
+    private fun observePendingVoiceSessionEnd(tabId: String) {
+        pendingVoiceSessionEndJob?.cancel()
+        pendingVoiceSessionEndJob = viewModelScope.launch {
+            duckChat.observeTriggerVoiceSessionEnd()
+                .filter { it == tabId }
+                .collect {
+                    val event = duckChatJSHelper.onNativeAction(NativeAction.END_VOICE_SESSION)
+                    _subscriptionEventDataChannel.send(event)
+                }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -900,7 +900,7 @@ class BrowserTabViewModel @Inject constructor(
     private fun observePendingVoiceSessionEnd(tabId: String) {
         pendingVoiceSessionEndJob?.cancel()
         pendingVoiceSessionEndJob = viewModelScope.launch {
-            duckChat.observeTriggerVoiceSessionEnd()
+            duckChat.observeTriggerVoiceChatSessionEnd()
                 .filter { it == tabId }
                 .collect {
                     val event = duckChatJSHelper.onNativeAction(NativeAction.END_VOICE_SESSION)

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/AppBrowserNav.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/AppBrowserNav.kt
@@ -55,4 +55,11 @@ class AppBrowserNav @Inject constructor() : BrowserNav {
     ): Intent {
         return BrowserActivity.intent(context = context, closeDuckChat = true)
     }
+
+    override fun openExistingTab(
+        context: Context,
+        tabId: String,
+    ): Intent {
+        return BrowserActivity.intent(context = context, openExistingTabId = tabId)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -599,7 +599,7 @@ class BrowserTabViewModelTest {
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
     private val voiceSessionEndTriggerFlow = MutableSharedFlow<String>(extraBufferCapacity = 8)
     private val mockDuckChat: DuckChat = mock {
-        on { observeTriggerVoiceSessionEnd() } doReturn voiceSessionEndTriggerFlow
+        on { observeTriggerVoiceChatSessionEnd() } doReturn voiceSessionEndTriggerFlow
     }
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -597,7 +597,10 @@ class BrowserTabViewModelTest {
     private val mockDuckChatJSHelper: DuckChatJSHelper = mock()
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
-    private val mockDuckChat: DuckChat = mock()
+    private val voiceSessionEndTriggerFlow = MutableSharedFlow<String>(extraBufferCapacity = 8)
+    private val mockDuckChat: DuckChat = mock {
+        on { observeTriggerVoiceSessionEnd() } doReturn voiceSessionEndTriggerFlow
+    }
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()
     private val subscriptionStatusFlow = MutableSharedFlow<SubscriptionStatus>()
@@ -9512,6 +9515,36 @@ class BrowserTabViewModelTest {
         }
 
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED)
+    }
+
+    @Test
+    fun whenObserveTriggerVoiceSessionEndEmitsMatchingTabIdThenEndVoiceSessionEventDispatched() = runTest {
+        val expectedEvent = SubscriptionEventData(
+            featureName = "aiChat",
+            subscriptionName = "endVoiceSession",
+            params = JSONObject(),
+        )
+        whenever(mockDuckChatJSHelper.onNativeAction(NativeAction.END_VOICE_SESSION)).thenReturn(expectedEvent)
+
+        testee.subscriptionEventDataFlow.test {
+            voiceSessionEndTriggerFlow.emit("abc")
+
+            val emittedEvent = awaitItem()
+            assertEquals(expectedEvent.featureName, emittedEvent.featureName)
+            assertEquals(expectedEvent.subscriptionName, emittedEvent.subscriptionName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenObserveTriggerVoiceSessionEndEmitsDifferentTabIdThenNoEventDispatched() = runTest {
+        testee.subscriptionEventDataFlow.test {
+            voiceSessionEndTriggerFlow.emit("some-other-tab")
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(mockDuckChatJSHelper, never()).onNativeAction(NativeAction.END_VOICE_SESSION)
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/BrowserNav.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/BrowserNav.kt
@@ -28,4 +28,10 @@ interface BrowserNav {
     fun openInCurrentTab(context: Context, url: String): Intent
     fun openDuckChat(context: Context, hasSessionActive: Boolean = false, duckChatUrl: String): Intent
     fun closeDuckChat(context: Context): Intent
+
+    /**
+     * Returns an Intent that brings the browser to the foreground and switches to the tab
+     * identified by [tabId].
+     */
+    fun openExistingTab(context: Context, tabId: String): Intent
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -130,5 +130,5 @@ interface DuckChat {
      * foreground service notification). Tabs should collect this flow and dispatch the
      * end-voice-session JS event when their id is emitted.
      */
-    fun observeTriggerVoiceSessionEnd(): Flow<String>
+    fun observeTriggerVoiceChatSessionEnd(): Flow<String>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -124,4 +124,11 @@ interface DuckChat {
      * Returns `true` if a voice session is currently active.
      */
     fun isVoiceSessionActive(): Boolean
+
+    /**
+     * Emits the tab id whenever an end-voice-session action is requested (e.g. from the
+     * foreground service notification). Tabs should collect this flow and dispatch the
+     * end-voice-session JS event when their id is emitted.
+     */
+    fun observeTriggerVoiceSessionEnd(): Flow<String>
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -806,6 +806,8 @@ class RealDuckChat @Inject constructor(
 
     override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
+    override fun observeTriggerVoiceSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
+
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -806,7 +806,7 @@ class RealDuckChat @Inject constructor(
 
     override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
 
-    override fun observeTriggerVoiceSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
+    override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
 
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {
         duckChatFeatureRepository.setDefaultTogglePosition(position.name)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -82,6 +82,7 @@ enum class NativeAction {
     NEW_CHAT,
     SIDEBAR,
     DUCK_AI_SETTINGS,
+    END_VOICE_SESSION,
 }
 
 @ContributesBinding(AppScope::class)
@@ -247,6 +248,7 @@ class RealDuckChatJSHelper @Inject constructor(
             NativeAction.NEW_CHAT -> SUBSCRIPTION_NEW_CHAT
             NativeAction.SIDEBAR -> SUBSCRIPTION_TOGGLE_SIDEBAR
             NativeAction.DUCK_AI_SETTINGS -> SUBSCRIPTION_DUCK_AI_SETTINGS
+            NativeAction.END_VOICE_SESSION -> SUBSCRIPTION_END_VOICE_SESSION
         }
 
         return SubscriptionEventData(
@@ -500,5 +502,6 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUBSCRIPTION_TOGGLE_SIDEBAR = "submitToggleSidebarAction"
         private const val SUBSCRIPTION_DUCK_AI_SETTINGS = "submitOpenSettingsAction"
         private const val SUBSCRIPTION_SUBMIT_NATIVE_PROMPT = "submitAIChatNativePrompt"
+        private const val SUBSCRIPTION_END_VOICE_SESSION = "endVoiceSession"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -29,6 +29,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.duckchat.impl.R
@@ -48,6 +49,9 @@ class DuckChatVoiceMicrophoneService : Service() {
 
     @Inject
     lateinit var voiceSessionStateManager: VoiceSessionStateManager
+
+    @Inject
+    lateinit var browserNav: BrowserNav
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -98,8 +102,10 @@ class DuckChatVoiceMicrophoneService : Service() {
     }
 
     private fun openChatPendingIntent(tabId: String): PendingIntent {
-        val intent = DuckChatVoiceNotificationActionReceiver.openChatIntent(this, tabId)
-        return PendingIntent.getBroadcast(
+        val intent = browserNav.openExistingTab(this, tabId).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        return PendingIntent.getActivity(
             this,
             REQUEST_CODE_OPEN_CHAT,
             intent,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import dagger.android.AndroidInjection
 import javax.inject.Inject
 
@@ -44,6 +45,9 @@ class DuckChatVoiceMicrophoneService : Service() {
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var voiceSessionStateManager: VoiceSessionStateManager
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -72,20 +76,52 @@ class DuckChatVoiceMicrophoneService : Service() {
     }
 
     private fun buildNotification(): Notification {
-        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        val pendingIntent = launchIntent?.let {
-            PendingIntent.getActivity(this, 0, it, PendingIntent.FLAG_IMMUTABLE)
-        }
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        val tabId = voiceSessionStateManager.activeSessionTabId
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.duckAiVoiceNotificationTitle))
             .setContentText(getString(R.string.duckAiVoiceNotificationMessage))
             .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setContentIntent(pendingIntent)
-            .build()
+
+        if (tabId != null) {
+            val openChatPendingIntent = openChatPendingIntent(tabId)
+            val endSessionPendingIntent = endSessionPendingIntent(tabId)
+            builder
+                .setContentIntent(openChatPendingIntent)
+                .addAction(0, getString(R.string.duckAiVoiceNotificationActionOpenChat), openChatPendingIntent)
+                .addAction(0, getString(R.string.duckAiVoiceNotificationActionEndSession), endSessionPendingIntent)
+        } else {
+            builder.setContentIntent(fallbackLaunchPendingIntent())
+        }
+        return builder.build()
+    }
+
+    private fun openChatPendingIntent(tabId: String): PendingIntent {
+        val intent = DuckChatVoiceNotificationActionReceiver.openChatIntent(this, tabId)
+        return PendingIntent.getBroadcast(
+            this,
+            REQUEST_CODE_OPEN_CHAT,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun endSessionPendingIntent(tabId: String): PendingIntent {
+        val intent = DuckChatVoiceNotificationActionReceiver.endSessionIntent(this, tabId)
+        return PendingIntent.getBroadcast(
+            this,
+            REQUEST_CODE_END_SESSION,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun fallbackLaunchPendingIntent(): PendingIntent? {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        } ?: return null
+        return PendingIntent.getActivity(this, REQUEST_CODE_FALLBACK, launchIntent, PendingIntent.FLAG_IMMUTABLE)
     }
 
     private fun createNotificationChannel() {
@@ -100,6 +136,9 @@ class DuckChatVoiceMicrophoneService : Service() {
     companion object {
         private const val NOTIFICATION_ID = 9100
         private const val CHANNEL_ID = "duck_ai_voice_microphone"
+        private const val REQUEST_CODE_OPEN_CHAT = 1
+        private const val REQUEST_CODE_END_SESSION = 2
+        private const val REQUEST_CODE_FALLBACK = 3
 
         fun start(context: Context) {
             ContextCompat.startForegroundService(context, Intent(context, DuckChatVoiceMicrophoneService::class.java))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
@@ -37,7 +36,6 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class DuckChatVoiceNotificationActionReceiver @Inject constructor(
     private val context: Context,
-    private val browserNav: BrowserNav,
     private val voiceSessionStateManager: VoiceSessionStateManager,
 ) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
@@ -58,38 +56,12 @@ class DuckChatVoiceNotificationActionReceiver @Inject constructor(
         if (intent.action != INTENT_VOICE_NOTIFICATION_ACTION) return
         val tabId = intent.getStringExtra(EXTRA_TAB_ID)?.takeIf { it.isNotBlank() } ?: return
 
-        when (intent.getStringExtra(EXTRA_ACTION)) {
-            ACTION_OPEN_CHAT -> openExistingTab(context, tabId)
-            ACTION_END_SESSION -> {
-                openExistingTab(context, tabId)
-                voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
-            }
-        }
-    }
-
-    private fun openExistingTab(context: Context, tabId: String) {
-        val intent = browserNav.openExistingTab(context, tabId).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        context.startActivity(intent)
+        voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
     }
 
     companion object {
         private const val INTENT_VOICE_NOTIFICATION_ACTION = "com.duckduckgo.duckchat.voice.notification.action"
-        private const val EXTRA_ACTION = "EXTRA_ACTION"
         private const val EXTRA_TAB_ID = "EXTRA_TAB_ID"
-        private const val ACTION_OPEN_CHAT = "ACTION_OPEN_CHAT"
-        private const val ACTION_END_SESSION = "ACTION_END_SESSION"
-
-        fun openChatIntent(
-            context: Context,
-            tabId: String,
-        ): Intent =
-            Intent(INTENT_VOICE_NOTIFICATION_ACTION).apply {
-                setPackage(context.packageName)
-                putExtra(EXTRA_ACTION, ACTION_OPEN_CHAT)
-                putExtra(EXTRA_TAB_ID, tabId)
-            }
 
         fun endSessionIntent(
             context: Context,
@@ -97,7 +69,6 @@ class DuckChatVoiceNotificationActionReceiver @Inject constructor(
         ): Intent =
             Intent(INTENT_VOICE_NOTIFICATION_ACTION).apply {
                 setPackage(context.packageName)
-                putExtra(EXTRA_ACTION, ACTION_END_SESSION)
                 putExtra(EXTRA_TAB_ID, tabId)
             }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -37,6 +38,7 @@ import javax.inject.Inject
 class DuckChatVoiceNotificationActionReceiver @Inject constructor(
     private val context: Context,
     private val browserNav: BrowserNav,
+    private val voiceSessionStateManager: VoiceSessionStateManager,
 ) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -58,7 +60,10 @@ class DuckChatVoiceNotificationActionReceiver @Inject constructor(
 
         when (intent.getStringExtra(EXTRA_ACTION)) {
             ACTION_OPEN_CHAT -> openExistingTab(context, tabId)
-            ACTION_END_SESSION -> Unit // intentional no-op for now
+            ACTION_END_SESSION -> {
+                openExistingTab(context, tabId)
+                voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
+            }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class DuckChatVoiceNotificationActionReceiver @Inject constructor(
+    private val context: Context,
+    private val browserNav: BrowserNav,
+) : BroadcastReceiver(), MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        context.registerNotExportedReceiver(this, IntentFilter(INTENT_VOICE_NOTIFICATION_ACTION))
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        context.unregisterReceiver(this)
+    }
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action != INTENT_VOICE_NOTIFICATION_ACTION) return
+        val tabId = intent.getStringExtra(EXTRA_TAB_ID)?.takeIf { it.isNotBlank() } ?: return
+
+        when (intent.getStringExtra(EXTRA_ACTION)) {
+            ACTION_OPEN_CHAT -> openExistingTab(context, tabId)
+            ACTION_END_SESSION -> Unit // intentional no-op for now
+        }
+    }
+
+    private fun openExistingTab(context: Context, tabId: String) {
+        val intent = browserNav.openExistingTab(context, tabId).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        context.startActivity(intent)
+    }
+
+    companion object {
+        private const val INTENT_VOICE_NOTIFICATION_ACTION = "com.duckduckgo.duckchat.voice.notification.action"
+        private const val EXTRA_ACTION = "EXTRA_ACTION"
+        private const val EXTRA_TAB_ID = "EXTRA_TAB_ID"
+        private const val ACTION_OPEN_CHAT = "ACTION_OPEN_CHAT"
+        private const val ACTION_END_SESSION = "ACTION_END_SESSION"
+
+        fun openChatIntent(
+            context: Context,
+            tabId: String,
+        ): Intent =
+            Intent(INTENT_VOICE_NOTIFICATION_ACTION).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_ACTION, ACTION_OPEN_CHAT)
+                putExtra(EXTRA_TAB_ID, tabId)
+            }
+
+        fun endSessionIntent(
+            context: Context,
+            tabId: String,
+        ): Intent =
+            Intent(INTENT_VOICE_NOTIFICATION_ACTION).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_ACTION, ACTION_END_SESSION)
+                putExtra(EXTRA_TAB_ID, tabId)
+            }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -35,6 +35,14 @@ import javax.inject.Inject
 interface VoiceSessionStateManager {
     val isVoiceSessionActive: Boolean
         get() = false
+
+    /**
+     * The tab id bound to the active voice session, or null if there is no active session
+     * or the session is a standalone (non-tab) session.
+     */
+    val activeSessionTabId: String?
+        get() = null
+
     fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded()
 }
@@ -53,14 +61,17 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     // null = no session, STANDALONE_SESSION_ID = session without a browser tab, non-empty = tab session
     @Volatile
-    private var activeSessionTabId: String? = null
+    private var _activeSessionTabId: String? = null
+
+    override val activeSessionTabId: String?
+        get() = _activeSessionTabId?.takeUnless { it == STANDALONE_SESSION_ID }
 
     override val isVoiceSessionActive: Boolean
-        get() = activeSessionTabId != null
+        get() = _activeSessionTabId != null
 
     @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {
-        activeSessionTabId = tabId.ifBlank { STANDALONE_SESSION_ID }
+        _activeSessionTabId = tabId.ifBlank { STANDALONE_SESSION_ID }
         if (duckChatFeature.duckAiVoiceChatService().isEnabled()) {
             DuckChatVoiceMicrophoneService.start(context)
         }
@@ -72,7 +83,7 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Synchronized
     override fun onVoiceSessionEnded() {
         listenJob.cancel()
-        activeSessionTabId = null
+        _activeSessionTabId = null
         DuckChatVoiceMicrophoneService.stop(context)
     }
 
@@ -89,7 +100,7 @@ class RealVoiceSessionStateManager @Inject constructor(
     private fun listenToTabRemoval() {
         listenJob += appCoroutineScope.launch {
             tabRepository.flowTabs.drop(1).collect { tabs ->
-                val tabId = activeSessionTabId ?: return@collect
+                val tabId = _activeSessionTabId ?: return@collect
                 if (tabs.none { it.tabId == tabId }) {
                     onVoiceSessionEnded()
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -28,6 +28,10 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -43,8 +47,16 @@ interface VoiceSessionStateManager {
     val activeSessionTabId: String?
         get() = null
 
+    /**
+     * Emits the tab id whenever an end-voice-session action is requested (e.g. from the
+     * foreground service notification). Tabs should collect this flow and dispatch the
+     * end-voice-session JS event when their id is emitted.
+     */
+    fun observeTriggerVoiceSessionEnd(): Flow<String>
+
     fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded()
+    fun triggerVoiceSessionEnd(tabId: String)
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -63,11 +75,24 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Volatile
     private var _activeSessionTabId: String? = null
 
+    private val _voiceSessionEndTrigger = MutableSharedFlow<String>(
+        replay = 0,
+        extraBufferCapacity = 8,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
     override val activeSessionTabId: String?
         get() = _activeSessionTabId?.takeUnless { it == STANDALONE_SESSION_ID }
 
     override val isVoiceSessionActive: Boolean
         get() = _activeSessionTabId != null
+
+    override fun observeTriggerVoiceSessionEnd(): Flow<String> = _voiceSessionEndTrigger.asSharedFlow()
+
+    override fun triggerVoiceSessionEnd(tabId: String) {
+        if (tabId.isBlank()) return
+        _voiceSessionEndTrigger.tryEmit(tabId)
+    }
 
     @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -31,6 +31,8 @@
     <string name="duckAiVoiceNotificationTitle">Duck.ai Voice Chat Active</string>
     <string name="duckAiVoiceNotificationMessage">Microphone is in use by Duck.ai</string>
     <string name="duckAiVoiceNotificationChannelName">Duck.ai Voice Chat</string>
+    <string name="duckAiVoiceNotificationActionOpenChat">Open chat</string>
+    <string name="duckAiVoiceNotificationActionEndSession">End session</string>
 
     <!-- Start chat icon content description -->
     <string name="duckChatStartChatContentDescription">Start chat</string>

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.duckchat.impl.ui.DuckChatVoiceNotificationActionReceiver.Companion.endSessionIntent
+import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+@RunWith(AndroidJUnit4::class)
+class DuckChatVoiceNotificationActionReceiverTest {
+
+    private val context: Context = mock()
+    private val voiceSessionStateManager: VoiceSessionStateManager = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
+
+    private lateinit var receiver: DuckChatVoiceNotificationActionReceiver
+
+    @Before
+    fun setUp() {
+        receiver = DuckChatVoiceNotificationActionReceiver(context, voiceSessionStateManager)
+    }
+
+    @Test
+    fun whenOnReceiveWithValidIntentThenTriggersVoiceSessionEnd() {
+        val intent = endSessionIntent(context, TAB_ID)
+
+        receiver.onReceive(context, intent)
+
+        verify(voiceSessionStateManager).triggerVoiceSessionEnd(TAB_ID)
+    }
+
+    @Test
+    fun whenOnReceiveWithWrongActionThenDoesNothing() {
+        val intent = Intent("com.duckduckgo.some.other.action").apply {
+            putExtra("EXTRA_TAB_ID", TAB_ID)
+        }
+
+        receiver.onReceive(context, intent)
+
+        verifyNoInteractions(voiceSessionStateManager)
+    }
+
+    @Test
+    fun whenOnReceiveWithoutTabIdThenDoesNothing() {
+        val action = endSessionIntent(context, TAB_ID).action
+        val intent = Intent(action)
+
+        receiver.onReceive(context, intent)
+
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenOnReceiveWithBlankTabIdThenDoesNothing() {
+        val intent = endSessionIntent(context, "   ")
+
+        receiver.onReceive(context, intent)
+
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenOnReceiveWithEmptyTabIdThenDoesNothing() {
+        val intent = endSessionIntent(context, "")
+
+        receiver.onReceive(context, intent)
+
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun whenEndSessionIntentThenIntentTargetsCurrentPackage() {
+        val intent = endSessionIntent(context, TAB_ID)
+
+        assertEquals(context.packageName, intent.`package`)
+    }
+
+    companion object {
+        private const val TAB_ID = "tab-123"
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1437,7 +1437,7 @@ class DuckChatContextualViewModelTest {
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(): Boolean = false
-        override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+        override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
     }
 
     private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1437,6 +1437,7 @@ class DuckChatContextualViewModelTest {
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(): Boolean = false
+        override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
     }
 
     private class FakeDuckChatContextualDataStore : DuckChatContextualDataStore {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1400,6 +1400,14 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenNativeActionEndVoiceSessionRequestedThenSubscriptionDataSent() = runTest {
+        val result = testee.onNativeAction(NativeAction.END_VOICE_SESSION)
+
+        assertEquals("endVoiceSession", result.subscriptionName)
+        assertEquals(DUCK_CHAT_FEATURE_NAME, result.featureName)
+    }
+
+    @Test
     fun whenGetAIChatNativeHandoffDataThenReportOpenIsCalled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeHandoffData"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -110,6 +110,7 @@ class FakeDuckChat(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(): Boolean = false
+    override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -110,7 +110,7 @@ class FakeDuckChat(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(): Boolean = false
-    override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+    override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -184,7 +184,7 @@ class FakeDuckChatInternal(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(): Boolean = false
-    override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+    override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -184,6 +184,7 @@ class FakeDuckChatInternal(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(): Boolean = false
+    override fun observeTriggerVoiceSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.voice
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import app.cash.turbine.test
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -233,6 +235,47 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted(TAB_ID)
 
         testee.onVoiceSessionEnded()
+
+        assertFalse(testee.isVoiceSessionActive)
+    }
+
+    @Test
+    fun whenTriggerVoiceSessionEndCalledThenTabIdIsEmittedOnObserveFlow() = coroutineTestRule.testScope.runTest {
+        testee.observeTriggerVoiceSessionEnd().test {
+            testee.triggerVoiceSessionEnd(TAB_ID)
+
+            assertEquals(TAB_ID, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenTriggerVoiceSessionEndCalledWithBlankTabIdThenNoEmission() = coroutineTestRule.testScope.runTest {
+        testee.observeTriggerVoiceSessionEnd().test {
+            testee.triggerVoiceSessionEnd("")
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenTriggerVoiceSessionEndCalledMultipleTimesThenAllTabIdsEmitted() = coroutineTestRule.testScope.runTest {
+        testee.observeTriggerVoiceSessionEnd().test {
+            testee.triggerVoiceSessionEnd(TAB_ID)
+            testee.triggerVoiceSessionEnd(OTHER_TAB_ID)
+
+            assertEquals(TAB_ID, awaitItem())
+            assertEquals(OTHER_TAB_ID, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenTriggerVoiceSessionEndCalledThenIsVoiceSessionActiveUnchanged() {
+        assertFalse(testee.isVoiceSessionActive)
+
+        testee.triggerVoiceSessionEnd(TAB_ID)
 
         assertFalse(testee.isVoiceSessionActive)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214486550259824?focus=true

### Description
This branch adds Open chat and End session action buttons to the Duck.ai voice-chat ongoing notification, and re-targets the notification body tap to open the originating tab.     

### Steps to test this PR
_Setup_                                                                                                                                                                                                                                            
  - Confirm `duckAiVoiceChatService` remote flag is enabled                                                                                                          
                                                                                                                                                                                                                   
_1. Notification appearance (tab-bound session)_                                                                                                                                                                                                                                                                                                                                                                                
- [x] Start a voice session from a Duck.ai tab                                                                                                                                                                         
- [x] Notification IS visible with Open chat and End session action buttons                                                                                                                                          
                                                                                                                                                                                                                     
_2. Tap notification body / Open chat_                                                                                                                                                                               
- [x] Switch to a different tab (and background the app), then tap the notification body                                                                                                                                
- [x] App returns to the originating tab, voice session still active                                                                                                                                                 
- [x] Same behavior when tapping Open chat                                                                                                                                                                             
                                                                                                                                                                                                                     
_3. Tap End session_
- [x] Tap End session from the notification                                                                                                                                                                            
- [x] Notification IS dismissed, voice session ends, originating tab is preserved
- [x] Starting a new voice session works again                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                     
_4. duckAiVoiceChatService disabled_                                                                                                                                                                                
- [x] No notification appears; in-app voice flow still works                                                                                                                                                           
                                                                                                                                                                                                                   
_Regression checks_
- [ ] Closing the originating tab while voice is active still ends the session and dismisses the notification                                                                                                          
- [ ] ther BrowserNav entry points and other Duck.ai JS subscription events (new chat, sidebar, settings) are unaffected



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new notification actions and cross-component signaling to end voice sessions, touching foreground service, navigation intents, and JS event dispatching; behavior is user-facing and timing/flow handling could regress session/tab coordination.
> 
> **Overview**
> Improves Duck.ai voice-chat’s ongoing microphone notification by retargeting taps to the originating tab and adding **Open chat** and **End session** actions when a tab-bound voice session is active.
> 
> Introduces a tab-id–based end-session signal: `DuckChatVoiceNotificationActionReceiver` triggers `VoiceSessionStateManager.triggerVoiceSessionEnd(tabId)`, `DuckChat.observeTriggerVoiceChatSessionEnd()` exposes this as a `Flow`, and `BrowserTabViewModel` listens per-tab to dispatch the `endVoiceSession` JS subscription event (`NativeAction.END_VOICE_SESSION`).
> 
> Extends `BrowserNav` with `openExistingTab` to support bringing a specific tab to the foreground from the notification, and updates tests/fakes to cover the new flow and JS subscription mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4c6b2c06af9e500848098bc0fa4421ac9f905d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->