### PR TITLE
Sync NTP content offset with widget animation frames

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -36,8 +36,22 @@ data class Margins(val top: Int, val bottom: Int)
 
 interface NativeInputAnimator {
     fun init(widgetCard: View, omnibarCard: View, omnibarWidth: Int, omnibarHeight: Int, isBottom: Boolean): Margins?
-    fun animateEnter(widgetCard: View, omnibarCard: View, widgetView: View, margins: Margins, onComplete: () -> Unit = {})
-    fun animateExit(widgetCard: View, widgetView: View, omnibarCard: View, isBottom: Boolean, onComplete: () -> Unit)
+    fun animateEnter(
+        widgetCard: View,
+        omnibarCard: View,
+        widgetView: View,
+        margins: Margins,
+        onUpdate: (fraction: Float) -> Unit = {},
+        onComplete: () -> Unit = {},
+    )
+    fun animateExit(
+        widgetCard: View,
+        widgetView: View,
+        omnibarCard: View,
+        isBottom: Boolean,
+        onUpdate: (fraction: Float) -> Unit = {},
+        onComplete: () -> Unit,
+    )
     fun cancelAnimation()
     fun applyLayoutTransitions(widgetView: View)
     fun applyLayoutTransitions(widgetView: View, isBottom: Boolean)
@@ -86,6 +100,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         omnibarCard: View,
         widgetView: View,
         margins: Margins,
+        onUpdate: (fraction: Float) -> Unit,
         onComplete: () -> Unit,
     ) {
         cancelAnimation()
@@ -104,6 +119,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 startWidth,
                 startHeight,
                 omnibarPosition,
+                onUpdate,
                 onComplete,
             )
         }
@@ -114,6 +130,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         widgetView: View,
         omnibarCard: View,
         isBottom: Boolean,
+        onUpdate: (fraction: Float) -> Unit,
         onComplete: () -> Unit,
     ) {
         cancelAnimation()
@@ -124,7 +141,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val snapshot = snapshotBeforeExit(widgetCard, omnibarCard)
 
         waitForLayout(widgetCard) {
-            performExitAnimation(widgetCard, omnibarCard, snapshot, isBottom, onComplete)
+            performExitAnimation(widgetCard, omnibarCard, snapshot, isBottom, onUpdate, onComplete)
         }
     }
 
@@ -150,6 +167,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         omnibarCard: View,
         snapshot: ExitSnapshot,
         isBottom: Boolean,
+        onUpdate: (fraction: Float) -> Unit,
         onComplete: () -> Unit,
     ) {
         val postPosition = windowPosition(widgetCard)
@@ -181,6 +199,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 (widgetCard as? MaterialCardView)?.radius = lerpF(widgetCornerRadius, omnibarCornerRadius, fraction)
                 widgetContent?.alpha = 1 - fraction
                 omnibarCard.alpha = fraction
+                onUpdate(fraction)
             },
             onEnd = {
                 omnibarCard.alpha = 1f
@@ -259,6 +278,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         startWidth: Int,
         startHeight: Int,
         omnibarPosition: Position,
+        onUpdate: (fraction: Float) -> Unit,
         onComplete: () -> Unit,
     ) {
         val offsetToOmnibar = positionCardOverOmnibar(card, omnibarPosition)
@@ -283,6 +303,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 (card as? MaterialCardView)?.radius = lerpF(omnibarCornerRadius, widgetCornerRadius, fraction)
                 widgetContent?.alpha = fraction
                 omnibarCard.alpha = 1 - fraction
+                onUpdate(fraction)
             },
             onEnd = {
                 widgetContent?.alpha = 1f

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -42,6 +42,7 @@ interface NativeInputAnimator {
         widgetView: View,
         margins: Margins,
         onUpdate: (fraction: Float) -> Unit = {},
+        onCancel: () -> Unit = {},
         onComplete: () -> Unit = {},
     )
     fun animateExit(
@@ -50,6 +51,7 @@ interface NativeInputAnimator {
         omnibarCard: View,
         isBottom: Boolean,
         onUpdate: (fraction: Float) -> Unit = {},
+        onCancel: () -> Unit = {},
         onComplete: () -> Unit,
     )
     fun cancelAnimation()
@@ -101,6 +103,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         widgetView: View,
         margins: Margins,
         onUpdate: (fraction: Float) -> Unit,
+        onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
         cancelAnimation()
@@ -120,6 +123,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 startHeight,
                 omnibarPosition,
                 onUpdate,
+                onCancel,
                 onComplete,
             )
         }
@@ -131,6 +135,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         omnibarCard: View,
         isBottom: Boolean,
         onUpdate: (fraction: Float) -> Unit,
+        onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
         cancelAnimation()
@@ -141,7 +146,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val snapshot = snapshotBeforeExit(widgetCard, omnibarCard)
 
         waitForLayout(widgetCard) {
-            performExitAnimation(widgetCard, omnibarCard, snapshot, isBottom, onUpdate, onComplete)
+            performExitAnimation(widgetCard, omnibarCard, snapshot, isBottom, onUpdate, onCancel, onComplete)
         }
     }
 
@@ -168,6 +173,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         snapshot: ExitSnapshot,
         isBottom: Boolean,
         onUpdate: (fraction: Float) -> Unit,
+        onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
         val postPosition = windowPosition(widgetCard)
@@ -201,6 +207,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 omnibarCard.alpha = fraction
                 onUpdate(fraction)
             },
+            onCancel = onCancel,
             onEnd = {
                 omnibarCard.alpha = 1f
                 onComplete()
@@ -279,6 +286,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         startHeight: Int,
         omnibarPosition: Position,
         onUpdate: (fraction: Float) -> Unit,
+        onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
         val offsetToOmnibar = positionCardOverOmnibar(card, omnibarPosition)
@@ -305,6 +313,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                 omnibarCard.alpha = 1 - fraction
                 onUpdate(fraction)
             },
+            onCancel = onCancel,
             onEnd = {
                 widgetContent?.alpha = 1f
                 omnibarCard.alpha = 1f
@@ -405,7 +414,12 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     private fun lerpF(from: Float, to: Float, fraction: Float): Float =
         from + (to - from) * fraction
 
-    private fun runAnimator(cleanup: (() -> Unit)?, onUpdate: (fraction: Float) -> Unit, onEnd: () -> Unit) {
+    private fun runAnimator(
+        cleanup: (() -> Unit)?,
+        onUpdate: (fraction: Float) -> Unit,
+        onCancel: () -> Unit = {},
+        onEnd: () -> Unit,
+    ) {
         cancelAnimation()
         animationCleanup = cleanup
         transitionAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
@@ -414,7 +428,10 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
             addUpdateListener { onUpdate(it.animatedFraction) }
             addListener(object : AnimatorListenerAdapter() {
                 private var cancelled = false
-                override fun onAnimationCancel(animation: Animator) { cancelled = true }
+                override fun onAnimationCancel(animation: Animator) {
+                    cancelled = true
+                    onCancel()
+                }
                 override fun onAnimationEnd(animation: Animator) {
                     transitionAnimator = null
                     animationCleanup = null

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -231,7 +231,13 @@ class NativeInputLayoutCoordinator(
         widgetAnimationFrameHandler = lambda@{ card ->
             if (!widgetView.isShown) return@lambda
             val parent = card.parent as? View ?: return@lambda
-            val params = card.layoutParams as? FrameLayout.LayoutParams ?: return@lambda
+            val params = card.layoutParams as? FrameLayout.LayoutParams
+            if (params == null) {
+                // Layout params don't carry position info we can project — fall back to reading
+                // the anchor's actual position for this frame.
+                applyOffset()
+                return@lambda
+            }
             val parentLocation = IntArray(2).also { parent.getLocationInWindow(it) }
             val cardVisualTopInWindow = parentLocation[1] + params.topMargin + card.translationY.toInt()
             val cardVisualBottomInWindow = cardVisualTopInWindow + params.height
@@ -254,6 +260,7 @@ class NativeInputLayoutCoordinator(
                     ntpGroup?.layoutTransition = previousNtpTransition
                     pendingContentLayoutTransition = null
                     widgetAnimationFrameHandler = null
+                    isWidgetAnimating = false
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -20,6 +20,7 @@ import android.animation.LayoutTransition
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.duckduckgo.app.browser.R
 import com.google.android.material.card.MaterialCardView
@@ -31,6 +32,20 @@ class NativeInputLayoutCoordinator(
     private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
 
     private fun View.snapshotPadding() = Padding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+
+    private var pendingContentLayoutTransition: Pair<ViewGroup, LayoutTransition>? = null
+
+    /** Set in [configureContentOffset]; invoked per-frame from the enter/exit animators. */
+    private var widgetAnimationFrameHandler: ((card: View) -> Unit)? = null
+
+    /**
+     * While true, the [configureContentOffset] layout listener no-ops. Set by the manager
+     * around `animateEnter` / `animateExit` so the snapshot/setup phases of those animators
+     * (which briefly mutate the card's layoutParams before translation is applied) don't
+     * cause the content offset to snap to an intermediate state. During the actual animation,
+     * [onWidgetAnimationFrame] drives the offset from the animator's `onUpdate`.
+     */
+    private var isWidgetAnimating: Boolean = false
 
     fun buildWidgetLayoutParams(isBottom: Boolean): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
@@ -138,16 +153,24 @@ class NativeInputLayoutCoordinator(
         val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
 
         // Animate child reflows when the widget toggles Search ↔ DuckAI changes our padding.
+        // The transition is staged here but only assigned to the parent once the enter animation
+        // completes (see enableContentLayoutTransition). Otherwise the per-frame setPadding
+        // calls during the enter animation would each spawn a fresh CHANGING animator and the
+        // content would visibly lag behind the widget growth.
         val ntpGroup = newTabContent as? ViewGroup
         val previousNtpTransition = ntpGroup?.layoutTransition
-        ntpGroup?.layoutTransition = LayoutTransition().apply {
-            disableTransitionType(LayoutTransition.APPEARING)
-            disableTransitionType(LayoutTransition.DISAPPEARING)
-            disableTransitionType(LayoutTransition.CHANGE_APPEARING)
-            disableTransitionType(LayoutTransition.CHANGE_DISAPPEARING)
-            enableTransitionType(LayoutTransition.CHANGING)
-            setDuration(RealNativeInputAnimator.ANIMATION_DURATION_MS)
-            setAnimateParentHierarchy(false)
+        if (ntpGroup != null) {
+            pendingContentLayoutTransition =
+                ntpGroup to
+                LayoutTransition().apply {
+                    disableTransitionType(LayoutTransition.APPEARING)
+                    disableTransitionType(LayoutTransition.DISAPPEARING)
+                    disableTransitionType(LayoutTransition.CHANGE_APPEARING)
+                    disableTransitionType(LayoutTransition.CHANGE_DISAPPEARING)
+                    enableTransitionType(LayoutTransition.CHANGING)
+                    setDuration(RealNativeInputAnimator.ANIMATION_DURATION_MS)
+                    setAnimateParentHierarchy(false)
+                }
         }
 
         fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
@@ -181,13 +204,7 @@ class NativeInputLayoutCoordinator(
             }
         }
 
-        fun applyOffset() {
-            if (!widgetView.isShown) {
-                targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
-                return
-            }
-            val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
-            val anchorBottomInWindow = anchorLocation[1] + anchor.height
+        fun applyOffsetWithBottom(anchorBottomInWindow: Int) {
             val deltaBottom = computeDeltaBottom()
             targets.forEach { target ->
                 val deltaTop = computeDeltaTop(target.view, anchorBottomInWindow)
@@ -195,9 +212,36 @@ class NativeInputLayoutCoordinator(
             }
         }
 
+        fun applyOffset() {
+            if (!widgetView.isShown) {
+                targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
+                return
+            }
+            val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
+            val anchorBottomInWindow = anchorLocation[1] + anchor.height
+            applyOffsetWithBottom(anchorBottomInWindow)
+        }
+
+        // Called from the enter/exit animators' onUpdate, BEFORE the layout pass that
+        // processes the new card layoutParams. We project the card's current visual bottom
+        // from the values the animator has just written (layoutParams + translation), so the
+        // setPadding here and the card's own requestLayout coalesce into the same
+        // measure/layout pass — content tracks the widget's growth/shrinkage in the same
+        // frame instead of lagging by one.
+        widgetAnimationFrameHandler = lambda@{ card ->
+            if (!widgetView.isShown) return@lambda
+            val parent = card.parent as? View ?: return@lambda
+            val params = card.layoutParams as? FrameLayout.LayoutParams ?: return@lambda
+            val parentLocation = IntArray(2).also { parent.getLocationInWindow(it) }
+            val cardVisualTopInWindow = parentLocation[1] + params.topMargin + card.translationY.toInt()
+            val cardVisualBottomInWindow = cardVisualTopInWindow + params.height
+            applyOffsetWithBottom(cardVisualBottomInWindow)
+        }
+
         widgetView.post { applyOffset() }
         val layoutListener =
             View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                if (isWidgetAnimating) return@OnLayoutChangeListener
                 applyOffset()
             }
         widgetView.addOnLayoutChangeListener(layoutListener)
@@ -208,6 +252,8 @@ class NativeInputLayoutCoordinator(
 
                 override fun onViewDetachedFromWindow(v: View) {
                     ntpGroup?.layoutTransition = previousNtpTransition
+                    pendingContentLayoutTransition = null
+                    widgetAnimationFrameHandler = null
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
                     }
@@ -217,6 +263,20 @@ class NativeInputLayoutCoordinator(
                 }
             },
         )
+    }
+
+    fun onWidgetAnimationFrame(card: View) {
+        widgetAnimationFrameHandler?.invoke(card)
+    }
+
+    fun setWidgetAnimating(animating: Boolean) {
+        isWidgetAnimating = animating
+    }
+
+    fun enableContentLayoutTransition() {
+        val (ntpGroup, transition) = pendingContentLayoutTransition ?: return
+        ntpGroup.layoutTransition = transition
+        pendingContentLayoutTransition = null
     }
 
     fun applyForcedBottomTranslation(widgetView: View, isBottom: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -194,6 +194,7 @@ class RealNativeInputManager @Inject constructor(
                 omnibarCard = omnibarCard,
                 isBottom = isBottom,
                 onUpdate = { layoutCoordinator.onWidgetAnimationFrame(card) },
+                onCancel = { layoutCoordinator.setWidgetAnimating(false) },
                 onComplete = {
                     layoutCoordinator.setWidgetAnimating(false)
                     isExiting = false
@@ -591,6 +592,7 @@ class RealNativeInputManager @Inject constructor(
             widgetView = widgetView,
             margins = margins,
             onUpdate = { layoutCoordinator.onWidgetAnimationFrame(widgetCard) },
+            onCancel = { layoutCoordinator.setWidgetAnimating(false) },
             onComplete = {
                 layoutCoordinator.setWidgetAnimating(false)
                 onEnterComplete(widgetView)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -187,10 +187,19 @@ class RealNativeInputManager @Inject constructor(
         val isBottom = widgetFrom(widgetView)?.isWidgetBottom() ?: false
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
-            animator.animateExit(card, widgetView, omnibarCard, isBottom) {
-                isExiting = false
-                onHide()
-            }
+            layoutCoordinator.setWidgetAnimating(true)
+            animator.animateExit(
+                widgetCard = card,
+                widgetView = widgetView,
+                omnibarCard = omnibarCard,
+                isBottom = isBottom,
+                onUpdate = { layoutCoordinator.onWidgetAnimationFrame(card) },
+                onComplete = {
+                    layoutCoordinator.setWidgetAnimating(false)
+                    isExiting = false
+                    onHide()
+                },
+            )
         } else {
             isExiting = false
             onHide()
@@ -575,11 +584,23 @@ class RealNativeInputManager @Inject constructor(
         val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 
-        animator.animateEnter(widgetCard, omnibarCard, widgetView, margins) { onEnterComplete(widgetView) }
+        layoutCoordinator.setWidgetAnimating(true)
+        animator.animateEnter(
+            widgetCard = widgetCard,
+            omnibarCard = omnibarCard,
+            widgetView = widgetView,
+            margins = margins,
+            onUpdate = { layoutCoordinator.onWidgetAnimationFrame(widgetCard) },
+            onComplete = {
+                layoutCoordinator.setWidgetAnimating(false)
+                onEnterComplete(widgetView)
+            },
+        )
         return true
     }
 
     private fun onEnterComplete(widgetView: View) {
+        layoutCoordinator.enableContentLayoutTransition()
         if (omnibarController.isDuckAiMode()) return
         omnibarController.hide()
         widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)


### PR DESCRIPTION
Task/Issue URL:

### Description

Stacked on top of #8501. Polishes the NTP enter/exit animation so the
content padding tracks the widget card in the same frame instead of
lagging by one.

The widget enter/exit animations resize the widget card through its
layoutParams. NTP content padding was tracking the card via a
LayoutTransition CHANGING animator, but each per-frame setPadding
spawned a fresh transition animator, so the content visibly lagged a
frame behind the widget growth/shrinkage.

Changes:
- `NativeInputAnimator` gains an `onUpdate(fraction)` callback on
  `animateEnter` / `animateExit`, fired from the same ValueAnimator
  that drives the card geometry.
- `NativeInputLayoutCoordinator` computes content padding from the
  card's current `layoutParams + translationY` on every onUpdate, so
  the padding pass coalesces with the card's `requestLayout` in the
  same measure/layout cycle. The CHANGING `LayoutTransition` on the
  NTP group is staged on first configure but only installed once the
  enter animation completes, so later Search ↔ DuckAI toggles still
  animate smoothly.
- `NativeInputManager` flips a `setWidgetAnimating` guard around
  enter/exit and forwards onUpdate frames to the coordinator.

### Steps to test this PR

_NTP enter animation_
- [ ] Open a new tab and trigger the native input widget; NTP content
      below should track the widget card growth without a one-frame
      lag.

_NTP exit animation_
- [ ] Dismiss the native input widget from NTP; content should track
      the widget shrinking back to the omnibar without a snap or lag.

_Search ↔ DuckAI toggle_
- [ ] After the enter animation, toggle Search ↔ DuckAI; the content
      padding should still animate smoothly via the LayoutTransition.

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches enter/exit animation and per-frame layout/padding calculations for the native input widget/NTP, which can cause UI jank or incorrect offsets if the new frame projection or transition staging is wrong.
> 
> **Overview**
> Improves the native input widget enter/exit experience by syncing New Tab Page (NTP) content padding updates to the same `ValueAnimator` frames that resize/translate the widget card, eliminating the previous one-frame lag.
> 
> `NativeInputAnimator` now exposes `onUpdate` and `onCancel` callbacks for `animateEnter`/`animateExit` (and propagates cancel handling through `runAnimator`). `NativeInputLayoutCoordinator` adds per-frame offset projection from the card’s `layoutParams` + `translationY`, guards layout listeners while animations run, and **stages** the NTP `LayoutTransition` so it’s only enabled after enter completes (keeping later Search ↔ DuckAI padding changes animated without fighting the enter animation). `NativeInputManager` wires these pieces together by toggling the animating guard and forwarding animator updates/cancel/complete events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9572b9c0dcaaec85c21d624634ade4e1f2e07c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->