### PR TITLE
Add feature flag in DuckAiChatHistoryFeature for native chat history

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckAiChatHistoryFeature.kt
@@ -29,4 +29,19 @@ interface DuckAiChatHistoryFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
+
+    /**
+     * @return `true` when the native chat history screen can be launched.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun historyScreen(): Toggle
+
+    /**
+     * @return `true` when the per-row Fire-icon delete affordance on Duck.ai chat-history
+     * suggestions in the omnibar autocomplete is visible.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun deleteFromAutocomplete(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214582224401688?focus=true 

### Description

Adds two per-surface toggles to `DuckAiChatHistoryFeature` so the upcoming Duck.ai chat-history work

- **`historyScreen()`** — gates the native chat history screen
- **`deleteFromAutocomplete()`** — gates the per-row Fire-icon delete affordance on Duck.ai chat-history suggestions in the omnibar autocomplete

### Steps to test this PR

nu/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new remote feature toggles only, with `INTERNAL` defaults, and no behavioral code changes in this PR.
> 
> **Overview**
> Adds two per-surface remote toggles to `DuckAiChatHistoryFeature`: `historyScreen()` (gates launching the native chat history screen) and `deleteFromAutocomplete()` (gates the per-row delete icon in omnibar autocomplete).
> 
> Both new toggles default to `INTERNAL` when the remote config is absent, leaving existing `self()` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069726bb25b4d1e222ce620f3370468a3bbc7a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->