### PR TITLE
Fix lint for Metro build

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -3752,17 +3752,6 @@
 
     <issue
         id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val bookmarkRootRelations = savedSitesRelationsDao.relations(SavedSitesNames.BOOKMARKS_ROOT).first()"
-        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/bookmarks/mapper/migration/BookmarksMigrationTest.kt"
-            line="262"
-            column="37"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
         message="Deprecated and may not be reliable. Use AppBuildConfig.isNewInstall() to check for new installs, or PackageInfo.firstInstallTime / lastUpdateTime if you need the actual timestamp."
         errorLine1="        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(1)"
         errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -4115,94 +4104,6 @@
 
     <issue
         id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val rootRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_ROOT).first()"
-        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="96"
-            column="29"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val nativeRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_MOBILE_ROOT).first()"
-        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="97"
-            column="31"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val desktopRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_DESKTOP_ROOT).first()"
-        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="114"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val nativeRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_MOBILE_ROOT).first()"
-        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="115"
-            column="31"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val rootRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_ROOT).first()"
-        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="116"
-            column="29"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val desktopRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_DESKTOP_ROOT).first()"
-        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="134"
-            column="32"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val nativeRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_MOBILE_ROOT).first()"
-        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="135"
-            column="31"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        val rootRelations = savedSitesRelationsDao.relations(SavedSitesNames.FAVORITES_ROOT).first()"
-        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/sync/RealSavedSitesFormFactorSyncMigrationTest.kt"
-            line="136"
-            column="29"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
         message="No one remembers what these constants map to. Use the API level integer value directly since it&apos;s self-defining."
         errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {"
         errorLine2="                                     ~~~~~~~~~~~~~~~~~~~~~">
@@ -4221,17 +4122,6 @@
             file="src/main/java/com/duckduckgo/app/browser/certificates/remoteconfig/SSLCertificatesFeature.kt"
             line="71"
             column="58"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        Assert.assertEquals(listOf(bookmark), repository.getBookmarks().first())"
-        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt"
-            line="409"
-            column="47"/>
     </issue>
 
     <issue
@@ -4529,17 +4419,6 @@
             file="src/androidTest/java/com/duckduckgo/app/fire/UnsentForgetAllPixelStoreSharedPreferencesTest.kt"
             line="33"
             column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="first() will throw if flow is empty, firstOrNull() it&apos;s a safer option."
-        errorLine1="        assertEquals(1, dao.allDomainsFlow().first().size)"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/androidTest/java/com/duckduckgo/app/privacy/db/UserAllowListDaoTest.kt"
-            line="72"
-            column="25"/>
     </issue>
 
     <issue

--- a/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
@@ -48,22 +48,26 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
         DenyListedEntry(
             className = "kotlinx.coroutines.flow.FlowKt__ReduceKt",
             functionName = "first",
-            errorMessage = "first() will throw if flow is empty, firstOrNull() it's a safer option."
+            errorMessage = "first() will throw if flow is empty, firstOrNull() it's a safer option.",
+            allowInTests = true,
         ),
         DenyListedEntry(
             className = "kotlinx.coroutines.flow.FlowKt__ReduceKt",
             functionName = "last",
-            errorMessage = "last() will throw if there's not at least one item, lastOrNull() it's a safer option."
+            errorMessage = "last() will throw if there's not at least one item, lastOrNull() it's a safer option.",
+            allowInTests = true,
         ),
         DenyListedEntry(
             className = "com.duckduckgo.feature.toggles.api.Toggle",
             functionName = "setRawStoredState",
-            errorMessage = "If you find yourself using this API in production, you're doing something wrong!!"
+            errorMessage = "If you find yourself using this API in production, you're doing something wrong!!",
+            allowInTests = true,
         ),
         DenyListedEntry(
             className = "com.duckduckgo.feature.toggles.api.Toggle",
             functionName = "getRawStoredState",
-            errorMessage = "If you find yourself using this API in production, you're doing something wrong!!"
+            errorMessage = "If you find yourself using this API in production, you're doing something wrong!!",
+            allowInTests = true,
         ),
         DenyListedEntry(
             className = "com.duckduckgo.feature.toggles.api.FeatureTogglesPlugin",
@@ -177,6 +181,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
                     typeConfig.functionEntries.getOrDefault(MATCH_ALL, emptyList())
 
                 deniedFunctions.forEach { denyListEntry ->
+                    if (denyListEntry.allowInTests && context.isTestSource) return@forEach
                     if (denyListEntry.parametersMatchWith(function) && denyListEntry.argumentsMatchWith(node)) {
                         context.report(
                             issue = ISSUE,
@@ -206,6 +211,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
                     typeConfig.referenceEntries.getOrDefault(MATCH_ALL, emptyList())
 
                 deniedFunctions.forEach { denyListEntry ->
+                    if (denyListEntry.allowInTests && context.isTestSource) return@forEach
                     context.report(
                         issue = ISSUE,
                         location = context.getLocation(node),
@@ -290,6 +296,8 @@ data class DenyListedEntry(
     /** Argument expressions to match at the call site, or null to match all invocations. */
     val arguments: List<String>? = null,
     val errorMessage: String,
+    /** When true, this entry is not reported in test sources (`src/test/...`, `src/androidTest/...`). */
+    val allowInTests: Boolean = false,
 ) {
     init {
         require((functionName == null) xor (fieldName == null)) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214654883579438?focus=true

### Description
When running lint checks on Metro variant, there were over 264 errors flagged, all of them under the `src/test` and `src/androidTest` source-sets:
* _"If you find yourself using this API in production, you're doing something wrong!!"_ (`Toggle.setRawStoredState` / `Toggle.getRawStoredState`)
* "_first() will throw if flow is empty, firstOrNull() it's a safer option."_ (`Flow.first()`)

Instead of adding all errors to the baseline, we've updated the `DenyListedApiDetector` to ignore those errors for test files.

### Steps to test this PR

_Verify lint on both DI build variants_
- [ ] Run `./gradlew assembleInternalDebug -Pforce-default-variant -Pskip-onboarding -Pddg.di=Metro -x lint`
- [ ] Run `./gradlew assembleInternalDebug -Pforce-default-variant -Pskip-onboarding -x lint`

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect custom lint reporting by skipping selected deny-list violations in `src/test` and `src/androidTest`, without altering production code behavior.
> 
> **Overview**
> Updates the custom `DenyListedApiDetector` to support per-entry `allowInTests`, and uses it to *suppress deny-listed API reports in test sources* for `Flow.first/last` and toggle raw-state APIs.
> 
> Cleans up `app/lint-baseline.xml` by removing baseline entries that are no longer reported once those checks are ignored in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c06719a1b5ca1cbe75a772cdc5b5ce36642c26c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->