### PR TITLE
Improve minimize transition and make it smooth

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -174,12 +174,13 @@ class NativeInputLayoutCoordinator(
         }
 
         fun applyPadding(view: View, padding: Padding, deltaTop: Int, deltaBottom: Int) {
-            view.setPadding(
-                padding.left,
-                padding.top + deltaTop,
-                padding.right,
-                padding.bottom + deltaBottom,
-            )
+            val newTop = padding.top + deltaTop
+            val newBottom = padding.bottom + deltaBottom
+            if (view.paddingTop == newTop && view.paddingBottom == newBottom) return
+            view.setPadding(padding.left, newTop, padding.right, newBottom)
+            // Force a layout pass for children (e.g. WebView) that cache their measured size and
+            // otherwise leave a gap until the next user interaction.
+            view.post { view.requestLayout() }
         }
 
         fun isLogoOnlyContent(view: View): Boolean {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -366,7 +366,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
             // (state-driven) and by NativeInputManager.setToggleVisible (keyboard-visibility
             // driven on duck.ai). Re-evaluating it from the focus listener would race with
             // setToggleVisible — e.g. re-show the toggle after the keyboard has been dismissed.
-            beginFocusTransition()
+            // Only animate on focus-gain — focus-loss pairs with an instant setToggleVisible hide,
+            // and animating the padding shrink afterwards looks like a two-step collapse.
+            if (hasFocus) beginFocusTransition()
             updateBottomRowVisibility()
             applyVerticalPaddingForFocus()
             if (!hasFocus && isDuckAiPageContext()) {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214736879874292?focus=true

### Description
Make sure the minimize transition is smooth by requesting an extra layout pass.

### Steps to test this PR
- Open duck.ai
- focus widget with keyboard opened.
- minimize keyboard or unfocus the widget.


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="280" height="607" alt="before" src="https://github.com/user-attachments/assets/ddc30c03-06fd-40f4-93aa-d35f09c5d668" />|<img width="280" height="607" alt="after" src="https://github.com/user-attachments/assets/8203c6cf-f770-4b53-a024-6251e0554e6e" />|







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout tweak; main impact is extra `requestLayout` calls after padding updates and a focus animation behavior change, which could affect performance/jank in edge cases.
> 
> **Overview**
> Improves native input minimize/resize smoothness by only applying padding updates when they change and then forcing an additional layout pass (`post { requestLayout() }`) so children like `WebView` don’t leave visible gaps after the widget animates.
> 
> Adjusts the native input widget focus handling to **only animate padding transitions on focus gain**, avoiding a “two-step” collapse when focus is lost and the toggle row is hidden instantly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b710925f83a1ac1beac7e1ef865f7d83be499130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->