### PR TITLE
Add lint rule to prevent introducing new Metro-incompatible patterns

### DIFF
--- a/lint-rules/src/main/java/com/duckduckgo/lint/MissingContributesToOnModuleDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/MissingContributesToOnModuleDetector.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UClass
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class MissingContributesToOnModuleDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = Handler(context)
+
+    internal class Handler(private val context: JavaContext) : UElementHandler() {
+        override fun visitClass(node: UClass) {
+            val moduleAnnotation = node.uAnnotations.firstOrNull { it.qualifiedName == DAGGER_MODULE } ?: return
+
+            val hasContributesTo = node.uAnnotations.any { it.qualifiedName == ANVIL_CONTRIBUTES_TO }
+            if (!hasContributesTo) {
+                context.report(
+                    MISSING_CONTRIBUTES_TO_ON_MODULE,
+                    moduleAnnotation,
+                    context.getNameLocation(moduleAnnotation),
+                    "Dagger @Module must be annotated with @ContributesTo to be discovered by Metro DI. " +
+                        "Add @ContributesTo(AppScope::class) — or the appropriate scope (ActivityScope, FragmentScope, " +
+                        "VpnScope, etc.) — alongside @Module.",
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val DAGGER_MODULE = "dagger.Module"
+        private const val ANVIL_CONTRIBUTES_TO = "com.squareup.anvil.annotations.ContributesTo"
+
+        val MISSING_CONTRIBUTES_TO_ON_MODULE = Issue.create(
+            "MissingContributesToOnModule",
+            "Dagger @Module is missing @ContributesTo",
+            """
+                Every Dagger @Module must also be annotated with @ContributesTo so that Metro DI can
+                auto-discover it. Add @ContributesTo(AppScope::class), or the appropriate scope
+                (ActivityScope, FragmentScope, VpnScope, etc.), alongside @Module.
+
+                This is required for the Anvil → Metro migration: Metro relies on @ContributesTo to
+                merge modules into the dependency graph.
+            """.trimIndent(),
+            Category.CORRECTNESS,
+            10,
+            ERROR,
+            Implementation(MissingContributesToOnModuleDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES)),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/MissingExplicitReturnTypeOnProvidesBindsDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/MissingExplicitReturnTypeOnProvidesBindsDetector.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.uast.UMethod
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class MissingExplicitReturnTypeOnProvidesBindsDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UMethod::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = Handler(context)
+
+    internal class Handler(private val context: JavaContext) : UElementHandler() {
+        override fun visitMethod(node: UMethod) {
+            val isProvidesOrBinds = node.uAnnotations.any { it.qualifiedName in DAGGER_BINDING_ANNOTATIONS }
+            if (!isProvidesOrBinds) return
+
+            // Java methods always have an explicit return type. Only Kotlin expression-body
+            // functions can omit it via inference, so only inspect Kotlin sources.
+            val ktFunction = node.sourcePsi as? KtNamedFunction ?: return
+            if (ktFunction.typeReference == null) {
+                context.report(
+                    MISSING_EXPLICIT_RETURN_TYPE,
+                    node,
+                    context.getNameLocation(node),
+                    "@Provides/@Binds methods must declare an explicit return type for Metro compatibility. " +
+                        "Change 'fun foo(...) = expr' to 'fun foo(...): ReturnType = expr'.",
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val DAGGER_BINDING_ANNOTATIONS = setOf("dagger.Provides", "dagger.Binds")
+
+        val MISSING_EXPLICIT_RETURN_TYPE = Issue.create(
+            "MissingExplicitReturnTypeOnProvidesBinds",
+            "@Provides/@Binds method is missing an explicit return type",
+            """
+                Dagger @Provides and @Binds methods must declare an explicit return type. Metro DI
+                cannot rely on Kotlin return-type inference: it needs the declared type to wire the
+                binding into the dependency graph.
+
+                Change 'fun foo(...) = expr' to 'fun foo(...): ReturnType = expr'.
+            """.trimIndent(),
+            Category.CORRECTNESS,
+            10,
+            ERROR,
+            Implementation(
+                MissingExplicitReturnTypeOnProvidesBindsDetector::class.java,
+                EnumSet.of(JAVA_FILE, TEST_SOURCES),
+            ),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/MissingHasMemberInjectionsDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/MissingHasMemberInjectionsDetector.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiModifier
+import org.jetbrains.uast.UClass
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class MissingHasMemberInjectionsDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = Handler(context)
+
+    internal class Handler(private val context: JavaContext) : UElementHandler() {
+        override fun visitClass(node: UClass) {
+            // @HasMemberInjections is only required on non-final classes
+            if (node.hasModifierProperty(PsiModifier.FINAL)) return
+
+            // Member injection means @Inject on a field/property declaration (not a constructor param).
+            // UAST exposes Kotlin properties as fields; constructor `val`/`var` parameters are not
+            // included unless explicitly redeclared in the class body, so checking field-level
+            // @Inject is sufficient to disambiguate constructor injection from member injection.
+            val hasMemberInjection = node.fields.any { field ->
+                field.uAnnotations.any { it.qualifiedName == JAVAX_INJECT }
+            }
+            if (!hasMemberInjection) return
+
+            val hasMarker = node.uAnnotations.any { it.qualifiedName == METRO_HAS_MEMBER_INJECTIONS }
+            if (!hasMarker) {
+                context.report(
+                    MISSING_HAS_MEMBER_INJECTIONS,
+                    node,
+                    context.getNameLocation(node),
+                    "Class has @Inject members but is missing @HasMemberInjections. Metro requires this " +
+                        "marker on every class with field/property injection. Add @HasMemberInjections from " +
+                        "dev.zacsweers.metro.",
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val JAVAX_INJECT = "javax.inject.Inject"
+        private const val METRO_HAS_MEMBER_INJECTIONS = "dev.zacsweers.metro.HasMemberInjections"
+
+        val MISSING_HAS_MEMBER_INJECTIONS = Issue.create(
+            "MissingHasMemberInjections",
+            "Class with @Inject members is missing @HasMemberInjections",
+            """
+                Any class that uses field or property injection (@Inject on a member, as opposed to
+                @Inject constructor) must also be annotated with @HasMemberInjections from
+                dev.zacsweers.metro. Without this marker, Metro will not generate the member-injection
+                plumbing and the class will fail at runtime under Metro DI.
+
+                The marker must be declared on every class with @Inject members directly — including
+                concrete subclasses of bases that already declare it.
+            """.trimIndent(),
+            Category.CORRECTNESS,
+            10,
+            ERROR,
+            Implementation(MissingHasMemberInjectionsDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES)),
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -26,6 +26,9 @@ import com.duckduckgo.lint.NoFragmentDetector.Companion.NO_FRAGMENT_ISSUE
 import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion.NO_HARCODED_COROUTINE_DISPATCHER
 import com.duckduckgo.lint.NoImplImportsInAppModuleDetector.Companion.NO_IMPL_IMPORTS_IN_APP_MODULE_ISSUE
 import com.duckduckgo.lint.MetricsPixelNumericValueDetector.Companion.NUMERIC_VALUE_REQUIRED
+import com.duckduckgo.lint.MissingContributesToOnModuleDetector.Companion.MISSING_CONTRIBUTES_TO_ON_MODULE
+import com.duckduckgo.lint.MissingExplicitReturnTypeOnProvidesBindsDetector.Companion.MISSING_EXPLICIT_RETURN_TYPE
+import com.duckduckgo.lint.MissingHasMemberInjectionsDetector.Companion.MISSING_HAS_MEMBER_INJECTIONS
 import com.duckduckgo.lint.NoMetricsPixelExtensionUsageDetector.Companion.NO_METRICS_PIXEL_EXTENSION_USAGE
 import com.duckduckgo.lint.NoLifecycleObserverDetector.Companion.NO_LIFECYCLE_OBSERVER_ISSUE
 import com.duckduckgo.lint.NoLifecycleScopeInFragmentDetector.Companion.NO_LIFECYCLE_SCOPE_IN_FRAGMENT
@@ -85,6 +88,9 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             DenyListedApiDetector.ISSUE,
             NO_LIFECYCLE_SCOPE_IN_FRAGMENT,
             NO_POST_VALUE_ON_SINGLE_LIVE_EVENT,
+            MISSING_CONTRIBUTES_TO_ON_MODULE,
+            MISSING_HAS_MEMBER_INJECTIONS,
+            MISSING_EXPLICIT_RETURN_TYPE,
 
             // Android Design System
             DEPRECATED_WIDGET_IN_XML,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/MissingContributesToOnModuleDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/MissingContributesToOnModuleDetectorTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class MissingContributesToOnModuleDetectorTest {
+
+    private val daggerStubs = kt(
+        """
+        package dagger
+        annotation class Module
+        annotation class Provides
+        annotation class Binds
+        """,
+    ).indented()
+
+    private val anvilStubs = kt(
+        """
+        package com.squareup.anvil.annotations
+        import kotlin.reflect.KClass
+        annotation class ContributesTo(val scope: KClass<*>)
+        """,
+    ).indented()
+
+    private val scopeStubs = kt(
+        """
+        package com.duckduckgo.di.scopes
+        abstract class AppScope private constructor()
+        abstract class ActivityScope private constructor()
+        """,
+    ).indented()
+
+    @Test
+    fun whenObjectModuleHasNoContributesToThenFailWithError() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+
+                    @Module
+                    object FooModule
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenAbstractClassModuleHasNoContributesToThenFailWithError() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+
+                    @Module
+                    abstract class FooModule
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenInterfaceModuleHasNoContributesToThenFailWithError() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+
+                    @Module
+                    interface FooModule
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenModuleHasContributesToAppScopeThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                scopeStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import com.duckduckgo.di.scopes.AppScope
+                    import com.squareup.anvil.annotations.ContributesTo
+                    import dagger.Module
+
+                    @Module
+                    @ContributesTo(AppScope::class)
+                    object FooModule
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenModuleHasContributesToActivityScopeThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                scopeStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import com.duckduckgo.di.scopes.ActivityScope
+                    import com.squareup.anvil.annotations.ContributesTo
+                    import dagger.Module
+
+                    @Module
+                    @ContributesTo(ActivityScope::class)
+                    object FooModule
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenClassIsNotAModuleThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                anvilStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+
+                    class PlainClass {
+                        fun work() {}
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingContributesToOnModuleDetector.MISSING_CONTRIBUTES_TO_ON_MODULE)
+            .run()
+            .expectClean()
+    }
+
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/MissingExplicitReturnTypeOnProvidesBindsDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/MissingExplicitReturnTypeOnProvidesBindsDetectorTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class MissingExplicitReturnTypeOnProvidesBindsDetectorTest {
+
+    private val daggerStubs = kt(
+        """
+        package dagger
+        annotation class Module
+        annotation class Provides
+        annotation class Binds
+        """,
+    ).indented()
+
+    private val depStubs = kt(
+        """
+        package com.duckduckgo.example
+        interface Foo
+        class RealFoo : Foo
+        class Bar
+        """,
+    ).indented()
+
+    @Test
+    fun whenProvidesMethodOmitsReturnTypeThenFailWithError() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+                    import dagger.Provides
+
+                    @Module
+                    object FooModule {
+                        @Provides
+                        fun providesFoo() = RealFoo()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenProvidesMethodHasExplicitReturnTypeWithExpressionBodyThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+                    import dagger.Provides
+
+                    @Module
+                    object FooModule {
+                        @Provides
+                        fun providesFoo(): Foo = RealFoo()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenProvidesMethodHasExplicitReturnTypeWithBlockBodyThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+                    import dagger.Provides
+
+                    @Module
+                    object FooModule {
+                        @Provides
+                        fun providesFoo(): Foo {
+                            return RealFoo()
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenBindsMethodHasExplicitReturnTypeThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Binds
+                    import dagger.Module
+
+                    @Module
+                    abstract class FooModule {
+                        @Binds
+                        abstract fun bindFoo(impl: RealFoo): Foo
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenRegularFunctionWithoutAnnotationOmitsReturnTypeThenSucceed() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+
+                    object Helpers {
+                        fun makeFoo() = RealFoo()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenMultipleProvidesMethodsMissingReturnTypeThenFailForEach() {
+        lint()
+            .files(
+                daggerStubs,
+                depStubs,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dagger.Module
+                    import dagger.Provides
+
+                    @Module
+                    object FooModule {
+                        @Provides
+                        fun providesFoo() = RealFoo()
+
+                        @Provides
+                        fun providesBar() = Bar()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingExplicitReturnTypeOnProvidesBindsDetector.MISSING_EXPLICIT_RETURN_TYPE)
+            .run()
+            .expectErrorCount(2)
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/MissingHasMemberInjectionsDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/MissingHasMemberInjectionsDetectorTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class MissingHasMemberInjectionsDetectorTest {
+
+    private val injectStub = kt(
+        """
+        package javax.inject
+        annotation class Inject
+        annotation class Qualifier
+        """,
+    ).indented()
+
+    private val metroStub = kt(
+        """
+        package dev.zacsweers.metro
+        annotation class HasMemberInjections
+        """,
+    ).indented()
+
+    private val depStub = kt(
+        """
+        package com.duckduckgo.example
+        class Dep
+        class OtherDep
+        """,
+    ).indented()
+
+    @Test
+    fun whenOpenClassHasInjectMemberWithoutMarkerThenFailWithError() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+
+                    open class Foo {
+                        @Inject lateinit var dep: Dep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenOpenClassHasQualifiedInjectMemberWithoutMarkerThenFailWithError() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+                    import javax.inject.Qualifier
+
+                    @Qualifier annotation class Named
+
+                    open class Foo {
+                        @Inject @field:Named lateinit var dep: Dep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenOpenClassHasInjectMemberAndMarkerThenSucceed() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import dev.zacsweers.metro.HasMemberInjections
+                    import javax.inject.Inject
+
+                    @HasMemberInjections
+                    open class Foo {
+                        @Inject lateinit var dep: Dep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenFinalClassHasInjectMemberWithoutMarkerThenSucceed() {
+        // Kotlin classes are final by default. Final classes cannot be subclassed, so Metro does
+        // not require @HasMemberInjections on them.
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+
+                    class Foo {
+                        @Inject lateinit var dep: Dep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenClassUsesOnlyConstructorInjectionThenSucceed() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+
+                    class Foo @Inject constructor(val dep: Dep)
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenClassHasNoInjectAtAllThenSucceed() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+
+                    class Foo {
+                        var dep: Dep? = null
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenAbstractClassHasInjectMemberWithoutMarkerThenFailWithError() {
+        // Abstract bases also require @HasMemberInjections; the Metro migration declares it on
+        // every class with member injection, regardless of whether it is abstract.
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+
+                    abstract class Base {
+                        @Inject lateinit var dep: Dep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenOpenClassHasBothConstructorInjectionAndMemberInjectionWithoutMarkerThenFailWithError() {
+        lint()
+            .files(
+                injectStub,
+                metroStub,
+                depStub,
+                kt(
+                    """
+                    package com.duckduckgo.example
+                    import javax.inject.Inject
+
+                    open class Foo @Inject constructor(val a: Dep) {
+                        @Inject lateinit var b: OtherDep
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(MissingHasMemberInjectionsDetector.MISSING_HAS_MEMBER_INJECTIONS)
+            .run()
+            .expectErrorCount(1)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214119362406643/task/1214612447889130?focus=true

### Description
- Adds lint rules to prevent introducing new Metro-incompatible patterns. (54746ee6d78c3a0686870bae28e6d772ac39d78f)
- Fixes existing lint violations (ea438f81707a3fa731d39fd2faa6ebd2f6bfca2f)

### Steps to test this PR

- [ ] CI build passes
- [ ] Lint check passes

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new **error-level** lint checks that can fail builds across the repo if existing code violates the new Metro compatibility constraints.
> 
> **Overview**
> Adds three new **error-level** Android Lint detectors to block Metro-incompatible DI patterns: `@Module` declarations missing Anvil `@ContributesTo`, Kotlin `@Provides`/`@Binds` methods that rely on inferred return types, and non-final classes using member injection without Metro’s `@HasMemberInjections` marker.
> 
> Registers these new issues in `DuckDuckGoIssueRegistry` and adds dedicated lint tests covering both failure and clean cases for each rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703d6ccabb23e7b5999a8008b3d6e65ea6b25a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->