### PR TITLE
Add 'pro' tier mapping to free trial conversion wide event

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -327,6 +327,7 @@ enum class ReportMetric(
 enum class ModelTier(val model: String) {
     FREE("free"),
     PLUS("plus"),
+    PRO("pro"),
     INTERNAL("internal"),
     UNKNOWN("unknown"),
     ;

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeatureCallbacks.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeatureCallbacks.kt
@@ -72,6 +72,6 @@ class SubscriptionFeatureCallbacks @Inject constructor(
 
     private companion object {
         const val KEY_MODEL_TIER = "modelTier"
-        val MODEL_TIERS_PAID: Set<String> = setOf("plus")
+        val MODEL_TIERS_PAID: Set<String> = setOf("plus", "pro")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1214695284864157?focus=true

### Description

### Steps to test this PR

- [ ] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [ ] Enable Free Trial eligibility in Play Billing Lab app
- [ ] Purchase a test free trial PRO subscription
- [ ]  Use duck.ai with Claude Opus 4.6 model
- [ ] Check in logcat that pixel `subscription_free_trial_duck_ai_paid_used_u` is sent
- [ ] Wait until subscription expires or cancels
- [ ] Check in logcat that pixel `wide_free-trial-conversion_c` has as a param `feature.data.ext.step.duck_ai_paid_used=true`

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small enum/mapping update that only affects how paid Duck.ai usage is classified for free-trial conversion tracking.
> 
> **Overview**
> Adds a new Duck.ai `ModelTier.PRO` value and updates paid-tier detection so free-trial conversion tracking treats `modelTier=pro` the same as `plus`.
> 
> This ensures `onDuckAiPaidPromptSubmitted` (and the associated wide event/pixel) fires for PRO subscriptions as well as PLUS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0030f651cf3afffa760ee07f8a1890a3d1f4000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->