### PR TITLE
[Android] Bump NDK version to 28.2.13676358

### DIFF
--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -70,7 +70,7 @@ android {
         generateDaggerFactories = true // default is false
     }
 
-    ndkVersion '21.4.7075529'
+    ndkVersion '28.2.13676358'
     namespace 'com.duckduckgo.app.anr'
     compileOptions {
         coreLibraryDesugaringEnabled = true

--- a/httpsupgrade/httpsupgrade-impl/build.gradle
+++ b/httpsupgrade/httpsupgrade-impl/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 }
 
 android {
-    ndkVersion '21.4.7075529'
+    ndkVersion '28.2.13676358'
     namespace 'com.duckduckgo.httpsupgrade.impl'
     anvil {
         generateDaggerFactories = true // default is false

--- a/install_tools.sh
+++ b/install_tools.sh
@@ -3,7 +3,7 @@ echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/androi
 echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license";
 echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license";
 echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license";
-sdkmanager 'ndk;21.4.7075529'
+sdkmanager 'ndk;28.2.13676358'
 sdkmanager tools;
 yes | sdkmanager --licenses;
 echo "Fetching ndk-bundle. Suppressing output to avoid travis 4MG size limit";


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1214687607254026?focus=true

### Description

Update NDK version to 28.2.13676358 in build.gradle files.

### Steps to test this PR

- [x] Test http -> https upgrade
- [x] Test crash / anr

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/toolchain-only change, but upgrading the NDK can affect native compilation and runtime behavior in the ANR and HTTPS upgrade native components, potentially surfacing new build or crash issues across CI/dev environments.
> 
> **Overview**
> Updates the Android NDK version from `21.4.7075529` to `28.2.13676358` for native builds in the `anrs-impl` and `httpsupgrade-impl` modules.
> 
> Adjusts the tooling install script (`install_tools.sh`) to download the same newer NDK via `sdkmanager`, keeping local/CI toolchains in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755e5205fd3e6d706fe4dde20c2b3547922624a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->