### PR TITLE
Add DaxRadioButton to Compose ADS

### DIFF
--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -110,6 +110,12 @@ tags:
             id: "com.duckduckgo.mobile.android:id/dax_switch_one"
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/radio_button_two"
+        - scrollUntilVisible:
+            timeout: 50000
+            speed: 60
+            element:
+              text: "Remember my choice"
+            direction: DOWN
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/checkbox_one"
         - tapOn:

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.common.ui.compose.cards.DaxCard
 import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
-import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
 import com.duckduckgo.common.ui.view.MessageCta
@@ -112,26 +111,24 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
             view.setupThemedComposeView(id = R.id.compose_dax_radio_button, isDarkTheme = isDarkTheme) {
                 var indexSelected by remember { mutableIntStateOf(0) }
 
-                DuckDuckGoTheme {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        DaxRadioButton(
-                            selected = indexSelected == 0,
-                            onClick = { indexSelected = 0 },
-                        )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    DaxRadioButton(
+                        selected = indexSelected == 0,
+                        onClick = { indexSelected = 0 },
+                    )
 
-                        DaxRadioButton(
-                            selected = indexSelected == 1,
-                            onClick = { indexSelected = 1 },
-                        )
+                    DaxRadioButton(
+                        selected = indexSelected == 1,
+                        onClick = { indexSelected = 1 },
+                    )
 
-                        DaxRadioButton(selected = false, onClick = {}, enabled = false)
+                    DaxRadioButton(selected = false, onClick = {}, enabled = false)
 
-                        DaxRadioButton(selected = true, onClick = {}, enabled = false)
-                    }
+                    DaxRadioButton(selected = true, onClick = {}, enabled = false)
                 }
             }
         }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -24,19 +24,24 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.common.ui.compose.cards.DaxCard
 import com.duckduckgo.common.ui.compose.cards.DaxSurface
+import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
 import com.duckduckgo.common.ui.view.MessageCta
@@ -99,8 +104,38 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
-    class RadioButtonComponentViewHolder(parent: ViewGroup) :
-        ComponentViewHolder(inflate(parent, R.layout.component_radio_button))
+    class RadioButtonComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_radio_button)) {
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(id = R.id.compose_dax_radio_button, isDarkTheme = isDarkTheme) {
+                var indexSelected by remember { mutableIntStateOf(0) }
+
+                DuckDuckGoTheme {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        DaxRadioButton(
+                            selected = indexSelected == 0,
+                            onClick = { indexSelected = 0 },
+                        )
+
+                        DaxRadioButton(
+                            selected = indexSelected == 1,
+                            onClick = { indexSelected = 1 },
+                        )
+
+                        DaxRadioButton(selected = false, onClick = {}, enabled = false)
+
+                        DaxRadioButton(selected = true, onClick = {}, enabled = false)
+                    }
+                }
+            }
+        }
+    }
 
     class CheckboxComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_checkbox))
@@ -451,7 +486,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.BUTTON -> ButtonComponentViewHolder(parent)
                 Component.TOP_APP_BAR -> TopAppBarComponentViewHolder(parent)
                 Component.SWITCH -> SwitchComponentViewHolder(parent, isDarkTheme)
-                Component.RADIO_BUTTON -> RadioButtonComponentViewHolder(parent)
+                Component.RADIO_BUTTON -> RadioButtonComponentViewHolder(parent, isDarkTheme)
                 Component.CHECKBOX -> CheckboxComponentViewHolder(parent)
                 Component.SLIDER -> SliderComponentViewHolder(parent)
                 Component.SNACKBAR -> SnackbarComponentViewHolder(parent)

--- a/android-design-system/design-system-internal/src/main/res/layout/component_radio_button.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_radio_button.xml
@@ -55,4 +55,26 @@
 
     </RadioGroup>
 
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/compose_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_4"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/radio_group"
+        app:primaryText="Compose Radio Button" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_dax_radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_2"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:paddingStart="@dimen/keyline_4"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/compose_label" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/dialog/DaxRadioOptions.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/dialog/DaxRadioOptions.kt
@@ -27,8 +27,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +36,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.button.DaxGhostButton
 import com.duckduckgo.common.ui.compose.button.DaxPrimaryButton
+import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
 import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
@@ -86,14 +85,9 @@ fun DaxRadioOptions(
                         vertical = dimensionResource(R.dimen.keyline_3),
                     ),
             ) {
-                // TODO: replace with DaxRadioButton once the ADS radio button is migrated to Compose.
-                RadioButton(
+                DaxRadioButton(
                     selected = selectedIndex == index,
                     onClick = null,
-                    colors = RadioButtonDefaults.colors(
-                        selectedColor = DuckDuckGoTheme.colors.brand.accentBlue,
-                        unselectedColor = DuckDuckGoTheme.textColors.secondary,
-                    ),
                 )
                 Spacer(modifier = Modifier.width(16.dp))
                 DaxText(

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/radiobutton/DaxRadioButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/radiobutton/DaxRadioButton.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.radiobutton
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system composable radio button component.
+ *
+ * Wraps Material3 [RadioButton] with DuckDuckGo theme colors matching the XML
+ * [com.duckduckgo.common.ui.view.button.RadioButton].
+ *
+ * @param selected whether the radio button is selected
+ * @param onClick callback invoked when the radio button is clicked, or null to make the radio button non-interactive
+ * @param modifier the [Modifier] to apply
+ * @param enabled whether the radio button is enabled
+ * @param interactionSource the [MutableInteractionSource] representing the stream of interactions for this radio button
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1214777812685547?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=892-1080&m=dev
+ */
+@Composable
+fun DaxRadioButton(
+    selected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+) {
+    RadioButton(
+        selected = selected,
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        colors = RadioButtonDefaults.colors(
+            selectedColor = DaxRadioButtonDefaults.colors.selected,
+            unselectedColor = DaxRadioButtonDefaults.colors.unselected,
+            disabledSelectedColor = DaxRadioButtonDefaults.colors.disabled,
+            disabledUnselectedColor = DaxRadioButtonDefaults.colors.disabled,
+        ),
+    )
+}
+
+private object DaxRadioButtonDefaults {
+
+    val colors: DaxRadioButtonColors
+        @Composable
+        get() = DaxRadioButtonColors(
+            selected = DuckDuckGoTheme.colors.brand.accentBlue,
+            unselected = DuckDuckGoTheme.colors.brand.accentBlue,
+            disabled = DuckDuckGoTheme.colors.backgrounds.containerDisabled,
+        )
+}
+
+private data class DaxRadioButtonColors(
+    val selected: Color,
+    val unselected: Color,
+    val disabled: Color,
+)
+
+@PreviewLightDark
+@Composable
+private fun DaxRadioButtonAllStatesPreview() {
+    PreviewBox {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            DaxRadioButton(selected = false, onClick = {})
+            DaxRadioButton(selected = true, onClick = {})
+            DaxRadioButton(selected = false, onClick = {}, enabled = false)
+            DaxRadioButton(selected = true, onClick = {}, enabled = false)
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.lint.ui.NoRawM3ButtonUsageDetector.Companion.NO_RAW_M3_BUT
 import com.duckduckgo.lint.ui.NoRawM3SurfaceUsageDetector.Companion.NO_RAW_M3_SURFACE_USAGE
 import com.duckduckgo.lint.ui.DaxTextFieldTrailingIconDetector.Companion.INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE
 import com.duckduckgo.lint.ui.DaxSecureTextFieldTrailingIconDetector.Companion.INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3SwitchUsageDetector.Companion.NO_MATERIAL3_SWITCH_USAGE
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
 import com.duckduckgo.lint.ui.DeprecatedAndroidWidgetsUsedInXmlDetector.Companion.DEPRECATED_WIDGET_IN_XML
@@ -113,6 +114,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE,
             INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE,
             NO_MATERIAL3_SWITCH_USAGE,
+            NO_MATERIAL3_RADIO_BUTTON_USAGE,
             NO_RAW_M3_BUTTON_USAGE,
             NO_RAW_M3_ALERT_DIALOG_USAGE,
             NO_RAW_M3_SURFACE_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3RadioButtonUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3RadioButtonUsageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3RadioButtonUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = RadioButtonUsageHandler(context)
+
+    internal class RadioButtonUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            if (methodName == "RadioButton") {
+                val resolved = node.resolve() ?: return
+                val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+                if (qualifiedName == MATERIAL3_PACKAGE) {
+                    context.report(
+                        issue = NO_MATERIAL3_RADIO_BUTTON_USAGE,
+                        location = context.getLocation(node),
+                        message = NO_MATERIAL3_RADIO_BUTTON_USAGE.getExplanation(TextFormat.RAW),
+                    )
+                }
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        val NO_MATERIAL3_RADIO_BUTTON_USAGE = Issue
+            .create(
+                id = "NoMaterial3RadioButtonUsage",
+                briefDescription = "Use DaxRadioButton instead of Material3 RadioButton",
+                explanation = "Use `DaxRadioButton` from the design system instead of the Material3 `RadioButton` composable " +
+                    "to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3RadioButtonUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3RadioButtonUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3RadioButtonUsageDetectorTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
+import org.junit.Test
+
+class NoMaterial3RadioButtonUsageDetectorTest {
+
+    private val radioButtonStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun RadioButton(
+            selected: Boolean,
+            onClick: (() -> Unit)?,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxRadioButtonStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.radiobutton
+
+        fun DaxRadioButton(
+            selected: Boolean,
+            onClick: (() -> Unit)?,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3RadioButtonUsedThenError() {
+        lint()
+            .files(
+                radioButtonStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.RadioButton
+
+                    fun MyScreen() {
+                        RadioButton(selected = true, onClick = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_RADIO_BUTTON_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxRadioButton from the design system instead of the Material3 RadioButton composable to ensure consistent styling across the app. [NoMaterial3RadioButtonUsage]
+                    RadioButton(selected = true, onClick = {})
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenDaxRadioButtonUsedThenNoError() {
+        lint()
+            .files(
+                daxRadioButtonStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
+
+                    fun MyScreen() {
+                        DaxRadioButton(selected = true, onClick = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_RADIO_BUTTON_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoRadioButtonUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val selected = true
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_RADIO_BUTTON_USAGE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1211659112661276?focus=true

### Description
Adds `DaxRadioButton` to the Compose design system

### Steps to test this PR

_ADS Preview_
- [x] Open ADS Preview screen
- [x] Go to Interactive tab
- [x] Compare XML and Compose versions

### UI changes
See ADS Preview screen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new shared Compose component plus a new **error-level** lint rule that will fail builds where `androidx.compose.material3.RadioButton` is used outside the design-system modules.
> 
> **Overview**
> Adds a new Compose design-system component, `DaxRadioButton`, which wraps Material3 `RadioButton` with DuckDuckGo theme colors.
> 
> Updates `DaxRadioOptions` and the ADS preview (`ComponentViewHolder`/`component_radio_button.xml`) to use and showcase the new Compose radio button alongside the existing XML version.
> 
> Adds `NoMaterial3RadioButtonUsageDetector` (registered in `DuckDuckGoIssueRegistry` with tests) to enforce `DaxRadioButton` usage by flagging Material3 `RadioButton` calls outside `design-system`/`design-system-internal`, and tweaks the Maestro ADS preview flow to scroll to the next target element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b77faa4d7de93f98b768c2c8d3320fcb3254748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->