### PR TITLE
Fix blank space in browser activity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/CoordinatorLayoutHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/CoordinatorLayoutHelper.kt
@@ -67,12 +67,23 @@ class CoordinatorLayoutHelper {
         val childBounds = IntArray(2)
         coordinatorChildView!!.getLocationOnScreen(childBounds)
         if (childBounds[1] != lastYPosition) {
-            val childBottom = childBounds[1] + coordinatorChildView!!.height
+            val childHeight = coordinatorChildView!!.height
+            val parentHeight = coordinatorParentView!!.height
+
+            // When the IME inset shrinks the parent mid-layout, the child can still report its
+            // pre-resize height. Computing a diff here would bake the keyboard height into
+            // bottomMargin permanently. Skip without recording lastYPosition so a future call
+            // can run once layout has settled.
+            if (childHeight > parentHeight) {
+                return
+            }
+
+            val childBottom = childBounds[1] + childHeight
             lastYPosition = childBounds[1]
 
             val parentBounds = IntArray(2)
             coordinatorParentView!!.getLocationOnScreen(parentBounds)
-            val parentBottom = parentBounds[1] + coordinatorParentView!!.height
+            val parentBottom = parentBounds[1] + parentHeight
 
             val diff = childBottom - parentBottom
             if (diff != 0) {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214444878566531?focus=true

### Description
If a page load completes (which triggers `computeBottomMarginIfNeeded`), while a keyboard is being launched at the same time, there's a window where the child (browserLayout) would still be smaller in height than the parent (rootView), this would happen mid-layout and it would later match the parent size, but this causes the `computeBottomMarginIfNeeded` to incorrectly adjusts the browserLayout to match its parent and adds a persistent diff that is exactly the keyboard IME size. 

### Steps to test this PR
This is a race-condition that's hard to replicate, so it will need mutliple tries. also for some-reason enabling native-input with the toggle disabled makes it easier to repro.

- open a new website.
- try to open the keyboard by tapping the address bar as the page is about to finish loading.

I was able to verify the fix by having a log in the if statement added here, this log always triggers when the bug repros, and with the fix in place, the bug doesn't repro anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized guard in `CoordinatorLayoutHelper.computeBottomMarginIfNeeded` to avoid applying an incorrect margin during an IME/layout race; main risk is skipping a needed margin update in some edge cases until the next layout pass.
> 
> **Overview**
> Prevents a race where `computeBottomMarginIfNeeded` could permanently add the keyboard (IME) height to the child view’s `bottomMargin` while the parent is mid-resize.
> 
> The method now snapshots `childHeight`/`parentHeight` and **bails out when the child reports a height larger than the parent**, without updating `lastYPosition`, so a later call can recompute once layout has settled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b8822b8d123c27811e935b1f8eda47d5dccf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->