### PR TITLE
Onboarding Brand Design Update: Copy and copy related layout changes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -68,6 +68,7 @@ import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.google.android.material.button.MaterialButton
 import kotlin.collections.forEachIndexed
 import kotlin.collections.toMutableList
@@ -1495,7 +1496,7 @@ sealed class DaxBubbleCta(
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA
 
             val daxTitle = container.context.getString(title)
-            val daxDescription = container.context.getString(description)
+            val daxDescription = container.context.getString(description).preventWidows()
 
             val titleView = container.findViewById<DaxTypeAnimationTextView>(R.id.brandDesignTitle)
             val hiddenTitle = container.findViewById<DaxTextView>(R.id.brandDesignHiddenTitle)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCta.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxEndBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -48,8 +49,9 @@ data class DaxEndBrandDesignUpdateContextualCta(
     override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override fun configureContentViews(view: View) {
-        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)
-            ?.setText(R.string.onboardingEndDaxDialogDescription)
+        val context = view.context
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
+            context.getString(R.string.onboardingEndDaxDialogDescription).preventWidows()
     }
 
     override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCta.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxMainNetworkBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -55,7 +56,7 @@ data class DaxMainNetworkBrandDesignUpdateContextualCta(
     override fun configureContentViews(view: View) {
         val context = view.context
         view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.apply {
-            text = getTrackersDescription(context).html(context)
+            text = getTrackersDescription(context).preventWidows().html(context)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCta.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxNoTrackersBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -49,7 +50,7 @@ data class DaxNoTrackersBrandDesignUpdateContextualCta(
     override fun configureContentViews(view: View) {
         val context = view.context
         view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
-            context.getString(R.string.daxNonSerpCtaText).html(context)
+            context.getString(R.string.daxNonSerpCtaText).preventWidows().html(context)
     }
 
     override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCta.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.onboarding.ui.view.DaxTypeAnimationTextView
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxSerpBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -47,10 +48,11 @@ data class DaxSerpBrandDesignUpdateContextualCta(
     override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override fun configureContentViews(view: View) {
+        val context = view.context
         view.findViewById<DaxTypeAnimationTextView>(R.id.contextualBrandDesignTitle)
             ?.setText(R.string.onboardingSerpDaxDialogBrandDesignTitle)
-        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)
-            ?.setText(R.string.onboardingSerpDaxDialogBrandDesignDescription)
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
+            context.getString(R.string.onboardingSerpDaxDialogBrandDesignDescription).preventWidows()
     }
 
     override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCta.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxSiteSuggestionsBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -54,7 +55,7 @@ data class DaxSiteSuggestionsBrandDesignUpdateContextualCta(
         view.findViewById<DaxTypeAnimationTextView>(R.id.contextualBrandDesignTitle)
             .text = context.getString(R.string.onboardingSitesSuggestionsDaxDialogTitle).html(context)
         view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)
-            .text = context.getString(R.string.onboardingSitesDaxDialogDescription).html(context)
+            .text = context.getString(R.string.onboardingSitesDaxDialogDescription).preventWidows().html(context)
 
         val options = onboardingStore.getSitesOptions()
         val optionsViews = listOf(

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCta.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.view.button.DaxButtonPrimary
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 
 data class DaxTrackersBlockedBrandDesignUpdateContextualCta(
     override val onboardingStore: OnboardingStore,
@@ -56,7 +57,7 @@ data class DaxTrackersBlockedBrandDesignUpdateContextualCta(
     override fun configureContentViews(view: View) {
         val context = view.context
         view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
-            getTrackersDescription(context, trackers).html(context)
+            getTrackersDescription(context, trackers).preventWidows().html(context)
     }
 
     override fun onTypingAnimationSettled(onTypingAnimationFinished: () -> Unit) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateDefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateDefaultBrowserPage.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.button.DaxButton
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.di.scopes.FragmentScope
 import logcat.LogPriority.WARN
 import logcat.asLog
@@ -202,14 +203,14 @@ class BrandDesignUpdateDefaultBrowserPage :
 
     private fun setUiForDialog() {
         // Brand-design variant uses a single placeholder illustration for both states; only copy varies.
-        subtitle.setText(R.string.defaultBrowserDescriptionNoDefault)
+        subtitle.text = getString(R.string.defaultBrowserDescriptionNoDefault).preventWidows()
         title.setText(R.string.onboardingDefaultBrowserTitle)
         primaryButton.setText(R.string.setAsDefaultBrowser)
         setButtonsBehaviour()
     }
 
     private fun setUiForSettings() {
-        subtitle.setText(R.string.onboardingDefaultBrowserDescription)
+        subtitle.text = getString(R.string.onboardingDefaultBrowserDescription).preventWidows()
         title.setText(R.string.onboardingDefaultBrowserTitle)
         primaryButton.setText(R.string.setAsDefaultBrowser)
         setButtonsBehaviour()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -657,7 +657,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                     getString(R.string.preOnboardingWelcomeDialogTitle),
                                 ) {
                                     val animators = mutableListOf<Animator>(
-                                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText, View.ALPHA, 1f)
+                                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
+                                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
+                                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText2, View.ALPHA, 1f)
                                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.primaryCta, View.ALPHA, 1f)
                                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
@@ -889,7 +891,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     val fadeOutAnimators = listOf<Animator>(
                         ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.titleText, View.ALPHA, 0f)
                             .setDuration(OUTRO_FADE_DURATION),
-                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText, View.ALPHA, 0f)
+                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 0f)
+                            .setDuration(OUTRO_FADE_DURATION),
+                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText2, View.ALPHA, 0f)
                             .setDuration(OUTRO_FADE_DURATION),
                         ObjectAnimator.ofFloat(binding.daxDialogCta.primaryCta, View.ALPHA, 0f)
                             .setDuration(OUTRO_FADE_DURATION),
@@ -903,8 +907,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             override fun onAnimationEnd(animation: Animator) {
                                 binding.daxDialogCta.welcomeContent.hiddenTitleText.text =
                                     getString(R.string.preOnboardingDaxDialog3Title)
-                                binding.daxDialogCta.welcomeContent.bodyText.text =
+                                binding.daxDialogCta.welcomeContent.bodyText1.text =
                                     getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
+                                binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
 
                                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                                 binding.daxDialogCta.welcomeContent.titleText.text = ""
@@ -918,7 +923,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                 ) {
                                     skipOnboardingFadeInAnimatorSet = AnimatorSet().apply {
                                         playTogether(
-                                            ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText, View.ALPHA, 1f)
+                                            ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
                                                 .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                                             ObjectAnimator.ofFloat(binding.daxDialogCta.primaryCta, View.ALPHA, 1f)
                                                 .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
@@ -1255,7 +1260,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.welcomeContent.root.alpha = 1f
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                 binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingWelcomeDialogTitle)
-                binding.daxDialogCta.welcomeContent.bodyText.alpha = 1f
+                binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
+                binding.daxDialogCta.welcomeContent.bodyText2.alpha = 1f
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
                 if (onboardingDialogType == INITIAL_REINSTALL_USER) {
@@ -1356,9 +1362,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                 binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingDaxDialog3Title)
                 binding.daxDialogCta.welcomeContent.titleText.alpha = 1f
-                binding.daxDialogCta.welcomeContent.bodyText.text =
+                binding.daxDialogCta.welcomeContent.bodyText1.text =
                     getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
-                binding.daxDialogCta.welcomeContent.bodyText.alpha = 1f
+                binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
+                binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
 
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog3Button)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1245,6 +1245,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.Welcome)
 
+                binding.daxDialogCta.secondaryCta.visibility =
+                    if (onboardingDialogType == INITIAL_REINSTALL_USER) View.INVISIBLE else View.GONE
+
                 val showWalkingDax = applyWalkingDaxLayout()
                 if (showWalkingDax) {
                     with(binding.welcomeScreenWalkingDax) {
@@ -1346,6 +1349,16 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.welcomeTitle.alpha = 0f
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.Welcome)
 
+                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+                binding.daxDialogCta.welcomeContent.root.isVisible = true
+                binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(R.string.preOnboardingDaxDialog3Title)
+                binding.daxDialogCta.welcomeContent.bodyText1.text =
+                    getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
+                binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
+                binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog3Button)
+                binding.daxDialogCta.secondaryCta.text = getString(R.string.preOnboardingDaxDialog3SecondaryButton)
+                binding.daxDialogCta.secondaryCta.visibility = View.INVISIBLE
+
                 val showWalkingDax = applyWalkingDaxLayout()
                 if (showWalkingDax) {
                     with(binding.welcomeScreenWalkingDax) {
@@ -1356,24 +1369,16 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                 }
 
-                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
-                binding.daxDialogCta.welcomeContent.root.isVisible = true
-                binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(R.string.preOnboardingDaxDialog3Title)
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                 binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingDaxDialog3Title)
                 binding.daxDialogCta.welcomeContent.titleText.alpha = 1f
-                binding.daxDialogCta.welcomeContent.bodyText1.text =
-                    getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
                 binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
-                binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
 
                 binding.daxDialogCta.primaryCta.alpha = 1f
-                binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog3Button)
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
 
                 binding.daxDialogCta.secondaryCta.isVisible = true
                 binding.daxDialogCta.secondaryCta.alpha = 1f
-                binding.daxDialogCta.secondaryCta.text = getString(R.string.preOnboardingDaxDialog3SecondaryButton)
                 binding.daxDialogCta.secondaryCta.setOnClickListener { viewModel.onSecondaryCtaClicked() }
 
                 binding.daxDialogCta.root.isVisible = true

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -79,6 +79,7 @@ import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.isTablet
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.FragmentScope
 import kotlinx.coroutines.Job
@@ -908,7 +909,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                 binding.daxDialogCta.welcomeContent.hiddenTitleText.text =
                                     getString(R.string.preOnboardingDaxDialog3Title)
                                 binding.daxDialogCta.welcomeContent.bodyText1.text =
-                                    getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
+                                    getString(R.string.preOnboardingDaxDialog3Text).preventWidows().html(requireContext())
                                 binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
 
                                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
@@ -1094,7 +1095,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.comparisonChartContent.root.isVisible = false
                     binding.daxDialogCta.addressBarContent.root.isVisible = false
 
-                    val descriptionText = getString(R.string.preOnboardingInputScreenDescription)
+                    val descriptionText = getString(R.string.preOnboardingInputScreenDescription).preventWidows()
                     binding.daxDialogCta.inputScreenContent.inputScreenDescription.text = descriptionText.html(requireContext())
 
                     binding.daxDialogCta.inputScreenContent.root.isVisible = true
@@ -1353,7 +1354,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.welcomeContent.root.isVisible = true
                 binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(R.string.preOnboardingDaxDialog3Title)
                 binding.daxDialogCta.welcomeContent.bodyText1.text =
-                    getString(R.string.preOnboardingDaxDialog3Text).html(requireContext())
+                    getString(R.string.preOnboardingDaxDialog3Text).preventWidows().html(requireContext())
                 binding.daxDialogCta.welcomeContent.bodyText2.isGone = true
                 binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog3Button)
                 binding.daxDialogCta.secondaryCta.text = getString(R.string.preOnboardingDaxDialog3SecondaryButton)
@@ -1499,7 +1500,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.comparisonChartContent.root.isVisible = false
                 binding.daxDialogCta.addressBarContent.root.isVisible = false
 
-                val descriptionText = getString(R.string.preOnboardingInputScreenDescription)
+                val descriptionText = getString(R.string.preOnboardingInputScreenDescription).preventWidows()
                 binding.daxDialogCta.inputScreenContent.inputScreenDescription.text = descriptionText.html(requireContext())
 
                 binding.daxDialogCta.inputScreenContent.root.isVisible = true

--- a/app/src/main/res/layout-sw600dp/content_onboarding_welcome_page_update.xml
+++ b/app/src/main/res/layout-sw600dp/content_onboarding_welcome_page_update.xml
@@ -116,6 +116,7 @@
         android:layout_marginTop="32dp"
         android:alpha="0"
         android:visibility="invisible"
+        app:layout_constrainedHeight="true"
         app:layout_constrainedWidth="true"
         app:layout_constraintBottom_toTopOf="@+id/welcomeScreenWalkingDax"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/content_onboarding_welcome_page_update.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome_page_update.xml
@@ -114,6 +114,7 @@
         android:layout_marginTop="4dp"
         android:alpha="0"
         android:visibility="invisible"
+        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toTopOf="@+id/welcomeScreenWalkingDax"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
+++ b/app/src/main/res/layout/include_brand_design_dialog_welcome.xml
@@ -48,14 +48,26 @@
     </FrameLayout>
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/bodyText"
+        android:id="@+id/bodyText1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="20dp"
         android:alpha="0"
         android:gravity="center"
         android:includeFontPadding="false"
-        android:text="@string/preOnboardingWelcomeDialogBody"
+        android:text="@string/preOnboardingWelcomeDialogBody1"
+        app:typography="onboarding_body"
+        tools:alpha="1" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/bodyText2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:alpha="0"
+        android:gravity="center"
+        android:includeFontPadding="false"
+        android:text="@string/preOnboardingWelcomeDialogBody2"
         app:typography="onboarding_body"
         tools:alpha="1" />
 

--- a/app/src/main/res/layout/pre_onboarding_dax_dialog_cta_brand_design_update.xml
+++ b/app/src/main/res/layout/pre_onboarding_dax_dialog_cta_brand_design_update.xml
@@ -33,6 +33,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="20dp"
         app:arrowOffsetStart="96dp"
+        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0">

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -93,8 +93,9 @@
     </string>
 
     <!--Onboarding Rebrand Design Update-->
-    <string name="preOnboardingWelcomeDialogTitle">Hi there!</string>
-    <string name="preOnboardingWelcomeDialogBody">Ready for a faster browser that protects you and lets you decide when and how to use AI?</string>
+    <string name="preOnboardingWelcomeDialogTitle">Hi there.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ready for a faster browser that\nputs you in control?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI is always optional, and\nprivacy protection is always on.</string>
     <string name="onboardingStepIndicatorText" tools:ignore="MissingInstruction">%1$d of %2$d</string>
 
     <!-- Input Mode Demo Onboarding step -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1213611375324061?focus=true

### Description

Four related changes to the brand-design onboarding flow:

1. **Welcome screen copy.** Splits the welcome body into two lines and hides the second line on the skip-onboarding screen so it doesn't bleed through.
2. **Welcome dialog height cap.** Stops the welcome dialog sliding under the status bar at very large font scales; the existing inner scroll handles overflow. Portrait + tablet only — landscape already scrolls.
3. **Walking Dax sizing on font-scale change.** The state-restoration path measured the dialog before its content was updated, so Dax stayed at max size on subsequent font-scale changes and overlapped the secondary CTA. Aligns this path with the first-launch ordering.
4. **Prevent widows in onboarding descriptions.** Replaces the last space in each description with a non-breaking space so the final two words stay together. Covers the welcome flow, default browser page, bubble CTAs, and in-context dialog CTAs. Welcome body strings already use explicit line splits and are intentionally untouched.

### Steps to test this PR

To see these changes, patch:

```
Index: app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(revision f9fa85d8c08818408f0676a2ab82909b579676b2)
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt	(date 1778894400000)
@@ -34,13 +34,13 @@
      * Main toggle for the onboarding brand design update feature.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
      * Toggle for the brand design update variant.
      * Default value: false (disabled).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 }
Index: app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(revision f9fa85d8c08818408f0676a2ab82909b579676b2)
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt	(date 1778894400000)
@@ -54,7 +54,7 @@
     val viewState = _viewState.asStateFlow()
 
     fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+        pageLayoutManager.buildBrandDesignUpdatePageBlueprints()
     }
 
     fun pageCount(): Int {
@@ -100,7 +100,7 @@
     }
 
     fun initializeOnboardingSkipper() {
-        if (!appBuildConfig.canSkipOnboarding) return
+        return
 
         // delay showing skip button until privacy config downloaded
         viewModelScope.launch {
Index: duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt	(revision f9fa85d8c08818408f0676a2ab82909b579676b2)
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt	(date 1778894400000)
@@ -133,7 +133,7 @@
     /**
      * @return `true` when the "Native Input Field" option should be visible in AI Features Settings.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun nativeInputField(): Toggle
 
     /**
```

_Welcome screen copy_
- [x] Launch the app on a fresh install
- [x] Verify the welcome dialog title is followed by two distinct body lines, both fading in together
- [x] Verify the copy reads correctly across portrait and landscape

_Skip-onboarding transition_
- [x] Tap the secondary button on the welcome screen ("I've been here before") to open the skip-onboarding screen
- [x] Verify the skip-onboarding dialog shows the title and a single body line — the second body line from the welcome screen must not remain visible
- [x] Rotate the device while on the skip-onboarding screen and confirm the second body line is still hidden after rotation
- [x] Repeat with the welcome typing animation interrupted mid-way (tap skip while the title is still typing); the same outcome should hold

_Welcome dialog height cap (status bar) at large font_
- [x] Set the system font scale to the largest setting (Settings → Display → Font size, or `adb shell settings put system font_scale 2.0`)
- [x] Launch the app on a fresh install and reach the welcome screen
- [x] Verify the top of the welcome dialog card stays below the status bar
- [x] Verify all dialog content remains reachable — if the content overflows, the dialog scrolls internally so the buttons can be reached
- [x] Repeat on a tablet — same behaviour
- [x] Reset the font scale to default and confirm no visual regression at the default font size

_Walking Dax sizing across font-scale changes_
- [x] Reinstall the app so the welcome screen shows the secondary "I've been here before" button
- [x] At the default font scale, note the size of the walking Dax at the bottom of the welcome screen
- [x] Change the system font scale to the largest setting. Verify the walking Dax visibly shrinks (or hides at the extreme) and does not overlap the secondary button
- [x] Change the system font scale back down to default. Verify Dax returns to its original size
- [x] Change the system font scale up to the largest setting again. Verify Dax shrinks again and does not overlap the secondary button
- [x] Tap the secondary button to open the skip-onboarding screen, then repeat the up / down / up font-scale sequence. Verify Dax adapts on each change

_Prevent widows_
- [x] At a font scale where the last line of each description wraps (try 1.5× and 2.0×), verify no description ends with a single orphaned word on its own line. The last two words should stay together
- [x] Spot-check descriptions on these surfaces:
  - [x] Welcome flow: skip-onboarding body, input-screen description
  - [x] Default browser page subtitle, on both the "set as default" prompt and the "open system settings" prompt
  - [x] Try-a-search bubble (appears on the new-tab page after onboarding completes)
  - [x] Visit-site suggestions bubble
  - [x] End-of-onboarding bubble
  - [x] Privacy Pro promo bubble
  - [x] In-context dialogs encountered during browsing: trackers blocked, no trackers, main network, site suggestions, SERP, end
- [x] Confirm no regression at the default font scale — descriptions should wrap naturally; the only visible difference is at larger scales where the last word would otherwise wrap alone

### UI changes
 See [task](https://app.asana.com/1/137249556945/project/1207908166761516/task/1214890440559922?focus=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI copy/layout adjustments in the onboarding brand-design flow, but it touches welcome-screen view bindings/animations and layout constraints, which could regress onboarding rendering at different font scales/orientations.
> 
> **Overview**
> Updates the brand-design onboarding welcome dialog copy by splitting the body text into two separate lines (new `bodyText1`/`bodyText2`) and adjusts the animation/state-restoration paths so the second line is correctly hidden on the skip-onboarding screen.
> 
> Adds height-constraining tweaks to the welcome dialog includes/card to prevent the dialog from sliding under the status bar at large font scales, and applies `preventWidows()` across onboarding CTAs and default-browser page descriptions to keep the final two words together when wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f5baf39b7041ddaf0006eae9ce7c533f1e10ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->