### PR TITLE
Add OS version to purchase pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -117,7 +117,7 @@
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["atb", "appVersion", "freeTrial"]
+        "parameters": ["atb", "appVersion", "freeTrial", "osVersion"]
     },
     "m_subscribe": {
         "description": "Fired when a subscription purchase completes, capturing purchase origin and locale.",
@@ -147,11 +147,7 @@
         "parameters": [
             "appVersion",
             "petal",
-            {
-                "key": "os_version",
-                "description": "OS version of the device",
-                "type": "integer"
-            }
+            "osVersion"
         ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -144,10 +144,6 @@
         "owners": ["lmac012"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": [
-            "appVersion",
-            "petal",
-            "osVersion"
-        ]
+        "parameters": ["appVersion", "petal", "osVersion"]
     }
 }

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -9,6 +9,11 @@
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
         "examples": ["0.89.3"]
     },
+    "osVersion": {
+        "key": "os_version",
+        "type": "integer",
+        "description": "OS version of the device"
+    },
     "atb": {
         "key": "atb",
         "type": "string",

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -184,7 +184,13 @@ class SubscriptionPixelSenderImpl @Inject constructor(
         fire(PURCHASE_FAILURE_ACCOUNT_CREATION)
 
     override fun reportPurchaseSuccess(isFreeTrial: Boolean) =
-        fire(PURCHASE_SUCCESS, mapOf(SubscriptionPixelParameter.FREE_TRIAL to isFreeTrial.toString()))
+        fire(
+            PURCHASE_SUCCESS,
+            mapOf(
+                SubscriptionPixelParameter.FREE_TRIAL to isFreeTrial.toString(),
+                SubscriptionPixelParameter.OS_VERSION to appBuildConfig.sdkInt.toString(),
+            ),
+        )
 
     override fun reportPurchaseSuccessOrigin(origin: String?, isFreeTrial: Boolean) {
         val map = mutableMapOf(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209991789468715/task/1213641618459911?focus=true

### Description
Add OS param to purchase pixel

### Steps to test this PR

- [ ] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [ ] Purchase a test subscription
- [ ] Check in logcat that pixel is sent with new param `Pixel sent: m_privacy-pro_app_subscription-purchase_success_c with params: {free_trial=false, os_version=36} {}`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change that adds an extra parameter to an existing subscription purchase success pixel; main risk is downstream analytics/schema expectations for the new `os_version` field.
> 
> **Overview**
> Adds device OS version (`os_version`) as a first-class pixel parameter and includes it in the subscription purchase success telemetry.
> 
> Updates the pixel definitions to reference a shared `osVersion` param (including refactoring the active-subscription daily pixel to use it), and extends `SubscriptionPixelSender.reportPurchaseSuccess` to send `os_version` using `AppBuildConfig.sdkInt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fad2c8ea3435b34028aa720e229c95329ca81b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->