### PR TITLE
Fix inline PDF crash on data, file, content schemas

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -124,6 +124,10 @@ class RealInlinePdfHandler @Inject constructor(
 
     override fun classifyPdfRequest(url: String, contentDisposition: String?, mimeType: String): PdfRenderDecision {
         if (!androidBrowserConfigFeature.pdfViewer().isEnabled()) return PdfRenderDecision.NotApplicable
+        // downloadToCache fetches via OkHttp, which rejects any scheme other than http/https.
+        // Let data:/file:/content: PDFs fall through to the standard download flow.
+        val scheme = url.toUri().scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") return PdfRenderDecision.NotApplicable
         // Use lastPathSegment so query strings and fragments don't break the .pdf check
         // (e.g. signed URLs like https://cdn.example.com/report.pdf?auth=token).
         val pathEndsInPdf = url.toUri().lastPathSegment?.endsWith(".pdf", ignoreCase = true) == true

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -219,6 +219,30 @@ class InlinePdfHandlerTest {
         )
     }
 
+    @Test
+    fun whenUrlIsDataUriThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.classifyPdfRequest("data:application/pdf;base64,JVBERi0xLjQK", null, "application/pdf"),
+        )
+    }
+
+    @Test
+    fun whenUrlIsFileSchemeThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.classifyPdfRequest("file:///sdcard/doc.pdf", null, "application/pdf"),
+        )
+    }
+
+    @Test
+    fun whenUrlIsContentSchemeThenDecisionIsNotApplicable() {
+        assertEquals(
+            PdfRenderDecision.NotApplicable,
+            inlinePdfHandler.classifyPdfRequest("content://media/external/file/doc.pdf", null, "application/pdf"),
+        )
+    }
+
     // endregion
 
     // region feature flag tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1214745682763200?focus=true 

### Description

Fixes an `IllegalArgumentException: Expected URL scheme 'http' or 'https' but was 'data'` thrown from `InlinePdfHandler.downloadToCache`

Root cause: `RealInlinePdfHandler.classifyPdfRequest` returned `PdfRenderDecision.Inline` whenever the MIME type was `application/pdf` or the path ended in `.pdf`, but it never checked the URL scheme.

### Steps to test this PR

> [!NOTE]
> Please unzip and read README.md file in the following test-fixtures to start a local server that allow you to open a PDF file with data schema: [test-fixtures.zip](https://github.com/user-attachments/files/27646587/test-fixtures.zip)

_Regression repro (would crash before the fix)_
- [x] Start the test-fixture server: `test-fixtures/pdf_test_server.py`
- [x] On the device/emulator, open `http://10.0.2.2:8000/data-uri.html`
- [x] Tap **Download data: URI PDF**
- [x] Confirm the app does **not** crash and the file lands in Downloads via the standard download flow

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fd0c492fd95065f8ad665932e32d8e3c8469c0a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->