### PR TITLE
PIR: Fix IndexOutOfBoundsException on stale action

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepActionFailed
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
@@ -30,6 +31,7 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerStepCompleted.StepStatus.Failure
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.Broker
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
@@ -57,6 +59,23 @@ class BrokerActionFailedEventHandler @Inject constructor(
          * This means we have received an error from the JS layer for the last action we pushed.
          * We end the run for the broker.
          */
+        if (!isEventValid(state)) {
+            // Stale event: arrived after the broker step / action was already considered completed.
+            val broker = if (state.brokerStepsToExecute.size <= state.currentBrokerStepIndex) {
+                Broker.unknown()
+            } else {
+                state.brokerStepsToExecute[state.currentBrokerStepIndex].broker
+            }
+
+            pirRunStateHandler.handleState(
+                BrokerStepInvalidEvent(
+                    broker = broker,
+                    runType = state.runType,
+                ),
+            )
+            return Next(nextState = state)
+        }
+
         val currentBrokerStep = state.brokerStepsToExecute[state.currentBrokerStepIndex]
         val currentAction = currentBrokerStep.step.actions[state.currentActionIndex]
         val error = (event as BrokerActionFailed).error
@@ -89,6 +108,16 @@ class BrokerActionFailedEventHandler @Inject constructor(
                 ),
             )
         }
+    }
+
+    private fun isEventValid(state: State): Boolean {
+        // Broker steps has probably been considered completed before the js error arrived
+        if (state.brokerStepsToExecute.size <= state.currentBrokerStepIndex) return false
+
+        // Broker step actions has probably been considered completed before the js error arrived
+        if (state.brokerStepsToExecute[state.currentBrokerStepIndex].step.actions.size <= state.currentActionIndex) return false
+
+        return true
     }
 
     private fun shouldRetryFailedAction(

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOut
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_OPTOUT
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_SCAN
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
@@ -348,6 +349,80 @@ class BrokerActionFailedEventHandlerTest {
         assertEquals(2, result.nextState.actionRetryCount)
         val nextEvent = result.nextEvent as ExecuteBrokerStepAction
         assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
+    }
+
+    @Test
+    fun whenBrokerStepIndexExceedsBrokerStepsSizeThenEventIsInvalidAndReturnsUnchangedState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testClickAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 1, // Exceeds broker steps size (1)
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertNull(result.nextEvent)
+        assertNull(result.sideEffect)
+        verify(mockPirRunStateHandler).handleState(
+            BrokerStepInvalidEvent(
+                broker = Broker.unknown(),
+                runType = RunType.MANUAL,
+            ),
+        )
+    }
+
+    @Test
+    fun whenActionIndexExceedsActionsSizeThenEventIsInvalidAndReturnsUnchangedState() = runTest {
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testClickAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 10, // Exceeds actions size (1)
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(state, result.nextState)
+        assertNull(result.nextEvent)
+        assertNull(result.sideEffect)
+        verify(mockPirRunStateHandler).handleState(
+            BrokerStepInvalidEvent(
+                broker = testBroker,
+                runType = RunType.MANUAL,
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214749665788799?focus=true

### Description
Fixes an `IndexOutOfBoundsException` exception when we receive a stale event from the JS layer after the broker step / action was already considered completed. The fix follows what we already do for a few other events in PIR.

### Steps to test this PR
QA optional 

- [ ] Run a PIR scan and verify if completes

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds bounds checks in an event handler to avoid `IndexOutOfBoundsException` from stale JS error events and only reports an existing invalid-event state/pixel without changing normal failure/retry logic.
> 
> **Overview**
> Prevents crashes when a `BrokerActionFailed` event arrives after the engine has already advanced past the referenced broker step/action.
> 
> `BrokerActionFailedEventHandler` now validates `currentBrokerStepIndex`/`currentActionIndex` before indexing; invalid (stale) events are ignored, emit `BrokerStepInvalidEvent` (using `Broker.unknown()` when the step index is out of range), and keep state unchanged. Tests were added to cover both out-of-range scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c80b2c61d88de54e70c6fb9e41b1875597f8a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->