### PR TITLE
Update promo modal origins

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -275,11 +275,11 @@ class CtaViewModel @Inject constructor(
             when {
                 canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(
                     isFreeTrialCopy = freeTrialCopyAvailable(),
-                    origin = "funnel_skippedonboarding_android",
+                    origin = "funnel_modal_android__skippedonboardingupsell",
                 )
                 canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
                     isFreeTrialCopy = freeTrialCopyAvailable(),
-                    origin = "funnel_newusermodal_android",
+                    origin = "funnel_modal_android__subscriptionnudge",
                 )
                 else -> null
             }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3398,21 +3398,21 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenUserClickedSubscriptionPromoModalCtaThenLaunchSubscriptionWithReinstallModalOrigin() {
-        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_skippedonboarding_android")
+        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__skippedonboardingupsell")
         setCta(cta)
         testee.onUserClickCtaOkButton(cta)
         assertCommandIssued<LaunchSubscription> {
-            assertEquals("funnel_skippedonboarding_android", uri.getQueryParameter("origin"))
+            assertEquals("funnel_modal_android__skippedonboardingupsell", uri.getQueryParameter("origin"))
         }
     }
 
     @Test
     fun whenUserClickedPromoModalSubscriptionPromoCtaThenLaunchSubscriptionWithPromoModalOrigin() {
-        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android")
+        val cta = SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__subscriptionnudge")
         setCta(cta)
         testee.onUserClickCtaOkButton(cta)
         assertCommandIssued<LaunchSubscription> {
-            assertEquals("funnel_newusermodal_android", uri.getQueryParameter("origin"))
+            assertEquals("funnel_modal_android__subscriptionnudge", uri.getQueryParameter("origin"))
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -1080,7 +1080,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenOnUserClickCtaOkButtonWithSubscriptionPromoModalCtaThenDismissedCtaIsInserted() = runTest {
-        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
+        testee.onUserClickCtaOkButton(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__subscriptionnudge"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1092,7 +1092,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenSubscriptionPromoPluginsAreCalled() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__subscriptionnudge"))
         verify(mockSubscriptionPromoCtaShownPlugin).onSubscriptionPromoCtaShown()
     }
 
@@ -1220,7 +1220,7 @@ class CtaViewModelTest {
 
     @Test
     fun whenSubscriptionPromoModalCtaIsShownThenDismissedCtaIsInserted() = runTest {
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__subscriptionnudge"))
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_INTRO_PRIVACY_PRO))
     }
 
@@ -1356,7 +1356,7 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
 
-        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_newusermodal_android"))
+        testee.onCtaShown(SubscriptionPromoModalCta(isFreeTrialCopy = false, origin = "funnel_modal_android__subscriptionnudge"))
 
         // After modal is shown, DAX_INTRO_PRIVACY_PRO is in dismissed_cta, so bubble must not show
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214600823883574?focus=true

### Description
Update promo modal origins to match new specs

### Steps to test this PR _(Optional)_
- [ ] Check origins are updated
- [ ] Check CI checks are ✅ 

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to updating `origin` query parameter values for subscription promo modals and aligning unit tests; no logic flow or data handling is modified.
> 
> **Overview**
> Updates the `origin` strings passed by `CtaViewModel.getPromoCtaOnForeground` for the two subscription promo modal cases to match new funnel naming specs.
> 
> Adjusts related unit tests (`BrowserTabViewModelTest`, `CtaViewModelTest`) to assert the new `origin` query parameter values when launching subscriptions and when recording CTA interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6d0ced4aafdc35711fe5a88e4be7e799c03f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->