### PR TITLE
PIR: Fix NPE when accessing destroyed WebView

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
@@ -259,7 +259,7 @@ class RealPirActionsRunner @AssistedInject constructor(
             None, CompleteExecution -> {}
             is LoadUrl ->
                 withContext(dispatcherProvider.main()) {
-                    detachedWebView!!.loadUrl(effect.url)
+                    detachedWebView?.loadUrl(effect.url)
                 }
 
             is PushJsAction -> pushJsAction(effect)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214749665788797?focus=true

### Description
Fixes NPE when accessing a web view that could be destroyed

### Steps to test this PR
QA-optional 

- [ ] Smoke test PIR scan

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk null-safety change that prevents a crash when `detachedWebView` is destroyed while side effects are still being processed.
> 
> **Overview**
> Prevents a potential NPE in `RealPirActionsRunner.handleEffect` by switching the `LoadUrl` side effect from `detachedWebView!!` to a safe call, so URL loads are skipped if the detached `WebView` has already been destroyed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e80e152d14b4a2bef7f2be2b07c9c5a40cf608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->