### PR TITLE
Hide model selector for ongoing chats

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -89,6 +89,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -1322,6 +1323,7 @@ class BrowserTabFragment :
             layoutInflater = layoutInflater,
             lifecycleOwner = viewLifecycleOwner,
             tabs = viewModel.tabs,
+            currentTabUrl = viewModel.siteLiveData.asFlow().map { it?.url },
             query = query,
             callbacks = NativeInputCallbacks(
                 onSearchTextChanged = { text -> onUserEnteredText(text) },
@@ -1347,10 +1349,9 @@ class BrowserTabFragment :
                                     JSONObject().apply {
                                         put("prompt", query)
                                         put("autoSubmit", true)
-                                        // TODO: This currently causes a new chat to be sent if set
-                                        // if (modelId != null) {
-                                        //     put("modelId", modelId)
-                                        // }
+                                        if (modelId != null) {
+                                            put("modelId", modelId)
+                                        }
                                         if (reasoningEffort != null) {
                                             put("reasoningEffort", reasoningEffort)
                                         }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -24,6 +24,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
+import androidx.core.net.toUri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.lifecycleScope
@@ -46,7 +47,9 @@ import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import org.json.JSONArray
 import javax.inject.Inject
@@ -87,6 +90,7 @@ interface NativeInputManager {
         layoutInflater: LayoutInflater,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
+        currentTabUrl: Flow<String?>,
         query: String = "",
         callbacks: NativeInputCallbacks,
     )
@@ -289,6 +293,7 @@ class RealNativeInputManager @Inject constructor(
         layoutInflater: LayoutInflater,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
+        currentTabUrl: Flow<String?>,
         query: String,
         callbacks: NativeInputCallbacks,
     ) {
@@ -309,7 +314,7 @@ class RealNativeInputManager @Inject constructor(
         val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
         val widgetView = createWidgetView(layoutInflater, isBottom)
         val prefillText = query.ifEmpty { omnibarController.getText() }
-        bindWidget(widgetView, lifecycleOwner, tabs, callbacks, isBottom)
+        bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             callbacks.onClearAutocomplete()
             widgetFrom(widgetView)?.apply {
@@ -440,6 +445,7 @@ class RealNativeInputManager @Inject constructor(
         widgetView: View,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
+        currentTabUrl: Flow<String?>,
         callbacks: NativeInputCallbacks,
         isBottom: Boolean,
     ) {
@@ -465,6 +471,10 @@ class RealNativeInputManager @Inject constructor(
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         bindVoiceButtons(widgetView, callbacks)
+        // Picker tied to whether the current tab is a Duck.ai page that already has a chatId (existing chat) or new chat.
+        widgetFrom(widgetView)?.bindModelPickerEnabledSource(
+            currentTabUrl.map { !isExistingDuckAiChat(it) },
+        )
     }
 
     private fun bindVoiceButtons(
@@ -671,6 +681,14 @@ class RealNativeInputManager @Inject constructor(
 
     private fun launchUpgrade() {
         globalActivityStarter.start(rootView.context, SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE))
+    }
+
+    /** True if [rawUrl] points at an in-progress Duck.ai chat (Duck.ai URL with a non-blank `chatID`). */
+    internal fun isExistingDuckAiChat(rawUrl: String?): Boolean {
+        if (rawUrl.isNullOrBlank()) return false
+        val uri = runCatching { rawUrl.toUri() }.getOrNull() ?: return false
+        if (!duckChat.isDuckChatUrl(uri)) return false
+        return !uri.getQueryParameter("chatID").isNullOrBlank()
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.voice.api.VoiceSearchAvailability
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealNativeInputManagerTest {
+
+    private val duckChat: DuckChat = mock()
+    private val animator: NativeInputAnimator = mock()
+    private val voiceSearchAvailability: VoiceSearchAvailability = mock()
+    private val globalActivityStarter: GlobalActivityStarter = mock()
+    private val queryUrlPredictor: QueryUrlPredictor = mock()
+    private val duckAiFeatureState: DuckAiFeatureState = mock()
+
+    private lateinit var testee: RealNativeInputManager
+
+    @Before
+    fun setUp() {
+        testee = RealNativeInputManager(
+            duckChat,
+            animator,
+            voiceSearchAvailability,
+            globalActivityStarter,
+            queryUrlPredictor,
+            duckAiFeatureState,
+        )
+    }
+
+    @Test
+    fun whenUrlIsNullThenIsExistingDuckAiChatFalse() {
+        assertFalse(testee.isExistingDuckAiChat(null))
+    }
+
+    @Test
+    fun whenUrlIsBlankThenIsExistingDuckAiChatFalse() {
+        assertFalse(testee.isExistingDuckAiChat(""))
+        assertFalse(testee.isExistingDuckAiChat("   "))
+    }
+
+    @Test
+    fun whenUrlIsNotDuckAiThenIsExistingDuckAiChatFalse() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+
+        assertFalse(testee.isExistingDuckAiChat("https://example.com/?chatID=abcd"))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithoutChatIdThenIsExistingDuckAiChatFalse() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        assertFalse(testee.isExistingDuckAiChat("https://duck.ai/"))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithBlankChatIdThenIsExistingDuckAiChatFalse() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        assertFalse(testee.isExistingDuckAiChat("https://duck.ai/?chatID="))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithChatIdThenIsExistingDuckAiChatTrue() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+
+        assertTrue(testee.isExistingDuckAiChat("https://duck.ai/?chatID=abc-123"))
+    }
+
+    @Test
+    fun whenIsDuckChatUrlChecksParsedUriThenCheckedWithSameUri() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        val raw = "https://duck.ai/chat?chatID=xyz"
+
+        testee.isExistingDuckAiChat(raw)
+
+        verify(duckChat).isDuckChatUrl(Uri.parse(raw))
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -59,6 +59,7 @@ class RealContextualNativeInputManager @Inject constructor(
     private var isNativeInputEnabled = false
     private var card: MaterialCardView? = null
     private var jsMessaging: JsMessaging? = null
+    private var widget: NativeInputModeWidget? = null
 
     override fun init(
         card: MaterialCardView,
@@ -71,6 +72,7 @@ class RealContextualNativeInputManager @Inject constructor(
     ) {
         this.card = card
         this.jsMessaging = jsMessaging
+        this.widget = widget
 
         applyCardShape(card)
         setupWidget(widget, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
@@ -79,10 +81,15 @@ class RealContextualNativeInputManager @Inject constructor(
 
     override fun onWebViewMode() {
         if (isNativeInputEnabled) card?.show() else card?.gone()
+        // WEBVIEW mode means a chat is in progress.
+        // Hide the picker so the user can't change models mid-chat.
+        widget?.setModelPickerEnabled(false)
     }
 
     override fun onInputMode() {
         card?.gone()
+        // INPUT mode is a new chat: restore the picker
+        widget?.setModelPickerEnabled(true)
     }
 
     private fun applyCardShape(card: MaterialCardView) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -111,6 +111,9 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val _plugins = MutableStateFlow<List<NativeInputPlugin>>(emptyList())
     val plugins: StateFlow<List<NativeInputPlugin>> = _plugins.asStateFlow()
 
+    private val _modelPickerEnabled = MutableStateFlow(true)
+    val modelPickerEnabled: StateFlow<Boolean> = _modelPickerEnabled.asStateFlow()
+
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
     val commands = commandChannel.receiveAsFlow()
 
@@ -127,7 +130,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
     }
 
+    fun setModelPickerEnabled(enabled: Boolean) {
+        _modelPickerEnabled.value = enabled
+    }
+
     fun getSelectedModelId(): String? {
+        if (!_modelPickerEnabled.value) return null
         return _plugins.value.firstNotNullOfOrNull { plugin ->
             (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -64,6 +64,8 @@ import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
@@ -109,6 +111,12 @@ interface NativeInputWidget {
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
     fun getResolvedReasoningEffort(): String?
+    fun setModelPickerEnabled(enabled: Boolean)
+
+    /**
+     * Binds a reactive source of "should the model picker be enabled?"
+     */
+    fun bindModelPickerEnabledSource(source: Flow<Boolean>)
     fun getImageAttachmentsJson(): JSONArray?
     fun getFileAttachmentsJson(): JSONArray?
     fun clearAttachments()
@@ -180,6 +188,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var tierJob: Job? = null
     private var nativeInputStateJob: Job? = null
     private var pluginsJob: Job? = null
+    private var modelPickerEnabledJob: Job? = null
+    private var modelPickerEnabledSource: Flow<Boolean>? = null
+    private var modelPickerView: ModelPicker? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
     private var attachmentLimitExceeded: Boolean = false
@@ -226,6 +237,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         setupPlugins()
+        observeModelPickerEnabledSource()
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
@@ -247,6 +259,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
                         if (plugin.containerId != R.id.startChatContainer) {
                             container.isVisible = isChatTabSelected()
                         }
+                        if (pluginView is ModelPicker) {
+                            modelPickerView = pluginView
+                            // Apply the current enabled state. The host may have set it
+                            // before plugins were created.
+                            pluginView.setPickerEnabled(viewModel.modelPickerEnabled.value)
+                        }
                         wirePluginView(pluginView, scope)
                     }
                 }
@@ -263,6 +281,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
                                 command.visible && hasAttachments
                         }
                     }
+                }
+            }
+            launch {
+                viewModel.modelPickerEnabled.collect { enabled ->
+                    modelPickerView?.setPickerEnabled(enabled)
                 }
             }
         }
@@ -305,6 +328,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         nativeInputStateJob = null
         pluginsJob?.cancel()
         pluginsJob = null
+        modelPickerEnabledJob?.cancel()
+        modelPickerEnabledJob = null
+        modelPickerView = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -638,6 +664,25 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
 
     override fun getResolvedReasoningEffort(): String? = viewModel.getResolvedReasoningEffort()
+
+    override fun setModelPickerEnabled(enabled: Boolean) {
+        viewModel.setModelPickerEnabled(enabled)
+    }
+
+    override fun bindModelPickerEnabledSource(source: Flow<Boolean>) {
+        modelPickerEnabledSource = source
+        if (isAttachedToWindow) observeModelPickerEnabledSource()
+    }
+
+    private fun observeModelPickerEnabledSource() {
+        val source = modelPickerEnabledSource ?: return
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        modelPickerEnabledJob?.cancel()
+        modelPickerEnabledJob = source
+            .distinctUntilChanged()
+            .onEach { viewModel.setModelPickerEnabled(it) }
+            .launchIn(scope)
+    }
 
     override fun getImageAttachmentsJson(): JSONArray? = attachmentView?.getImageAttachmentsJson()
 

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -206,10 +206,19 @@
                         android:orientation="horizontal">
 
                         <FrameLayout
+                            android:id="@id/reasoningModePickerContainer"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+
+                        <FrameLayout
                             android:id="@id/modelPickerContainer"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
+                            android:layout_marginStart="@dimen/keyline_1"
                             android:visibility="gone"
                             tools:visibility="visible" />
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -482,6 +482,28 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenModelPickerDisabledThenGetSelectedModelIdReturnsNull() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+
+        viewModel.setModelPickerEnabled(false)
+
+        assertNull(viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenModelPickerReEnabledThenGetSelectedModelIdReturnsSelection() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+
+        viewModel.setModelPickerEnabled(false)
+        assertNull(viewModel.getSelectedModelId())
+
+        viewModel.setModelPickerEnabled(true)
+        assertEquals("claude-3", viewModel.getSelectedModelId())
+    }
+
+    @Test
     fun whenPluginReturnsReasoningEffortSelectionThenGetResolvedReasoningEffortReturnsIt() = runTest {
         val plugin = fakeReasoningPlugin(containerId = 7, effort = "low")
         val viewModel = createViewModel(plugins = listOf(plugin))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214693602247412?focus=true 

## Summary

The model picker chip lets users pick which AI model to use for their next prompt, and shows/hides based on whether the current context is a new chat or an existing one. The reasoning-mode picker (Fast / Reasoning / Extended Reasoning) appears next to it when the selected model supports multiple reasoning levels.

Note: Added the missing frame layout for the reason picker to `view_native_input_mode_switch_widget.xml` part of this PR

## What it does

- **Model picker**: shown when starting a new chat (any non-Duck.ai tab, or a Duck.ai tab without a `chatID`); hidden on a Duck.ai tab that already has a `chatID` in the URL
- **Reactive to in-page navigation**: when the omnibar is in Duck.ai mode, tapping "new chat" or a chat-history item inside Duck.ai pushState's the URL. The picker reacts and shows/hides accordingly.
- **Reasoning-mode picker**: appears when the backend reports more than one supported reasoning effort for the selected model. Selection is persisted.
- **Contextual sheet**: picker hidden in WEBVIEW mode (chat in progress).
- **Payload**: selected `modelId` and `reasoningEffort` are included in `submitAIChatNativePrompt` subscription events and in the deferred `getAIChatNativePrompt` callback used when opening Duck.ai from a non-Duck.ai tab.

## Test plan

**Native input - browser**
- [ ] Open native input on a non-Duck.ai tab → model picker chip visible. Tap chip, select a model, submit a prompt → Duck.ai opens and the response uses the selected model.
- [ ] Open native input on Duck.ai tab with **no** chat (new chat session) → picker visible.
- [ ] Open native input on Duck.ai tab on an existing chat → picker hidden.
- [ ] In Duck.ai mode with native input still visible, tap "new chat" inside Duck.ai's web UI → picker reappears.
- [ ] In Duck.ai mode, tap a chat-history item inside Duck.ai → picker hides.

**Contextual sheet**
- [ ] Open contextual sheet on a fresh tab. Submit a prompt → sheet transitions to WEBVIEW, picker hiden.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Duck.ai prompt metadata (`modelId`) is selected and sent by dynamically disabling the model picker based on URL/context, which could affect chat submission behavior and UI state across navigation.
> 
> **Overview**
> Ensures the Duck.ai **model picker is only available for new chats**, and is disabled/hidden for *in-progress chats* (Duck.ai URLs with a non-blank `chatID`) across both the browser native input and the contextual sheet.
> 
> This wires the current tab URL into `NativeInputManager` as a `Flow`, adds a reactive `modelPickerEnabled` state in `NativeInputModeWidgetViewModel`/`NativeInputModeWidget`, and updates prompt submission to include `modelId` when enabled. It also updates the widget layout to include the missing `reasoningModePickerContainer`, and adds unit tests for chat URL detection and model-picker enable/disable behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82549dcdaf817c9ad3fe96f60638ce73a9da3ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->