### PR TITLE
Persist NTP after-idle hatch across background

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -62,12 +62,18 @@ class FirstScreenHandlerImpl @Inject constructor(
 ) : BrowserLifecycleObserver {
 
     override fun onOpen(isFreshLaunch: Boolean) {
-        // Notify the NtpAfterIdleManager synchronously when the currently selected tab is already
-        // an NTP: BrowserViewModel's flowSelectedTab subscription can fire onNtpShown immediately
-        // on activity recreation, and the async handler path below doesn't run in time to classify
-        // it. Gated on "already on NTP" so LastOpenedTab/SpecificPage users on a URL tab don't
-        // leave a stale pendingAfterIdle flag behind for a later user-initiated NTP.
-        if (androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+        // Notify the NtpAfterIdleManager synchronously on a fresh launch when the currently
+        // selected tab is already an NTP: BrowserViewModel's flowSelectedTab subscription will
+        // fire onNtpShown immediately on activity recreation, and the async handler path below
+        // doesn't run in time to classify it.
+        //
+        // Restricted to isFreshLaunch=true: on plain background+resume, NtpAfterIdleManager
+        // preserves the prior session's classification, so the existing _isAfterIdleReturn value
+        // is correct without a fresh trigger. Setting pendingAfterIdle here would leak — no
+        // onNtpShown fires (same NTP tab), and the next user action that DOES show an NTP
+        // (e.g. opening a new tab manually) would incorrectly consume the stale pending flag.
+        if (isFreshLaunch &&
+            androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
             computeWasIdle() &&
             isCurrentSelectedTabNtp()
         ) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -72,19 +72,21 @@ class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
         when (option) {
             LastOpenedTab -> Unit
             NewTabPage -> {
-                if (fromInactivity) {
-                    // Fires regardless of whether we add a new tab: when the user is already on
-                    // an NTP, no new tab is added but the current NTP still counts as an after-idle
-                    // shown event. Gating on "new tab added" would leave that case unclassified.
-                    ntpAfterIdleManager.onIdleReturnTriggered()
-                }
                 val selectedTab = tabRepository.getSelectedTab()
                 if (selectedTab == null || !selectedTab.url.isNullOrBlank()) {
                     if (fromInactivity) {
+                        // Set pendingAfterIdle BEFORE adding the tab so BrowserViewModel's
+                        // flowSelectedTab emit consumes it via onNtpShown for the new NTP.
+                        ntpAfterIdleManager.onIdleReturnTriggered()
                         notifyAutofillIdleReturn("new_tab_page")
                     }
                     tabRepository.add()
                 }
+                // When the user is already on an NTP we deliberately don't trigger here:
+                // - If the prior session classified this NTP as auto-initiated, NtpAfterIdleManager
+                //   has preserved the state across the background; the hatch is still correct.
+                // - Setting pendingAfterIdle here would leak to the next NTP shown (e.g. a
+                //   manually-opened new tab), incorrectly classifying it as auto-initiated.
             }
             is SpecificPage -> {
                 if (fromInactivity) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -427,68 +427,84 @@ class FirstScreenHandlerImplTest {
         verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
     }
 
-    // --- Synchronous onIdleReturnTriggered (only when current tab is already an NTP) ---
+    // --- Synchronous onIdleReturnTriggered (only on fresh launch when current tab is already an NTP) ---
 
     @Test
-    fun whenIdleReturnEnabledAndIdleAndCurrentTabIsNtpThenNotifiesNtpAfterIdleManagerSynchronously() {
+    fun whenFreshLaunchAndIdleReturnEnabledAndIdleAndCurrentTabIsNtpThenNotifiesNtpAfterIdleManagerSynchronously() {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
         liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
 
         // Called synchronously from onOpen, before any coroutine advances.
         verify(ntpAfterIdleManager).onIdleReturnTriggered()
     }
 
     @Test
-    fun whenIdleReturnEnabledAndIdleAndCurrentTabHasUrlThenDoesNotNotifyNtpAfterIdleManager() {
+    fun whenNotFreshLaunchAndIdleAndCurrentTabIsNtpThenDoesNotNotifyNtpAfterIdleManager() {
+        // On plain background+resume (non-fresh) with the same NTP still selected, no new
+        // onNtpShown will fire to consume the pending flag, so triggering would leak the
+        // classification onto the next manually-shown NTP.
+        whenever(idleReturnToggle.isEnabled()).thenReturn(true)
+        whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
+        val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
+        whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
+        liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
+
+        testee.onOpen(isFreshLaunch = false)
+
+        verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
+    }
+
+    @Test
+    fun whenFreshLaunchAndIdleReturnEnabledAndIdleAndCurrentTabHasUrlThenDoesNotNotifyNtpAfterIdleManager() {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
         liveSelectedTab.value = TabEntity(tabId = "web", url = "https://example.com")
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
 
         verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }
 
     @Test
-    fun whenIdleReturnEnabledAndElapsedUnderTimeoutThenDoesNotNotifyNtpAfterIdleManager() {
+    fun whenFreshLaunchAndIdleReturnEnabledAndElapsedUnderTimeoutThenDoesNotNotifyNtpAfterIdleManager() {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         val thirtySecondsAgo = System.currentTimeMillis() - (30 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(thirtySecondsAgo)
         liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
 
         verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }
 
     @Test
-    fun whenIdleReturnEnabledAndNoPriorTimestampThenDoesNotNotifyNtpAfterIdleManager() {
+    fun whenFreshLaunchAndIdleReturnEnabledAndNoPriorTimestampThenDoesNotNotifyNtpAfterIdleManager() {
         whenever(idleReturnToggle.isEnabled()).thenReturn(true)
         whenever(idleReturnToggle.getSettings()).thenReturn("""{"defaultIdleThresholdSeconds": 300}""")
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(0L)
         liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
 
         verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }
 
     @Test
-    fun whenIdleReturnDisabledThenDoesNotNotifyNtpAfterIdleManager() {
+    fun whenFreshLaunchAndIdleReturnDisabledThenDoesNotNotifyNtpAfterIdleManager() {
         whenever(idleReturnToggle.isEnabled()).thenReturn(false)
         val sixMinutesAgo = System.currentTimeMillis() - (6 * 60 * 1000)
         whenever(settingsDataStore.lastSessionBackgroundTimestamp).thenReturn(sixMinutesAgo)
         liveSelectedTab.value = TabEntity(tabId = "ntp", url = null)
 
-        testee.onOpen(isFreshLaunch = false)
+        testee.onOpen(isFreshLaunch = true)
 
         verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -852,16 +852,18 @@ class ShowOnAppLaunchOptionHandlerImplTest {
     }
 
     @Test
-    fun whenInactivityWasIdleTrueAndOptionNewTabPageAndSelectedTabIsAlreadyNtpThenIdleReturnIsNotified() = runTest {
-        // Even when no new tab is added because the user is already on an NTP, the handler should
-        // still notify — the currently-shown NTP counts as an after-idle shown event.
+    fun whenInactivityWasIdleTrueAndOptionNewTabPageAndSelectedTabIsAlreadyNtpThenIdleReturnNotNotified() = runTest {
+        // When the user is already on an NTP, no new tab is added — and we deliberately don't
+        // call onIdleReturnTriggered(): NtpAfterIdleManager has preserved the prior session's
+        // classification across the background, and a stale pending flag here would leak onto
+        // the next NTP shown (e.g. a manually-opened new tab).
         fakeDataStore.setShowOnAppLaunchOption(NewTabPage)
         (fakeTabRepository as FakeTabRepository).selectedTab =
             TabEntity(tabId = "1", url = null, position = 0)
 
         testee.handleAfterInactivityOption(wasIdle = true)
 
-        verify(ntpAfterIdleManager).onIdleReturnTriggered()
+        verify(ntpAfterIdleManager, never()).onIdleReturnTriggered()
     }
 
     @Test

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
@@ -54,17 +54,19 @@ class NtpAfterIdleManagerImpl @Inject constructor(
     override val isAfterIdleReturn: StateFlow<Boolean> = _isAfterIdleReturn.asStateFlow()
 
     override fun onOpen(isFreshLaunch: Boolean) {
-        // pendingAfterIdle is intentionally NOT reset here. FirstScreenHandlerImpl.onOpen
-        // synchronously calls onIdleReturnTriggered() when appropriate, and BrowserLifecycleObserver
-        // callbacks run in a non-deterministic multibinding order — clearing here could wipe a
-        // just-set value. The flag is consumed by onNtpShown() (getAndSet(false)), and any residual
-        // stale state is cleared in onClose() when the app backgrounds.
-        _isAfterIdleReturn.value = false
+        // No-op. Neither pendingAfterIdle nor _isAfterIdleReturn is reset here:
+        // - pendingAfterIdle: FirstScreenHandlerImpl.onOpen may synchronously call
+        //   onIdleReturnTriggered(), and BrowserLifecycleObserver callbacks fire in a
+        //   non-deterministic multibinding order. Clearing would risk wiping a just-set value.
+        //   The flag is consumed by onNtpShown() via getAndSet(false).
+        // - _isAfterIdleReturn: must survive background+resume on the same auto-NTP.
+        //   BrowserViewModel.flowSelectedTab won't re-emit when the NTP tab hasn't changed, so
+        //   onNtpShown() doesn't fire to restore it; resetting here would leave the hatch hidden.
     }
 
     override fun onClose() {
         pendingAfterIdle.set(false)
-        _isAfterIdleReturn.value = false
+        // _isAfterIdleReturn is intentionally preserved across background; see onOpen() comment.
     }
 
     override fun onIdleReturnTriggered() {

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
@@ -54,14 +54,19 @@ class NtpAfterIdleManagerImpl @Inject constructor(
     override val isAfterIdleReturn: StateFlow<Boolean> = _isAfterIdleReturn.asStateFlow()
 
     override fun onOpen(isFreshLaunch: Boolean) {
-        // No-op. Neither pendingAfterIdle nor _isAfterIdleReturn is reset here:
-        // - pendingAfterIdle: FirstScreenHandlerImpl.onOpen may synchronously call
-        //   onIdleReturnTriggered(), and BrowserLifecycleObserver callbacks fire in a
-        //   non-deterministic multibinding order. Clearing would risk wiping a just-set value.
-        //   The flag is consumed by onNtpShown() via getAndSet(false).
-        // - _isAfterIdleReturn: must survive background+resume on the same auto-NTP.
-        //   BrowserViewModel.flowSelectedTab won't re-emit when the NTP tab hasn't changed, so
-        //   onNtpShown() doesn't fire to restore it; resetting here would leave the hatch hidden.
+        // pendingAfterIdle is intentionally NOT reset: FirstScreenHandlerImpl.onOpen may
+        // synchronously call onIdleReturnTriggered(), and BrowserLifecycleObserver callbacks fire
+        // in a non-deterministic multibinding order. Clearing would risk wiping a just-set value.
+        // The flag is consumed by onNtpShown() via getAndSet(false).
+        if (isFreshLaunch) {
+            // The singleton can carry stale state from a previous session in the same process
+            // (e.g. user swiped from recents, then re-opened). Reset so the next onNtpShown()
+            // classifies the new NTP from a clean slate.
+            _isAfterIdleReturn.value = false
+        }
+        // For non-fresh launches (background+resume), _isAfterIdleReturn must survive:
+        // BrowserViewModel.flowSelectedTab won't re-emit when the NTP tab hasn't changed, so
+        // onNtpShown() doesn't fire to restore it; resetting would leave the hatch hidden.
     }
 
     override fun onClose() {

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -159,7 +159,7 @@ class NtpAfterIdleManagerImplTest {
     }
 
     @Test
-    fun whenOnOpenThenCurrentAfterIdleIsPreserved() {
+    fun whenOnOpenNotFreshLaunchThenCurrentAfterIdleIsPreserved() {
         testee.onIdleReturnTriggered()
         testee.onNtpShown() // currentAfterIdle = true
 
@@ -167,6 +167,20 @@ class NtpAfterIdleManagerImplTest {
         testee.onReturnToPageTapped()
 
         verify(hatchPixels).fireReturnToPageTapped(afterIdle = true)
+    }
+
+    @Test
+    fun whenOnOpenFreshLaunchThenCurrentAfterIdleIsCleared() {
+        // The singleton can carry stale _isAfterIdleReturn=true from a previous session in the
+        // same process. A fresh launch must reset it so the next onNtpShown() classification
+        // doesn't inherit the previous session's state.
+        testee.onIdleReturnTriggered()
+        testee.onNtpShown() // currentAfterIdle = true (stale from prior session)
+
+        testee.onOpen(isFreshLaunch = true)
+        testee.onReturnToPageTapped()
+
+        verify(hatchPixels).fireReturnToPageTapped(afterIdle = false)
     }
 
     @Test

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -118,7 +118,7 @@ class NtpAfterIdleManagerImplTest {
         verify(hatchPixels).fireReturnToPageTapped(afterIdle = false)
     }
 
-    // --- onClose resets transient state across sessions ---
+    // --- onClose / onOpen lifecycle behaviour ---
 
     @Test
     fun whenOnCloseThenPendingAfterIdleIsCleared() {
@@ -132,14 +132,16 @@ class NtpAfterIdleManagerImplTest {
     }
 
     @Test
-    fun whenOnCloseThenCurrentAfterIdleIsCleared() {
+    fun whenOnCloseThenCurrentAfterIdleIsPreserved() {
+        // When the auto-NTP is still selected on resume, BrowserViewModel.flowSelectedTab won't
+        // re-emit and onNtpShown() won't fire — so the state must survive the background.
         testee.onIdleReturnTriggered()
         testee.onNtpShown() // currentAfterIdle = true
 
         testee.onClose()
         testee.onReturnToPageTapped()
 
-        verify(hatchPixels).fireReturnToPageTapped(afterIdle = false)
+        verify(hatchPixels).fireReturnToPageTapped(afterIdle = true)
     }
 
     @Test
@@ -157,14 +159,29 @@ class NtpAfterIdleManagerImplTest {
     }
 
     @Test
-    fun whenOnOpenThenCurrentAfterIdleIsCleared() {
+    fun whenOnOpenThenCurrentAfterIdleIsPreserved() {
         testee.onIdleReturnTriggered()
         testee.onNtpShown() // currentAfterIdle = true
 
         testee.onOpen(isFreshLaunch = false)
         testee.onReturnToPageTapped()
 
-        verify(hatchPixels).fireReturnToPageTapped(afterIdle = false)
+        verify(hatchPixels).fireReturnToPageTapped(afterIdle = true)
+    }
+
+    @Test
+    fun whenBackgroundedAndResumedOnSameAutoNtpThenAfterIdleStateSurvives() {
+        // Regression: hatch was disappearing on the second background+resume because the manager
+        // cleared currentAfterIdle on every onClose/onOpen and BrowserViewModel's flowSelectedTab
+        // doesn't re-emit when the same NTP tab stays selected.
+        testee.onIdleReturnTriggered()
+        testee.onNtpShown() // auto-NTP shown, currentAfterIdle = true
+
+        testee.onClose()
+        testee.onOpen(isFreshLaunch = false)
+        testee.onReturnToPageTapped()
+
+        verify(hatchPixels).fireReturnToPageTapped(afterIdle = true)
     }
 
     // --- onNtpSearchSubmitted classification ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214582550691757?focus=true

### Description

Fixes the bug reported in the linked task: with the escape hatch enabled, the hatch UI disappears after the second background+resume cycle while the user stays on the auto-NTP.

`NtpAfterIdleManagerImpl` was clearing `_isAfterIdleReturn` in both `onClose()` and `onOpen()`. The state is normally restored by `onNtpShown()` (fired by `BrowserViewModel.flowSelectedTab`), but that flow uses `distinctUntilChanged` on `(tabId, isUrlBlank)` and won't re-emit when the same NTP tab is still selected on resume — so the state stayed stuck at `false`. `FirstScreenHandlerImpl.onOpen()` already detects this case and synchronously sets `pendingAfterIdle = true`, but with no `onNtpShown()` to consume it the pending flag stayed unread.

This PR stops clearing `_isAfterIdleReturn` on the lifecycle callbacks. `onNtpShown()` remains the sole mutator: it correctly classifies new NTP showings (auto vs user-initiated) and the state now survives background+resume on the same auto-NTP. `pendingAfterIdle` is still cleared in `onClose()` so stale pending flags don't leak across sessions.

Aligns with the iOS behaviour confirmed in the task thread: if the NTP was automatically shown due to inactivity, backgrounding the app keeps the hatch on the next startup.

### Steps to test this PR

_Escape hatch persistence_
- [x] Set the escape hatch setting to **Always** (Settings → General → Show on app launch → After inactivity).
- [x] Visit a site (e.g. duckduckgo.com).
- [x] Switch apps and come back — confirm the hatch shows below the address bar.
- [x] Switch apps and come back again without doing anything else — **the hatch should still be visible** (this was the bug).
- [x] Repeat the background+resume a few more times — the hatch should remain visible.
- [x] Tap the hatch — confirm it switches to the previous tab and the hatch hides.

_User-initiated NTP still does not show the hatch_
- [x] Open a new tab manually (tap the new-tab button) — confirm no hatch appears.
- [x] Background and resume — the hatch should still not appear on this NTP.

_New auto-NTP after activity_
- [x] On a webpage, background long enough to trigger the after-idle return — confirm a fresh auto-NTP with the hatch.

### UI changes
No visual changes. Only the persistence behaviour of the existing hatch is corrected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle/state management for the after-idle NTP hatch, which can affect when the hatch appears/disappears across app background/resume and fresh launches. Risk is moderate due to timing/order sensitivity around lifecycle callbacks and tab selection events.
> 
> **Overview**
> Fixes a regression where the *after-idle escape hatch* disappeared after repeated background+resume while staying on the same auto-shown NTP.
> 
> `NtpAfterIdleManagerImpl` now **preserves** `_isAfterIdleReturn` across `onClose()` and non-fresh `onOpen()` (background+resume), while still resetting it on **fresh launches** to avoid stale state; `pendingAfterIdle` continues to be cleared on `onClose()`.
> 
> App-launch routing is adjusted to avoid leaking a stale pending flag: `FirstScreenHandlerImpl` only triggers `onIdleReturnTriggered()` synchronously when `isFreshLaunch` and the current tab is already an NTP, and `ShowOnAppLaunchOptionHandlerImpl` only triggers `onIdleReturnTriggered()` when it will actually add/select a new NTP tab (not when already on an NTP). Tests are updated/expanded to cover these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935ec3cb36df4ddd0fe925d1fce6bec9eec767c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->