### PR TITLE
Fix fire burn animation not filling the screen on tablets

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -66,6 +66,7 @@ import com.google.android.material.R as MaterialR
 private const val ANIMATION_MAX_SPEED = 1.4f
 private const val ANIMATION_SPEED_INCREMENT = 0.15f
 private const val BOTTOM_SHEET_MAX_WIDTH_DP = 640
+private const val NO_MAX_WIDTH = -1
 private const val ARG_ORIGIN = "origin"
 
 @InjectWith(FragmentScope::class)
@@ -327,6 +328,8 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
 
     private fun hideDialog() {
         binding.fireDialogRootView.gone()
+        // lift the 640dp cap so the burn animation fills the screen on tablets
+        (dialog as? BottomSheetDialog)?.behavior?.maxWidth = NO_MAX_WIDTH
     }
 
     private fun playAnimation() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214631706678033?focus=true

### Description

`SingleTabFireDialog` caps its bottom sheet at 640dp so the dialog UI doesn't stretch on tablets, but the full-screen burn animation (a child of the same sheet) was rendering in a 640dp centred band on tablets instead of filling the window — the rest of the screen sat empty.

This lifts the cap inside `hideDialog()`, which runs the moment a Delete button is tapped, *after* the dialog content has been hidden. The dialog itself still appears at 640dp; only the burn animation that follows fills the full window. Affects every fire animation (HeroFire, HeroWater, HeroAbstract) — not gated behind any feature flag, since the bug applies to the existing animations too.

### Steps to test this PR

_Tablet — portrait_
- [x] Open the app on a sw600dp+ tablet in portrait
- [x] Tap the fire button on the browser screen
- [x] Confirm the SingleTabFireDialog appears at ~640dp wide, centred (unchanged)
- [x] Tap **Delete all** (or **Delete this tab**)
- [x] Confirm the burn animation fills the full screen width — no empty bands on either side

_Tablet — landscape_
- [x] Rotate the tablet to landscape
- [x] Repeat the flow above
- [x] Confirm the dialog still caps at 640dp and the burn animation fills the full landscape width

_Phone_
- [x] On a phone (any size), tap the fire button → Delete
- [x] Confirm no regression — dialog and burn animation behave exactly as before (phone screens were already <640dp so the cap never engaged)

_Animation off_
- [x] In Settings → Fire Button, set Fire Animation to None
- [x] Tap fire → Delete on a tablet
- [x] Confirm the dialog dismisses cleanly with no animation flash

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout tweak that only adjusts `BottomSheetBehavior.maxWidth` when the dialog content is hidden to play the burn animation; minimal impact outside tablet animation presentation.
> 
> **Overview**
> Fixes the fire “burn” animation being constrained to the dialog’s 640dp max width on tablets.
> 
> When the user taps a delete action, `SingleTabFireDialog.hideDialog()` now removes the bottom sheet max-width cap (sets `maxWidth` to `-1`) so the subsequent full-screen animation can expand to the full window while keeping the initial dialog itself capped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad9522995c7fe92156486e074868639c4ee9a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->