### PR TITLE
PIR: Add wide event for time to scan jobs completion

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2514,5 +2514,134 @@
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
             }
         ]
+    },
+    "wide_pir-time-to-first-scan-complete": {
+        "description": "Long-lived wide event measuring the wall-clock duration from the first time the user starts the initial PIR scan (MANUAL_INITIAL) to the moment every broker has at least one completed scan job (the dashboard's 'all done' state). Spans multiple foreground service runs and scheduled worker runs since the foreground service is frequently killed and the worker resumes the work later. One-shot per install (cleared only via PIR data reset). 30-day cleanup timeout records abandoned journeys as Unknown.",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "widePixelPlatform",
+            "widePixelType",
+            "widePixelSampleRate",
+            "widePixelFeatureStatus",
+            "widePixelAppVersion",
+            "widePixelAppName",
+            "widePixelFormFactor",
+            "widePixelDevMode",
+            {
+                "key": "feature.name",
+                "description": "Feature identifier for this wide event",
+                "enum": ["pir-time-to-first-scan-complete"]
+            },
+            {
+                "key": "context.name",
+                "description": "Entry point that triggered the time-to-first-scan-complete flow",
+                "enum": ["funnel_pir_time_to_first_scan_complete_android"]
+            },
+            {
+                "key": "feature.data.ext.profile_queries_count",
+                "description": "Number of user profile queries at the moment the flow started (first MANUAL_INITIAL run)",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.broker_count",
+                "description": "Number of active brokers at the moment the flow started",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.total_scan_jobs",
+                "description": "Total number of (broker x profile) scan jobs eligible for execution at the moment the flow started",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.web_view_count",
+                "description": "Number of parallel WebView runners used at the start of the flow. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
+                "type": "string"
+            },
+            {
+                "key": "manufacturer",
+                "description": "Manufacturer of the device. Injected by PirPixelInterceptor.",
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
+            },
+            {
+                "key": "feature.data.ext.power_saving",
+                "description": "Whether the device was in power saving mode at the moment the flow started",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "feature.data.ext.battery_optimizations",
+                "description": "Whether battery optimizations were enabled for the app at the moment the flow started",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "feature.data.ext.vpn_connection_state",
+                "description": "Reported VPN connection state at the moment the flow started",
+                "enum": ["connected", "disconnected"]
+            },
+            {
+                "key": "feature.data.ext.notifications_permission_granted",
+                "description": "Whether the user had granted the POST_NOTIFICATIONS runtime permission at the moment the flow started",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "feature.data.ext.tracker_blocking_state",
+                "description": "Whether tracker blocking was enabled or disabled at the moment the flow started",
+                "enum": ["enabled", "disabled"]
+            },
+            {
+                "key": "feature.data.ext.total_scan_jobs_at_finish",
+                "description": "Total number of valid scan jobs at the moment the flow completed. Can differ from total_scan_jobs because the user may edit their profile or brokers may be added/removed during the multi-day journey. Only present on Success events.",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.foreground_run_count",
+                "description": "Number of foreground service runs (MANUAL_INITIAL or MANUAL_EDIT_PROFILE) that contributed to the journey. Higher counts indicate the user re-opened the app multiple times to make progress. Only present on Success events.",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.scheduled_run_count",
+                "description": "Number of scheduled WorkManager runs that contributed to the journey. Higher counts indicate the foreground service was killed by the system and the work was picked up by background workers. Only present on Success events.",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.total_duration_ms_bucketed",
+                "description": "Total wall-clock duration from the first MANUAL_INITIAL run starting to the moment every broker had a completed scan job. Bucketed using the lower bucket boundary. Only present on Success events.",
+                "enum": [
+                    "0",
+                    "60000",
+                    "300000",
+                    "600000",
+                    "1800000",
+                    "3600000",
+                    "10800000",
+                    "21600000",
+                    "43200000",
+                    "86400000",
+                    "259200000",
+                    "604800000",
+                    "1209600000",
+                    "2592000000"
+                ]
+            }
+        ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2542,22 +2542,22 @@
             {
                 "key": "feature.data.ext.profile_queries_count",
                 "description": "Number of user profile queries at the moment the flow started (first MANUAL_INITIAL run)",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.broker_count",
                 "description": "Number of active brokers at the moment the flow started",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.total_scan_jobs",
                 "description": "Total number of (broker x profile) scan jobs eligible for execution at the moment the flow started",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.web_view_count",
                 "description": "Number of parallel WebView runners used at the start of the flow. Equals min(total_scan_jobs, MAX_DETACHED_WEBVIEW_COUNT=20). 0 when there are no eligible scan jobs.",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "manufacturer",
@@ -2610,17 +2610,17 @@
             {
                 "key": "feature.data.ext.total_scan_jobs_at_finish",
                 "description": "Total number of valid scan jobs at the moment the flow completed. Can differ from total_scan_jobs because the user may edit their profile or brokers may be added/removed during the multi-day journey. Only present on Success events.",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.foreground_run_count",
                 "description": "Number of foreground service runs (MANUAL_INITIAL or MANUAL_EDIT_PROFILE) that contributed to the journey. Higher counts indicate the user re-opened the app multiple times to make progress. Only present on Success events.",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.scheduled_run_count",
                 "description": "Number of scheduled WorkManager runs that contributed to the journey. Higher counts indicate the foreground service was killed by the system and the work was picked up by background workers. Only present on Success events.",
-                "type": "string"
+                "type": "integer"
             },
             {
                 "key": "feature.data.ext.total_duration_ms_bucketed",

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -1034,5 +1034,6 @@ class PirEndToEndTest {
         ) = Unit
 
         override suspend fun onScanCompleted() = Unit
+        override suspend fun onUserReset() = Unit
     }
 }

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -105,6 +105,7 @@ import com.duckduckgo.pir.impl.store.db.BrokerEntity
 import com.duckduckgo.pir.impl.store.db.BrokerOptOut
 import com.duckduckgo.pir.impl.store.db.BrokerScan
 import com.duckduckgo.pir.impl.store.db.BrokerSchedulingConfigEntity
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
@@ -369,6 +370,7 @@ class PirEndToEndTest {
             },
             pirRemoteFeatures = FakeFeatureToggleFactory.create(PirRemoteFeatures::class.java),
             pirScanWideEvent = NoOpPirScanWideEvent,
+            pirInitialScanCompletionWideEvent = NoOpPirInitialScanCompletionWideEvent,
             networkProtectionState = fakeNetworkProtectionState,
         )
 
@@ -1015,5 +1017,22 @@ class PirEndToEndTest {
         override suspend fun onRunFailed(executionType: PirExecutionType, reason: PirScanWideEvent.FailureReason) = Unit
         override suspend fun onRunCancelled(executionType: PirExecutionType) = Unit
         override suspend fun onUserReset() = Unit
+    }
+
+    private object NoOpPirInitialScanCompletionWideEvent : PirInitialScanCompletionWideEvent {
+        override suspend fun onRunStarted(
+            executionType: PirExecutionType,
+            profileQueriesCount: Int,
+            brokerCount: Int,
+            totalScanJobs: Int,
+            webViewCount: Int,
+            isPowerSavingEnabled: Boolean,
+            isVpnConnected: Boolean,
+            batteryOptimizationsEnabled: Boolean,
+            notificationsPermissionGranted: Boolean,
+            isTrackerBlockingEnabled: Boolean,
+        ) = Unit
+
+        override suspend fun onScanCompleted() = Unit
     }
 }

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
@@ -31,6 +31,10 @@ class FakePirDataStore : PirDataStore {
     override var hasBrokerConfigBeenManuallyUpdated: Boolean = false
     override var latestBackgroundScanRunInMs: Long = 0L
     override var featureReceivedMs: Long = 0L
+    override var hasInitialScanEverStarted: Boolean = false
+    override var initialScanCompletionFlowId: Long = 0L
+    override var initialScanCompletionForegroundRunCount: Int = 0
+    override var initialScanCompletionScheduledRunCount: Int = 0
 
     override fun reset() {
         mainConfigEtag = null
@@ -46,5 +50,9 @@ class FakePirDataStore : PirDataStore {
         mauLastSentMs = 0L
         weeklyStatLastSentMs = 0L
         latestBackgroundScanRunInMs = 0L
+        hasInitialScanEverStarted = false
+        initialScanCompletionFlowId = 0L
+        initialScanCompletionForegroundRunCount = 0
+        initialScanCompletionScheduledRunCount = 0
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirFeatureDataCleaner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirFeatureDataCleaner.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.store.PirEventsRepository
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -35,10 +36,12 @@ class RealPirFeatureDataCleaner @Inject constructor(
     private val pirSchedulingRepository: PirSchedulingRepository,
     private val pirEventsRepository: PirEventsRepository,
     private val pirScanWideEvent: PirScanWideEvent,
+    private val pirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent,
 ) : PirFeatureDataCleaner {
 
     override suspend fun removeAllData() {
         pirScanWideEvent.onUserReset()
+        pirInitialScanCompletionWideEvent.onUserReset()
         pirRepository.clearAllData()
         pirSchedulingRepository.clearAllData()
         pirEventsRepository.clearAllData()
@@ -46,6 +49,7 @@ class RealPirFeatureDataCleaner @Inject constructor(
 
     override suspend fun removeUserData() {
         pirScanWideEvent.onUserReset()
+        pirInitialScanCompletionWideEvent.onUserReset()
         pirRepository.clearUserData()
         pirSchedulingRepository.clearAllData()
         pirEventsRepository.clearAllData()

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/di/PirModule.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.GetCaptchaInfoR
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.NavigateResponse
 import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse.SolveCaptchaResponse
 import com.duckduckgo.pir.impl.service.DbpService
+import com.duckduckgo.pir.impl.store.PirDataStore
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.RealPirDataStore
 import com.duckduckgo.pir.impl.store.RealPirRepository
@@ -69,8 +70,14 @@ class PirModule {
 
     @Provides
     @SingleInstanceIn(AppScope::class)
-    fun providePirRepository(
+    fun providePirDataStore(
         sharedPreferencesProvider: SharedPreferencesProvider,
+    ): PirDataStore = RealPirDataStore(sharedPreferencesProvider)
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun providePirRepository(
+        pirDataStore: PirDataStore,
         dispatcherProvider: DispatcherProvider,
         currentTimeProvider: CurrentTimeProvider,
         dbpService: DbpService,
@@ -79,7 +86,7 @@ class PirModule {
         pixelSender: PirPixelSender,
     ): PirRepository = RealPirRepository(
         dispatcherProvider,
-        RealPirDataStore(sharedPreferencesProvider),
+        pirDataStore,
         currentTimeProvider,
         databaseFactory,
         dbpService,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -108,6 +108,7 @@ class PirPixelInterceptor @Inject constructor(
             "m_dbp_initial_scan_duration",
             "wide_pir-initial-scan",
             "wide_pir-scheduled-scan",
+            "wide_pir-time-to-first-scan-complete",
         )
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scan.PirScan
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.FailureReason
 import com.squareup.anvil.annotations.ContributesBinding
@@ -79,6 +80,7 @@ class RealPirJobsRunner @Inject constructor(
     private val brokerJsonUpdater: BrokerJsonUpdater,
     private val pirRemoteFeatures: PirRemoteFeatures,
     private val pirScanWideEvent: PirScanWideEvent,
+    private val pirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent,
     private val networkProtectionState: NetworkProtectionState,
 ) : PirJobsRunner {
     override suspend fun runEligibleJobs(
@@ -144,17 +146,37 @@ class RealPirJobsRunner @Inject constructor(
             emptyList()
         }
 
+        val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
+        val isVpnConnected = networkProtectionState.safeIsVpnRunning()
+        val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
+        val notificationsPermissionGranted = context.areNotificationsPermissionGranted()
+        val isTrackerBlockingEnabled = pirRemoteFeatures.trackerBlocking().isEnabled()
+        val webViewCount = minOf(eligibleJobs.size, MAX_DETACHED_WEBVIEW_COUNT)
+
         pirScanWideEvent.onRunStarted(
             executionType = executionType,
             profileQueriesCount = profileQueries.size,
             brokerCount = activeBrokers.size,
             totalScanJobs = eligibleJobs.size,
-            webViewCount = minOf(eligibleJobs.size, MAX_DETACHED_WEBVIEW_COUNT),
-            isPowerSavingEnabled = context.isPowerSavingModeEnabled(),
-            isVpnConnected = networkProtectionState.safeIsVpnRunning(),
-            batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations(),
-            notificationsPermissionGranted = context.areNotificationsPermissionGranted(),
-            isTrackerBlockingEnabled = pirRemoteFeatures.trackerBlocking().isEnabled(),
+            webViewCount = webViewCount,
+            isPowerSavingEnabled = isPowerSavingEnabled,
+            isVpnConnected = isVpnConnected,
+            batteryOptimizationsEnabled = batteryOptimizationsEnabled,
+            notificationsPermissionGranted = notificationsPermissionGranted,
+            isTrackerBlockingEnabled = isTrackerBlockingEnabled,
+        )
+
+        pirInitialScanCompletionWideEvent.onRunStarted(
+            executionType = executionType,
+            profileQueriesCount = profileQueries.size,
+            brokerCount = activeBrokers.size,
+            totalScanJobs = eligibleJobs.size,
+            webViewCount = webViewCount,
+            isPowerSavingEnabled = isPowerSavingEnabled,
+            isVpnConnected = isVpnConnected,
+            batteryOptimizationsEnabled = batteryOptimizationsEnabled,
+            notificationsPermissionGranted = notificationsPermissionGranted,
+            isTrackerBlockingEnabled = isTrackerBlockingEnabled,
         )
 
         if (activeBrokers.isEmpty()) {
@@ -190,6 +212,7 @@ class RealPirJobsRunner @Inject constructor(
             )
 
             pirScanWideEvent.onScanCompleted(executionType)
+            pirInitialScanCompletionWideEvent.onScanCompleted()
 
             if (executionType.isManual) {
                 val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
@@ -31,6 +31,24 @@ interface PirDataStore {
     var latestBackgroundScanRunInMs: Long
     var featureReceivedMs: Long
 
+    /**
+     * Set the first time `MANUAL_INITIAL` runs for a user. Once set, the
+     * `pir-time-to-first-scan-complete` wide event will not start a new flow for that user.
+     */
+    var hasInitialScanEverStarted: Boolean
+
+    /**
+     * Persisted `flowId` of the in-progress `pir-time-to-first-scan-complete` wide event.
+     * `0L` when no flow is open.
+     */
+    var initialScanCompletionFlowId: Long
+
+    /** Number of foreground service runs that have contributed to the open completion flow. */
+    var initialScanCompletionForegroundRunCount: Int
+
+    /** Number of scheduled worker runs that have contributed to the open completion flow. */
+    var initialScanCompletionScheduledRunCount: Int
+
     fun reset()
     fun resetUserData()
 }
@@ -117,6 +135,38 @@ internal class RealPirDataStore(
             }
         }
 
+    override var hasInitialScanEverStarted: Boolean
+        get() = preferences.getBoolean(KEY_HAS_INITIAL_SCAN_EVER_STARTED, false)
+        set(value) {
+            preferences.edit {
+                putBoolean(KEY_HAS_INITIAL_SCAN_EVER_STARTED, value)
+            }
+        }
+
+    override var initialScanCompletionFlowId: Long
+        get() = preferences.getLong(KEY_INITIAL_SCAN_COMPLETION_FLOW_ID, 0L)
+        set(value) {
+            preferences.edit {
+                putLong(KEY_INITIAL_SCAN_COMPLETION_FLOW_ID, value)
+            }
+        }
+
+    override var initialScanCompletionForegroundRunCount: Int
+        get() = preferences.getInt(KEY_INITIAL_SCAN_COMPLETION_FOREGROUND_RUN_COUNT, 0)
+        set(value) {
+            preferences.edit {
+                putInt(KEY_INITIAL_SCAN_COMPLETION_FOREGROUND_RUN_COUNT, value)
+            }
+        }
+
+    override var initialScanCompletionScheduledRunCount: Int
+        get() = preferences.getInt(KEY_INITIAL_SCAN_COMPLETION_SCHEDULED_RUN_COUNT, 0)
+        set(value) {
+            preferences.edit {
+                putInt(KEY_INITIAL_SCAN_COMPLETION_SCHEDULED_RUN_COUNT, value)
+            }
+        }
+
     override fun reset() {
         mainConfigEtag = null
         hasBrokerConfigBeenManuallyUpdated = false
@@ -131,6 +181,10 @@ internal class RealPirDataStore(
         mauLastSentMs = 0L
         weeklyStatLastSentMs = 0L
         latestBackgroundScanRunInMs = 0L
+        hasInitialScanEverStarted = false
+        initialScanCompletionFlowId = 0L
+        initialScanCompletionForegroundRunCount = 0
+        initialScanCompletionScheduledRunCount = 0
     }
 
     companion object {
@@ -144,5 +198,9 @@ internal class RealPirDataStore(
         private const val KEY_BROKER_CONFIG_MANUALLY_UPDATED = "KEY_BROKER_CONFIG_MANUALLY_UPDATED"
         private const val KEY_LAST_BG_SCAN_RUN = "KEY_LAST_BG_SCAN_RUN_MS"
         private const val KEY_FEATURE_RECEIVED_MS = "KEY_FEATURE_RECEIVED_MS"
+        private const val KEY_HAS_INITIAL_SCAN_EVER_STARTED = "KEY_HAS_INITIAL_SCAN_EVER_STARTED"
+        private const val KEY_INITIAL_SCAN_COMPLETION_FLOW_ID = "KEY_INITIAL_SCAN_COMPLETION_FLOW_ID"
+        private const val KEY_INITIAL_SCAN_COMPLETION_FOREGROUND_RUN_COUNT = "KEY_INITIAL_SCAN_COMPLETION_FOREGROUND_RUN_COUNT"
+        private const val KEY_INITIAL_SCAN_COMPLETION_SCHEDULED_RUN_COUNT = "KEY_INITIAL_SCAN_COMPLETION_SCHEDULED_RUN_COUNT"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.wideevents
+
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.duckduckgo.pir.impl.store.PirDataStore
+import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+
+/**
+ * Long-lived wide event that measures the wall-clock duration from the very first time a user
+ * starts the initial scan to the moment the dashboard would first show "all brokers scanned".
+ *
+ * Spans multiple foreground service runs and scheduled worker runs, since the foreground service
+ * can be killed and the worker resumes the work later.
+ *
+ * One-shot per install: once started, never starts again unless the user fully resets PIR data.
+ */
+interface PirInitialScanCompletionWideEvent {
+
+    /**
+     * Called by `PirJobsRunner` when a scan run begins. Starts the long-lived flow on the very
+     * first MANUAL_INITIAL run, and increments the foreground/scheduled run counter while a flow
+     * is open.
+     */
+    suspend fun onRunStarted(
+        executionType: PirExecutionType,
+        profileQueriesCount: Int,
+        brokerCount: Int,
+        totalScanJobs: Int,
+        webViewCount: Int,
+        isPowerSavingEnabled: Boolean,
+        isVpnConnected: Boolean,
+        batteryOptimizationsEnabled: Boolean,
+        notificationsPermissionGranted: Boolean,
+        isTrackerBlockingEnabled: Boolean,
+    )
+
+    /**
+     * Called by `PirJobsRunner` after the scan phase of a run completes. If a flow is open and
+     * every valid scan job now has a `lastScanDateInMillis > 0`, finishes the flow with Success.
+     */
+    suspend fun onScanCompleted()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class PirInitialScanCompletionWideEventImpl @Inject constructor(
+    private val wideEventClient: WideEventClient,
+    private val pirRemoteFeatures: PirRemoteFeatures,
+    private val pirDataStore: PirDataStore,
+    private val pirSchedulingRepository: PirSchedulingRepository,
+    private val dispatchers: DispatcherProvider,
+) : PirInitialScanCompletionWideEvent {
+
+    private val mutex = Mutex()
+
+    override suspend fun onRunStarted(
+        executionType: PirExecutionType,
+        profileQueriesCount: Int,
+        brokerCount: Int,
+        totalScanJobs: Int,
+        webViewCount: Int,
+        isPowerSavingEnabled: Boolean,
+        isVpnConnected: Boolean,
+        batteryOptimizationsEnabled: Boolean,
+        notificationsPermissionGranted: Boolean,
+        isTrackerBlockingEnabled: Boolean,
+    ) {
+        if (!isFeatureEnabled()) return
+
+        withContext(dispatchers.io()) {
+            mutex.withLock {
+                val flowAlreadyOpen = pirDataStore.initialScanCompletionFlowId != 0L
+
+                if (!flowAlreadyOpen) {
+                    if (executionType != PirExecutionType.MANUAL_INITIAL) return@withLock
+                    if (pirDataStore.hasInitialScanEverStarted) return@withLock
+
+                    val newFlowId = wideEventClient.flowStart(
+                        name = WIDE_EVENT_NAME,
+                        flowEntryPoint = ENTRY_POINT,
+                        metadata = mapOf(
+                            KEY_PROFILE_QUERIES_COUNT to profileQueriesCount.toString(),
+                            KEY_BROKER_COUNT to brokerCount.toString(),
+                            KEY_TOTAL_SCAN_JOBS to totalScanJobs.toString(),
+                            KEY_WEB_VIEW_COUNT to webViewCount.toString(),
+                            KEY_POWER_SAVING to isPowerSavingEnabled.toString(),
+                            KEY_BATTERY_OPTIMIZATIONS to batteryOptimizationsEnabled.toString(),
+                            KEY_VPN_CONNECTION_STATE to isVpnConnected.toVpnConnectionState(),
+                            KEY_NOTIFICATIONS_PERMISSION_GRANTED to notificationsPermissionGranted.toString(),
+                            KEY_TRACKER_BLOCKING_STATE to isTrackerBlockingEnabled.toTrackerBlockingState(),
+                        ),
+                        cleanupPolicy = CleanupPolicy.OnTimeout(
+                            duration = COMPLETION_FLOW_TIMEOUT,
+                            flowStatus = FlowStatus.Unknown,
+                        ),
+                    ).getOrNull() ?: return@withLock
+
+                    pirDataStore.initialScanCompletionFlowId = newFlowId
+                    pirDataStore.hasInitialScanEverStarted = true
+                    pirDataStore.initialScanCompletionForegroundRunCount = 0
+                    pirDataStore.initialScanCompletionScheduledRunCount = 0
+                    wideEventClient.intervalStart(wideEventId = newFlowId, key = INTERVAL_TOTAL_DURATION)
+                }
+
+                when (executionType) {
+                    PirExecutionType.MANUAL_INITIAL,
+                    PirExecutionType.MANUAL_EDIT_PROFILE,
+                    -> {
+                        pirDataStore.initialScanCompletionForegroundRunCount += 1
+                    }
+                    PirExecutionType.SCHEDULED -> {
+                        pirDataStore.initialScanCompletionScheduledRunCount += 1
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun onScanCompleted() {
+        if (!isFeatureEnabled()) return
+
+        withContext(dispatchers.io()) {
+            mutex.withLock {
+                val flowId = pirDataStore.initialScanCompletionFlowId
+                if (flowId == 0L) return@withLock
+
+                val scanJobs = pirSchedulingRepository.getAllValidScanJobRecords()
+                if (scanJobs.isEmpty()) return@withLock
+                if (scanJobs.any { it.lastScanDateInMillis == 0L }) return@withLock
+
+                wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_DURATION)
+                wideEventClient.flowFinish(
+                    wideEventId = flowId,
+                    status = FlowStatus.Success,
+                    metadata = mapOf(
+                        KEY_TOTAL_SCAN_JOBS_AT_FINISH to scanJobs.size.toString(),
+                        KEY_FOREGROUND_RUN_COUNT to pirDataStore.initialScanCompletionForegroundRunCount.toString(),
+                        KEY_SCHEDULED_RUN_COUNT to pirDataStore.initialScanCompletionScheduledRunCount.toString(),
+                    ),
+                )
+
+                pirDataStore.initialScanCompletionFlowId = 0L
+                pirDataStore.initialScanCompletionForegroundRunCount = 0
+                pirDataStore.initialScanCompletionScheduledRunCount = 0
+            }
+        }
+    }
+
+    private suspend fun isFeatureEnabled(): Boolean = withContext(dispatchers.io()) {
+        pirRemoteFeatures.sendScanWideEvent().isEnabled()
+    }
+
+    private fun Boolean.toVpnConnectionState(): String = if (this) "connected" else "disconnected"
+
+    private fun Boolean.toTrackerBlockingState(): String = if (this) "enabled" else "disabled"
+
+    companion object {
+        const val WIDE_EVENT_NAME = "pir-time-to-first-scan-complete"
+        const val ENTRY_POINT = "funnel_pir_time_to_first_scan_complete_android"
+
+        val COMPLETION_FLOW_TIMEOUT = 30.days
+
+        const val INTERVAL_TOTAL_DURATION = "total_duration_ms_bucketed"
+
+        const val KEY_PROFILE_QUERIES_COUNT = "profile_queries_count"
+        const val KEY_BROKER_COUNT = "broker_count"
+        const val KEY_TOTAL_SCAN_JOBS = "total_scan_jobs"
+        const val KEY_WEB_VIEW_COUNT = "web_view_count"
+        const val KEY_POWER_SAVING = "power_saving"
+        const val KEY_BATTERY_OPTIMIZATIONS = "battery_optimizations"
+        const val KEY_VPN_CONNECTION_STATE = "vpn_connection_state"
+        const val KEY_NOTIFICATIONS_PERMISSION_GRANTED = "notifications_permission_granted"
+        const val KEY_TRACKER_BLOCKING_STATE = "tracker_blocking_state"
+
+        const val KEY_TOTAL_SCAN_JOBS_AT_FINISH = "total_scan_jobs_at_finish"
+        const val KEY_FOREGROUND_RUN_COUNT = "foreground_run_count"
+        const val KEY_SCHEDULED_RUN_COUNT = "scheduled_run_count"
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Long-lived wide event that measures the wall-clock duration from the very first time a user
@@ -127,7 +129,11 @@ class PirInitialScanCompletionWideEventImpl @Inject constructor(
                     pirDataStore.hasInitialScanEverStarted = true
                     pirDataStore.initialScanCompletionForegroundRunCount = 0
                     pirDataStore.initialScanCompletionScheduledRunCount = 0
-                    wideEventClient.intervalStart(wideEventId = newFlowId, key = INTERVAL_TOTAL_DURATION)
+                    wideEventClient.intervalStart(
+                        wideEventId = newFlowId,
+                        key = INTERVAL_TOTAL_DURATION,
+                        buckets = COMPLETION_INTERVAL_BUCKETS,
+                    )
                 }
 
                 when (executionType) {
@@ -189,6 +195,29 @@ class PirInitialScanCompletionWideEventImpl @Inject constructor(
         val COMPLETION_FLOW_TIMEOUT = 30.days
 
         const val INTERVAL_TOTAL_DURATION = "total_duration_ms_bucketed"
+
+        /**
+         * Bucket boundaries for the total-duration interval. The default `DEFAULT_INTERVAL_BUCKETS`
+         * caps at 10 minutes, which would collapse this multi-day metric into a single "10m+" bucket.
+         * This set spans 1 minute up to 30 days (matching the [COMPLETION_FLOW_TIMEOUT] cleanup
+         * window) and aligns with the enum in `PixelDefinitions/.../personal_information_removal.json5`.
+         * Durations below 1 minute are recorded as "0".
+         */
+        val COMPLETION_INTERVAL_BUCKETS = setOf(
+            1.minutes,
+            5.minutes,
+            10.minutes,
+            30.minutes,
+            1.hours,
+            3.hours,
+            6.hours,
+            12.hours,
+            1.days,
+            3.days,
+            7.days,
+            14.days,
+            30.days,
+        )
 
         const val KEY_PROFILE_QUERIES_COUNT = "profile_queries_count"
         const val KEY_BROKER_COUNT = "broker_count"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
@@ -69,6 +69,12 @@ interface PirInitialScanCompletionWideEvent {
      * every valid scan job now has a `lastScanDateInMillis > 0`, finishes the flow with Success.
      */
     suspend fun onScanCompleted()
+
+    /**
+     * Aborts any open flow so it is discarded rather than eventually emitting
+     * a stale `FlowStatus.Unknown` record via the cleanup-on-timeout policy.
+     */
+    suspend fun onUserReset()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -176,6 +182,17 @@ class PirInitialScanCompletionWideEventImpl @Inject constructor(
                 pirDataStore.initialScanCompletionFlowId = 0L
                 pirDataStore.initialScanCompletionForegroundRunCount = 0
                 pirDataStore.initialScanCompletionScheduledRunCount = 0
+            }
+        }
+    }
+
+    override suspend fun onUserReset() {
+        withContext(dispatchers.io()) {
+            mutex.withLock {
+                val flowId = pirDataStore.initialScanCompletionFlowId
+                if (flowId == 0L) return@withLock
+
+                wideEventClient.flowAbort(flowId)
             }
         }
     }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/PirFeatureDataCleanerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/PirFeatureDataCleanerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl
 import com.duckduckgo.pir.impl.store.PirEventsRepository
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -33,6 +34,7 @@ class PirFeatureDataCleanerTest {
     private val pirSchedulingRepository: PirSchedulingRepository = mock()
     private val pirEventsRepository: PirEventsRepository = mock()
     private val pirScanWideEvent: PirScanWideEvent = mock()
+    private val pirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent = mock()
 
     private lateinit var testee: RealPirFeatureDataCleaner
 
@@ -43,6 +45,7 @@ class PirFeatureDataCleanerTest {
             pirSchedulingRepository = pirSchedulingRepository,
             pirEventsRepository = pirEventsRepository,
             pirScanWideEvent = pirScanWideEvent,
+            pirInitialScanCompletionWideEvent = pirInitialScanCompletionWideEvent,
         )
     }
 
@@ -50,8 +53,9 @@ class PirFeatureDataCleanerTest {
     fun whenRemoveAllDataThenWideEventResetCalledBeforeRepositoryClear() = runTest {
         testee.removeAllData()
 
-        inOrder(pirScanWideEvent, pirRepository).run {
+        inOrder(pirScanWideEvent, pirInitialScanCompletionWideEvent, pirRepository).run {
             verify(pirScanWideEvent).onUserReset()
+            verify(pirInitialScanCompletionWideEvent).onUserReset()
             verify(pirRepository).clearAllData()
         }
         verify(pirSchedulingRepository).clearAllData()
@@ -62,8 +66,9 @@ class PirFeatureDataCleanerTest {
     fun whenRemoveUserDataThenWideEventResetCalledBeforeRepositoryClear() = runTest {
         testee.removeUserData()
 
-        inOrder(pirScanWideEvent, pirRepository).run {
+        inOrder(pirScanWideEvent, pirInitialScanCompletionWideEvent, pirRepository).run {
             verify(pirScanWideEvent).onUserReset()
+            verify(pirInitialScanCompletionWideEvent).onUserReset()
             verify(pirRepository).clearUserData()
         }
         verify(pirSchedulingRepository).clearAllData()

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.store.PirDataStore
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
 import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.COMPLETION_FLOW_TIMEOUT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.COMPLETION_INTERVAL_BUCKETS
 import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.ENTRY_POINT
 import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.INTERVAL_TOTAL_DURATION
 import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_BATTERY_OPTIMIZATIONS
@@ -158,7 +159,11 @@ class PirInitialScanCompletionWideEventTest {
             ),
             cleanupPolicy = CleanupPolicy.OnTimeout(duration = COMPLETION_FLOW_TIMEOUT, flowStatus = FlowStatus.Unknown),
         )
-        verify(wideEventClient).intervalStart(wideEventId = 42L, key = INTERVAL_TOTAL_DURATION)
+        verify(wideEventClient).intervalStart(
+            wideEventId = 42L,
+            key = INTERVAL_TOTAL_DURATION,
+            buckets = COMPLETION_INTERVAL_BUCKETS,
+        )
         assertTrue(dataStore.hasInitialScanEverStarted)
         assertEquals(42L, dataStore.initialScanCompletionFlowId)
         assertEquals(1, dataStore.initialScanCompletionForegroundRunCount)

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.wideevents
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
+import com.duckduckgo.app.statistics.wideevents.FlowStatus
+import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.duckduckgo.pir.impl.store.PirDataStore
+import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.COMPLETION_FLOW_TIMEOUT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.ENTRY_POINT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.INTERVAL_TOTAL_DURATION
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_BATTERY_OPTIMIZATIONS
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_BROKER_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_FOREGROUND_RUN_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_NOTIFICATIONS_PERMISSION_GRANTED
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_POWER_SAVING
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_PROFILE_QUERIES_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_SCHEDULED_RUN_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_TOTAL_SCAN_JOBS
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_TOTAL_SCAN_JOBS_AT_FINISH
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_TRACKER_BLOCKING_STATE
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_VPN_CONNECTION_STATE
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.KEY_WEB_VIEW_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEventImpl.Companion.WIDE_EVENT_NAME
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class PirInitialScanCompletionWideEventTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val wideEventClient: WideEventClient = mock()
+    private val pirSchedulingRepository: PirSchedulingRepository = mock()
+    private val dataStore = FakePirDataStore()
+
+    @SuppressLint("DenyListedApi")
+    private val pirRemoteFeatures: PirRemoteFeatures =
+        FakeFeatureToggleFactory.create(PirRemoteFeatures::class.java).apply {
+            sendScanWideEvent().setRawStoredState(Toggle.State(true))
+        }
+
+    private lateinit var testee: PirInitialScanCompletionWideEventImpl
+
+    @Before
+    fun setUp() {
+        testee = PirInitialScanCompletionWideEventImpl(
+            wideEventClient = wideEventClient,
+            pirRemoteFeatures = pirRemoteFeatures,
+            pirDataStore = dataStore,
+            pirSchedulingRepository = pirSchedulingRepository,
+            dispatchers = coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    private suspend fun runStarted(
+        executionType: PirExecutionType = PirExecutionType.MANUAL_INITIAL,
+        profileQueriesCount: Int = 1,
+        brokerCount: Int = 5,
+        totalScanJobs: Int = 10,
+        webViewCount: Int = 10,
+        isPowerSavingEnabled: Boolean = false,
+        isVpnConnected: Boolean = false,
+        batteryOptimizationsEnabled: Boolean = false,
+        notificationsPermissionGranted: Boolean = true,
+        isTrackerBlockingEnabled: Boolean = false,
+    ) {
+        testee.onRunStarted(
+            executionType = executionType,
+            profileQueriesCount = profileQueriesCount,
+            brokerCount = brokerCount,
+            totalScanJobs = totalScanJobs,
+            webViewCount = webViewCount,
+            isPowerSavingEnabled = isPowerSavingEnabled,
+            isVpnConnected = isVpnConnected,
+            batteryOptimizationsEnabled = batteryOptimizationsEnabled,
+            notificationsPermissionGranted = notificationsPermissionGranted,
+            isTrackerBlockingEnabled = isTrackerBlockingEnabled,
+        )
+    }
+
+    @SuppressLint("DenyListedApi")
+    @Test
+    fun whenFeatureFlagDisabledThenNothingIsSent() = runTest {
+        pirRemoteFeatures.sendScanWideEvent().setRawStoredState(Toggle.State(false))
+
+        runStarted()
+        testee.onScanCompleted()
+
+        verifyNoInteractions(wideEventClient)
+        assertFalse(dataStore.hasInitialScanEverStarted)
+        assertEquals(0L, dataStore.initialScanCompletionFlowId)
+    }
+
+    @Test
+    fun whenManualInitialRunStartedAndFlagFalseThenFlowStartedWithExpectedMetadata() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(42L))
+
+        testee.onRunStarted(
+            executionType = PirExecutionType.MANUAL_INITIAL,
+            profileQueriesCount = 2,
+            brokerCount = 5,
+            totalScanJobs = 10,
+            webViewCount = 7,
+            isPowerSavingEnabled = true,
+            isVpnConnected = true,
+            batteryOptimizationsEnabled = false,
+            notificationsPermissionGranted = true,
+            isTrackerBlockingEnabled = true,
+        )
+
+        verify(wideEventClient).flowStart(
+            name = WIDE_EVENT_NAME,
+            flowEntryPoint = ENTRY_POINT,
+            metadata = mapOf(
+                KEY_PROFILE_QUERIES_COUNT to "2",
+                KEY_BROKER_COUNT to "5",
+                KEY_TOTAL_SCAN_JOBS to "10",
+                KEY_WEB_VIEW_COUNT to "7",
+                KEY_POWER_SAVING to "true",
+                KEY_BATTERY_OPTIMIZATIONS to "false",
+                KEY_VPN_CONNECTION_STATE to "connected",
+                KEY_NOTIFICATIONS_PERMISSION_GRANTED to "true",
+                KEY_TRACKER_BLOCKING_STATE to "enabled",
+            ),
+            cleanupPolicy = CleanupPolicy.OnTimeout(duration = COMPLETION_FLOW_TIMEOUT, flowStatus = FlowStatus.Unknown),
+        )
+        verify(wideEventClient).intervalStart(wideEventId = 42L, key = INTERVAL_TOTAL_DURATION)
+        assertTrue(dataStore.hasInitialScanEverStarted)
+        assertEquals(42L, dataStore.initialScanCompletionFlowId)
+        assertEquals(1, dataStore.initialScanCompletionForegroundRunCount)
+        assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
+    }
+
+    @Test
+    fun whenManualInitialRunStartedAndFlagAlreadyTrueThenNothingIsStarted() = runTest {
+        dataStore.hasInitialScanEverStarted = true
+
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+
+        verifyNoInteractions(wideEventClient)
+        assertEquals(0L, dataStore.initialScanCompletionFlowId)
+        assertEquals(0, dataStore.initialScanCompletionForegroundRunCount)
+    }
+
+    @Test
+    fun whenScheduledRunStartedAndNoFlowOpenThenNothingIsStarted() = runTest {
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+
+        verifyNoInteractions(wideEventClient)
+        assertFalse(dataStore.hasInitialScanEverStarted)
+        assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
+    }
+
+    @Test
+    fun whenManualEditProfileRunStartedAndNoFlowOpenThenNothingIsStarted() = runTest {
+        runStarted(executionType = PirExecutionType.MANUAL_EDIT_PROFILE)
+
+        verifyNoInteractions(wideEventClient)
+        assertFalse(dataStore.hasInitialScanEverStarted)
+    }
+
+    @Test
+    fun whenScheduledRunStartedWhileFlowOpenThenScheduledCountIncrementedAndNoNewFlow() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(1L))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+        // foreground=1 after the manual initial run
+
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+
+        verify(wideEventClient).flowStart(any(), any(), any(), any())
+        assertEquals(1L, dataStore.initialScanCompletionFlowId)
+        assertEquals(1, dataStore.initialScanCompletionForegroundRunCount)
+        assertEquals(2, dataStore.initialScanCompletionScheduledRunCount)
+    }
+
+    @Test
+    fun whenManualEditProfileRunStartedWhileFlowOpenThenForegroundCountIncremented() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(1L))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+
+        runStarted(executionType = PirExecutionType.MANUAL_EDIT_PROFILE)
+
+        verify(wideEventClient).flowStart(any(), any(), any(), any())
+        assertEquals(2, dataStore.initialScanCompletionForegroundRunCount)
+        assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
+    }
+
+    @Test
+    fun whenScanCompletedAndAllJobsDoneThenFlowFinishedWithSuccess() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(99L))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+        whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
+            listOf(
+                ScanJobRecord(brokerName = "b1", userProfileId = 1, lastScanDateInMillis = 1000L),
+                ScanJobRecord(brokerName = "b2", userProfileId = 1, lastScanDateInMillis = 2000L),
+            ),
+        )
+
+        testee.onScanCompleted()
+
+        verify(wideEventClient).intervalEnd(wideEventId = 99L, key = INTERVAL_TOTAL_DURATION)
+        verify(wideEventClient).flowFinish(
+            wideEventId = 99L,
+            status = FlowStatus.Success,
+            metadata = mapOf(
+                KEY_TOTAL_SCAN_JOBS_AT_FINISH to "2",
+                KEY_FOREGROUND_RUN_COUNT to "1",
+                KEY_SCHEDULED_RUN_COUNT to "1",
+            ),
+        )
+        assertEquals(0L, dataStore.initialScanCompletionFlowId)
+        assertEquals(0, dataStore.initialScanCompletionForegroundRunCount)
+        assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
+        // Flag remains set so we never start a second flow.
+        assertTrue(dataStore.hasInitialScanEverStarted)
+    }
+
+    @Test
+    fun whenScanCompletedAndSomeJobsNotDoneThenFlowRemainsOpen() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(99L))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+        whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
+            listOf(
+                ScanJobRecord(brokerName = "b1", userProfileId = 1, lastScanDateInMillis = 1000L),
+                ScanJobRecord(brokerName = "b2", userProfileId = 1, lastScanDateInMillis = 0L),
+            ),
+        )
+
+        testee.onScanCompleted()
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+        verify(wideEventClient, never()).intervalEnd(any(), any())
+        assertEquals(99L, dataStore.initialScanCompletionFlowId)
+    }
+
+    @Test
+    fun whenScanCompletedAndNoFlowOpenThenNoOp() = runTest {
+        whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
+            listOf(
+                ScanJobRecord(brokerName = "b1", userProfileId = 1, lastScanDateInMillis = 1000L),
+            ),
+        )
+
+        testee.onScanCompleted()
+
+        verifyNoInteractions(wideEventClient)
+    }
+
+    @Test
+    fun whenJourneySpansMultipleRunsThenSuccessReportsTotalCounts() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(7L))
+
+        // Initial foreground run starts the flow.
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+        // Service gets killed; scheduled worker picks up.
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+        // Worker doesn't finish; another scheduled run resumes.
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+        // User edits profile, foreground service runs again.
+        runStarted(executionType = PirExecutionType.MANUAL_EDIT_PROFILE)
+        // Final scheduled run completes the work.
+        runStarted(executionType = PirExecutionType.SCHEDULED)
+
+        whenever(pirSchedulingRepository.getAllValidScanJobRecords()).thenReturn(
+            listOf(
+                ScanJobRecord(brokerName = "b1", userProfileId = 1, lastScanDateInMillis = 1000L),
+                ScanJobRecord(brokerName = "b2", userProfileId = 1, lastScanDateInMillis = 2000L),
+                ScanJobRecord(brokerName = "b3", userProfileId = 1, lastScanDateInMillis = 3000L),
+            ),
+        )
+
+        testee.onScanCompleted()
+
+        verify(wideEventClient).flowFinish(
+            wideEventId = 7L,
+            status = FlowStatus.Success,
+            metadata = mapOf(
+                KEY_TOTAL_SCAN_JOBS_AT_FINISH to "3",
+                KEY_FOREGROUND_RUN_COUNT to "2",
+                KEY_SCHEDULED_RUN_COUNT to "3",
+            ),
+        )
+    }
+}
+
+private class FakePirDataStore : PirDataStore {
+    override var mainConfigEtag: String? = null
+    override var customStatsPixelsLastSentMs: Long = 0L
+    override var dauLastSentMs: Long = 0L
+    override var wauLastSentMs: Long = 0L
+    override var mauLastSentMs: Long = 0L
+    override var weeklyStatLastSentMs: Long = 0L
+    override var hasBrokerConfigBeenManuallyUpdated: Boolean = false
+    override var latestBackgroundScanRunInMs: Long = 0L
+    override var featureReceivedMs: Long = 0L
+    override var hasInitialScanEverStarted: Boolean = false
+    override var initialScanCompletionFlowId: Long = 0L
+    override var initialScanCompletionForegroundRunCount: Int = 0
+    override var initialScanCompletionScheduledRunCount: Int = 0
+
+    override fun reset() {
+        mainConfigEtag = null
+        hasBrokerConfigBeenManuallyUpdated = false
+        featureReceivedMs = 0L
+        resetUserData()
+    }
+
+    override fun resetUserData() {
+        customStatsPixelsLastSentMs = 0L
+        dauLastSentMs = 0L
+        wauLastSentMs = 0L
+        mauLastSentMs = 0L
+        weeklyStatLastSentMs = 0L
+        latestBackgroundScanRunInMs = 0L
+        hasInitialScanEverStarted = false
+        initialScanCompletionFlowId = 0L
+        initialScanCompletionForegroundRunCount = 0
+        initialScanCompletionScheduledRunCount = 0
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -288,6 +288,39 @@ class PirInitialScanCompletionWideEventTest {
     }
 
     @Test
+    fun whenOnUserResetCalledAndFlowOpenThenFlowAborted() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(55L))
+        whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+
+        testee.onUserReset()
+
+        verify(wideEventClient).flowAbort(55L)
+    }
+
+    @Test
+    fun whenOnUserResetCalledAndNoFlowOpenThenWideEventClientNotCalled() = runTest {
+        testee.onUserReset()
+
+        verify(wideEventClient, never()).flowAbort(any())
+    }
+
+    @SuppressLint("DenyListedApi")
+    @Test
+    fun whenOnUserResetCalledAndFeatureFlagDisabledMidFlightThenInFlightFlowStillAborted() = runTest {
+        // Flow opens while flag is ON, then flag flips OFF before user reset. We must still abort
+        // the in-flight flow so it doesn't get auto-finished as Unknown by the cleanup timeout.
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(55L))
+        whenever(wideEventClient.flowAbort(any())).thenReturn(Result.success(Unit))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+        pirRemoteFeatures.sendScanWideEvent().setRawStoredState(Toggle.State(false))
+
+        testee.onUserReset()
+
+        verify(wideEventClient).flowAbort(55L)
+    }
+
+    @Test
     fun whenJourneySpansMultipleRunsThenSuccessReportsTotalCounts() = runTest {
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(7L))
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_INITIAL
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType.SCHEDULED
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import com.duckduckgo.pir.impl.wideevents.PirInitialScanCompletionWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.FailureReason
 import kotlinx.coroutines.CancellationException
@@ -82,6 +83,7 @@ class RealPirJobsRunnerTest {
     private val mockEnsureBrokerDataToggle: Toggle = mock()
     private val mockTrackerBlockingToggle: Toggle = mock()
     private val mockPirScanWideEvent: PirScanWideEvent = mock()
+    private val mockPirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent = mock()
     private val mockNetworkProtectionState: NetworkProtectionState = mock()
 
     @Before
@@ -109,6 +111,7 @@ class RealPirJobsRunnerTest {
             brokerJsonUpdater = mockBrokerJsonUpdater,
             pirRemoteFeatures = mockPirRemoteFeatures,
             pirScanWideEvent = mockPirScanWideEvent,
+            pirInitialScanCompletionWideEvent = mockPirInitialScanCompletionWideEvent,
             networkProtectionState = mockNetworkProtectionState,
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214605416413803?focus=true

### Description
Adds a new wide event to understand how long it takes to scan all brokers for the very first time across foreground and background scans. 

### Steps to test this PR
See https://app.asana.com/1/137249556945/task/1214605416413806?focus=true

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new long-lived wide-event flow with persisted state and hooks it into `PirJobsRunner` and data reset paths; mistakes could skew analytics or leave stale flows running across app restarts. No user-facing or security-sensitive logic changes beyond telemetry/state tracking.
> 
> **Overview**
> Adds a new **long-lived wide event** `wide_pir-time-to-first-scan-complete` to measure wall-clock time from the first `MANUAL_INITIAL` scan start until *all* brokers have at least one completed scan job, spanning multiple foreground and scheduled runs.
> 
> Implements `PirInitialScanCompletionWideEvent` with persisted flow state in `PirDataStore` (flow id + run counters + one-shot flag), wires it into `PirJobsRunner` start/completion callbacks, and ensures flows are aborted on PIR data reset via `PirFeatureDataCleaner`. Updates pixel definitions and interceptor allowlist, plus adjusts DI to provide `PirDataStore` separately and extends unit/integration tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be40b8e2642d763d64cfa342ce7457154c3d8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->