### PR TITLE
Skip Duck.ai onboarding experiment when default variant is forced

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles.DuckAiOnboardingExperimentCohort
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.isTablet
@@ -53,6 +54,7 @@ class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
     private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
     private val deviceInfo: DeviceInfo,
+    private val appBuildConfig: AppBuildConfig,
 ) : DuckAiOnboardingExperimentManager {
 
     override suspend fun enroll(): DuckAiOnboardingExperimentVariant? = withContext(dispatcherProvider.io()) {
@@ -69,7 +71,8 @@ class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
     }
 
     private fun arePrerequisitesMet(): Boolean =
-        browserConfig.showInputScreenOnboarding().isEnabled() &&
+        !appBuildConfig.isDefaultVariantForced &&
+            browserConfig.showInputScreenOnboarding().isEnabled() &&
             browserConfig.singleTabFireDialog().isEnabled() &&
             !onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled() &&
             !deviceInfo.isTablet()

--- a/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles.DuckAiOnboardingExperimentCohort
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor
@@ -45,6 +46,7 @@ class DuckAiOnboardingExperimentManagerTest {
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
     private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val deviceInfo: DeviceInfo = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
 
     private val showInputScreenOnboardingToggle: Toggle = mock()
     private val singleTabFireDialogToggle: Toggle = mock()
@@ -66,7 +68,19 @@ class DuckAiOnboardingExperimentManagerTest {
             onboardingBrandDesignUpdateToggles = onboardingBrandDesignUpdateToggles,
             extendedOnboardingFeatureToggles = extendedOnboardingFeatureToggles,
             deviceInfo = deviceInfo,
+            appBuildConfig = appBuildConfig,
         )
+    }
+
+    @Test
+    fun whenDefaultVariantForcedThenReturnsNullAndDoesNotEnroll() = runTest {
+        givenPrerequisitesMet()
+        whenever(appBuildConfig.isDefaultVariantForced).thenReturn(true)
+
+        val result = testee.enroll()
+
+        assertNull(result)
+        verify(experimentToggle, never()).enroll()
     }
 
     @Test
@@ -181,6 +195,7 @@ class DuckAiOnboardingExperimentManagerTest {
     }
 
     private suspend fun givenPrerequisitesMet() {
+        whenever(appBuildConfig.isDefaultVariantForced).thenReturn(false)
         whenever(showInputScreenOnboardingToggle.isEnabled()).thenReturn(true)
         whenever(singleTabFireDialogToggle.isEnabled()).thenReturn(true)
         whenever(brandDesignUpdateToggle.isEnabled()).thenReturn(false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1214683333207680?focus=true

### Description

The Duck.ai-focused onboarding experiment uses the NA experiment framework (`toggle.enroll()` / `toggle.getCohort()`) rather than the legacy ATB-variant framework. As a result, the `-Pforce-default-variant` Gradle flag — which is already set in builds submitted to maestro — does not prevent users from being assigned to a treatment cohort.

When the `onboardingDuckAiExperimentMay26` remote toggle is enabled, treatment-cohort users see an additional `INPUT_SCREEN_PREVIEW` dialog after tapping "Next" on the input-screen step. This breaks `.maestro/shared/pre_onboarding.yaml` (and every flow that depends on it), because the assertion immediately after expects "Try a search!" to be visible.

This PR extends `DuckAiOnboardingExperimentManager.arePrerequisitesMet()` to also gate on `appBuildConfig.isDefaultVariantForced`. The maestro CI already builds with `-Pforce-default-variant`, so this change makes the existing flag suppress NA-framework enrollment too — no new infrastructure required.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional build-config gate to prevent experiment enrollment in forced-default builds and updates unit tests accordingly.
> 
> **Overview**
> Prevents Duck.ai onboarding experiment enrollment when the build is running with `isDefaultVariantForced`, so forced-default (e.g., CI/maestro) builds won’t be assigned to NA-framework treatment cohorts.
> 
> Updates `DuckAiOnboardingExperimentManagerImpl` to include this prerequisite check and extends `DuckAiOnboardingExperimentManagerTest` with a dedicated case plus updated setup mocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e339b09b087494bd4e8938976c54c10b6d8a84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->