### PR TITLE
Duck.Ai/Voice chat/Unified Input: Hide unusable buttons during active voice session

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -369,6 +369,7 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -405,6 +406,8 @@ class BrowserTabFragment :
     private var duckAiContextualFragment: DuckChatContextualFragment? = null
     private var contextualSheetLayoutChangeListener: View.OnLayoutChangeListener? = null
     private var contextualSheetBottomSheetCallback: BottomSheetBehavior.BottomSheetCallback? = null
+
+    private var voiceActiveOnThisTab: Boolean = false
 
     @Inject
     lateinit var nativeInputManager: NativeInputManager
@@ -4364,11 +4367,18 @@ class BrowserTabFragment :
         }
 
         binding.swipeRefreshContainer.setCanChildScrollUpCallback {
-            webView?.canScrollVertically(-1) ?: false
+            voiceActiveOnThisTab || (webView?.canScrollVertically(-1) ?: false)
         }
 
         // avoids progressView from showing under toolbar
         binding.swipeRefreshContainer.progressViewStartOffset -= 15
+
+        duckChat.activeVoiceChatSessions
+            .map { tabId in it }
+            .distinctUntilChanged()
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach { voiceActiveOnThisTab = it }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     @Suppress("NewApi") // This API and the behaviour described only apply to apps with targetSdkVersion ≥ TIRAMISU.

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -206,7 +206,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         )
 
     private val voiceActiveOnSelectedTab: StateFlow<Boolean> = combine(
-        duckChat.activeVoiceSessions,
+        duckChat.activeVoiceChatSessions,
         tabRepository.flowSelectedTab,
     ) { activeSessions, selectedTab ->
         selectedTab?.tabId?.let { it in activeSessions } == true

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -204,6 +205,13 @@ class OmnibarLayoutViewModel @Inject constructor(
             initialValue = true,
         )
 
+    private val voiceActiveOnSelectedTab: StateFlow<Boolean> = combine(
+        duckChat.activeVoiceSessions,
+        tabRepository.flowSelectedTab,
+    ) { activeSessions, selectedTab ->
+        selectedTab?.tabId?.let { it in activeSessions } == true
+    }.distinctUntilChanged().stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
 
@@ -304,6 +312,12 @@ class OmnibarLayoutViewModel @Inject constructor(
             }
         }.launchIn(viewModelScope)
 
+        voiceActiveOnSelectedTab.onEach { voiceActive ->
+            _viewState.update {
+                it.copy(showDuckAISidebar = shouldShowDuckAiSidebar(it.viewMode, it.hasFocus, voiceActive))
+            }
+        }.launchIn(viewModelScope)
+
         viewState.map {
             NewTabPixelParams(
                 isNtp = it.viewMode == NewTab,
@@ -389,7 +403,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                     updateOmnibarText = shouldUpdateOmnibarText,
                     omnibarText = omnibarText,
                     showDuckAIHeader = shouldShowDuckAiHeader(_viewState.value.viewMode, true),
-                    showDuckAISidebar = shouldShowDuckAiHeader(_viewState.value.viewMode, true),
+                    showDuckAISidebar = shouldShowDuckAiSidebar(_viewState.value.viewMode, true),
                 )
             }
         } else {
@@ -453,7 +467,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                     updateOmnibarText = shouldUpdateOmnibarText,
                     omnibarText = omnibarText,
                     showDuckAIHeader = shouldShowDuckAiHeader(_viewState.value.viewMode, false),
-                    showDuckAISidebar = shouldShowDuckAiHeader(_viewState.value.viewMode, false),
+                    showDuckAISidebar = shouldShowDuckAiSidebar(_viewState.value.viewMode, false),
                 )
             }
 
@@ -563,6 +577,12 @@ class OmnibarLayoutViewModel @Inject constructor(
         }
     }
 
+    private fun shouldShowDuckAiSidebar(
+        viewMode: ViewMode,
+        hasFocus: Boolean,
+        voiceActive: Boolean = voiceActiveOnSelectedTab.value,
+    ): Boolean = shouldShowDuckAiHeader(viewMode, hasFocus) && !voiceActive
+
     fun onViewModeChanged(viewMode: ViewMode) {
         val currentViewMode = _viewState.value.viewMode
         val hasFocus = _viewState.value.hasFocus
@@ -598,7 +618,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                             omnibarText = "",
                             updateOmnibarText = true,
                             showDuckAIHeader = shouldShowDuckAiHeader(viewMode, hasFocus),
-                            showDuckAISidebar = shouldShowDuckAiHeader(viewMode, hasFocus),
+                            showDuckAISidebar = shouldShowDuckAiSidebar(viewMode, hasFocus),
                         )
                     }
                 }
@@ -637,7 +657,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                             ),
                             showShadows = false,
                             showDuckAIHeader = shouldShowDuckAiHeader(viewMode, hasFocus),
-                            showDuckAISidebar = shouldShowDuckAiHeader(viewMode, hasFocus),
+                            showDuckAISidebar = shouldShowDuckAiSidebar(viewMode, hasFocus),
                         )
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch
 
-import androidx.core.net.toUri
 import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
@@ -126,10 +125,9 @@ class FirstScreenHandlerImpl @Inject constructor(
     }
 
     private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean = withContext(dispatcherProvider.io()) {
-        if (!duckChat.isVoiceSessionActive()) return@withContext false
         val selectedTab = tabRepository.getSelectedTab()
-        return@withContext selectedTab?.url?.toUri()?.let {
-            duckChat.isDuckChatUrl(it)
+        return@withContext selectedTab?.tabId?.let {
+            duckChat.isVoiceSessionActive(it)
         } == true
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -127,7 +127,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private suspend fun isVoiceSessionActiveOnCurrentTab(): Boolean = withContext(dispatcherProvider.io()) {
         val selectedTab = tabRepository.getSelectedTab()
         return@withContext selectedTab?.tabId?.let {
-            duckChat.isVoiceSessionActive(it)
+            duckChat.isVoiceChatSessionActive(it)
         } == true
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -98,6 +98,8 @@ class OmnibarLayoutViewModelTest {
     private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val nativeInputFieldSettingFlow = MutableStateFlow(false)
     private val inputScreenUserSettingFlow = MutableStateFlow(false)
+    private val activeVoiceSessionsFlow = MutableStateFlow<Set<String>>(emptySet())
+    private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val isFullUrlEnabledFlow = MutableStateFlow(true)
     private val settingsDataStore: SettingsDataStore = mock()
     private val urlDisplayRepository: UrlDisplayRepository = mock()
@@ -129,6 +131,7 @@ class OmnibarLayoutViewModelTest {
     @Before
     fun before() {
         whenever(tabRepository.flowTabs).thenReturn(flowOf(emptyList()))
+        whenever(tabRepository.flowSelectedTab).thenReturn(selectedTabFlow)
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
         whenever(duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow)
@@ -136,6 +139,7 @@ class OmnibarLayoutViewModelTest {
         whenever(urlDisplayRepository.isFullUrlEnabled).then { isFullUrlEnabledFlow }
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
+        whenever(duckChat.activeVoiceSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(serpEasterEggLogosToggles.setFavourite()).thenReturn(mock())
         whenever(serpEasterEggLogosToggles.setFavourite().isEnabled()).thenReturn(false)
@@ -2392,6 +2396,67 @@ class OmnibarLayoutViewModelTest {
             val viewState = expectMostRecentItem()
             assertFalse(viewState.showDuckAISidebar)
             assertFalse(viewState.showDuckAISidebar)
+        }
+    }
+
+    @Test
+    fun whenDuckAILoadedAndVoiceSessionActiveOnSelectedTabThenSidebarHiddenButHeaderShown() = runTest {
+        selectedTabFlow.value = TabEntity(tabId = "tab1", position = 0)
+        activeVoiceSessionsFlow.value = setOf("tab1")
+        initializeViewModel()
+
+        givenDuckAILoaded()
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.showDuckAISidebar)
+            assertTrue(viewState.showDuckAIHeader)
+        }
+    }
+
+    @Test
+    fun whenDuckAILoadedAndVoiceSessionActiveOnDifferentTabThenSidebarShown() = runTest {
+        selectedTabFlow.value = TabEntity(tabId = "tab1", position = 0)
+        activeVoiceSessionsFlow.value = setOf("other-tab")
+        initializeViewModel()
+
+        givenDuckAILoaded()
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.showDuckAISidebar)
+            assertTrue(viewState.showDuckAIHeader)
+        }
+    }
+
+    @Test
+    fun whenDuckAILoadedAndVoiceSessionStartsOnSelectedTabThenSidebarHides() = runTest {
+        selectedTabFlow.value = TabEntity(tabId = "tab1", position = 0)
+        initializeViewModel()
+        givenDuckAILoaded()
+
+        activeVoiceSessionsFlow.value = setOf("tab1")
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.showDuckAISidebar)
+            assertTrue(viewState.showDuckAIHeader)
+        }
+    }
+
+    @Test
+    fun whenDuckAILoadedAndVoiceSessionEndsOnSelectedTabThenSidebarReappears() = runTest {
+        selectedTabFlow.value = TabEntity(tabId = "tab1", position = 0)
+        activeVoiceSessionsFlow.value = setOf("tab1")
+        initializeViewModel()
+        givenDuckAILoaded()
+
+        activeVoiceSessionsFlow.value = emptySet()
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.showDuckAISidebar)
+            assertTrue(viewState.showDuckAIHeader)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -139,7 +139,7 @@ class OmnibarLayoutViewModelTest {
         whenever(urlDisplayRepository.isFullUrlEnabled).then { isFullUrlEnabledFlow }
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
-        whenever(duckChat.activeVoiceSessions).thenReturn(activeVoiceSessionsFlow)
+        whenever(duckChat.activeVoiceChatSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(serpEasterEggLogosToggles.setFavourite()).thenReturn(mock())
         whenever(serpEasterEggLogosToggles.setFavourite().isEnabled()).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -78,7 +78,7 @@ class FirstScreenHandlerImplTest {
         whenever(androidBrowserConfigFeature.showNTPAfterIdleReturn()).thenReturn(idleReturnToggle)
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
-        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
+        whenever(duckChat.isVoiceChatSessionActive(any())).thenReturn(false)
         whenever(customTabDetector.isCustomTab()).thenReturn(false)
         whenever(tabRepository.liveSelectedTab).thenReturn(liveSelectedTab)
         whenever(appBuildConfig.isNewInstall()).thenReturn(false)
@@ -341,7 +341,7 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(true)
+        whenever(duckChat.isVoiceChatSessionActive(any())).thenReturn(true)
         whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
@@ -358,8 +358,8 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive("tab1")).thenReturn(false)
-        whenever(duckChat.isVoiceSessionActive("tab2")).thenReturn(true)
+        whenever(duckChat.isVoiceChatSessionActive("tab1")).thenReturn(false)
+        whenever(duckChat.isVoiceChatSessionActive("tab2")).thenReturn(true)
         val selectedTab = TabEntity(tabId = "tab1", url = "https://example.com")
         whenever(tabRepository.getSelectedTab()).thenReturn(selectedTab)
 
@@ -375,7 +375,7 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
+        whenever(duckChat.isVoiceChatSessionActive(any())).thenReturn(false)
 
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
@@ -389,7 +389,7 @@ class FirstScreenHandlerImplTest {
     fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndVoiceSessionActiveOnDuckAiTabThenDoesNothing() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(true)
+        whenever(duckChat.isVoiceChatSessionActive(any())).thenReturn(true)
         whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
@@ -404,8 +404,8 @@ class FirstScreenHandlerImplTest {
     fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndNoVoiceSessionOnSelectedTabThenDelegates() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive("tab1")).thenReturn(false)
-        whenever(duckChat.isVoiceSessionActive("tab2")).thenReturn(true)
+        whenever(duckChat.isVoiceChatSessionActive("tab1")).thenReturn(false)
+        whenever(duckChat.isVoiceChatSessionActive("tab2")).thenReturn(true)
         val selectedTab = TabEntity(tabId = "tab1", url = "https://example.com")
         whenever(tabRepository.getSelectedTab()).thenReturn(selectedTab)
 
@@ -419,7 +419,7 @@ class FirstScreenHandlerImplTest {
     fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndNoVoiceSessionActiveThenDelegates() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
+        whenever(duckChat.isVoiceChatSessionActive(any())).thenReturn(false)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -78,7 +78,7 @@ class FirstScreenHandlerImplTest {
         whenever(androidBrowserConfigFeature.showNTPAfterIdleReturn()).thenReturn(idleReturnToggle)
         whenever(showOnAppLaunchFeature.self()).thenReturn(showOnAppLaunchToggle)
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
         whenever(customTabDetector.isCustomTab()).thenReturn(false)
         whenever(tabRepository.liveSelectedTab).thenReturn(liveSelectedTab)
         whenever(appBuildConfig.isNewInstall()).thenReturn(false)
@@ -341,7 +341,7 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(true)
         whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
@@ -353,15 +353,15 @@ class FirstScreenHandlerImplTest {
     }
 
     @Test
-    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndVoiceSessionActiveOnNonDuckAiTabThenDelegates() = runTest {
+    fun whenIdleReturnEnabledAndElapsedExceedsTimeoutAndNoVoiceSessionOnSelectedTabThenDelegates() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
-        val nonDuckAiTab = TabEntity(tabId = "tab1", url = "https://example.com")
-        whenever(tabRepository.getSelectedTab()).thenReturn(nonDuckAiTab)
-        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive("tab1")).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive("tab2")).thenReturn(true)
+        val selectedTab = TabEntity(tabId = "tab1", url = "https://example.com")
+        whenever(tabRepository.getSelectedTab()).thenReturn(selectedTab)
 
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
@@ -375,7 +375,7 @@ class FirstScreenHandlerImplTest {
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
 
         testee.onOpen(isFreshLaunch = false)
         testScope.testScheduler.advanceUntilIdle()
@@ -389,7 +389,7 @@ class FirstScreenHandlerImplTest {
     fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndVoiceSessionActiveOnDuckAiTabThenDoesNothing() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
+        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(true)
         whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
         val duckAiTab = TabEntity(tabId = "tab1", url = "https://duck.ai/?mode=voice-mode")
         whenever(tabRepository.getSelectedTab()).thenReturn(duckAiTab)
@@ -401,13 +401,13 @@ class FirstScreenHandlerImplTest {
     }
 
     @Test
-    fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndVoiceSessionActiveOnNonDuckAiTabThenDelegates() = runTest {
+    fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndNoVoiceSessionOnSelectedTabThenDelegates() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(true)
-        val nonDuckAiTab = TabEntity(tabId = "tab1", url = "https://example.com")
-        whenever(tabRepository.getSelectedTab()).thenReturn(nonDuckAiTab)
-        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive("tab1")).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive("tab2")).thenReturn(true)
+        val selectedTab = TabEntity(tabId = "tab1", url = "https://example.com")
+        whenever(tabRepository.getSelectedTab()).thenReturn(selectedTab)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()
@@ -419,7 +419,7 @@ class FirstScreenHandlerImplTest {
     fun whenIdleReturnDisabledAndFreshLaunchAndShowOnAppLaunchEnabledAndNoVoiceSessionActiveThenDelegates() = runTest {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         whenever(showOnAppLaunchToggle.isEnabled()).thenReturn(true)
-        whenever(duckChat.isVoiceSessionActive()).thenReturn(false)
+        whenever(duckChat.isVoiceSessionActive(any())).thenReturn(false)
 
         testee.onOpen(isFreshLaunch = true)
         testScope.testScheduler.advanceUntilIdle()

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -123,12 +123,12 @@ interface DuckChat {
     /**
      * Returns `true` if a voice session is currently active on the tab with the given [tabId].
      */
-    fun isVoiceSessionActive(tabId: String): Boolean
+    fun isVoiceChatSessionActive(tabId: String): Boolean
 
     /**
      * Emits the set of tab IDs that currently have an active voice session.
      */
-    val activeVoiceSessions: Flow<Set<String>>
+    val activeVoiceChatSessions: Flow<Set<String>>
 
     /**
      * Emits the tab id whenever an end-voice-session action is requested (e.g. from the

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -121,9 +121,9 @@ interface DuckChat {
     fun openVoiceDuckChat()
 
     /**
-     * Returns `true` if a voice session is currently active.
+     * Returns `true` if a voice session is currently active on the tab with the given [tabId].
      */
-    fun isVoiceSessionActive(): Boolean
+    fun isVoiceSessionActive(tabId: String): Boolean
 
     /**
      * Emits the tab id whenever an end-voice-session action is requested (e.g. from the

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -126,6 +126,11 @@ interface DuckChat {
     fun isVoiceSessionActive(tabId: String): Boolean
 
     /**
+     * Emits the set of tab IDs that currently have an active voice session.
+     */
+    val activeVoiceSessions: Flow<Set<String>>
+
+    /**
      * Emits the tab id whenever an end-voice-session action is requested (e.g. from the
      * foreground service notification). Tabs should collect this flow and dispatch the
      * end-voice-session JS event when their id is emitted.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -806,6 +806,8 @@ class RealDuckChat @Inject constructor(
 
     override fun isVoiceSessionActive(tabId: String): Boolean = voiceSessionStateManager.isVoiceSessionActive(tabId)
 
+    override val activeVoiceSessions: Flow<Set<String>> get() = voiceSessionStateManager.activeVoiceSessions
+
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
 
     override suspend fun setDefaultTogglePosition(position: DefaultTogglePosition) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -804,7 +804,7 @@ class RealDuckChat @Inject constructor(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> =
         duckChatFeatureRepository.observeChatSuggestionsUserSettingEnabled()
 
-    override fun isVoiceSessionActive(): Boolean = voiceSessionStateManager.isVoiceSessionActive
+    override fun isVoiceSessionActive(tabId: String): Boolean = voiceSessionStateManager.isVoiceSessionActive(tabId)
 
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -804,9 +804,9 @@ class RealDuckChat @Inject constructor(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> =
         duckChatFeatureRepository.observeChatSuggestionsUserSettingEnabled()
 
-    override fun isVoiceSessionActive(tabId: String): Boolean = voiceSessionStateManager.isVoiceSessionActive(tabId)
+    override fun isVoiceChatSessionActive(tabId: String): Boolean = voiceSessionStateManager.isVoiceSessionActive(tabId)
 
-    override val activeVoiceSessions: Flow<Set<String>> get() = voiceSessionStateManager.activeVoiceSessions
+    override val activeVoiceChatSessions: Flow<Set<String>> get() = voiceSessionStateManager.activeVoiceSessions
 
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -243,7 +243,7 @@ class RealDuckChatJSHelper @Inject constructor(
             }
 
             METHOD_VOICE_SESSION_ENDED -> {
-                voiceSessionStateManager.onVoiceSessionEnded()
+                voiceSessionStateManager.onVoiceSessionEnded(tabId)
                 null
             }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -126,7 +126,13 @@ class RealDuckChatJSHelper @Inject constructor(
             METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA ->
                 id?.let {
                     getAIChatNativeHandoffData(featureName, method, it)
-                }.also { registerDuckChatIsOpenDebounced() }
+                }.also {
+                    if (voiceSessionStateManager.isVoiceSessionActive(tabId)) {
+                        // NOTE: Force end native chat state if duck ai chat has been refreshed with an active voice session
+                        voiceSessionStateManager.onVoiceSessionEnded(tabId)
+                    }
+                    registerDuckChatIsOpenDebounced()
+                }
 
             METHOD_GET_AI_CHAT_NATIVE_CONFIG_VALUES ->
                 id?.let {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -80,7 +80,7 @@ class DuckChatVoiceMicrophoneService : Service() {
     }
 
     private fun buildNotification(): Notification {
-        val tabId = voiceSessionStateManager.activeSessionTabId
+        val tabId = voiceSessionStateManager.
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.duckAiVoiceNotificationTitle))
             .setContentText(getString(R.string.duckAiVoiceNotificationMessage))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import dagger.android.AndroidInjection
 import javax.inject.Inject
 
@@ -46,9 +45,6 @@ class DuckChatVoiceMicrophoneService : Service() {
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
-
-    @Inject
-    lateinit var voiceSessionStateManager: VoiceSessionStateManager
 
     @Inject
     lateinit var browserNav: BrowserNav
@@ -66,10 +62,11 @@ class DuckChatVoiceMicrophoneService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
+        val tabId = intent?.getStringExtra(EXTRA_TAB_ID)?.takeIf { it.isNotBlank() }
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,
-            buildNotification(),
+            buildNotification(tabId),
             if (appBuildConfig.sdkInt >= 30) {
                 FOREGROUND_SERVICE_TYPE_MICROPHONE
             } else {
@@ -79,8 +76,7 @@ class DuckChatVoiceMicrophoneService : Service() {
         return START_NOT_STICKY
     }
 
-    private fun buildNotification(): Notification {
-        val tabId = voiceSessionStateManager.
+    private fun buildNotification(tabId: String?): Notification {
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.duckAiVoiceNotificationTitle))
             .setContentText(getString(R.string.duckAiVoiceNotificationMessage))
@@ -145,9 +141,13 @@ class DuckChatVoiceMicrophoneService : Service() {
         private const val REQUEST_CODE_OPEN_CHAT = 1
         private const val REQUEST_CODE_END_SESSION = 2
         private const val REQUEST_CODE_FALLBACK = 3
+        private const val EXTRA_TAB_ID = "EXTRA_TAB_ID"
 
-        fun start(context: Context) {
-            ContextCompat.startForegroundService(context, Intent(context, DuckChatVoiceMicrophoneService::class.java))
+        fun start(context: Context, tabId: String) {
+            val intent = Intent(context, DuckChatVoiceMicrophoneService::class.java).apply {
+                putExtra(EXTRA_TAB_ID, tabId)
+            }
+            ContextCompat.startForegroundService(context, intent)
         }
 
         fun stop(context: Context) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -43,9 +43,11 @@ import javax.inject.Inject
 interface VoiceSessionStateManager {
     val activeVoiceSessions: Flow<Set<String>>
         get() = flowOf(emptySet())
+
     fun isVoiceSessionActive(tabId: String): Boolean = false
     fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded(tabId: String)
+
     /**
      * Emits the tab id whenever an end-voice-session action is requested (e.g. from the
      * foreground service notification). Tabs should collect this flow and dispatch the
@@ -91,7 +93,7 @@ class RealVoiceSessionStateManager @Inject constructor(
         if (tabId.isBlank()) return
         _activeVoiceSessions.update { it + tabId }
         if (duckChatFeature.duckAiVoiceChatService().isEnabled()) {
-            DuckChatVoiceMicrophoneService.start(context)
+            DuckChatVoiceMicrophoneService.start(context, tabId)
         }
         if (!listenJob.isActive) {
             listenToTabRemoval()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -31,12 +31,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 interface VoiceSessionStateManager {
+    val activeVoiceSessions: Flow<Set<String>>
+        get() = flowOf(emptySet())
     fun isVoiceSessionActive(tabId: String): Boolean = false
     fun onVoiceSessionStarted(tabId: String)
     fun onVoiceSessionEnded(tabId: String)
@@ -61,15 +67,17 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     private val listenJob = ConflatedJob()
 
-    private val activeSessionTabIds = mutableSetOf<String>()
     private val _voiceSessionEndTrigger = MutableSharedFlow<String>(
         replay = 0,
         extraBufferCapacity = 8,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
+    private val _activeVoiceSessions = MutableStateFlow<Set<String>>(emptySet())
+    override val activeVoiceSessions: Flow<Set<String>> = _activeVoiceSessions.asStateFlow()
+
     @Synchronized
-    override fun isVoiceSessionActive(tabId: String): Boolean = tabId.isNotBlank() && tabId in activeSessionTabIds
+    override fun isVoiceSessionActive(tabId: String): Boolean = tabId.isNotBlank() && tabId in _activeVoiceSessions.value
 
     override fun observeTriggerVoiceSessionEnd(): Flow<String> = _voiceSessionEndTrigger.asSharedFlow()
 
@@ -81,7 +89,7 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {
         if (tabId.isBlank()) return
-        activeSessionTabIds += tabId
+        _activeVoiceSessions.update { it + tabId }
         if (duckChatFeature.duckAiVoiceChatService().isEnabled()) {
             DuckChatVoiceMicrophoneService.start(context)
         }
@@ -93,8 +101,8 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Synchronized
     override fun onVoiceSessionEnded(tabId: String) {
         if (tabId.isBlank()) return
-        activeSessionTabIds -= tabId
-        if (activeSessionTabIds.isEmpty()) {
+        _activeVoiceSessions.update { it - tabId }
+        if (_activeVoiceSessions.value.isEmpty()) {
             endAllSessions()
         }
     }
@@ -112,7 +120,7 @@ class RealVoiceSessionStateManager @Inject constructor(
     @Synchronized
     private fun endAllSessions() {
         listenJob.cancel()
-        activeSessionTabIds.clear()
+        _activeVoiceSessions.value = emptySet()
         DuckChatVoiceMicrophoneService.stop(context)
     }
 
@@ -121,8 +129,10 @@ class RealVoiceSessionStateManager @Inject constructor(
             tabRepository.flowTabs.drop(1).collect { tabs ->
                 val existingTabIds = tabs.mapTo(mutableSetOf()) { it.tabId }
                 val becameEmpty = synchronized(this@RealVoiceSessionStateManager) {
-                    activeSessionTabIds.removeAll { it !in existingTabIds }
-                    activeSessionTabIds.isEmpty()
+                    _activeVoiceSessions.update { current ->
+                        current.filterTo(mutableSetOf()) { it in existingTabIds }
+                    }
+                    _activeVoiceSessions.value.isEmpty()
                 }
                 if (becameEmpty) {
                     endAllSessions()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -37,25 +37,15 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 interface VoiceSessionStateManager {
-    val isVoiceSessionActive: Boolean
-        get() = false
-
-    /**
-     * The tab id bound to the active voice session, or null if there is no active session
-     * or the session is a standalone (non-tab) session.
-     */
-    val activeSessionTabId: String?
-        get() = null
-
+    fun isVoiceSessionActive(tabId: String): Boolean = false
+    fun onVoiceSessionStarted(tabId: String)
+    fun onVoiceSessionEnded(tabId: String)
     /**
      * Emits the tab id whenever an end-voice-session action is requested (e.g. from the
      * foreground service notification). Tabs should collect this flow and dispatch the
      * end-voice-session JS event when their id is emitted.
      */
     fun observeTriggerVoiceSessionEnd(): Flow<String>
-
-    fun onVoiceSessionStarted(tabId: String)
-    fun onVoiceSessionEnded()
     fun triggerVoiceSessionEnd(tabId: String)
 }
 
@@ -71,21 +61,15 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     private val listenJob = ConflatedJob()
 
-    // null = no session, STANDALONE_SESSION_ID = session without a browser tab, non-empty = tab session
-    @Volatile
-    private var _activeSessionTabId: String? = null
-
+    private val activeSessionTabIds = mutableSetOf<String>()
     private val _voiceSessionEndTrigger = MutableSharedFlow<String>(
         replay = 0,
         extraBufferCapacity = 8,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
-    override val activeSessionTabId: String?
-        get() = _activeSessionTabId?.takeUnless { it == STANDALONE_SESSION_ID }
-
-    override val isVoiceSessionActive: Boolean
-        get() = _activeSessionTabId != null
+    @Synchronized
+    override fun isVoiceSessionActive(tabId: String): Boolean = tabId.isNotBlank() && tabId in activeSessionTabIds
 
     override fun observeTriggerVoiceSessionEnd(): Flow<String> = _voiceSessionEndTrigger.asSharedFlow()
 
@@ -96,44 +80,54 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     @Synchronized
     override fun onVoiceSessionStarted(tabId: String) {
-        _activeSessionTabId = tabId.ifBlank { STANDALONE_SESSION_ID }
+        if (tabId.isBlank()) return
+        activeSessionTabIds += tabId
         if (duckChatFeature.duckAiVoiceChatService().isEnabled()) {
             DuckChatVoiceMicrophoneService.start(context)
         }
-        if (tabId.isNotBlank()) {
+        if (!listenJob.isActive) {
             listenToTabRemoval()
         }
     }
 
     @Synchronized
-    override fun onVoiceSessionEnded() {
-        listenJob.cancel()
-        _activeSessionTabId = null
-        DuckChatVoiceMicrophoneService.stop(context)
+    override fun onVoiceSessionEnded(tabId: String) {
+        if (tabId.isBlank()) return
+        activeSessionTabIds -= tabId
+        if (activeSessionTabIds.isEmpty()) {
+            endAllSessions()
+        }
     }
 
     override fun onOpen(isFreshLaunch: Boolean) {
         if (isFreshLaunch) {
-            onVoiceSessionEnded()
+            endAllSessions()
         }
     }
 
     override fun onExit() {
-        onVoiceSessionEnded()
+        endAllSessions()
+    }
+
+    @Synchronized
+    private fun endAllSessions() {
+        listenJob.cancel()
+        activeSessionTabIds.clear()
+        DuckChatVoiceMicrophoneService.stop(context)
     }
 
     private fun listenToTabRemoval() {
         listenJob += appCoroutineScope.launch {
             tabRepository.flowTabs.drop(1).collect { tabs ->
-                val tabId = _activeSessionTabId ?: return@collect
-                if (tabs.none { it.tabId == tabId }) {
-                    onVoiceSessionEnded()
+                val existingTabIds = tabs.mapTo(mutableSetOf()) { it.tabId }
+                val becameEmpty = synchronized(this@RealVoiceSessionStateManager) {
+                    activeSessionTabIds.removeAll { it !in existingTabIds }
+                    activeSessionTabIds.isEmpty()
+                }
+                if (becameEmpty) {
+                    endAllSessions()
                 }
             }
         }
-    }
-
-    companion object {
-        private const val STANDALONE_SESSION_ID = "__duck_ai_standalone__"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -128,14 +128,13 @@ class RealVoiceSessionStateManager @Inject constructor(
         listenJob += appCoroutineScope.launch {
             tabRepository.flowTabs.drop(1).collect { tabs ->
                 val existingTabIds = tabs.mapTo(mutableSetOf()) { it.tabId }
-                val becameEmpty = synchronized(this@RealVoiceSessionStateManager) {
+                synchronized(this@RealVoiceSessionStateManager) {
                     _activeVoiceSessions.update { current ->
                         current.filterTo(mutableSetOf()) { it in existingTabIds }
                     }
-                    _activeVoiceSessions.value.isEmpty()
-                }
-                if (becameEmpty) {
-                    endAllSessions()
+                    if (_activeVoiceSessions.value.isEmpty()) {
+                        endAllSessions()
+                    }
                 }
             }
         }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1437,6 +1437,7 @@ class DuckChatContextualViewModelTest {
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
         override fun isVoiceSessionActive(tabId: String): Boolean = false
+        override val activeVoiceSessions: Flow<Set<String>> = flowOf(emptySet())
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1436,8 +1436,8 @@ class DuckChatContextualViewModelTest {
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
-        override fun isVoiceSessionActive(tabId: String): Boolean = false
-        override val activeVoiceSessions: Flow<Set<String>> = flowOf(emptySet())
+        override fun isVoiceChatSessionActive(tabId: String): Boolean = false
+        override val activeVoiceChatSessions: Flow<Set<String>> = flowOf(emptySet())
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1436,7 +1436,7 @@ class DuckChatContextualViewModelTest {
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)
         override fun openVoiceDuckChat() { }
-        override fun isVoiceSessionActive(): Boolean = false
+        override fun isVoiceSessionActive(tabId: String): Boolean = false
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1691,16 +1691,18 @@ class RealDuckChatJSHelperTest {
 
     @Test
     fun whenVoiceSessionEndedThenNoPixelFiredAndStateUpdated() = runTest {
+        val tabId = "test-tab-id"
         val result = testee.processJsCallbackMessage(
             "aiChat",
             "voiceSessionEnded",
             null,
             null,
             pageContext = viewModel.updatedPageContext,
+            tabId = tabId,
         )
 
         assertNull(result)
-        verify(mockVoiceSessionStateManager).onVoiceSessionEnded()
+        verify(mockVoiceSessionStateManager).onVoiceSessionEnded(tabId)
         verifyNoInteractions(mockDuckChatPixels)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1791,4 +1791,38 @@ class RealDuckChatJSHelperTest {
         val query = result!!.params.getJSONObject("query")
         assertFalse(query.has("images"))
     }
+
+    @Test
+    fun whenGetAIChatNativeHandoffDataAndVoiceSessionActiveThenForceEndNativeVoiceSession() = runTest {
+        val tabId = "test-tab-id"
+        whenever(mockVoiceSessionStateManager.isVoiceSessionActive(tabId)).thenReturn(true)
+
+        testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeHandoffData",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+            tabId = tabId,
+        )
+
+        verify(mockVoiceSessionStateManager).onVoiceSessionEnded(tabId)
+    }
+
+    @Test
+    fun whenGetAIChatNativeHandoffDataAndVoiceSessionNotActiveThenDoNotEndNativeVoiceSession() = runTest {
+        val tabId = "test-tab-id"
+        whenever(mockVoiceSessionStateManager.isVoiceSessionActive(tabId)).thenReturn(false)
+
+        testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativeHandoffData",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+            tabId = tabId,
+        )
+
+        verify(mockVoiceSessionStateManager, never()).onVoiceSessionEnded(any())
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -110,6 +110,7 @@ class FakeDuckChat(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(tabId: String): Boolean = false
+    override val activeVoiceSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     fun setEnabled(enabled: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -109,8 +109,8 @@ class FakeDuckChat(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
-    override fun isVoiceSessionActive(tabId: String): Boolean = false
-    override val activeVoiceSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
+    override fun isVoiceChatSessionActive(tabId: String): Boolean = false
+    override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     fun setEnabled(enabled: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -109,7 +109,7 @@ class FakeDuckChat(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
-    override fun isVoiceSessionActive(): Boolean = false
+    override fun isVoiceSessionActive(tabId: String): Boolean = false
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     fun setEnabled(enabled: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -184,6 +184,7 @@ class FakeDuckChatInternal(
 
     override fun openVoiceDuckChat() { }
     override fun isVoiceSessionActive(tabId: String): Boolean = false
+    override val activeVoiceSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -183,7 +183,7 @@ class FakeDuckChatInternal(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
-    override fun isVoiceSessionActive(): Boolean = false
+    override fun isVoiceSessionActive(tabId: String): Boolean = false
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -183,8 +183,8 @@ class FakeDuckChatInternal(
     override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = chatSuggestionsUserSettingEnabled
 
     override fun openVoiceDuckChat() { }
-    override fun isVoiceSessionActive(tabId: String): Boolean = false
-    override val activeVoiceSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
+    override fun isVoiceChatSessionActive(tabId: String): Boolean = false
+    override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     private val _defaultTogglePosition = MutableStateFlow<String?>(null)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -58,7 +58,7 @@ class RealVoiceSessionStateManagerTest {
     @After
     fun teardown() {
         // Cancels the flowTabs collect coroutine so runTest doesn't fail with UncompletedCoroutinesError
-        testee.onVoiceSessionEnded()
+        testee.onExit()
     }
 
     @Before
@@ -76,29 +76,29 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenCreatedThenVoiceSessionIsNotActive() {
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
     fun whenVoiceSessionStartedThenIsVoiceSessionActiveIsTrue() {
         testee.onVoiceSessionStarted(TAB_ID)
 
-        assertTrue(testee.isVoiceSessionActive)
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
     fun whenVoiceSessionEndedThenIsVoiceSessionActiveIsFalse() {
         testee.onVoiceSessionStarted(TAB_ID)
-        testee.onVoiceSessionEnded()
+        testee.onVoiceSessionEnded(TAB_ID)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
     fun whenVoiceSessionEndedWithoutStartThenIsVoiceSessionActiveIsFalse() {
-        testee.onVoiceSessionEnded()
+        testee.onVoiceSessionEnded(TAB_ID)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -106,7 +106,7 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted(TAB_ID)
         testee.onVoiceSessionStarted(TAB_ID)
 
-        assertTrue(testee.isVoiceSessionActive)
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -114,7 +114,7 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted(TAB_ID)
         testee.onOpen(isFreshLaunch = true)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -122,14 +122,14 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted(TAB_ID)
         testee.onOpen(isFreshLaunch = false)
 
-        assertTrue(testee.isVoiceSessionActive)
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
     fun whenFreshLaunchAndNoActiveSessionThenRemainsInactive() {
         testee.onOpen(isFreshLaunch = true)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -137,27 +137,31 @@ class RealVoiceSessionStateManagerTest {
         testee.onVoiceSessionStarted(TAB_ID)
         testee.onExit()
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
     fun whenExitAndNoActiveSessionThenRemainsInactive() {
         testee.onExit()
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
-    fun whenVoiceSessionStartedWithBlankTabIdThenSessionIsActiveButTabRemovalNotTracked() = coroutineTestRule.testScope.runTest {
-        tabsFlow.value = listOf(tabEntity(TAB_ID))
+    fun whenVoiceSessionStartedWithBlankTabIdThenSessionIsNotActive() {
         testee.onVoiceSessionStarted("")
 
-        tabsFlow.value = emptyList()
-        advanceUntilIdle()
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+    }
 
-        // Session stays active — no tab to track, so tab removal has no effect
-        assertTrue(testee.isVoiceSessionActive)
-        testee.onVoiceSessionEnded()
+    @Test
+    fun whenVoiceSessionEndedWithBlankTabIdThenActiveSessionIsUnchanged() {
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        testee.onVoiceSessionEnded("")
+
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
+        testee.onVoiceSessionEnded(TAB_ID)
     }
 
     @Test
@@ -168,7 +172,7 @@ class RealVoiceSessionStateManagerTest {
         tabsFlow.value = emptyList()
         advanceUntilIdle()
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -179,8 +183,8 @@ class RealVoiceSessionStateManagerTest {
         tabsFlow.value = listOf(tabEntity(TAB_ID))
         advanceUntilIdle()
 
-        assertTrue(testee.isVoiceSessionActive)
-        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
+        testee.onVoiceSessionEnded(TAB_ID) // cancel collect coroutine before runTest checks for leaks
     }
 
     @Test
@@ -191,20 +195,20 @@ class RealVoiceSessionStateManagerTest {
         tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
         advanceUntilIdle()
 
-        assertTrue(testee.isVoiceSessionActive)
-        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
+        testee.onVoiceSessionEnded(TAB_ID) // cancel collect coroutine before runTest checks for leaks
     }
 
     @Test
     fun whenSessionEndedManuallyAndActiveTabSubsequentlyRemovedThenNoAdditionalEffect() = coroutineTestRule.testScope.runTest {
         tabsFlow.value = listOf(tabEntity(TAB_ID))
         testee.onVoiceSessionStarted(TAB_ID)
-        testee.onVoiceSessionEnded()
+        testee.onVoiceSessionEnded(TAB_ID)
 
         tabsFlow.value = emptyList()
         advanceUntilIdle()
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     @Test
@@ -219,8 +223,8 @@ class RealVoiceSessionStateManagerTest {
 
         testee.onVoiceSessionStarted(TAB_ID)
 
-        assertTrue(testee.isVoiceSessionActive)
-        testee.onVoiceSessionEnded() // cancel collect coroutine before runTest checks for leaks
+        assertTrue(testee.isVoiceSessionActive(TAB_ID))
+        testee.onVoiceSessionEnded(TAB_ID) // cancel collect coroutine before runTest checks for leaks
     }
 
     @Test
@@ -234,9 +238,77 @@ class RealVoiceSessionStateManagerTest {
         )
         testee.onVoiceSessionStarted(TAB_ID)
 
-        testee.onVoiceSessionEnded()
+        testee.onVoiceSessionEnded(TAB_ID)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+    }
+
+    @Test
+    fun whenSessionsActiveOnTwoTabsAndOneEndsThenOtherTabSessionRemainsActive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionStarted(OTHER_TAB_ID)
+
+        testee.onVoiceSessionEnded(TAB_ID)
+
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+        assertTrue(testee.isVoiceSessionActive(OTHER_TAB_ID))
+        testee.onVoiceSessionEnded(OTHER_TAB_ID) // cancel collect coroutine before runTest checks for leaks
+    }
+
+    @Test
+    fun whenSessionsActiveOnTwoTabsAndBothEndThenSessionsInactive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionStarted(OTHER_TAB_ID)
+
+        testee.onVoiceSessionEnded(TAB_ID)
+        testee.onVoiceSessionEnded(OTHER_TAB_ID)
+
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+        assertFalse(testee.isVoiceSessionActive(OTHER_TAB_ID))
+    }
+
+    @Test
+    fun whenSessionsActiveOnTwoTabsAndOneTabClosedThenOtherTabSessionRemainsActive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionStarted(OTHER_TAB_ID)
+
+        tabsFlow.value = listOf(tabEntity(OTHER_TAB_ID))
+        advanceUntilIdle()
+
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+        assertTrue(testee.isVoiceSessionActive(OTHER_TAB_ID))
+        testee.onVoiceSessionEnded(OTHER_TAB_ID) // cancel collect coroutine before runTest checks for leaks
+    }
+
+    @Test
+    fun whenSessionsActiveOnTwoTabsAndAllTabsClosedThenSessionsInactive() = coroutineTestRule.testScope.runTest {
+        tabsFlow.value = listOf(tabEntity(TAB_ID), tabEntity(OTHER_TAB_ID))
+        testee.onVoiceSessionStarted(TAB_ID)
+        testee.onVoiceSessionStarted(OTHER_TAB_ID)
+
+        tabsFlow.value = emptyList()
+        advanceUntilIdle()
+
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
+        assertFalse(testee.isVoiceSessionActive(OTHER_TAB_ID))
+    }
+
+    @Test
+    fun whenSessionStartedOnTabThenIsVoiceSessionActiveOnDifferentTabIsFalse() {
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        assertFalse(testee.isVoiceSessionActive(OTHER_TAB_ID))
+    }
+
+    @Test
+    fun whenIsVoiceSessionActiveCalledWithBlankTabIdThenReturnsFalse() {
+        testee.onVoiceSessionStarted(TAB_ID)
+
+        assertFalse(testee.isVoiceSessionActive(""))
+        testee.onVoiceSessionEnded(TAB_ID)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -345,11 +345,11 @@ class RealVoiceSessionStateManagerTest {
 
     @Test
     fun whenTriggerVoiceSessionEndCalledThenIsVoiceSessionActiveUnchanged() {
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
 
         testee.triggerVoiceSessionEnd(TAB_ID)
 
-        assertFalse(testee.isVoiceSessionActive)
+        assertFalse(testee.isVoiceSessionActive(TAB_ID))
     }
 
     private fun tabEntity(tabId: String) = TabEntity(tabId = tabId)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214486944844103?focus=true 

### Description
The Duck.AI sidebar button in the omnibar hides while a Duck.AI voice chat session is active on the currently selected tab. The header remains visible. The visibility is per-tab. Multiple concurrent voice sessions across tabs are tracked independently.

### Steps to test this PR
 ### Setup                                                                                                                                                                                                          
  - [x] Install this branch; ensure Duck.AI is enabled and microphone permission is granted                                                                                                                          
  - [x] Have at least two tabs available                                                                                                                                                                             
                                                                                                                                                                                                                     
  ### 1. Duck.AI tab, no voice session                                                                                                                                                                               
  - [x] Sidebar button **IS** visible in the omnibar                                                                                                                                                                 
  - [x] Header **IS** visible                                                                                                                                                                                        
   
  ### 2. Voice session active on selected tab                                                                                                                                                                        
  - [x] Start a voice session on a Duck.AI tab                                                                                                                                                                     
  - [x] Sidebar button **IS NOT** visible                                                                                                                                                                            
  - [x] Header **IS** still visible
  - [x] End the session → sidebar **IS** visible again immediately                                                                                                                                                   
                                                                                                                                                                                                                   
  ### 3. Per-tab visibility (voice on background tab)                                                                                                                                                                
  - [x] Start a voice session on tab A, switch to tab B (no session)                                                                                                                                               
  - [x] On tab B: sidebar **IS** visible                                                                                                                                                                             
  - [x] Switch back to tab A: sidebar **IS NOT** visible                                                                                                                                                                                            
                                                                                                                                                                                                                     
  ### 4. Tab with active session closed                                                                                                                                                                              
  - [x] Start a voice session on tab A, close tab A from the tab switcher                                                                                                                                            
  - [x] If it was the only session, microphone indicator dismisses                                                                                                                                                   
  - [x] No leftover voice state affects other Duck.AI tabs (sidebar visible there)                                                                                                                                   
                                                                                                                                                                                                                     
  ### 5. Fresh app launch clears state                                                                                                                                                                               
  - [x] Start a voice session, kill the app process, cold-launch                                                                                                                                                     
  - [x] Sidebar **IS** visible; no microphone indicator remains                                                                                                                                                      
   
  ### Regression checks                                                                                                                                                                                              
  - [x] Non-Duck.AI tabs: sidebar/header still hidden (unchanged)                                                                                                                                                  
  - [x] Focusing the omnibar on a Duck.AI tab still hides sidebar and header                                                                                                                                         
  - [x] Duck.AI back button hides/shows alongside the sidebar                                                                                                                                                        
  - [x] `DUCK_CHAT_OMNIBAR_SIDEBAR_TAPPED` pixel still fires when tapping the sidebar                                                                                                                                
  - [x] **Show on app launch** / idle return: with an active voice session on the selected Duck.AI tab, app stays on that tab on return (does not redirect)         


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates voice-session tracking from a single global flag to per-tab state and wires it into UI and app-launch decisions; issues could surface as incorrect session cleanup or microphone service/notification behavior across tabs.
> 
> **Overview**
> Makes Duck.ai voice-session state **per-tab** instead of a single global flag by changing `DuckChat`/`VoiceSessionStateManager` to track a `Flow<Set<tabId>>` and to query `isVoiceChatSessionActive(tabId)`.
> 
> Uses that per-tab state to hide the Duck.ai **omnibar sidebar button** (but keep the header) when the *selected tab* has an active voice session, and to treat tabs with active voice sessions as non-scrollable for pull-to-refresh.
> 
> Updates the voice microphone foreground service to be started with an explicit `tabId`, ensures voice state is cleared on fresh launch/exit and when tabs are removed, and forces native voice state to end if the Duck.ai page refreshes while voice is active. Tests are expanded/updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa4ac73efb603cfaa9fe36568af7660b6036bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->