### PR TITLE
Onboarding Brand Design Update: Add in-context Main Network dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4983,7 +4983,6 @@ class BrowserTabViewModel @Inject constructor(
             is OnboardingDaxDialogCta.DaxMainNetworkCta,
             is DaxMainNetworkBrandDesignUpdateContextualCta,
             -> {
-                // TODO: replace in stage 2 (DaxMainNetworkCta brand-design migration).
                 viewModelScope.launch {
                     val cta =
                         withContext(dispatchers.io()) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -511,12 +511,12 @@ class CtaViewModel @Inject constructor(
                         OnboardingDaxDialogCta.mainTrackerNetworks.any { mainNetwork -> entity.displayName.contains(mainNetwork) }
                     ) {
                         if (isBrandDesignUpdateEnabled()) {
-                            // TODO: replace in stage 2 (DaxMainNetworkCta brand-design migration).
-                            return OnboardingDaxDialogCta.DaxMainNetworkCta(
-                                onboardingStore,
-                                appInstallStore,
-                                entity.displayName,
-                                host,
+                            return DaxMainNetworkBrandDesignUpdateContextualCta(
+                                onboardingStore = onboardingStore,
+                                appInstallStore = appInstallStore,
+                                network = entity.displayName,
+                                siteHost = host,
+                                isLightTheme = appTheme.isLightModeEnabled(),
                             )
                         }
                         return OnboardingDaxDialogCta.DaxMainNetworkCta(

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
@@ -16,19 +16,20 @@
 
 package com.duckduckgo.app.cta.ui
 
+import android.content.Context
+import android.net.Uri
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.common.utils.extensions.html
 
-/**
- * STUB: brand-design rebrand of [OnboardingDaxDialogCta.DaxMainNetworkCta]. A Stage 2 agent will
- * replace [activeIncludeId] and populate [configureContentViews] to render the
- * main-network-detected in-context dialog.
- */
 data class DaxMainNetworkBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
     override val appInstallStore: AppInstallStore,
@@ -48,9 +49,42 @@ data class DaxMainNetworkBrandDesignUpdateContextualCta(
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
 ) {
-    override val activeIncludeId: Int = 0 // TODO: replace in stage 2.
+    override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override fun configureContentViews(view: View) {
-        // TODO: implement in stage 2.
+        val context = view.context
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.apply {
+            text = getTrackersDescription(context).html(context)
+        }
+    }
+
+    override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {
+        ctaView?.findViewById<View>(R.id.contextualBrandDesignPrimaryCta)?.setOnClickListener {
+            onButtonClicked.invoke()
+        }
+    }
+
+    @VisibleForTesting
+    fun getTrackersDescription(context: Context): String =
+        if (isFromSameNetworkDomain()) {
+            context.resources.getString(
+                R.string.daxMainNetworkCtaText,
+                network,
+                Uri.parse(siteHost).baseHost?.removePrefix("m."),
+                network,
+            )
+        } else {
+            context.resources.getString(
+                R.string.daxMainNetworkOwnedCtaText,
+                network,
+                Uri.parse(siteHost).baseHost?.removePrefix("m."),
+                network,
+            )
+        }
+
+    private fun isFromSameNetworkDomain(): Boolean = MAIN_TRACKER_DOMAINS.any { siteHost.contains(it) }
+
+    private companion object {
+        private val MAIN_TRACKER_DOMAINS = listOf("facebook", "google")
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
@@ -48,6 +48,7 @@ data class DaxMainNetworkBrandDesignUpdateContextualCta(
     onboardingStore = onboardingStore,
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
+    backgroundRes = R.drawable.bg_onboarding_trackers_blocked,
 ) {
     override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCta.kt
@@ -16,7 +16,9 @@
 
 package com.duckduckgo.app.cta.ui
 
+import android.content.Context
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.install.AppInstallStore
@@ -53,14 +55,8 @@ data class DaxTrackersBlockedBrandDesignUpdateContextualCta(
 
     override fun configureContentViews(view: View) {
         val context = view.context
-        val descriptionHtml = OnboardingDaxDialogCta.DaxTrackersBlockedCta(
-            onboardingStore = onboardingStore,
-            appInstallStore = appInstallStore,
-            trackers = trackers,
-            settingsDataStore = settingsDataStore,
-        ).getTrackersDescription(context, trackers)
-
-        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text = descriptionHtml.html(context)
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
+            getTrackersDescription(context, trackers).html(context)
     }
 
     override fun onTypingAnimationSettled(onTypingAnimationFinished: () -> Unit) {
@@ -71,5 +67,34 @@ data class DaxTrackersBlockedBrandDesignUpdateContextualCta(
         ctaView?.findViewById<DaxButtonPrimary>(R.id.contextualBrandDesignPrimaryCta)?.setOnClickListener {
             onButtonClicked.invoke()
         }
+    }
+
+    @VisibleForTesting
+    fun getTrackersDescription(
+        context: Context,
+        trackersEntities: List<Entity>,
+    ): String {
+        val trackers = trackersEntities
+            .map { it.displayName }
+            .distinct()
+
+        val trackersFiltered = trackers.take(MAX_TRACKERS_SHOWS)
+        val trackersText = trackersFiltered.joinToString(", ")
+        val size = trackers.size - trackersFiltered.size
+        val quantityString =
+            if (size == 0) {
+                context.resources
+                    .getQuantityString(R.plurals.onboardingTrackersBlockedZeroDialogDescription, trackersFiltered.size)
+                    .getStringForOmnibarPosition(settingsDataStore.omnibarType)
+            } else {
+                context.resources
+                    .getQuantityString(R.plurals.onboardingTrackersBlockedDialogDescription, size, size)
+                    .getStringForOmnibarPosition(settingsDataStore.omnibarType)
+            }
+        return "<b>$trackersText</b>$quantityString"
+    }
+
+    private companion object {
+        private const val MAX_TRACKERS_SHOWS = 2
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.content.Context
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.asFlow
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.privacy.model.HttpsStatus
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_NETWORK_CTA_1
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.app.trackerdetection.model.TdsEntity
+import com.duckduckgo.app.trackerdetection.model.TrackingEvent
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+@FlowPreview
+@RunWith(AndroidJUnit4::class)
+class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
+
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val schedulers = InstantSchedulersRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var db: AppDatabase
+
+    private val mockWidgetCapabilities: WidgetCapabilities = mock()
+    private val mockDismissedCtaDao: DismissedCtaDao = mock()
+    private val mockPixel: Pixel = mock()
+    private val mockAppInstallStore: AppInstallStore = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockOnboardingStore: OnboardingStore = mock()
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
+    private val mockUserStageStore: UserStageStore = mock()
+    private val mockTabRepository: TabRepository = mock()
+    private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
+    private val mockDuckPlayer: DuckPlayer = mock()
+    private val mockSubscriptions: Subscriptions = mock()
+    private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
+    private val mockSubscriptionPromoCtaShownPlugin: SubscriptionPromoCtaShownPlugin = mock()
+    private val mockSubscriptionPromoCtaShownPlugins: PluginPoint<SubscriptionPromoCtaShownPlugin> = mock {
+        on { getPlugins() } doReturn listOf(mockSubscriptionPromoCtaShownPlugin)
+    }
+    private val mockDuckChat: DuckChat = mock()
+    private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val mockAppTheme: AppTheme = mock { on { isLightModeEnabled() } doReturn true }
+    private val detectedRefreshPatterns: Set<RefreshPattern> = emptySet()
+    private val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+    private val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+
+    val context: Context = ApplicationProvider.getApplicationContext()
+
+    private lateinit var testee: CtaViewModel
+
+    @Before
+    fun before() = runTest {
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
+        whenever(mockTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
+        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.isFeatureEnabled()).thenReturn(false)
+        whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(emptySet())
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+
+        testee = CtaViewModel(
+            appInstallStore = mockAppInstallStore,
+            pixel = mockPixel,
+            widgetCapabilities = mockWidgetCapabilities,
+            dismissedCtaDao = mockDismissedCtaDao,
+            userAllowListRepository = mockUserAllowListRepository,
+            settingsDataStore = mockSettingsDataStore,
+            onboardingStore = mockOnboardingStore,
+            userStageStore = mockUserStageStore,
+            tabRepository = mockTabRepository,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            duckChat = mockDuckChat,
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
+            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+            subscriptions = mockSubscriptions,
+            duckPlayer = mockDuckPlayer,
+            brokenSitePrompt = mockBrokenSitePrompt,
+            subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
+            onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
+            appTheme = mockAppTheme,
+        )
+    }
+
+    @After
+    fun after() {
+        db.close()
+    }
+
+    @Test
+    fun whenBrandDesignEnabledAndBrowsingMajorTrackerSiteThenReturnBrandDesignMainNetworkCta() = runTest {
+        givenDaxOnboardingActive()
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+
+        assertTrue(value is DaxMainNetworkBrandDesignUpdateContextualCta)
+    }
+
+    @Test
+    fun whenCtaShownThenShownPixelFiresWithNetworkParam() = runTest {
+        val cta = newCta()
+
+        testee.onCtaShown(cta)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_SHOWN),
+            argThat { get(CTA_SHOWN)?.startsWith(DAX_NETWORK_CTA_1) == true },
+            any(),
+            eq(Count),
+        )
+    }
+
+    @Test
+    fun whenOkButtonClickedThenOkPixelFiresWithNetworkParam() = runTest {
+        val cta = newCta()
+
+        testee.onUserClickCtaOkButton(cta)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON),
+            eq(mapOf(CTA_SHOWN to DAX_NETWORK_CTA_1)),
+            any(),
+            eq(Count),
+        )
+    }
+
+    @Test
+    fun whenDismissedViaCloseButtonThenClosePixelFiresWithNetworkParam() = runTest {
+        val cta = newCta()
+
+        testee.onUserDismissedCta(cta, viaCloseBtn = true)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON),
+            eq(mapOf(CTA_SHOWN to DAX_NETWORK_CTA_1)),
+            any(),
+            eq(Count),
+        )
+    }
+
+    private fun newCta(): DaxMainNetworkBrandDesignUpdateContextualCta =
+        DaxMainNetworkBrandDesignUpdateContextualCta(
+            onboardingStore = mockOnboardingStore,
+            appInstallStore = mockAppInstallStore,
+            network = "Facebook",
+            siteHost = "http://www.facebook.com",
+            isLightTheme = true,
+        )
+
+    private suspend fun givenDaxOnboardingActive() {
+        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+    }
+
+    private fun site(
+        url: String = "http://www.test.com",
+        uri: Uri? = Uri.parse(url),
+        https: HttpsStatus = HttpsStatus.SECURE,
+        trackerCount: Int = 0,
+        events: List<TrackingEvent> = emptyList(),
+        majorNetworkCount: Int = 0,
+        allTrackersBlocked: Boolean = true,
+        entity: Entity? = null,
+    ): Site {
+        val site: Site = mock()
+        whenever(site.url).thenReturn(url)
+        whenever(site.uri).thenReturn(uri)
+        whenever(site.https).thenReturn(https)
+        whenever(site.entity).thenReturn(entity)
+        whenever(site.trackingEvents).thenReturn(events)
+        whenever(site.trackerCount).thenReturn(trackerCount)
+        whenever(site.majorNetworkCount).thenReturn(majorNetworkCount)
+        whenever(site.allTrackersBlocked).thenReturn(allTrackersBlocked)
+        return site
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -25,6 +25,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.Site
@@ -73,6 +75,7 @@ import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeUnit
@@ -230,6 +233,41 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             any(),
             eq(Count),
         )
+    }
+
+    @Test
+    fun whenBrandDesignDisabledAndBrowsingMajorTrackerSiteThenReturnLegacyMainNetworkCta() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+
+        assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)
+    }
+
+    @Test
+    fun whenDismissedWithoutCloseButtonThenNoClosePixelFired() = runTest {
+        val cta = newCta()
+
+        testee.onUserDismissedCta(cta, viaCloseBtn = false)
+
+        verify(mockPixel, never()).fire(eq(AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON), any(), any(), any())
+    }
+
+    @Test
+    fun whenDismissedThenDismissalPersistedWithNetworkCtaId() = runTest {
+        val cta = newCta()
+
+        testee.onUserDismissedCta(cta)
+
+        verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_DIALOG_NETWORK))
     }
 
     private fun newCta(): DaxMainNetworkBrandDesignUpdateContextualCta =

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.cta.ui
 
 import android.content.Context
+import android.content.res.Resources
 import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.asFlow
@@ -66,6 +67,7 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -73,6 +75,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -271,6 +274,62 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
         testee.onUserDismissedCta(cta)
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_DIALOG_NETWORK))
+    }
+
+    @Test
+    fun whenSameNetworkFacebookDomainThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(network = "Facebook", siteHost = "www.facebook.com")
+    }
+
+    @Test
+    fun whenSameNetworkMobileFacebookDomainThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(network = "Facebook", siteHost = "m.facebook.com")
+    }
+
+    @Test
+    fun whenSameNetworkGoogleDomainThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(network = "Google", siteHost = "www.google.com")
+    }
+
+    @Test
+    fun whenFacebookOwnedDomainThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(network = "Facebook", siteHost = "www.instagram.com")
+    }
+
+    @Test
+    fun whenGoogleOwnedDomainThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(network = "Google", siteHost = "www.youtube.com")
+    }
+
+    private fun assertDescriptionMatchesLegacy(network: String, siteHost: String) {
+        val resourceContext = mockContextEncodingResourceArgs()
+        val brandDesignCta = DaxMainNetworkBrandDesignUpdateContextualCta(
+            onboardingStore = mockOnboardingStore,
+            appInstallStore = mockAppInstallStore,
+            network = network,
+            siteHost = siteHost,
+            isLightTheme = true,
+        )
+        val legacyCta = OnboardingDaxDialogCta.DaxMainNetworkCta(
+            onboardingStore = mockOnboardingStore,
+            appInstallStore = mockAppInstallStore,
+            network = network,
+            siteHost = siteHost,
+        )
+
+        assertEquals(
+            legacyCta.getTrackersDescription(resourceContext),
+            brandDesignCta.getTrackersDescription(resourceContext),
+        )
+    }
+
+    private fun mockContextEncodingResourceArgs(): Context {
+        val resources: Resources = mock {
+            on { getString(any(), any(), any(), any()) } doAnswer { invocation ->
+                "string:${invocation.arguments.joinToString(",")}"
+            }
+        }
+        return mock { on { this.resources } doReturn resources }
     }
 
     private fun newCta(): DaxMainNetworkBrandDesignUpdateContextualCta =

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -278,7 +278,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             onboardingStore = mockOnboardingStore,
             appInstallStore = mockAppInstallStore,
             network = "Facebook",
-            siteHost = "http://www.facebook.com",
+            siteHost = "www.facebook.com",
             isLightTheme = true,
         )
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentMetrics
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -118,6 +119,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
     private val mockDuckChat: DuckChat = mock()
     private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
     private val mockAppTheme: AppTheme = mock { on { isLightModeEnabled() } doReturn true }
+    private val mockDuckAiOnboardingExperimentMetrics: DuckAiOnboardingExperimentMetrics = mock()
     private val detectedRefreshPatterns: Set<RefreshPattern> = emptySet()
     private val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
     private val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
@@ -170,6 +172,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
             onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
             appTheme = mockAppTheme,
+            duckAiOnboardingExperimentMetrics = mockDuckAiOnboardingExperimentMetrics,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -16,9 +16,12 @@
 
 package com.duckduckgo.app.cta.ui
 
+import android.content.Context
+import android.content.res.Resources
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
@@ -35,6 +38,7 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
@@ -56,12 +60,14 @@ import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -242,6 +248,87 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
         testee.onUserDismissedCta(cta)
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_DIALOG_TRACKERS_FOUND))
+    }
+
+    @Test
+    fun whenSingleTrackerWithTopOmnibarThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(
+            trackers = listOf(entity("Facebook")),
+            omnibarType = OmnibarType.SINGLE_TOP,
+        )
+    }
+
+    @Test
+    fun whenMaxTrackersWithTopOmnibarThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(
+            trackers = listOf(entity("Facebook"), entity("Google")),
+            omnibarType = OmnibarType.SINGLE_TOP,
+        )
+    }
+
+    @Test
+    fun whenMoreThanMaxTrackersWithTopOmnibarThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(
+            trackers = listOf(entity("Facebook"), entity("Google"), entity("Amazon"), entity("Microsoft")),
+            omnibarType = OmnibarType.SINGLE_TOP,
+        )
+    }
+
+    @Test
+    fun whenDuplicateTrackersWithTopOmnibarThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(
+            trackers = listOf(entity("Facebook"), entity("Facebook"), entity("Google")),
+            omnibarType = OmnibarType.SINGLE_TOP,
+        )
+    }
+
+    @Test
+    fun whenSingleTrackerWithBottomOmnibarThenBrandDesignDescriptionMatchesLegacy() {
+        assertDescriptionMatchesLegacy(
+            trackers = listOf(entity("Facebook")),
+            omnibarType = OmnibarType.SINGLE_BOTTOM,
+        )
+    }
+
+    private fun entity(displayName: String): Entity = TdsEntity(displayName, displayName, 9.0)
+
+    private fun assertDescriptionMatchesLegacy(
+        trackers: List<Entity>,
+        omnibarType: OmnibarType,
+    ) {
+        whenever(mockSettingsDataStore.omnibarType).thenReturn(omnibarType)
+        val resourceContext = mockContextEncodingResourceArgs()
+
+        val brandDesignCta = DaxTrackersBlockedBrandDesignUpdateContextualCta(
+            onboardingStore = mockOnboardingStore,
+            appInstallStore = mockAppInstallStore,
+            trackers = trackers,
+            settingsDataStore = mockSettingsDataStore,
+            isLightTheme = true,
+        )
+        val legacyCta = OnboardingDaxDialogCta.DaxTrackersBlockedCta(
+            onboardingStore = mockOnboardingStore,
+            appInstallStore = mockAppInstallStore,
+            trackers = trackers,
+            settingsDataStore = mockSettingsDataStore,
+        )
+
+        assertEquals(
+            legacyCta.getTrackersDescription(resourceContext, trackers),
+            brandDesignCta.getTrackersDescription(resourceContext, trackers),
+        )
+    }
+
+    private fun mockContextEncodingResourceArgs(): Context {
+        val resources: Resources = mock {
+            on { getQuantityString(any(), any()) } doAnswer { invocation ->
+                "plural:${invocation.arguments.joinToString(",")}"
+            }
+            on { getQuantityString(any(), any(), any()) } doAnswer { invocation ->
+                "plural:${invocation.arguments.joinToString(",")}"
+            }
+        }
+        return mock { on { this.resources } doReturn resources }
     }
 
     private fun newCta() = DaxTrackersBlockedBrandDesignUpdateContextualCta(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1214598065379694?focus=true

### Description

Migrates the **Main Network** contextual onboarding dialog to the new brand-design layout introduced in #8439, gated behind the `onboardingBrandDesignUpdate` feature flag.

**With the flag on:**
- Main Network CTA renders in the new card chrome with title and body as distinct blocks.
- Reuses the **post-page-load CTA background banner** introduced for Trackers Blocked — slides up from behind the card on appear, slides out on dismiss / content swap.
- Adds parity tests for the migrated `DaxMainNetworkCta` (pixel names, `ctaPixelParam`, `ctaId`, body-string composition) so the brand-design path stays telemetry-equivalent to legacy.

**Out of scope** (still legacy / stub-only with the flag on, queued in follow-up PRs in this stack): no-trackers, fire-button, end. Their `Dax*BrandDesignUpdateContextualCta` classes remain as scaffolding.

### Steps to test this PR

[Designs](https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=16515-30762&m=dev)

Please run all [testing steps](https://app.asana.com/1/137249556945/project/1207908166761516/task/1214549026899402?focus=true) for in-context dialog changes from the contextual-end branch/PR to ease the testing burden.

To see these changes patch (Linear onboarding flag included just for continuity)

```
Index: app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(revision 6fd565c8894daba16281ae9bcf3452d038ae8d6d)
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(date 1777967047929)
@@ -34,13 +34,13 @@
      * Main toggle for the onboarding brand design update feature.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
      * Toggle for the brand design update variant.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 }
Index: app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(revision 6fd565c8894daba16281ae9bcf3452d038ae8d6d)
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(date 1777657893440)
@@ -45,7 +45,7 @@
     val viewState = _viewState.asStateFlow()
 
     fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+        pageLayoutManager.buildBrandDesignUpdatePageBlueprints()
     }
 
     fun pageCount(): Int {
@@ -69,8 +69,8 @@
         }
     }
 
-    fun initializeOnboardingSkipper() {
-        if (!appBuildConfig.canSkipOnboarding) return
+    fun initializeOnboardingSkipper() { 
+        return
 
         // delay showing skip button until privacy config downloaded
         viewModelScope.launch {

```

### UI changes

[Screenshots](https://app.asana.com/1/137249556945/task/1214598065379716)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when/which onboarding CTA class is returned and updates dialog rendering/content for a key in-context onboarding step, which could affect user flow and telemetry despite added parity tests.
> 
> **Overview**
> Routes the **Main Network** in-context onboarding CTA through the brand-design experience when the brand-design flag is enabled, returning `DaxMainNetworkBrandDesignUpdateContextualCta` instead of the legacy `DaxMainNetworkCta`.
> 
> Implements the previously stubbed `DaxMainNetworkBrandDesignUpdateContextualCta` to actually render content (description HTML, include layout/background, primary CTA click handling) and adds domain-based copy selection for same-network vs owned-site cases.
> 
> Refactors `DaxTrackersBlockedBrandDesignUpdateContextualCta` to generate its description internally (instead of instantiating the legacy CTA) and adds new tests to ensure brand-design descriptions and pixels remain equivalent to legacy for both main-network and trackers-blocked CTAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f73284271a6839360a0c6c3e446a9537bb0144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->