### PR TITLE
Hide loading bar on Duck.ai tab (Unified Input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -132,6 +132,7 @@ class RealNativeInputOmnibarController(
         omnibarView.findViewById<View?>(R.id.shieldIcon)?.gone()
         omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.gone()
         omnibarView.findViewById<View?>(R.id.pageLoadingIndicator)?.gone()
+        omnibarView.findViewById<View?>(R.id.pageLoadProgressBar)?.gone()
     }
 
     private var currentTier: DuckAiTier = DuckAiTier.Unknown


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214156122159495?focus=true

### Description

- Hides the loading bar on the Duck.ai screen when the unified input is enabled.

### Steps to test this PR

_With native input enabled_
- [ ] Open Duck..ai
- [ ] Verify that the loading bar is not visible

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="276" alt="Screenshot_20260511_194513" src="https://github.com/user-attachments/assets/4593ef23-a413-4636-8f36-efb23a24528d" />|<img width="1080" height="276" alt="Screenshot_20260511_194635" src="https://github.com/user-attachments/assets/c312e1d6-ffe8-43e4-afe1-0eb9b18b51e0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that hides an additional loading/progress view; minimal impact beyond Duck.ai omnibar presentation.
> 
> **Overview**
> When switching the omnibar into Duck.ai/unified input mode, the controller now also hides `R.id.pageLoadProgressBar` (in addition to the existing loading indicator and other omnibar elements), preventing the loading bar from appearing on the Duck.ai tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe7b0fb9095225120ab2f8e788d287bf021756b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->