### PR TITLE
show duck.ai buttons in omnibar when duck.ai tab is selected.

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -385,9 +385,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun updateBottomRowVisibility() {
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val rowSpacer = findViewById<View?>(R.id.rowSpacer)
-        // Keep row 2 visible while streaming so the stop button stays reachable in bottom mode
-        // (where it's hosted inside this row rather than in floatingSubmitContainer).
-        val visible = (inputField.hasFocus() || isStreaming) && isDuckAiPageContext()
+        val chatActive = isDuckAiPageContext() || (nativeInputState.toggleVisible && isChatTabSelected())
+        val visible = chatActive && (inputField.hasFocus() || isStreaming)
         bottomRow.isVisible = visible
         rowSpacer?.isVisible = visible
     }
@@ -863,6 +862,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             inputField.maxLines = MAX_LINES
         }
         updateSendButtonVisibility()
+        updateBottomRowVisibility()
     }
 
     override fun setImageButtonVisible(visible: Boolean) {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214734681195551?focus=true

### Description
- In omnibar the duck.ai buttons when toggle is enabled and selected should be shown.

### Steps to test this PR
- enable toggle.
- open toggle in omnibar and select duck.ai tab.
- any other behaviour remain unchanged.
### UI changes


| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/12ee7ed3-8937-4bad-9a82-2cb44b1a28c5" />|<img width="1440" height="3120" alt="test" src="https://github.com/user-attachments/assets/92f7d0a1-b9a8-48d7-8956-6d0e9e8b1e18" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state tweak limited to visibility logic for the omnibar bottom row; main risk is minor regressions in when chat controls appear/disappear across focus/streaming/tab changes.
> 
> **Overview**
> Adjusts `NativeInputModeWidget` bottom-row visibility so Duck.ai controls can appear in the browser omnibar when the input-mode toggle is enabled and the **Chat** tab is selected (in addition to Duck.ai page contexts).
> 
> Ensures tab switches immediately re-evaluate this visibility by calling `updateBottomRowVisibility()` from `applyTabUi()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74259094e9833f7733587d304c5fafbe5841383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->