### PR TITLE
HashMap-based domain lookup in TdsClient

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -46,7 +46,7 @@
                 "type": "boolean"
             },
             {
-                "key": "feature.data.ext.tracker_optimization_enabled_v2",
+                "key": "feature.data.ext.tracker_optimization_enabled_v3",
                 "description": "Whether tracker evaluation optimization is enabled",
                 "type": "boolean"
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt
@@ -330,7 +330,7 @@ class RealPageLoadWideEvent @Inject constructor(
         const val KEY_ERROR_CODE = "error_code"
         const val KEY_WEBVIEW_VERSION = "webview_version"
         const val KEY_CPM_ENABLED = "cpm_enabled"
-        const val KEY_TRACKER_OPTIMIZATION_ENABLED = "tracker_optimization_enabled_v2"
+        const val KEY_TRACKER_OPTIMIZATION_ENABLED = "tracker_optimization_enabled_v3"
         const val KEY_IS_TAB_IN_FOREGROUND_ON_FINISH = "is_tab_in_foreground_on_finish"
         const val KEY_ACTIVE_REQUESTS_ON_LOAD_START = "active_requests_on_load_start"
         const val KEY_CONCURRENT_REQUESTS_ON_FINISH = "concurrent_requests_on_finish"

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 private const val ELAPSED_TIME = "elapsed_time"
 private const val WEBVIEW_VERSION = "webview_version"
 private const val CPM_ENABLED = "cpm_enabled"
-private const val TRACKER_OPTIMIZATION_ENABLED_V2 = "tracker_optimization_enabled_v2"
+private const val TRACKER_OPTIMIZATION_ENABLED_V3 = "tracker_optimization_enabled_v3"
 private const val IS_TAB_IN_FOREGROUND_ON_FINISH = "is_tab_in_foreground_on_finish"
 private const val ACTIVE_REQUESTS_ON_LOAD_START = "active_requests_on_load_start"
 private const val CONCURRENT_REQUESTS_ON_FINISH = "concurrent_requests_on_finish"
@@ -53,7 +53,7 @@ class PageLoadedOfflinePixelSender @Inject constructor(
                     ELAPSED_TIME to it.elapsedTime.toString(),
                     WEBVIEW_VERSION to it.webviewVersion,
                     CPM_ENABLED to it.cpmEnabled.toString(),
-                    TRACKER_OPTIMIZATION_ENABLED_V2 to it.trackerOptimizationEnabled.toString(),
+                    TRACKER_OPTIMIZATION_ENABLED_V3 to it.trackerOptimizationEnabled.toString(),
                     IS_TAB_IN_FOREGROUND_ON_FINISH to it.isTabInForegroundOnFinish.toString(),
                     ACTIVE_REQUESTS_ON_LOAD_START to it.activeRequestsOnLoadStart.toString(),
                     CONCURRENT_REQUESTS_ON_FINISH to it.concurrentRequestsOnFinish.toString(),

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -57,8 +57,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled. Controls the HashMap label-walk tracker-domain lookup path.
      * If the remote feature is not present defaults to `false`. Always-on for internal builds.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    @Toggle.InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun optimizeTrackerEvaluationV3(): Toggle
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -53,12 +53,13 @@ interface AndroidBrowserConfigFeature {
     fun screenLock(): Toggle
 
     /**
-     * @return `true` when the remote config has the global "optimizeTrackerEvaluationV2" androidBrowserConfig
-     * sub-feature flag enabled
-     * If the remote feature is not present defaults to `false`
+     * @return `true` when the remote config has the global "optimizeTrackerEvaluationV3" androidBrowserConfig
+     * sub-feature flag enabled. Controls the HashMap label-walk tracker-domain lookup path.
+     * If the remote feature is not present defaults to `false`. Always-on for internal builds.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun optimizeTrackerEvaluationV2(): Toggle
+    @Toggle.InternalAlwaysEnabled
+    fun optimizeTrackerEvaluationV3(): Toggle
 
     /**
      * @return `true` when the remote config has the global "errorPagePixel" androidBrowserConfig

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/OptimizeTrackerEvaluationRCWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/OptimizeTrackerEvaluationRCWrapper.kt
@@ -28,5 +28,5 @@ interface OptimizeTrackerEvaluationRCWrapper {
 class RealOptimizeTrackerEvaluationRCWrapper @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : OptimizeTrackerEvaluationRCWrapper {
-    override val enabled by lazy { androidBrowserConfigFeature.optimizeTrackerEvaluationV2().isEnabled() }
+    override val enabled by lazy { androidBrowserConfigFeature.optimizeTrackerEvaluationV3().isEnabled() }
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomain
 import com.duckduckgo.app.trackerdetection.model.Action.BLOCK
 import com.duckduckgo.app.trackerdetection.model.Action.IGNORE
 import com.duckduckgo.app.trackerdetection.model.TdsTracker
+import com.duckduckgo.common.utils.extensions.toTldPlusOne
 
 class TdsClient(
     override val name: Client.ClientName,
@@ -78,9 +79,11 @@ class TdsClient(
     }
 
     private fun findTrackerByLabelWalk(host: String): TdsTracker? {
+        val eTldPlusOne = host.toTldPlusOne()
         var candidate: String = host
         while (true) {
             trackerByDomain[candidate]?.let { return it }
+            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -79,7 +79,7 @@ class TdsClient(
     }
 
     private fun findTrackerByLabelWalk(host: String): TdsTracker? {
-        val eTldPlusOne = host.toTldPlusOne()
+        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate: String = host
         while (true) {
             trackerByDomain[candidate]?.let { return it }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -28,22 +28,19 @@ class TdsClient(
     override val name: Client.ClientName,
     private val trackers: List<TdsTracker>,
     private val urlToTypeMapper: UrlToTypeMapper,
-    private val optimizeTrackerEvaluation: Boolean,
+    private val optimizeTrackerEvaluationV3: Boolean,
 ) : Client {
+
+    private val trackerByDomain: Map<String, TdsTracker> by lazy {
+        trackers.associateBy { it.domain.value }
+    }
 
     override fun matches(
         url: String,
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val tracker = if (optimizeTrackerEvaluation) {
-            val domain = host(url)?.let { Domain(it) }
-            trackers.firstOrNull {
-                domain?.let { domain -> sameOrSubdomain(domain, it.domain) } ?: false
-            } ?: return Client.Result(matches = false, isATracker = false)
-        } else {
-            trackers.firstOrNull { sameOrSubdomain(url, it.domain.value) } ?: return Client.Result(matches = false, isATracker = false)
-        }
+        val tracker = findTracker(host(url)) ?: return Client.Result(matches = false, isATracker = false)
         val matches = matchesTrackerEntry(tracker, url, documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,
@@ -59,12 +56,7 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val tracker = if (optimizeTrackerEvaluation) {
-            val domain = url.host?.let { Domain(it) }
-            trackers.firstOrNull { sameOrSubdomain(domain, it.domain) } ?: return Client.Result(matches = false, isATracker = false)
-        } else {
-            trackers.firstOrNull { sameOrSubdomain(url, it.domain.value) } ?: return Client.Result(matches = false, isATracker = false)
-        }
+        val tracker = findTracker(url.host) ?: return Client.Result(matches = false, isATracker = false)
         val matches = matchesTrackerEntry(tracker, url.toString(), documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,
@@ -73,6 +65,26 @@ class TdsClient(
             surrogate = matches.surrogate,
             isATracker = matches.isATracker,
         )
+    }
+
+    private fun findTracker(host: String?): TdsTracker? {
+        if (host.isNullOrEmpty()) return null
+        return if (optimizeTrackerEvaluationV3) {
+            findTrackerByLabelWalk(host)
+        } else {
+            val domain = Domain(host)
+            trackers.firstOrNull { sameOrSubdomain(domain, it.domain) }
+        }
+    }
+
+    private fun findTrackerByLabelWalk(host: String): TdsTracker? {
+        var candidate: String = host
+        while (true) {
+            trackerByDomain[candidate]?.let { return it }
+            val dot = candidate.indexOf('.')
+            if (dot < 0) return null
+            candidate = candidate.substring(dot + 1)
+        }
     }
 
     private fun matchesTrackerEntry(

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -117,7 +117,12 @@ class TrackerDataLoader @Inject constructor(
     fun loadTrackers() {
         val trackers = tdsTrackerDao.getAll()
         logcat { "Loaded ${trackers.size} tds trackers from DB" }
-        val client = TdsClient(Client.ClientName.TDS, trackers, urlToTypeMapper, optimizeTrackerEvaluationRCWrapper.enabled)
+        val client = TdsClient(
+            name = Client.ClientName.TDS,
+            trackers = trackers,
+            urlToTypeMapper = urlToTypeMapper,
+            optimizeTrackerEvaluationV3 = optimizeTrackerEvaluationRCWrapper.enabled,
+        )
         trackerDetectorClientProvider.addClient(client)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pageload/PageLoadWideEventTest.kt
@@ -193,7 +193,7 @@ class PageLoadWideEventTest {
             metadata = mapOf(
                 "webview_version" to "120",
                 "cpm_enabled" to "true",
-                "tracker_optimization_enabled_v2" to "true",
+                "tracker_optimization_enabled_v3" to "true",
                 "is_tab_in_foreground_on_finish" to "true",
                 "active_requests_on_load_start" to "5",
                 "concurrent_requests_on_finish" to "2",
@@ -233,7 +233,7 @@ class PageLoadWideEventTest {
             metadata = mapOf(
                 "webview_version" to "120",
                 "cpm_enabled" to "true",
-                "tracker_optimization_enabled_v2" to "true",
+                "tracker_optimization_enabled_v3" to "true",
                 "is_tab_in_foreground_on_finish" to "false",
                 "active_requests_on_load_start" to "3",
                 "concurrent_requests_on_finish" to "0",

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientBenchmark.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientBenchmark.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.trackerdetection.Client.ClientName.TDS
+import com.duckduckgo.app.trackerdetection.api.ActionJsonAdapter
+import com.duckduckgo.app.trackerdetection.api.TdsJson
+import com.duckduckgo.app.trackerdetection.model.TdsTracker
+import com.squareup.moshi.Moshi
+import okio.buffer
+import okio.source
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import java.io.File
+import kotlin.random.Random
+
+/**
+ * Microbenchmark comparing V2 (Domain-based linear scan with cached sameOrSubdomain)
+ * and V3 (HashMap label-walk) lookup paths in [TdsClient.matches], using the actual
+ * TDS dataset bundled in the app (`R.raw.tds`).
+ *
+ * Not part of the regular test suite — the @Test method is @Ignore'd. To run, remove
+ * the @Ignore annotation on `benchmarkV2vsV3`, then:
+ *
+ *   JAVA_HOME=/path/to/java21 ./gradlew :app:testPlayDebugUnitTest \
+ *     --tests "com.duckduckgo.app.trackerdetection.TdsClientBenchmark" \
+ *     --info
+ *
+ * The `--info` flag is what makes the println output visible in Gradle's stdout.
+ *
+ * URL mix:
+ *  - 90% non-tracker URLs (synthetic `nontrackerN.example` hosts, guaranteed misses
+ *    against any real TDS entry — the dominant case the optimization targets).
+ *  - 10% tracker URLs (sampled deterministically from the loaded TDS list, half as
+ *    exact-host requests, half as `cdn.<tracker>` subdomain requests).
+ *
+ * Caveats:
+ *  - Robolectric (AndroidJUnit4) adds JVM-level overhead vs pure-JVM benchmarks.
+ *    Absolute numbers are noisier than JMH; ratios are still meaningful.
+ *  - The V2 path's `sameOrSubdomain(Domain, Domain)` cache (250k LRU) warms up
+ *    quickly on a fixed URL set, so V2's measured cost reflects the warm-cache
+ *    case — its best showing.
+ *
+ * For end-to-end production validation, query the page-load wide event in the
+ * data warehouse with `tracker_optimization_enabled_v3` as the discriminator.
+ */
+@Ignore("Microbenchmark — remove this annotation and run with --info to see results")
+@RunWith(AndroidJUnit4::class)
+class TdsClientBenchmark {
+
+    private val mockUrlToTypeMapper: UrlToTypeMapper = mock()
+
+    private lateinit var trackers: List<TdsTracker>
+    private lateinit var urls: List<String>
+
+    @Before
+    fun loadTds() {
+        val moshi = Moshi.Builder().add(ActionJsonAdapter()).build()
+        val adapter = moshi.adapter(TdsJson::class.java)
+        val tdsJson = locateTdsFile().source().buffer().use { adapter.fromJson(it) }!!
+        trackers = tdsJson.jsonToTrackers().values.toList()
+        urls = buildUrlMix(trackers)
+    }
+
+    private fun locateTdsFile(): File {
+        // Test runner CWD is usually the module root (`app/`); fall back to repo root.
+        listOf("src/main/res/raw/tds.json", "app/src/main/res/raw/tds.json").forEach {
+            val file = File(it)
+            if (file.exists()) return file
+        }
+        error("Could not locate tds.json. CWD: ${File(".").absolutePath}")
+    }
+
+    @Test
+    fun benchmarkV2vsV3() {
+        val v2Client = TdsClient(TDS, trackers, mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = false)
+        val v3Client = TdsClient(TDS, trackers, mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        repeat(WARMUP_ITERATIONS) {
+            urls.forEach { v2Client.matches(it, DOCUMENT_URL, mapOf()) }
+            urls.forEach { v3Client.matches(it, DOCUMENT_URL, mapOf()) }
+        }
+
+        val v2Total = measureNanos(v2Client)
+        val v3Total = measureNanos(v3Client)
+
+        val totalCalls = (MEASUREMENT_ITERATIONS * urls.size).toLong()
+        val v2PerCall = v2Total / totalCalls
+        val v3PerCall = v3Total / totalCalls
+
+        println("===== TdsClient V2 vs V3 microbenchmark =====")
+        println("Trackers loaded from tds.json:   ${trackers.size}")
+        println("URL mix size:                    ${urls.size} (90% non-tracker, 10% tracker)")
+        println("Warmup iterations:               $WARMUP_ITERATIONS")
+        println("Measurement iterations:          $MEASUREMENT_ITERATIONS")
+        println("Total calls per path:            $totalCalls")
+        println()
+        println("V2 (linear + cached sameOrSubdomain): $v2PerCall ns/call")
+        println("V3 (HashMap label-walk):              $v3PerCall ns/call")
+        if (v3PerCall > 0L) {
+            val speedup = v2PerCall.toDouble() / v3PerCall.toDouble()
+            println("Speedup:                              ${"%.1f".format(speedup)}x")
+        }
+        println("=============================================")
+    }
+
+    private fun measureNanos(client: TdsClient): Long {
+        val start = System.nanoTime()
+        repeat(MEASUREMENT_ITERATIONS) {
+            urls.forEach { client.matches(it, DOCUMENT_URL, mapOf()) }
+        }
+        return System.nanoTime() - start
+    }
+
+    private fun buildUrlMix(trackers: List<TdsTracker>): List<String> {
+        val random = Random(SEED)
+        val nonTracker = List(URL_MIX_NON_TRACKER) {
+            "https://nontracker$it.example/script.js"
+        }
+        val sampledTrackers = trackers.shuffled(random).take(URL_MIX_TRACKER)
+        val trackerUrls = sampledTrackers.mapIndexed { idx, tracker ->
+            if (idx % 2 == 0) {
+                "https://${tracker.domain.value}/script.js"
+            } else {
+                "https://cdn.${tracker.domain.value}/script.js"
+            }
+        }
+        return nonTracker + trackerUrls
+    }
+
+    companion object {
+        private const val URL_MIX_NON_TRACKER = 180
+        private const val URL_MIX_TRACKER = 20
+        private const val WARMUP_ITERATIONS = 5
+        private const val MEASUREMENT_ITERATIONS = 500
+        private const val SEED = 42L
+
+        private val DOCUMENT_URL = "https://example.com/page".toUri()
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -463,6 +463,34 @@ class TdsClientTest {
         assertEquals(false, result.isATracker)
     }
 
+    @Test
+    fun whenV3EnabledAndUrlIsSubdomainOfTrackerWithMultiLabelSuffixThenTrackerIsFound() {
+        val tracker = TdsTracker(Domain("tracker.co.uk"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        assertEquals(true, testee.matches("http://static.tracker.co.uk/script.js", DOCUMENT_URL, mapOf()).matches)
+    }
+
+    @Test
+    fun whenV3EnabledAndHostIsExactlyETldPlusOneThenTrackerIsFound() {
+        val tracker = TdsTracker(Domain("tracker.co.uk"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        assertEquals(true, testee.matches("http://tracker.co.uk/script.js", DOCUMENT_URL, mapOf()).matches)
+    }
+
+    @Test
+    fun whenV3EnabledAndTrackerDomainIsAPublicSuffixThenWalkStopsAtETldPlusOne() {
+        // Walk for "static.tracker.co.uk" must stop after checking "tracker.co.uk" (the eTLD+1)
+        // and must not match a tracker whose domain is a public suffix like "co.uk".
+        val tracker = TdsTracker(Domain("co.uk"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("http://static.tracker.co.uk/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
+    }
+
     companion object {
         private const val OWNER = "A Network Owner"
         private val DOCUMENT_URL = "http://example.com/index.htm".toUri()

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -491,6 +491,18 @@ class TdsClientTest {
         assertEquals(false, result.isATracker)
     }
 
+    @Test
+    fun whenV3EnabledAndHostHasNoETldPlusOneThenResultIsNoMatch() {
+        // Hosts without a resolvable eTLD+1 (single-label, IPs, public-suffix-only) must never
+        // match — even if a tracker entry exists at the exact host key.
+        val tracker = TdsTracker(Domain("localhost"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("http://localhost/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
+    }
+
     companion object {
         private const val OWNER = "A Network Owner"
         private val DOCUMENT_URL = "http://example.com/index.htm".toUri()

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -362,9 +362,9 @@ class TdsClientTest {
         }
 
         for (useUri in listOf(false, true)) {
-            for (useTestee in listOf(true, false)) {
+            for (useV3 in listOf(true, false)) {
                 val tdsTracker = TdsTracker(trackerDomain, action, OWNER, CATEGORY, rule?.let { listOf(it) } ?: emptyList())
-                val testee = TdsClient(TDS, listOf(tdsTracker), mockUrlToTypeMapper, useTestee)
+                val testee = TdsClient(TDS, listOf(tdsTracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = useV3)
                 val result = if (useUri) {
                     testee.matches(url.toUri(), DOCUMENT_URL, mapOf())
                 } else {
@@ -379,10 +379,82 @@ class TdsClientTest {
     fun whenUrlMatchesRuleWithSurrogateThenSurrogateScriptIdReturned() {
         val rule = Rule("api\\.tracker\\.com\\/auth", BLOCK, null, "script.js", null)
 
-        val testee = TdsClient(TDS, listOf(TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, listOf(rule))), mockUrlToTypeMapper, false)
+        val testee = TdsClient(TDS, listOf(TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, listOf(rule))), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = false)
 
         assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js", DOCUMENT_URL, mapOf()).surrogate)
         assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js".toUri(), DOCUMENT_URL, mapOf()).surrogate)
+    }
+
+    @Test
+    fun whenV3EnabledAndUrlHasExactHostMatchThenTrackerIsFound() {
+        val tracker = TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        assertEquals(true, testee.matches("http://tracker.com/script.js", DOCUMENT_URL, mapOf()).matches)
+        assertEquals(true, testee.matches("http://tracker.com/script.js".toUri(), DOCUMENT_URL, mapOf()).matches)
+    }
+
+    @Test
+    fun whenV3EnabledAndUrlIsSubdomainOfTrackerThenTrackerIsFound() {
+        val tracker = TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        assertEquals(true, testee.matches("http://a.b.tracker.com/script.js", DOCUMENT_URL, mapOf()).matches)
+        assertEquals(true, testee.matches("http://a.b.tracker.com/script.js".toUri(), DOCUMENT_URL, mapOf()).matches)
+    }
+
+    @Test
+    fun whenV3EnabledAndOverlappingDomainsExistThenLongestSuffixWins() {
+        val parent = TdsTracker(Domain("tracker.com"), IGNORE, OWNER, CATEGORY, emptyList())
+        val child = TdsTracker(Domain("sub.tracker.com"), BLOCK, "ChildOwner", CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(parent, child), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        // api.sub.tracker.com matches both entries; longest-suffix-wins selects sub.tracker.com (BLOCK).
+        val result = testee.matches("http://api.sub.tracker.com/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(true, result.matches)
+        assertEquals("ChildOwner", result.entityName)
+    }
+
+    @Test
+    fun whenV3EnabledAndUrlHostHasNoMatchThenResultIsNoMatch() {
+        val tracker = TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("http://nontracker.com/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
+    }
+
+    @Test
+    fun whenV3EnabledAndUrlHasNoHostThenResultIsNoMatch() {
+        val tracker = TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("not-a-url", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
+    }
+
+    @Test
+    fun whenV3EnabledAndUrlIsSingleLabelHostThenResultIsNoMatch() {
+        val tracker = TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("http://localhost/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
+    }
+
+    @Test
+    fun whenV3EnabledAndHostHasNonLabelAlignedSuffixThenNoMatch() {
+        // tracker domain is "com.example" — request to "evilcom.example" must NOT match
+        // because label-walk only follows whole labels, not suffix substrings.
+        val tracker = TdsTracker(Domain("com.example"), BLOCK, OWNER, CATEGORY, emptyList())
+        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
+
+        val result = testee.matches("http://evilcom.example/script.js", DOCUMENT_URL, mapOf())
+        assertEquals(false, result.matches)
+        assertEquals(false, result.isATracker)
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -379,7 +379,13 @@ class TdsClientTest {
     fun whenUrlMatchesRuleWithSurrogateThenSurrogateScriptIdReturned() {
         val rule = Rule("api\\.tracker\\.com\\/auth", BLOCK, null, "script.js", null)
 
-        val testee = TdsClient(TDS, listOf(TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, listOf(rule))), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = false)
+        val testee =
+            TdsClient(
+                TDS,
+                listOf(TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, listOf(rule))),
+                mockUrlToTypeMapper,
+                optimizeTrackerEvaluationV3 = false,
+            )
 
         assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js", DOCUMENT_URL, mapOf()).surrogate)
         assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js".toUri(), DOCUMENT_URL, mapOf()).surrogate)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213796972971719?focus=true

### Description
  Replaces the per-request linear scan over the full TDS tracker list in `TdsClient.matches()` with a HashMap-based label-walk lookup, gated by a new `optimizeTrackerEvaluationV3` remote feature flag.                                                                                                  
                                                                                                                                                                                                                                                                                                          
  For non-tracker URLs (the majority of subresource requests), the linear scan visits every tracker entry before returning false. The new path walks the URL host's labels upward (`api.sub.tracker.com` → `sub.tracker.com` → `tracker.com`) doing a hash lookup at each step, bounded by host label count (typically 2–4 lookups). A local microbenchmark over the real `tds.json` shows ~90x faster on a mixed URL set; production validation will come from the page-load wide event once V3 is rolled out.
                                                                                                                                                                                                                                                                                                          
  Changes:                                               
  - New `optimizeTrackerEvaluationV3` toggle on `AndroidBrowserConfigFeature` (default OFF, internal-always-enabled). The old `optimizeTrackerEvaluationV2` toggle is removed.
  - V2 (parse host once, linear scan with cached `sameOrSubdomain`) is now the **unconditional fallback** when V3 is OFF. The legacy V1 path (re-parsing host per iteration) is removed entirely.                                                                                                         
  - `OptimizeTrackerEvaluationRCWrapper` repurposed to source from the V3 toggle; consumer call sites (`PageLoadWideEvent`, `PageLoadedHandler`, `TrackerDataLoader`) are unchanged.                                                                                                                      
  - Telemetry key value renamed `tracker_optimization_enabled_v2` → `tracker_optimization_enabled_v3` in both `PageLoadWideEvent` and `PageLoadedOfflinePixelSender` so the wide-event and offline-pixel pipelines stay in sync. Deliberate metric discontinuity — downstream dashboards keyed on the old name will need updating.                                                                                                                                                                                                                                                                                
  - `TdsClientTest` re-parametrised across V2/V3 with new V3-specific tests for exact-host match, subdomain match, longest-suffix-wins, no match, null/empty host, single-label host, and non-label-aligned suffix.                                                                                       
                                                                                                                                                                                                                                                                                                          
  Rollback: disable the V3 toggle remotely → users fall back to V2, the path the majority of the user base has been on. The deprecated `optimizeTrackerEvaluationV2` remote-config entry is now unreferenced by client code.                                            
                                                                                                                                                                                                                                                                                                          
  ### Steps to test this PR                                                                                                                                                                                                                                                                               
                                                         
  _V3 enabled (default for internal builds)_                                                                                                                                                                                                                                                              
  - [x] Install the internal build; browse normally — pages load and trackers are blocked.
  - [x] Visit a tracker-heavy site (any major news site); confirm the tracker shield count is non-zero and the listed entities match what you'd see on `develop`.
  - [ ] Confirm telemetry: the `tracker_optimization_enabled_v3` field reads `true` in the page-load wide event / offline pixel.                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                          
  _V3 disabled (V2 fallback)_                                                                                                                                                                                                                                                                             
  - [ ] Disable `optimizeTrackerEvaluationV3` via remote config; confirm browsing still works and the same tracker entities are blocked on a tracker-heavy site.                                                                                                                                          
  - [ ] Confirm `tracker_optimization_enabled_v3` reads `false` in telemetry.                                                                                                                                                                                                                             
   
  _Reference test suite_                                                                                                                                                                                                                                                                                  
  - [ ] CI runs `RequestBlocklistReferenceTest`, `SurrogatesReferenceTest`, and `DomainsReferenceTest` — these are the load-bearing behavioural validation against the upstream TDS reference set. They must pass.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tracker-detection matching behavior and lookup strategy, which could impact blocking decisions or performance if edge cases regress. Also renames telemetry keys, causing metric discontinuity and requiring downstream dashboard updates.
> 
> **Overview**
> Adds a new remote-config flag `optimizeTrackerEvaluationV3` (internal-by-default) and routes `OptimizeTrackerEvaluationRCWrapper` to it.
> 
> Updates `TdsClient` to use a HashMap-backed, label-walk domain lookup when V3 is enabled (falling back to the existing subdomain scan when disabled), and wires the flag through `TrackerDataLoader`.
> 
> Renames page-load telemetry from `tracker_optimization_enabled_v2` to `tracker_optimization_enabled_v3` across wide-event definitions, `PageLoadWideEvent`, and offline pixel sending, and expands tests (plus an ignored microbenchmark) to validate V3 lookup semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3155561a628170340b1df0327e7e22bfa8eeb8f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->