### PR TITLE
Update content scope scripts to version 14.7.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -2663,19 +2663,20 @@
       });
       return () => unsubscribe();
     }, [messaging2]);
-    function setEnabled() {
+    async function setEnabled() {
       const values = {
         privatePlayerMode: { enabled: {} },
         overlayInteracted: false
       };
-      messaging2.setUserValues(values).then((next) => {
+      try {
+        const next = await messaging2.setUserValues(values);
         console.log("response after setUserValues...", next);
         console.log("will set", values);
         setValue(values);
-      }).catch((err) => {
+      } catch (err) {
         console.error("could not set the enabled flag", err);
         messaging2.reportPageException({ message: "could not set the enabled flag: " + err.toString() });
-      });
+      }
     }
     return /* @__PURE__ */ k(UserValuesContext.Provider, { value: { value, setEnabled } }, children);
   }
@@ -3793,7 +3794,7 @@
   function PlayerError({ kind, layout }) {
     const { t: t3 } = useTypedTranslation();
     const errors = {
-      ["invalid-id"]: /* @__PURE__ */ k("span", { dangerouslySetInnerHTML: { __html: t3("invalidIdError") } })
+      "invalid-id": /* @__PURE__ */ k("span", { dangerouslySetInnerHTML: { __html: t3("invalidIdError") } })
     };
     const text = errors[kind] || errors["invalid-id"];
     return /* @__PURE__ */ k(
@@ -3833,7 +3834,7 @@
       ];
       const cleanups = [];
       const loadHandler = () => {
-        for (let feature of iframeFeatures) {
+        for (const feature of iframeFeatures) {
           try {
             cleanups.push(feature.iframeDidLoad(iframe));
           } catch (e3) {
@@ -3847,7 +3848,7 @@
         iframe.addEventListener("load", loadHandler);
       }
       return () => {
-        for (let cleanup of cleanups) {
+        for (const cleanup of cleanups) {
           cleanup?.();
         }
         iframe.removeEventListener("load", loadHandler);
@@ -3913,16 +3914,16 @@
         }
       }
     };
-    return versions[version]?.[youtubeError] || versions[version]?.["unknown"] || versions["v1"]["unknown"];
+    return youtubeError && versions[version]?.[youtubeError] || versions[version]?.unknown || versions.v1.unknown;
   }
   function YouTubeError({ layout, embed }) {
     const youtubeError = useYouTubeError();
-    if (!youtubeError) {
-      return null;
-    }
     const { t: t3 } = useTypedTranslation();
     const openOnYoutube = useOpenOnYoutubeHandler();
     const { heading, messages, variant } = useErrorStrings(youtubeError);
+    if (!youtubeError) {
+      return null;
+    }
     const classes = (0, import_classnames10.default)(YouTubeError_default.error, {
       [YouTubeError_default.desktop]: layout === "desktop",
       [YouTubeError_default.mobile]: layout === "mobile"
@@ -3949,11 +3950,11 @@
       platform: { name: "macos" },
       customError: { state: "enabled" }
     });
-    let embed = (
+    const embed = (
       /** @type {EmbedSettings} */
       EmbedSettings.fromHref("https://localhost?videoID=123")
     );
-    let url = embed?.toEmbedUrl();
+    const url = embed?.toEmbedUrl();
     if (!url) throw new Error("unreachable");
     return /* @__PURE__ */ k(S, null, /* @__PURE__ */ k("main", { class: Components_default.main }, /* @__PURE__ */ k("div", { class: Components_default.tube }, /* @__PURE__ */ k(Wordmark, null), /* @__PURE__ */ k("h2", null, "Floating Bar"), /* @__PURE__ */ k("div", { style: "position: relative; padding-left: 10em; min-height: 150px;" }, /* @__PURE__ */ k(InfoIcon, { debugStyles: true })), /* @__PURE__ */ k("h2", null, "Info Tooltip"), /* @__PURE__ */ k(FloatingBar, null, /* @__PURE__ */ k(Button, { icon: true }, /* @__PURE__ */ k(Icon, { src: info_data_default })), /* @__PURE__ */ k(Button, { icon: true }, /* @__PURE__ */ k(Icon, { src: cog_data_default })), /* @__PURE__ */ k(Button, { fill: true }, "Open in YouTube")), /* @__PURE__ */ k("h2", null, "Info Bar"), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(SwitchProvider, null, /* @__PURE__ */ k(InfoBar, { embed }))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k("h2", null, "Mobile Switch Bar (ios)"), /* @__PURE__ */ k(SwitchProvider, null, /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })), /* @__PURE__ */ k("h2", null, "Mobile Switch Bar (android)"), /* @__PURE__ */ k(SwitchProvider, null, /* @__PURE__ */ k(SwitchBarMobile, { platformName: "android" })), /* @__PURE__ */ k("h2", null, "Desktop Switch bar"), /* @__PURE__ */ k("h3", null, "idle"), /* @__PURE__ */ k(SwitchProvider, null, /* @__PURE__ */ k(SwitchBarDesktop, null))), /* @__PURE__ */ k("h2", null, /* @__PURE__ */ k("code", null, "inset=false (desktop)")), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(Player, { src: url, layout: "desktop", embed }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed })))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "sign-in-required", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(YouTubeError, { layout: "desktop" }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed }))))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "age-restricted", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(YouTubeError, { layout: "desktop" }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed }))))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "no-embed", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(YouTubeError, { layout: "desktop" }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed }))))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "unknown", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(YouTubeError, { layout: "desktop" }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed }))))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(SettingsProvider, { settings }, /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "unknown", locale: "es" }, /* @__PURE__ */ k(PlayerContainer, null, /* @__PURE__ */ k(YouTubeError, { layout: "desktop" }), /* @__PURE__ */ k(InfoBarContainer, null, /* @__PURE__ */ k(InfoBar, { embed }))))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k("h2", null, /* @__PURE__ */ k("code", null, "inset=true (mobile)")), /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(PlayerError, { layout: "mobile", kind: "invalid-id" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" }))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "sign-in-required", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(YouTubeError, { layout: "mobile" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "age-restricted", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(YouTubeError, { layout: "mobile" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "no-embed", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(YouTubeError, { layout: "mobile" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "unknown", locale: "en" }, /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(YouTubeError, { layout: "mobile" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })))), /* @__PURE__ */ k("br", null), /* @__PURE__ */ k(YouTubeErrorProvider, { initial: "unknown", locale: "es" }, /* @__PURE__ */ k(PlayerContainer, { inset: true }, /* @__PURE__ */ k(PlayerInternal, { inset: true }, /* @__PURE__ */ k(YouTubeError, { layout: "mobile" }), /* @__PURE__ */ k(SwitchBarMobile, { platformName: "ios" })))), /* @__PURE__ */ k("br", null)));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.77.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.77.1.tgz",
-      "integrity": "sha512-/4iRDgv3M4Z1karrarDOXKWjv3ChCLdheJMGeIDh1ugCzUwrbCOK+a8L0jnH88M178Z3JYZyiKT0o9FW5uST2w==",
+      "version": "14.78.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.78.0.tgz",
+      "integrity": "sha512-8nAG08z78eRkXUKososdbJYKoz7FS0St8LiZmyIoCHpMLb/rOZHJIlPR521wmc3y7yUQcywHl8+dIOnI3f/a9A==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#19457a000e37bc566174b598f3bd534194c0002d",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -437,13 +437,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1214629478708027/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a dependency/vendor update, but it changes shipped DuckPlayer runtime JS (user value persistence and error handling), which could impact embedded player behavior on Android special pages.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` to `14.7.0` and refreshes the vendored `duckplayer` Android build output.
> 
> The updated DuckPlayer bundle switches `setEnabled` to `async/await` with `try/catch` around `setUserValues`, and includes small runtime behavior/robustness tweaks (e.g., safer YouTube error string fallback/null handling, `const` iteration for iframe feature setup/cleanup, and minor const/quoting cleanups). Package lockfile also rolls forward related transitive versions (e.g., `@duckduckgo/autoconsent`, `terser`, `@types/node`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb573cc572aee389e266fb117846e025ee3dbfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->