### PR TITLE
Add duck_ai_prompt_sent retention metric

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/DuckAiPromptSentMetricPixelsPlugin.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricType
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class DuckAiPromptSentMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
+
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
+            listOf(
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "1",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                        ConversionWindow(lowerWindow = 1, upperWindow = 1),
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "4",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "6",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "11",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "21",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "duck_ai_prompt_sent",
+                    type = MetricType.COUNT_WHEN_IN_WINDOW,
+                    value = "30",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 DuckDuckGo
+ * Copyright (c) 2026 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -29,6 +29,7 @@ import javax.inject.Inject
 class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
     private val searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
     private val appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
+    private val duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : AtbLifecyclePlugin {
 
@@ -41,6 +42,12 @@ class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
     override fun onAppRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
         appCoroutineScope.launch {
             appUseMetricPixelsPlugin.getMetrics().forEach { it.send() }
+        }
+    }
+
+    override fun onDuckAiRetentionAtbRefreshed(oldAtb: String, newAtb: String, metadata: Map<String, String?>) {
+        appCoroutineScope.launch {
+            duckAiPromptSentMetricPixelsPlugin.getMetrics().forEach { it.send() }
         }
     }
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -45,6 +45,7 @@ class RetentionMetricsAtbLifecyclePluginTest {
     private lateinit var inventory: FeatureTogglesInventory
     private lateinit var searchMetricPixelsPlugin: SearchMetricPixelsPlugin
     private lateinit var appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin
+    private lateinit var duckAiPromptSentMetricPixelsPlugin: DuckAiPromptSentMetricPixelsPlugin
     private lateinit var atbLifecyclePlugin: RetentionMetricsAtbLifecyclePlugin
 
     @Before
@@ -70,10 +71,12 @@ class RetentionMetricsAtbLifecyclePluginTest {
 
         searchMetricPixelsPlugin = SearchMetricPixelsPlugin(inventory)
         appUseMetricPixelsPlugin = AppUseMetricPixelsPlugin(inventory)
+        duckAiPromptSentMetricPixelsPlugin = DuckAiPromptSentMetricPixelsPlugin(inventory)
 
         atbLifecyclePlugin = RetentionMetricsAtbLifecyclePlugin(
             searchMetricPixelsPlugin = searchMetricPixelsPlugin,
             appUseMetricPixelsPlugin = appUseMetricPixelsPlugin,
+            duckAiPromptSentMetricPixelsPlugin = duckAiPromptSentMetricPixelsPlugin,
             appCoroutineScope = coroutineRule.testScope,
         )
     }
@@ -169,6 +172,43 @@ class RetentionMetricsAtbLifecyclePluginTest {
         )
 
         atbLifecyclePlugin.onAppRetentionAtbRefreshed("", "")
+
+        assertTrue(fakeMetricsPixelExtension.sentMetrics.none { it.toggle.featureName().name == "experimentFooFeature" })
+        assertFalse(fakeMetricsPixelExtension.sentMetrics.none { it.toggle.featureName().name == "fooFeature" })
+    }
+
+    @Test
+    fun `when duck ai atb refreshed and cohorts assigned, send is called for all duck ai prompt sent metrics`() = runTest {
+        setCohorts(ZonedDateTime.now(ZoneId.of("America/New_York")).toString())
+
+        atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
+
+        val expected = duckAiPromptSentMetricPixelsPlugin.getMetrics()
+        assertEquals(expected.size, fakeMetricsPixelExtension.sentMetrics.size)
+        assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.metric == "duck_ai_prompt_sent" })
+    }
+
+    @Test
+    fun `when duck ai atb refreshed, only send metrics for active experiments`() = runTest {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = false,
+                enable = false,
+                cohorts = listOf(State.Cohort(name = "control", weight = 1, enrollmentDateET = today)),
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+        testFeature.fooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                cohorts = listOf(State.Cohort(name = "control", weight = 1, enrollmentDateET = today)),
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+
+        atbLifecyclePlugin.onDuckAiRetentionAtbRefreshed("", "", emptyMap())
 
         assertTrue(fakeMetricsPixelExtension.sentMetrics.none { it.toggle.featureName().name == "experimentFooFeature" })
         assertFalse(fakeMetricsPixelExtension.sentMetrics.none { it.toggle.featureName().name == "fooFeature" })

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.feature.toggles.impl.metrics
 
+import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeMetricsPixelExtension
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
@@ -35,6 +36,7 @@ import org.junit.Test
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
+@SuppressLint("DenyListedApi")
 class RetentionMetricsAtbLifecyclePluginTest {
     @get:Rule
     @Suppress("unused")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1214592944824788?focus=true

### Description

Adds a `duck_ai_prompt_sent` retention metric to the experiment metrics pipeline, alongside the existing `search` and `app_use` metrics. Wires `AtbLifecyclePlugin.onDuckAiRetentionAtbRefreshed` to a new `DuckAiPromptSentMetricPixelsPlugin` that emits values 1, 4, 6, 11, 21, 30 across d0/d1/d5-7/d8-14 conversion windows.

### Steps to test this PR

QA optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new retention-metrics emission path triggered on Duck AI ATB refresh, which could affect experiment telemetry volume/accuracy if misconfigured. Changes are localized and covered by unit tests.
> 
> **Overview**
> Adds support for a new experiment retention metric, `duck_ai_prompt_sent`, by introducing `DuckAiPromptSentMetricPixelsPlugin` that emits multiple `COUNT_WHEN_IN_WINDOW` pixels (values `1`, `4`, `6`, `11`, `21`, `30`) across configured conversion windows.
> 
> Wires `RetentionMetricsAtbLifecyclePlugin.onDuckAiRetentionAtbRefreshed` to send these pixels for all *active experiment* toggles, and extends `RetentionMetricsAtbLifecyclePluginTest` with coverage for Duck AI emission and active-experiment filtering (plus a small lint suppression/copyright header update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1334af1b4539e2568a8e338c995995ec0cc69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->