### PR TITLE
Add experiment toggle for the quick setup on the new onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.Experiment
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 
 /**
  * Feature toggles for the onboarding brand design updates.
@@ -43,4 +45,17 @@ interface OnboardingBrandDesignUpdateToggles {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun brandDesignUpdate(): Toggle
+
+    /**
+     * A/B test gating the re-installer quick-setup screen. Only users in the [QuickSetupCohorts.TREATMENT]
+     * cohort should be shown the quick-setup screen during onboarding.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Experiment
+    fun quickSetup(): Toggle
+
+    enum class QuickSetupCohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT("treatment"),
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
@@ -45,13 +45,13 @@ class OnboardingQuickSetupExperimentManagerImpl @Inject constructor(
 ) : OnboardingQuickSetupExperimentManager {
 
     override suspend fun enroll(): QuickSetupExperimentVariant? = withContext(dispatcherProvider.io()) {
-        toggles.quickSetup().enroll()
+        toggles.onboardingQuickSetupExperimentMay26().enroll()
         when {
-            toggles.quickSetup().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
+            toggles.onboardingQuickSetupExperimentMay26().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
                 QuickSetupExperimentVariant.TREATMENT
             }
 
-            toggles.quickSetup().isEnrolledAndEnabled(QuickSetupCohorts.CONTROL) -> {
+            toggles.onboardingQuickSetupExperimentMay26().isEnrolledAndEnabled(QuickSetupCohorts.CONTROL) -> {
                 QuickSetupExperimentVariant.CONTROL
             }
 

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboardingquicksetup
+
+import com.duckduckgo.app.onboardingquicksetup.OnboardingQuickSetupExperimentManager.QuickSetupExperimentVariant
+import com.duckduckgo.app.onboardingquicksetup.OnboardingQuickSetupToggles.QuickSetupCohorts
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface OnboardingQuickSetupExperimentManager {
+
+    /**
+     * Attempts to enroll the user into the quick-setup experiment and returns the assigned variant.
+     * Returns null if the user was not enrolled into the experiment.
+     */
+    suspend fun enroll(): QuickSetupExperimentVariant?
+
+    enum class QuickSetupExperimentVariant {
+        CONTROL,
+        TREATMENT,
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class OnboardingQuickSetupExperimentManagerImpl @Inject constructor(
+    private val toggles: OnboardingQuickSetupToggles,
+    private val dispatcherProvider: DispatcherProvider,
+) : OnboardingQuickSetupExperimentManager {
+
+    override suspend fun enroll(): QuickSetupExperimentVariant? = withContext(dispatcherProvider.io()) {
+        when {
+            toggles.quickSetup().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
+                QuickSetupExperimentVariant.TREATMENT
+            }
+
+            toggles.quickSetup().isEnrolledAndEnabled(QuickSetupCohorts.CONTROL) -> {
+                QuickSetupExperimentVariant.CONTROL
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
@@ -45,6 +45,7 @@ class OnboardingQuickSetupExperimentManagerImpl @Inject constructor(
 ) : OnboardingQuickSetupExperimentManager {
 
     override suspend fun enroll(): QuickSetupExperimentVariant? = withContext(dispatcherProvider.io()) {
+        toggles.quickSetup().enroll()
         when {
             toggles.quickSetup().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
                 QuickSetupExperimentVariant.TREATMENT

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
-import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 
 /**
@@ -44,8 +43,7 @@ interface OnboardingQuickSetupToggles {
      * cohort should be shown the quick-setup screen during onboarding.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    @Experiment
-    fun quickSetup(): Toggle
+    fun onboardingQuickSetupExperimentMay26(): Toggle
 
     enum class QuickSetupCohorts(override val cohortName: String) : CohortName {
         CONTROL("control"),

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
@@ -14,33 +14,41 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.onboardingbranddesignupdate
+package com.duckduckgo.app.onboardingquicksetup
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.Experiment
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 
 /**
- * Feature toggles for the onboarding brand design updates.
+ * Feature toggles for the reinstaller quick-setup onboarding experiment.
  */
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "onboardingBrandDesignUpdate",
+    featureName = "onboardingQuickSetup",
 )
-interface OnboardingBrandDesignUpdateToggles {
+interface OnboardingQuickSetupToggles {
 
     /**
-     * Main toggle for the onboarding brand design update feature.
+     * Main toggle for the onboarding quick-setup feature.
      * Default value: false (disabled).
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     /**
-     * Toggle for the brand design update variant.
-     * Default value: false (disabled).
+     * A/B test gating the re-installer quick-setup screen. Only users in the [QuickSetupCohorts.TREATMENT]
+     * cohort should be shown the quick-setup screen during onboarding.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun brandDesignUpdate(): Toggle
+    @Experiment
+    fun quickSetup(): Toggle
+
+    enum class QuickSetupCohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT("treatment"),
+    }
 }


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1211724162604201/task/1214705898682649?focus=true

### Description

Adds a new A/B test feature toggle `quickSetup()` to `OnboardingBrandDesignUpdateToggles` to gate the re-installer quick-setup screen during onboarding. The toggle is annotated as an `@Experiment` and includes two cohorts — `CONTROL` and `TREATMENT` — where only users assigned to the `TREATMENT` cohort will be shown the quick-setup screen.

Create `OnboardingQuickSetupExperimentManager` that assings the user to a cohort and returns the assigned experiment variant. 

### Steps to test this PR

_CI_ _passes_

### UI changes

No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new remote feature/experiment toggles and a small enrollment helper with defaults disabled; behavior changes only when the experiment is enabled remotely.
> 
> **Overview**
> Adds a new remote feature toggle set `OnboardingQuickSetupToggles` for onboarding quick-setup, including an `onboardingQuickSetupExperimentMay26` A/B experiment with `control` and `treatment` cohorts (default disabled).
> 
> Introduces `OnboardingQuickSetupExperimentManager` (AppScope DI binding) to enroll users into that experiment on an IO dispatcher and return the assigned variant (`CONTROL`/`TREATMENT`) or `null` when not enrolled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca36215dcceca903371448ba390c783eb08f995d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214975407918789