### PR TITLE
Fix: Android Crash: IndexOutOfBoundsException - Index -1

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -129,7 +129,7 @@ class TabPagerAdapter(
     }
 
     fun getTabIdAtPosition(position: Int): String? {
-        return if (position < tabs.size) {
+        return if (position >= 0 && position < tabs.size) {
             tabs[position].tabId
         } else {
             null


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1214746286867244?focus=true

### Description

Fixes a crash when a tab is being accessed using an invalid -1 position.

### Steps to test this PR

It's hard to reproduce so `QA-optional`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized bounds-check fix to prevent `IndexOutOfBoundsException` when an invalid (-1) tab position is queried; no behavior change for valid indices.
> 
> **Overview**
> Prevents a crash when tab lookups are performed with an invalid negative index.
> 
> `TabPagerAdapter.getTabIdAtPosition` now validates `position >= 0` before indexing into the tabs list, returning `null` for negative positions instead of throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101e0e1aa670c505ae3d551d8faf303e603fb73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->