### PR TITLE
Show keyboard on NTP show with native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -683,7 +683,10 @@ class BrowserTabFragment :
     private lateinit var autoCompleteSuggestionsAdapter: BrowserAutoCompleteSuggestionsAdapter
     private val autoCompleteKeyboardDismissScrollListener =
         object : RecyclerView.OnScrollListener() {
-            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            override fun onScrollStateChanged(
+                recyclerView: RecyclerView,
+                newState: Int,
+            ) {
                 if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
                     if (nativeInputManager.isNativeInputEnabled()) {
                         hideKeyboardImmediatelyRetainFocus()
@@ -1402,7 +1405,11 @@ class BrowserTabFragment :
         )
     }
 
-    private fun launchInputScreen(query: String, isNewTab: Boolean = false, showDuckAiEndCta: Boolean = false) {
+    private fun launchInputScreen(
+        query: String,
+        isNewTab: Boolean = false,
+        showDuckAiEndCta: Boolean = false,
+    ) {
         logcat { "Duck.ai: launchInputScreen" }
         val isTopOmnibar = omnibar.omnibarType != OmnibarType.SINGLE_BOTTOM
         val intent =
@@ -1857,7 +1864,10 @@ class BrowserTabFragment :
         }
     }
 
-    private fun fireMenuOpenedPixels(isFocusedNtp: Boolean, viewState: BrowserViewState?) {
+    private fun fireMenuOpenedPixels(
+        isFocusedNtp: Boolean,
+        viewState: BrowserViewState?,
+    ) {
         if (isActiveCustomTab()) {
             pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
         } else if (omnibar.viewMode == ViewMode.DuckAI) {
@@ -2188,7 +2198,10 @@ class BrowserTabFragment :
         }
     }
 
-    private fun showPdf(url: String, cachedFileUri: Uri) {
+    private fun showPdf(
+        url: String,
+        cachedFileUri: Uri,
+    ) {
         newBrowserTab.newTabLayout.gone()
         newBrowserTab.newTabRootLayout.gone()
         binding.browserLayout.show()
@@ -2642,7 +2655,16 @@ class BrowserTabFragment :
             }
 
             is Command.ShowKeyboard -> {
-                if (!nativeInputManager.isNativeInputEnabled()) {
+                if (nativeInputManager.isNativeInputEnabled()) {
+                    // Surface the native input widget so its onEnterComplete focuses the input
+                    // and brings up the keyboard via the same path as a manual omnibar tap.
+                    // Skip if the widget is already attached — Command.ShowKeyboard can fire
+                    // multiple times per session (e.g. CTA refresh) and showNativeInput()
+                    // tears down and re-animates the widget on each call.
+                    if (binding.rootView.findViewById<View?>(com.duckduckgo.app.browser.R.id.inputModeTopRoot) == null) {
+                        showNativeInput()
+                    }
+                } else {
                     showKeyboard()
                 }
             }
@@ -2839,6 +2861,7 @@ class BrowserTabFragment :
                     setNewTabBackgroundColor(it.backgroundColorAttr)
                 }
             }
+
             is Command.SetOnboardingDialogBackground -> setOnboardingDialogBackgroundRes(it.backgroundRes)
             is Command.SetOnboardingDialogBackgroundColor -> setOnboardingDialogBackgroundColor(it.colorRes)
             is Command.LaunchFireDialogFromOnboardingDialog -> {
@@ -2949,7 +2972,10 @@ class BrowserTabFragment :
         }
     }
 
-    private fun setBrowserBackgroundRes(@DrawableRes backgroundRes: Int, useRebrandBackground: Boolean) {
+    private fun setBrowserBackgroundRes(
+        @DrawableRes backgroundRes: Int,
+        useRebrandBackground: Boolean,
+    ) {
         if (useRebrandBackground) {
             newBrowserTab.browserBackground.apply {
                 setImageResource(0)
@@ -4989,7 +5015,10 @@ class BrowserTabFragment :
         launchCameraCapture(callback, fileChooserParams, MediaStore.ACTION_IMAGE_CAPTURE)
     }
 
-    private fun launchFilePicker(callback: ValueCallback<Array<Uri>>, mimeTypes: List<String>) {
+    private fun launchFilePicker(
+        callback: ValueCallback<Array<Uri>>,
+        mimeTypes: List<String>,
+    ) {
         nativeInputManager.setPickingImage(true)
         val fileChooserParams = FileChooserRequestedParams(
             filePickingMode = FileChooserParams.MODE_OPEN_MULTIPLE,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214282876290070?focus=true

### Description

When the native input field user setting is enabled, opening the NTP did not bring the keyboard up. The standard omnibar path worked because `Command.ShowKeyboard` calls `showKeyboard()` on the omnibar's text input; the native-input branch of the handler in `BrowserTabFragment` was a no-op.

This routes the command to `showNativeInput()` when native input is enabled, so the widget attaches and its existing `onEnterComplete` focuses the input — the same path that already works on a manual omnibar tap. The handler skips when the widget is already attached, since `Command.ShowKeyboard` can fire more than once per visit (e.g. CTA refresh) and `showNativeInput()` tears down and re-animates the widget on each call.

### Steps to test this PR

_Native input enabled_
- [x] Enable the native input field in settings.
- [x] Open a new tab / NTP. The native input widget appears and the keyboard is up with the input focused.
- [x] Cause a CTA refresh on the NTP — verify the widget does not flicker (no tear-down + re-animate).

_Native input disabled (regression check)_
- [x] Disable the native input field.
- [x] Open a new tab / NTP. The omnibar focuses and the keyboard appears, same as before.

### UI changes
| Before  | After |
| ------ | ----- |
| (Upload before screenshot) | (Upload after screenshot) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to `Command.ShowKeyboard`, now surfacing the native input widget and avoiding repeated re-attach animations when the command fires multiple times.
> 
> **Overview**
> Fixes NTP keyboard focus when *native input* is enabled by routing `Command.ShowKeyboard` to `showNativeInput()` (only if the widget isn’t already attached) instead of doing nothing.
> 
> Also includes minor Kotlin formatting/line-wrapping changes and a small command handler spacing tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9044bbc8674802c2d4d0c2d616ec0ce122b0e19f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->