### PR TITLE
Onboarding Brand Design Update: Add in-context End dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4949,36 +4949,8 @@ class BrowserTabViewModel @Inject constructor(
 
             is OnboardingDaxDialogCta.DaxTrackersBlockedCta,
             is DaxTrackersBlockedBrandDesignUpdateContextualCta,
-            -> {
-                viewModelScope.launch {
-                    val cta =
-                        withContext(dispatchers.io()) {
-                            if (currentBrowserViewState().maliciousSiteBlocked) null else ctaViewModel.getFireDialogCta()
-                        }
-                    ctaViewState.value = currentCtaViewState().copy(cta = cta)
-                    if (cta == null) {
-                        command.value = HideOnboardingDaxDialog(onboardingCta)
-                    }
-                }
-                null
-            }
-
             is OnboardingDaxDialogCta.DaxNoTrackersCta,
             is DaxNoTrackersBrandDesignUpdateContextualCta,
-            -> {
-                viewModelScope.launch {
-                    val cta =
-                        withContext(dispatchers.io()) {
-                            if (currentBrowserViewState().maliciousSiteBlocked) null else ctaViewModel.getFireDialogCta()
-                        }
-                    ctaViewState.value = currentCtaViewState().copy(cta = cta)
-                    if (cta == null) {
-                        command.value = HideOnboardingDaxDialog(onboardingCta)
-                    }
-                }
-                null
-            }
-
             is OnboardingDaxDialogCta.DaxMainNetworkCta,
             is DaxMainNetworkBrandDesignUpdateContextualCta,
             -> {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -318,8 +318,11 @@ class CtaViewModel @Inject constructor(
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() && daxDialogEndShown()) return@withContext null
             if (isBrandDesignUpdateEnabled()) {
-                // TODO: replace in stage 2 (DaxEndCta brand-design migration).
-                return@withContext OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore)
+                return@withContext DaxEndBrandDesignUpdateContextualCta(
+                    onboardingStore,
+                    appInstallStore,
+                    isLightTheme = appTheme.isLightModeEnabled(),
+                )
             }
             return@withContext OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore)
         }
@@ -556,8 +559,11 @@ class CtaViewModel @Inject constructor(
             // End
             if (canShowDaxCtaEndOfJourney() && daxDialogFireEducationShown()) {
                 if (isBrandDesignUpdateEnabled()) {
-                    // TODO: replace in stage 2 (DaxEndCta brand-design migration).
-                    return OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore)
+                    return DaxEndBrandDesignUpdateContextualCta(
+                        onboardingStore,
+                        appInstallStore,
+                        isLightTheme = appTheme.isLightModeEnabled(),
+                    )
                 }
                 return OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore)
             }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
@@ -23,12 +23,8 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.text.DaxTextView
 
-/**
- * STUB: brand-design rebrand of [OnboardingDaxDialogCta.DaxEndCta] (the in-context end-of-journey
- * variant — distinct from [DaxEndBrandDesignUpdateBubbleCta], which is the NTP bubble). A Stage 2
- * agent will replace [activeIncludeId] and populate [configureContentViews].
- */
 data class DaxEndBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
     override val appInstallStore: AppInstallStore,
@@ -48,9 +44,16 @@ data class DaxEndBrandDesignUpdateContextualCta(
 ) {
     override val markAsReadOnShow: Boolean = true
 
-    override val activeIncludeId: Int = 0 // TODO: replace in stage 2.
+    override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override fun configureContentViews(view: View) {
-        // TODO: implement in stage 2.
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)
+            ?.setText(R.string.onboardingEndDaxDialogDescription)
+    }
+
+    override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {
+        ctaView?.findViewById<View>(R.id.contextualBrandDesignPrimaryCta)?.setOnClickListener {
+            onButtonClicked.invoke()
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
@@ -41,6 +41,7 @@ data class DaxEndBrandDesignUpdateContextualCta(
     onboardingStore = onboardingStore,
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
+    backgroundRes = R.drawable.bg_onboarding_end,
 ) {
     override val markAsReadOnShow: Boolean = true
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON
+import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON
+import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_DAX_CTA_SHOWN
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class DaxEndBrandDesignUpdateContextualCtaTest {
+
+    @get:Rule
+    @Suppress("unused")
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val schedulers = InstantSchedulersRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var db: AppDatabase
+
+    private val mockWidgetCapabilities: WidgetCapabilities = mock()
+    private val mockDismissedCtaDao: DismissedCtaDao = mock()
+    private val mockPixel: Pixel = mock()
+    private val mockAppInstallStore: AppInstallStore = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockOnboardingStore: OnboardingStore = mock()
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
+    private val mockUserStageStore: UserStageStore = mock()
+    private val mockTabRepository: TabRepository = mock()
+    private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
+    private val mockDuckPlayer: DuckPlayer = mock()
+    private val mockSubscriptions: Subscriptions = mock()
+    private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
+    private val mockSubscriptionPromoCtaShownPlugin: SubscriptionPromoCtaShownPlugin = mock()
+    private val mockSubscriptionPromoCtaShownPlugins: PluginPoint<SubscriptionPromoCtaShownPlugin> = mock {
+        on { getPlugins() } doReturn listOf(mockSubscriptionPromoCtaShownPlugin)
+    }
+    private val mockDuckChat: DuckChat = mock()
+    private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val mockAppTheme: AppTheme = mock { on { isLightModeEnabled() } doReturn true }
+
+    private val detectedRefreshPatterns: Set<RefreshPattern> = emptySet()
+
+    private val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+    private val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+
+    private lateinit var testee: CtaViewModel
+
+    @Before
+    fun before() = runTest {
+        db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
+        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.isFeatureEnabled()).thenReturn(false)
+        whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(emptySet())
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+
+        testee = CtaViewModel(
+            appInstallStore = mockAppInstallStore,
+            pixel = mockPixel,
+            widgetCapabilities = mockWidgetCapabilities,
+            dismissedCtaDao = mockDismissedCtaDao,
+            userAllowListRepository = mockUserAllowListRepository,
+            settingsDataStore = mockSettingsDataStore,
+            onboardingStore = mockOnboardingStore,
+            userStageStore = mockUserStageStore,
+            tabRepository = mockTabRepository,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            duckChat = mockDuckChat,
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
+            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+            subscriptions = mockSubscriptions,
+            duckPlayer = mockDuckPlayer,
+            brokenSitePrompt = mockBrokenSitePrompt,
+            subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
+            onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
+            appTheme = mockAppTheme,
+        )
+    }
+
+    @After
+    fun after() {
+        db.close()
+    }
+
+    @Test
+    fun whenBrandDesignFlagEnabledAndGetEndStaticDialogCtaThenReturnsContextualBrandDesignCta() = runTest {
+        givenDaxOnboardingActive()
+        givenBrandDesignUpdateEnabled()
+
+        val value = testee.getEndStaticDialogCta()
+
+        assertTrue(value is DaxEndBrandDesignUpdateContextualCta)
+    }
+
+    @Test
+    fun whenBrandDesignFlagEnabledAndRefreshCtaEndOfJourneyConditionsMetThenReturnsContextualBrandDesignCta() = runTest {
+        givenDaxOnboardingActive()
+        givenBrandDesignUpdateEnabled()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = siteStub(),
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+
+        assertTrue(value is DaxEndBrandDesignUpdateContextualCta)
+    }
+
+    @Test
+    fun whenBrandDesignFlagDisabledAndGetEndStaticDialogCtaThenReturnsLegacyCta() = runTest {
+        givenDaxOnboardingActive()
+        givenBrandDesignUpdateDisabled()
+
+        val value = testee.getEndStaticDialogCta()
+
+        assertTrue(value is OnboardingDaxDialogCta.DaxEndCta)
+    }
+
+    @Test
+    fun whenCtaShownThenShownPixelFiredWithEndCtaParam() = runTest {
+        testee.onCtaShown(newContextualCta())
+
+        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_SHOWN), any(), any(), eq(Count))
+    }
+
+    @Test
+    fun whenUserClicksOkButtonThenOkPixelFiredWithEndCtaParam() = runTest {
+        testee.onUserClickCtaOkButton(newContextualCta())
+
+        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_OK_BUTTON), any(), any(), eq(Count))
+    }
+
+    @Test
+    fun whenUserDismissesViaCloseButtonThenClosePixelFiredWithEndCtaParam() = runTest {
+        testee.onUserDismissedCta(newContextualCta(), viaCloseBtn = true)
+
+        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_DISMISS_BUTTON), any(), any(), eq(Count))
+    }
+
+    @Test
+    fun whenMarkAsReadOnShowIsTrueThenDismissedCtaInsertedOnShown() = runTest {
+        testee.onCtaShown(newContextualCta())
+
+        verify(mockDismissedCtaDao).insert(com.duckduckgo.app.cta.model.DismissedCta(CtaId.DAX_END))
+    }
+
+    private fun newContextualCta() = DaxEndBrandDesignUpdateContextualCta(
+        onboardingStore = mockOnboardingStore,
+        appInstallStore = mockAppInstallStore,
+        isLightTheme = true,
+    )
+
+    private fun givenBrandDesignUpdateEnabled() {
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+    }
+
+    private fun givenBrandDesignUpdateDisabled() {
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+    }
+
+    private suspend fun givenDaxOnboardingActive() {
+        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+    }
+
+    private fun siteStub(): com.duckduckgo.app.global.model.Site {
+        val site: com.duckduckgo.app.global.model.Site = mock()
+        whenever(site.url).thenReturn("http://www.cnn.com")
+        whenever(site.uri).thenReturn(android.net.Uri.parse("http://www.cnn.com"))
+        whenever(site.https).thenReturn(com.duckduckgo.app.privacy.model.HttpsStatus.SECURE)
+        whenever(site.trackerCount).thenReturn(1)
+        whenever(site.majorNetworkCount).thenReturn(0)
+        whenever(site.allTrackersBlocked).thenReturn(true)
+        whenever(site.trackingEvents).thenReturn(emptyList())
+        whenever(site.entity).thenReturn(null)
+        return site
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -36,7 +36,9 @@ import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_DAX_CTA_SHOWN
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_ONBOARDING_END_CTA
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
@@ -204,21 +206,36 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
     fun whenCtaShownThenShownPixelFiredWithEndCtaParam() = runTest {
         testee.onCtaShown(newContextualCta())
 
-        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_SHOWN), any(), any(), eq(Count))
+        verify(mockPixel).fire(
+            eq(ONBOARDING_DAX_CTA_SHOWN),
+            any(),
+            any(),
+            eq(Count),
+        )
     }
 
     @Test
     fun whenUserClicksOkButtonThenOkPixelFiredWithEndCtaParam() = runTest {
         testee.onUserClickCtaOkButton(newContextualCta())
 
-        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_OK_BUTTON), any(), any(), eq(Count))
+        verify(mockPixel).fire(
+            eq(ONBOARDING_DAX_CTA_OK_BUTTON),
+            eq(mapOf(CTA_SHOWN to DAX_ONBOARDING_END_CTA)),
+            any(),
+            eq(Count),
+        )
     }
 
     @Test
     fun whenUserDismissesViaCloseButtonThenClosePixelFiredWithEndCtaParam() = runTest {
         testee.onUserDismissedCta(newContextualCta(), viaCloseBtn = true)
 
-        verify(mockPixel).fire(eq(ONBOARDING_DAX_CTA_DISMISS_BUTTON), any(), any(), eq(Count))
+        verify(mockPixel).fire(
+            eq(ONBOARDING_DAX_CTA_DISMISS_BUTTON),
+            eq(mapOf(CTA_SHOWN to DAX_ONBOARDING_END_CTA)),
+            any(),
+            eq(Count),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentMetrics
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -107,6 +108,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
     private val mockDuckChat: DuckChat = mock()
     private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
     private val mockAppTheme: AppTheme = mock { on { isLightModeEnabled() } doReturn true }
+    private val mockDuckAiOnboardingExperimentMetrics: DuckAiOnboardingExperimentMetrics = mock()
 
     private val detectedRefreshPatterns: Set<RefreshPattern> = emptySet()
 
@@ -156,6 +158,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
             onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
             appTheme = mockAppTheme,
+            duckAiOnboardingExperimentMetrics = mockDuckAiOnboardingExperimentMetrics,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1214598047620091?focus=true

### Description

Migrates the **End** contextual onboarding dialog ("You're all set!") to the new brand-design layout introduced in #8439, gated behind the `onboardingBrandDesignUpdate` feature flag — and closes out the in-context CTA migration started in this stack.

**With the flag on:**
- End CTA renders in the new card chrome with title and body as distinct blocks.
- End CTA wires up to its background banner — slides up from behind the card on appear, slides out on dismiss / content swap.
- **Consolidates trackers/no-trackers/main-network when the End CTA arms** — the three post-page-load CTAs converge cleanly into the End CTA hand-off so we don't double-fire / leave a stale background banner behind.
- Tightens `DaxEndCta` pixel param assertions in tests so the brand-design path stays telemetry-equivalent to legacy.

**With this PR merged**, all in-context dialogs (SERP, Trackers Blocked, No Trackers, Main Network, Fire Button, Site Suggestions, End) are migrated to the brand-design layout under `onboardingBrandDesignUpdate`. No legacy / stub paths remain on the brand-design code path.

### Steps to test this PR

[Designs](https://www.figma.com/design/YPE94Xkcrk2uqiF2l4VmSv/Onboarding--2026-?node-id=16515-30762&m=dev)

Please run all [testing steps](https://app.asana.com/1/137249556945/project/1207908166761516/task/1214549026899402?focus=true) for in-context dialog changes — this PR is the canonical surface to test the full contextual flow end-to-end.

To see these changes patch (Linear onboarding flag included just for continuity)

```
Index: app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(revision 6fd565c8894daba16281ae9bcf3452d038ae8d6d)
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(date 1777967047929)
@@ -34,13 +34,13 @@
      * Main toggle for the onboarding brand design update feature.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
      * Toggle for the brand design update variant.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 }
Index: app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(revision 6fd565c8894daba16281ae9bcf3452d038ae8d6d)
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(date 1777657893440)
@@ -45,7 +45,7 @@
     val viewState = _viewState.asStateFlow()
 
     fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+        pageLayoutManager.buildBrandDesignUpdatePageBlueprints()
     }
 
     fun pageCount(): Int {
@@ -69,8 +69,8 @@
         }
     }
 
-    fun initializeOnboardingSkipper() {
-        if (!appBuildConfig.canSkipOnboarding) return
+    fun initializeOnboardingSkipper() { 
+        return
 
         // delay showing skip button until privacy config downloaded
         viewModelScope.launch {

```

### UI changes

[Screenshots](https://app.asana.com/1/137249556945/project/1207908166761516/task/1214600612760360?focus=true)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding CTA selection and dismissal/hand-off logic plus adds new UI wiring for the end-of-journey dialog; regressions could cause incorrect CTA sequencing or missing/duplicated onboarding dialogs/pixels.
> 
> **Overview**
> Adds a new `DaxEndBrandDesignUpdateContextualCta` and updates `CtaViewModel` to return it (instead of `DaxEndCta`) for both the static end dialog and the end-of-journey refresh path when the brand-design update flag is enabled.
> 
> Wires the new contextual end dialog to the brand-design layout (active include, description binding, primary CTA click handling, and background resource), and simplifies `BrowserTabViewModel`’s post-dialog handoff by consolidating the Trackers/No-Trackers/Main-Network OK paths to the same “next = fire dialog” flow.
> 
> Adds instrumentation tests to ensure the brand-design end CTA is selected under the flag, remains pixel-equivalent to legacy, and is marked as read on show.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3abb1cfd6cb064d23cc3097061fca21d4f4203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->