### PR TITLE
Decouple StartChatView from NativeInputWidget

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -26,11 +26,15 @@ sealed class PromptContribution {
     data class ModelSelection(val modelId: String) : PromptContribution()
 }
 
+sealed class Action {
+    data object StartChat : Action()
+}
+
 interface NativeInputPlugin : ActivePlugin {
 
     val containerId: Int
 
-    fun createView(context: Context): View
+    fun createView(context: Context, onAction: (Action) -> Unit): View
 
     fun getPromptContribution(): PromptContribution?
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -128,6 +128,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         duckChatInternal.saveLastUsedTogglePosition(position)
     }
 
+    fun openNewChat() {
+        duckChatInternal.openNewDuckChatSession()
+    }
+
     fun setDuckAiMode(isDuckAiMode: Boolean) {
         val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
         widgetConfig.update { it.copy(inputContext = context) }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -21,6 +21,7 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.Action
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
@@ -40,7 +41,7 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
 
-    override fun createView(context: Context): View {
+    override fun createView(context: Context, onAction: (Action) -> Unit): View {
         return ModelPickerView(context).also { picker ->
             modelPicker = WeakReference(picker)
             picker.setPickerEnabled(true)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -21,6 +21,7 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.Action
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
@@ -36,7 +37,9 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.startChatContainer
 
-    override fun createView(context: Context): View = StartChatView(context)
+    override fun createView(context: Context, onAction: (Action) -> Unit): View = StartChatView(context).apply {
+        onIconClicked = { onAction(Action.StartChat) }
+    }
 
     override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
+import com.duckduckgo.duckchat.impl.nativeinput.Action
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
 import com.duckduckgo.duckchat.impl.ui.NativeInputState
@@ -208,7 +209,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 viewModel.plugins.collect { plugins ->
                     for (plugin in plugins) {
                         val container = findViewById<FrameLayout?>(plugin.containerId) ?: continue
-                        val pluginView = plugin.createView(context)
+                        val pluginView = plugin.createView(context, onPluginAction)
                         container.removeAllViews()
                         container.addView(pluginView)
                         // The start-chat container drives its own visibility from input mode.
@@ -726,6 +727,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun setFloatingSubmitContainer(container: ViewGroup) {
         floatingSubmitContainer = container
+    }
+
+    private val onPluginAction = fun(action: Action) {
+        when (action) {
+            Action.StartChat -> if (!submitAsChat()) viewModel.openNewChat()
+        }
     }
 
     private fun configureSubmitButtons() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatView.kt
@@ -52,6 +52,8 @@ class StartChatView @JvmOverloads constructor(
     private val icon: ImageView by lazy { findViewById(R.id.aiChatIconMenu) }
     private var visibilityJob: Job? = null
 
+    var onIconClicked: (() -> Unit)? = null
+
     init {
         inflate(context, R.layout.view_start_chat, this)
     }
@@ -59,10 +61,7 @@ class StartChatView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
-        icon.setOnClickListener {
-            val submitted = findNativeInputWidget()?.submitAsChat() == true
-            if (!submitted) viewModel.openNewChat()
-        }
+        icon.setOnClickListener { onIconClicked?.invoke() }
         observeVisibility()
     }
 
@@ -81,14 +80,5 @@ class StartChatView @JvmOverloads constructor(
                 (parent as? View)?.isVisible = visible
             }
             .launchIn(scope)
-    }
-
-    private fun findNativeInputWidget(): NativeInputWidget? {
-        var node: View? = this
-        while (node != null) {
-            if (node is NativeInputWidget) return node
-            node = node.parent as? View
-        }
-        return null
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -30,8 +30,8 @@ import javax.inject.Inject
 @ContributesViewModel(ViewScope::class)
 class StartChatViewModel @Inject constructor(
     duckAiFeatureState: DuckAiFeatureState,
-    private val duckChatInternal: DuckChatInternal,
-    private val duckChatInputModeState: DuckChatInputModeState,
+    duckChatInternal: DuckChatInternal,
+    duckChatInputModeState: DuckChatInputModeState,
 ) : ViewModel() {
 
     /**
@@ -48,9 +48,5 @@ class StartChatViewModel @Inject constructor(
         duckChatInputModeState.displayedMode,
     ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, displayedMode ->
         isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled && displayedMode == InputMode.SEARCH
-    }
-
-    fun openNewChat() {
-        duckChatInternal.openNewDuckChatSession()
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.nativeinput.Action
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.subscriptions.api.Product
@@ -485,7 +486,7 @@ class NativeInputModeWidgetViewModelTest {
     private fun fakePlugin(containerId: Int, modelId: String?): NativeInputPlugin {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
-            override fun createView(context: Context): View = View(context)
+            override fun createView(context: Context, onAction: (Action) -> Unit): View = View(context)
             override fun getPromptContribution(): PromptContribution? =
                 modelId?.let { PromptContribution.ModelSelection(it) }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214602146462764?focus=true

### Description

`StartChatView` previously walked the view tree to find an enclosing `NativeInputWidget` so it could call `submitAsChat()` on click. This refactor decouples the view from the host widget by adopting the same plugin-action pattern used by `AppTPStateMessagePlugin`:

- `NativeInputPlugin` defines a sealed `Action` (currently just `StartChat`) and `createView` now takes an `onAction: (Action) -> Unit` lambda.
- `StartChatView` exposes an `onIconClicked: (() -> Unit)?` callback and no longer references `NativeInputWidget` or walks the view hierarchy.
- `StartChatNativeInputPlugin` wires the click into `onAction(Action.StartChat)`.
- `NativeInputModeWidget` owns a single `when` over actions, deciding whether to submit the current input as chat or fall back to opening a new chat session.
- The `openNewChat()` call moved from `StartChatViewModel` into `NativeInputModeWidgetViewModel`, which already injects `DuckChatInternal`.

No behavior changes.

### Steps to test this PR

_Start-chat icon (Duck.ai enabled, input-screen toggle off)_
- [ ] Open the app with Duck.ai enabled but the input-screen toggle disabled — confirm the start-chat icon appears in the omnibar in SEARCH mode.
- [ ] Tap the icon with no text typed — a new Duck.ai session should open.
- [ ] Type a query, then tap the icon — the typed query should be submitted as a chat (not opened as a fresh session).
- [ ] Disable Duck.ai entirely — confirm the icon is hidden.
- [ ] Switch to chat mode (toggle on) — confirm the icon is hidden.

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the native input plugin interface and rewires start-chat click handling; behavioral intent is unchanged but regressions could break plugin rendering or start-chat navigation.
> 
> **Overview**
> Decouples `StartChatView` from `NativeInputWidget` by introducing a native-input plugin action callback: `NativeInputPlugin.createView` now receives `onAction: (Action) -> Unit`, and plugins can emit `Action` events (currently `StartChat`).
> 
> Moves the start-chat click decision into `NativeInputModeWidget` (submit current text as chat, else open a new session via `NativeInputModeWidgetViewModel.openNewChat()`), while `StartChatView` becomes a simple view exposing an `onIconClicked` callback. Updates existing plugins/tests to the new `createView` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b38960496a0b748a056c6c648f1d12d69579e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->