### PR TITLE
Pre-compiled TdsTracker regex patterns for rule matching

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -261,7 +261,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
         val entities = tdsJson.jsonToEntities()
         val domainEntities = tdsJson.jsonToDomainEntities()
         val cnameEntities = tdsJson.jsonToCnameEntities()
-        val client = TdsClient(Client.ClientName.TDS, trackers, RealUrlToTypeMapper(), false)
+        val client = TdsClient(Client.ClientName.TDS, trackers, RealUrlToTypeMapper(), false, false)
 
         tdsEntityDao.insertAll(entities)
         tdsDomainEntityDao.insertAll(domainEntities)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
@@ -314,7 +314,13 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
         val entities = tdsJson.jsonToEntities()
         val domainEntities = tdsJson.jsonToDomainEntities()
         val cnameEntities = tdsJson.jsonToCnameEntities()
-        val client = TdsClient(Client.ClientName.TDS, trackers, RealUrlToTypeMapper(), false)
+        val client = TdsClient(
+            name = Client.ClientName.TDS,
+            trackers = trackers,
+            urlToTypeMapper = RealUrlToTypeMapper(),
+            optimizeTrackerEvaluationV3 = false,
+            precompileRegex = false,
+        )
 
         tdsEntityDao.insertAll(entities)
         tdsDomainEntityDao.insertAll(domainEntities)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -256,7 +256,13 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
         val entities = tdsJson.jsonToEntities()
         val domainEntities = tdsJson.jsonToDomainEntities()
         val cnameEntities = tdsJson.jsonToCnameEntities()
-        val client = TdsClient(Client.ClientName.TDS, trackers, RealUrlToTypeMapper(), false)
+        val client = TdsClient(
+            name = Client.ClientName.TDS,
+            trackers = trackers,
+            urlToTypeMapper = RealUrlToTypeMapper(),
+            optimizeTrackerEvaluationV3 = false,
+            precompileRegex = false,
+        )
 
         tdsEntityDao.insertAll(entities)
         tdsDomainEntityDao.insertAll(domainEntities)

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TdsClientPerfAndroidTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TdsClientPerfAndroidTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.trackerdetection.Client.ClientName.TDS
+import com.duckduckgo.app.trackerdetection.api.ActionJsonAdapter
+import com.duckduckgo.app.trackerdetection.api.TdsJson
+import com.duckduckgo.app.trackerdetection.model.TdsTracker
+import com.squareup.moshi.Moshi
+import okio.buffer
+import okio.source
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.File
+
+/**
+ * On-device microbenchmark mirroring [TdsClientPerfTest] (the JVM unit test).
+ *
+ * Compares precompileRegex=false (legacy: compile-on-every-call) versus precompileRegex=true
+ * (new: compile-once-at-construction) on a real Android device or emulator, using the bundled
+ * tracker dataset shipped with the app at app/src/main/res/raw/tds.json (R.raw.tds).
+ *
+ * NOTE: this class is annotated @Ignore so CI does not run it. To execute manually:
+ *   1. From Android Studio: right-click the test method or class and choose "Run". The IDE
+ *      bypasses @Ignore for explicit invocations.
+ *   2. From the CLI: temporarily comment out the @Ignore annotation, run the gradle command
+ *      below, then revert. JUnit honors @Ignore even when --tests targets the class directly.
+ *
+ *     ./gradlew :app:connectedPlayDebugAndroidTest \
+ *         -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.app.trackerdetection.TdsClientPerfAndroidTest
+ *
+ * Output is emitted to logcat under tag "TdsClientPerf"; capture with:
+ *     adb logcat -s TdsClientPerf:I *:S
+ *
+ * Numbers are observation-only — no pass/fail assertion.
+ */
+@Ignore("Performance benchmark — run manually, not in CI. See class kdoc for instructions.")
+@RunWith(AndroidJUnit4::class)
+class TdsClientPerfAndroidTest {
+
+    private val mapper: UrlToTypeMapper = mock<UrlToTypeMapper>().also {
+        whenever(it.map(anyString(), anyMap())).thenReturn("script")
+    }
+
+    @Test
+    fun benchmarkRegexCompileOffVsOnUsingRealTds() {
+        logRuntimeContext()
+        val trackers = loadAllTrackersFromTdsJson()
+        val totalRules = trackers.sumOf { it.rules.size }
+        val urls = buildWorstCaseUrls(trackers, sampleSize = URL_SAMPLE_SIZE)
+        val documentUrl = Uri.parse("http://example.com/index.htm")
+
+        // JIT/ART warmup — both paths and both code branches.
+        repeat(WARMUP_ROUNDS) {
+            val warmOff = TdsClient(TDS, trackers, mapper, true, false)
+            val warmOn = TdsClient(TDS, trackers, mapper, true, true)
+            urls.forEach {
+                warmOff.matches(it, documentUrl, emptyMap())
+                warmOn.matches(it, documentUrl, emptyMap())
+            }
+        }
+
+        // Construction cost — pre-compile work happens here when flag is on.
+        val tStartConstructOff = System.nanoTime()
+        val clientOff = TdsClient(TDS, trackers, mapper, true, false)
+        val constructOffNs = System.nanoTime() - tStartConstructOff
+
+        val tStartConstructOn = System.nanoTime()
+        val clientOn = TdsClient(TDS, trackers, mapper, true, true)
+        val constructOnNs = System.nanoTime() - tStartConstructOn
+
+        // Match throughput.
+        val matchOffNs = measureMatchNs(clientOff, urls, documentUrl)
+        val matchOnNs = measureMatchNs(clientOn, urls, documentUrl)
+
+        val totalCalls = MEASURED_ITERATIONS.toLong() * urls.size
+        val perCallOffNs = matchOffNs / totalCalls
+        val perCallOnNs = matchOnNs / totalCalls
+        val speedup = matchOffNs.toDouble() / matchOnNs.toDouble()
+
+        log("=== TdsClient regex pre-compile benchmark (on-device) ===")
+        log(
+            "Device: ${Build.MANUFACTURER} ${Build.MODEL} | " +
+                "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT}) | " +
+                "ABI ${Build.SUPPORTED_ABIS.firstOrNull()}",
+        )
+        log("Trackers loaded: ${trackers.size} (total rules across all trackers: $totalRules)")
+        log("URL sample: ${urls.size} (each hits a tracker domain but no rule matches → all rules evaluated)")
+        log("Iterations: $MEASURED_ITERATIONS × ${urls.size} URLs = $totalCalls match calls per flag state")
+        log("")
+        log("[precompile=false] construct: ${constructOffNs / 1_000} µs | total match: ${matchOffNs / 1_000_000} ms | per-call: $perCallOffNs ns")
+        log("[precompile=true ] construct: ${constructOnNs / 1_000} µs | total match: ${matchOnNs / 1_000_000} ms | per-call: $perCallOnNs ns")
+        log("Match speedup: ${"%.2f".format(speedup)}x")
+        log("Construction overhead (on vs off): ${(constructOnNs - constructOffNs) / 1_000_000} ms")
+    }
+
+    private fun measureMatchNs(
+        client: TdsClient,
+        urls: List<String>,
+        documentUrl: Uri,
+    ): Long {
+        val start = System.nanoTime()
+        repeat(MEASURED_ITERATIONS) {
+            urls.forEach { client.matches(it, documentUrl, emptyMap()) }
+        }
+        return System.nanoTime() - start
+    }
+
+    private fun loadAllTrackersFromTdsJson(): List<TdsTracker> {
+        val moshi = Moshi.Builder().add(ActionJsonAdapter()).build()
+        val adapter = moshi.adapter(TdsJson::class.java)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val tdsJson = context.resources.openRawResource(R.raw.tds).source().buffer().use { adapter.fromJson(it) }
+            ?: error("Failed to parse R.raw.tds")
+        return tdsJson.jsonToTrackers().values.toList()
+    }
+
+    /**
+     * Build URLs that hit a tracker domain (so we enter matchesTrackerEntry) but with paths
+     * crafted to NOT match any rule. Forces every rule's regex to be evaluated — the worst case
+     * the optimization targets. Biased toward trackers with many rules to amplify the signal.
+     */
+    private fun buildWorstCaseUrls(trackers: List<TdsTracker>, sampleSize: Int): List<String> {
+        return trackers.asSequence()
+            .filter { it.rules.isNotEmpty() }
+            .sortedByDescending { it.rules.size }
+            .take(sampleSize)
+            .map { tracker ->
+                val nonce = "z9q8w7e6r5t4y3u2-${tracker.domain.value.hashCode()}"
+                "http://${tracker.domain.value}/no-rule-match-path/$nonce/end"
+            }
+            .toList()
+    }
+
+    /**
+     * Prints proof-of-environment up front so anyone reading the output knows this is genuinely
+     * running on the device's ART runtime and not on a JVM.
+     *
+     * Key signals to verify:
+     *   - vmName="Dalvik"  (Android keeps the legacy name; HotSpot would say "OpenJDK 64-Bit Server VM")
+     *   - PID is an Android-side PID; the test runs inside a forked zygote process
+     *   - heap.max reflects the device's heap budget (typically 512 MB on phones, larger on AVDs)
+     *   - SoC details identify the silicon — useful when comparing numbers across devices later
+     */
+    private fun logRuntimeContext() {
+        val rt = Runtime.getRuntime()
+        val vmName = System.getProperty("java.vm.name") ?: "?"
+        val vmVersion = System.getProperty("java.vm.version") ?: "?"
+        val mb = 1024L * 1024L
+        log("--- Runtime context ---")
+        log("PID: ${android.os.Process.myPid()} (this is the on-device app_process running ART)")
+        log("VM: $vmName $vmVersion (\"Dalvik\" = ART; not HotSpot)")
+        log("Cores available: ${rt.availableProcessors()}")
+        log("Heap: max=${rt.maxMemory() / mb} MB, total=${rt.totalMemory() / mb} MB, free=${rt.freeMemory() / mb} MB")
+        log("Build fingerprint: ${Build.FINGERPRINT}")
+        logSocDetails()
+        log("-----------------------")
+    }
+
+    /**
+     * Capture SoC identity. Build.SOC_MANUFACTURER/MODEL are the official source (API 31+);
+     * /proc/cpuinfo gives a fallback hardware/board hint and the actual core count seen by the
+     * kernel (which may differ from Runtime.availableProcessors() if the process is restricted).
+     */
+    private fun logSocDetails() {
+        val soc = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            "${Build.SOC_MANUFACTURER} / ${Build.SOC_MODEL}"
+        } else {
+            "n/a (requires API 31+, this device is API ${Build.VERSION.SDK_INT})"
+        }
+        log("SoC: $soc")
+        log("Hardware: ${Build.HARDWARE} | Board: ${Build.BOARD} | Device: ${Build.DEVICE}")
+        runCatching {
+            val cpuinfo = File("/proc/cpuinfo").readText()
+            val processorCount = cpuinfo.lineSequence().count { it.startsWith("processor") }
+            val hardwareLine = cpuinfo.lineSequence()
+                .firstOrNull { it.startsWith("Hardware") }
+                ?.substringAfter(":")?.trim()
+            val cpuParts = cpuinfo.lineSequence()
+                .filter { it.startsWith("CPU part") }
+                .map { it.substringAfter(":").trim() }
+                .toSet()
+            log("/proc/cpuinfo: kernel-visible cores=$processorCount, hardware=\"${hardwareLine ?: "(unset)"}\", distinct CPU parts=$cpuParts")
+        }.onFailure {
+            log("/proc/cpuinfo: not readable (${it.message})")
+        }
+    }
+
+    private fun log(message: String) {
+        // Single write per line. On Android, println() would route through System.out into logcat
+        // as a second entry under tag "System.out", causing duplicate lines in any unfiltered view.
+        Log.i(LOG_TAG, message)
+    }
+
+    companion object {
+        private const val LOG_TAG = "TdsClientPerf"
+        private const val WARMUP_ROUNDS = 5
+        private const val MEASURED_ITERATIONS = 500
+        private const val URL_SAMPLE_SIZE = 200
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TdsClientPerfAndroidTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/TdsClientPerfAndroidTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.trackerdetection
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Build
 import android.util.Log
@@ -187,6 +188,7 @@ class TdsClientPerfAndroidTest {
      * /proc/cpuinfo gives a fallback hardware/board hint and the actual core count seen by the
      * kernel (which may differ from Runtime.availableProcessors() if the process is restricted).
      */
+    @SuppressLint("DenyListedApi")
     private fun logSocDetails() {
         val soc = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             "${Build.SOC_MANUFACTURER} / ${Build.SOC_MODEL}"

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -61,6 +61,16 @@ interface AndroidBrowserConfigFeature {
     fun optimizeTrackerEvaluationV3(): Toggle
 
     /**
+     * Pre-compile TDS rule regex patterns once when TdsClient is built rather than recompiling
+     * on every URL match. When disabled, regex compilation happens per-call (legacy behavior).
+     * @return `true` when the remote config has the global "precompileTdsRegex" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun precompileTdsRegex(): Toggle
+
+    /**
      * @return `true` when the remote config has the global "errorPagePixel" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `true`

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/PrecompileTdsRegexRCWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/PrecompileTdsRegexRCWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels.remoteconfig
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface PrecompileTdsRegexRCWrapper {
+    val enabled: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealPrecompileTdsRegexRCWrapper @Inject constructor(
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : PrecompileTdsRegexRCWrapper {
+    override val enabled by lazy { androidBrowserConfigFeature.precompileTdsRegex().isEnabled() }
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -22,18 +22,39 @@ import com.duckduckgo.app.browser.UriString.Companion.host
 import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomain
 import com.duckduckgo.app.trackerdetection.model.Action.BLOCK
 import com.duckduckgo.app.trackerdetection.model.Action.IGNORE
+import com.duckduckgo.app.trackerdetection.model.Rule
 import com.duckduckgo.app.trackerdetection.model.TdsTracker
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
+import logcat.logcat
 
 class TdsClient(
     override val name: Client.ClientName,
-    private val trackers: List<TdsTracker>,
+    trackers: List<TdsTracker>,
     private val urlToTypeMapper: UrlToTypeMapper,
     private val optimizeTrackerEvaluationV3: Boolean,
+    precompileRegex: Boolean = false,
 ) : Client {
 
-    private val trackerByDomain: Map<String, TdsTracker> by lazy {
-        trackers.associateBy { it.domain.value }
+    private val precompileRegex: Boolean = precompileRegex && optimizeTrackerEvaluationV3
+
+    private val compiledTrackers: List<CompiledTracker> = trackers.map { tracker ->
+        CompiledTracker(
+            tracker = tracker,
+            rules = tracker.rules.map { rule ->
+                val regex = if (precompileRegex) {
+                    runCatching { ".*${rule.rule}.*".toRegex() }
+                        .onFailure { logcat { "TDS rule failed to compile, skipping: ${rule.rule} (${it.message})" } }
+                        .getOrNull()
+                } else {
+                    null
+                }
+                CompiledRule(rule = rule, regex = regex)
+            },
+        )
+    }
+
+    private val compiledTrackerByDomain: Map<String, CompiledTracker> by lazy {
+        compiledTrackers.associateBy { it.tracker.domain.value }
     }
 
     override fun matches(
@@ -41,12 +62,12 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val tracker = findTracker(host(url)) ?: return Client.Result(matches = false, isATracker = false)
-        val matches = matchesTrackerEntry(tracker, url, documentUrl, requestHeaders)
+        val compiled = findCompiledTracker(host(url)) ?: return Client.Result(matches = false, isATracker = false)
+        val matches = matchesTrackerEntry(compiled, url, documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,
-            entityName = tracker.ownerName,
-            categories = tracker.categories,
+            entityName = compiled.tracker.ownerName,
+            categories = compiled.tracker.categories,
             surrogate = matches.surrogate,
             isATracker = matches.isATracker,
         )
@@ -57,32 +78,32 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val tracker = findTracker(url.host) ?: return Client.Result(matches = false, isATracker = false)
-        val matches = matchesTrackerEntry(tracker, url.toString(), documentUrl, requestHeaders)
+        val compiled = findCompiledTracker(url.host) ?: return Client.Result(matches = false, isATracker = false)
+        val matches = matchesTrackerEntry(compiled, url.toString(), documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,
-            entityName = tracker.ownerName,
-            categories = tracker.categories,
+            entityName = compiled.tracker.ownerName,
+            categories = compiled.tracker.categories,
             surrogate = matches.surrogate,
             isATracker = matches.isATracker,
         )
     }
 
-    private fun findTracker(host: String?): TdsTracker? {
+    private fun findCompiledTracker(host: String?): CompiledTracker? {
         if (host.isNullOrEmpty()) return null
         return if (optimizeTrackerEvaluationV3) {
-            findTrackerByLabelWalk(host)
+            findCompiledTrackerByLabelWalk(host)
         } else {
             val domain = Domain(host)
-            trackers.firstOrNull { sameOrSubdomain(domain, it.domain) }
+            compiledTrackers.firstOrNull { sameOrSubdomain(domain, it.tracker.domain) }
         }
     }
 
-    private fun findTrackerByLabelWalk(host: String): TdsTracker? {
+    private fun findCompiledTrackerByLabelWalk(host: String): CompiledTracker? {
         val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate: String = host
         while (true) {
-            trackerByDomain[candidate]?.let { return it }
+            compiledTrackerByDomain[candidate]?.let { return it }
             if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
@@ -91,13 +112,18 @@ class TdsClient(
     }
 
     private fun matchesTrackerEntry(
-        tracker: TdsTracker,
+        compiled: CompiledTracker,
         url: String,
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): MatchedResult {
-        tracker.rules.forEach { rule ->
-            val regex = ".*${rule.rule}.*".toRegex()
+        compiled.rules.forEach { compiledRule ->
+            val rule = compiledRule.rule
+            val regex = if (precompileRegex) {
+                compiledRule.regex ?: return@forEach
+            } else {
+                ".*${rule.rule}.*".toRegex()
+            }
             if (url.matches(regex)) {
                 val type = urlToTypeMapper.map(url, requestHeaders)
 
@@ -128,7 +154,7 @@ class TdsClient(
             }
         }
 
-        return MatchedResult(shouldBlock = (tracker.defaultAction == BLOCK), isATracker = true)
+        return MatchedResult(shouldBlock = (compiled.tracker.defaultAction == BLOCK), isATracker = true)
     }
 
     private fun matchedDomainAndTypes(
@@ -153,6 +179,16 @@ class TdsClient(
             else -> false
         }
     }
+
+    private data class CompiledRule(
+        val rule: Rule,
+        val regex: Regex?,
+    )
+
+    private data class CompiledTracker(
+        val tracker: TdsTracker,
+        val rules: List<CompiledRule>,
+    )
 
     private data class MatchedResult(
         val shouldBlock: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.lifecycle.PirProcessLifecycleObserver
 import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
+import com.duckduckgo.app.pixels.remoteconfig.PrecompileTdsRegexRCWrapper
 import com.duckduckgo.app.trackerdetection.api.TdsJson
 import com.duckduckgo.app.trackerdetection.db.TdsCnameEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
@@ -66,6 +67,7 @@ class TrackerDataLoader @Inject constructor(
     private val urlToTypeMapper: UrlToTypeMapper,
     private val dispatcherProvider: DispatcherProvider,
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
+    private val precompileTdsRegexRCWrapper: PrecompileTdsRegexRCWrapper,
 ) : MainProcessLifecycleObserver, PirProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -122,6 +124,7 @@ class TrackerDataLoader @Inject constructor(
             trackers = trackers,
             urlToTypeMapper = urlToTypeMapper,
             optimizeTrackerEvaluationV3 = optimizeTrackerEvaluationRCWrapper.enabled,
+            precompileRegex = precompileTdsRegexRCWrapper.enabled,
         )
         trackerDetectorClientProvider.addClient(client)
     }

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -28,12 +28,14 @@ import com.duckduckgo.app.trackerdetection.model.Rule
 import com.duckduckgo.app.trackerdetection.model.RuleExceptions
 import com.duckduckgo.app.trackerdetection.model.TdsTracker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyMap
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.regex.PatternSyntaxException
 
 @RunWith(AndroidJUnit4::class)
 class TdsClientTest {
@@ -363,14 +365,22 @@ class TdsClientTest {
 
         for (useUri in listOf(false, true)) {
             for (useV3 in listOf(true, false)) {
-                val tdsTracker = TdsTracker(trackerDomain, action, OWNER, CATEGORY, rule?.let { listOf(it) } ?: emptyList())
-                val testee = TdsClient(TDS, listOf(tdsTracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = useV3)
-                val result = if (useUri) {
-                    testee.matches(url.toUri(), DOCUMENT_URL, mapOf())
-                } else {
-                    testee.matches(url, DOCUMENT_URL, mapOf())
+                for (precompile in listOf(false, true)) {
+                    val tdsTracker = TdsTracker(trackerDomain, action, OWNER, CATEGORY, rule?.let { listOf(it) } ?: emptyList())
+                    val testee = TdsClient(
+                        TDS,
+                        listOf(tdsTracker),
+                        mockUrlToTypeMapper,
+                        optimizeTrackerEvaluationV3 = useV3,
+                        precompileRegex = precompile,
+                    )
+                    val result = if (useUri) {
+                        testee.matches(url.toUri(), DOCUMENT_URL, mapOf())
+                    } else {
+                        testee.matches(url, DOCUMENT_URL, mapOf())
+                    }
+                    assertEquals(expected, result.matches)
                 }
-                assertEquals(expected, result.matches)
             }
         }
     }
@@ -379,16 +389,67 @@ class TdsClientTest {
     fun whenUrlMatchesRuleWithSurrogateThenSurrogateScriptIdReturned() {
         val rule = Rule("api\\.tracker\\.com\\/auth", BLOCK, null, "script.js", null)
 
-        val testee =
-            TdsClient(
+        for (precompile in listOf(false, true)) {
+            val testee = TdsClient(
                 TDS,
                 listOf(TdsTracker(Domain("tracker.com"), BLOCK, OWNER, CATEGORY, listOf(rule))),
                 mockUrlToTypeMapper,
                 optimizeTrackerEvaluationV3 = false,
+                precompileRegex = precompile,
             )
 
-        assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js", DOCUMENT_URL, mapOf()).surrogate)
-        assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js".toUri(), DOCUMENT_URL, mapOf()).surrogate)
+            assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js", DOCUMENT_URL, mapOf()).surrogate)
+            assertEquals("script.js", testee.matches("http://api.tracker.com/auth/script.js".toUri(), DOCUMENT_URL, mapOf()).surrogate)
+        }
+    }
+
+    @Test
+    fun whenPrecompileEnabledAndRuleHasInvalidRegexThenConstructionSucceedsAndRuleIsSkipped() {
+        // Unbalanced "(" — fails to compile. With precompile=true, construction must not crash
+        // and the rule must be treated as non-matching, falling through to the tracker's defaultAction.
+        // Precompile is gated on V3, so V3 must be enabled for the precompile path to run.
+        val invalidRule = Rule("api\\.tracker\\.com\\/auth(", BLOCK, null, null, null)
+
+        val testee = TdsClient(
+            TDS,
+            listOf(TdsTracker(trackerDomain, IGNORE, OWNER, CATEGORY, listOf(invalidRule))),
+            mockUrlToTypeMapper,
+            optimizeTrackerEvaluationV3 = true,
+            precompileRegex = true,
+        )
+
+        assertEquals(false, testee.matches(url, DOCUMENT_URL, mapOf()).matches)
+        assertEquals(false, testee.matches(url.toUri(), DOCUMENT_URL, mapOf()).matches)
+    }
+
+    @Test
+    fun whenV3DisabledAndPrecompileRequestedAndRuleHasInvalidRegexThenGateDisablesPrecompileAndLegacyPathThrows() {
+        // Sanity test for the V3 gate on precompile: with V3 off, precompile must NOT take effect.
+        // The precompile path skips invalid rules at construction; the legacy per-call path does not.
+        // So an invalid regex with V3=false + precompile=true must surface as a per-call exception,
+        // proving the gate prevented precompile from running.
+        val invalidRule = Rule("api\\.tracker\\.com\\/auth(", BLOCK, null, null, null)
+
+        val testee = TdsClient(
+            TDS,
+            listOf(TdsTracker(trackerDomain, IGNORE, OWNER, CATEGORY, listOf(invalidRule))),
+            mockUrlToTypeMapper,
+            optimizeTrackerEvaluationV3 = false,
+            precompileRegex = true,
+        )
+
+        try {
+            testee.matches(url, DOCUMENT_URL, mapOf())
+            fail("Expected legacy per-call regex compilation to throw — gate did not disable precompile")
+        } catch (_: PatternSyntaxException) {
+            // expected — legacy path compiles the invalid regex per-call and throws
+        }
+        try {
+            testee.matches(url.toUri(), DOCUMENT_URL, mapOf())
+            fail("Expected legacy per-call regex compilation to throw — gate did not disable precompile")
+        } catch (_: PatternSyntaxException) {
+            // expected — legacy path compiles the invalid regex per-call and throws
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
+import com.duckduckgo.app.pixels.remoteconfig.PrecompileTdsRegexRCWrapper
 import com.duckduckgo.app.trackerdetection.api.TdsJson
 import com.duckduckgo.app.trackerdetection.api.TdsJsonEntity
 import com.duckduckgo.app.trackerdetection.api.TdsJsonTracker
@@ -83,6 +84,10 @@ class TrackerDataLoaderTest {
             urlToTypeMapper = mockUrlToTypeMapper,
             coroutineRule.testDispatcherProvider,
             object : OptimizeTrackerEvaluationRCWrapper {
+                override val enabled: Boolean
+                    get() = false
+            },
+            object : PrecompileTdsRegexRCWrapper {
                 override val enabled: Boolean
                     get() = false
             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1213808460359637?focus=true

### Description

Pre-compiles the regex patterns for TDS tracker rules once at TdsClient construction time, instead of recompiling them on every URL match. On a typical browse session this is a large amount of redundant Pattern.compile() work — every request that hits a tracker domain currently recompiles every rule's regex until one matches (or all are exhausted).

The new path:

- TdsClient builds CompiledTracker / CompiledRule wrappers up front, compiling each rule's regex once.
- Invalid regex patterns are caught at construction (logged and skipped) rather than throwing per-call from inside matchesTrackerEntry.
- Gated by a new precompileTdsRegex sub-feature on AndroidBrowserConfigFeature (default INTERNAL), exposed via PrecompileTdsRegexRCWrapper and read by TrackerDataLoader when constructing the client.
- Also gated on optimizeTrackerEvaluationV3 — precompileRegex only takes effect when V3 is on, since they share the same fast-path code. With V3 off, the legacy per-call compile path runs unchanged.

Existing tracker tests (TdsClientTest, reference tests) were extended to run both precompile=false and precompile=true so all behaviour is covered. A new on-device microbenchmark, TdsClientPerfAndroidTest, mirrors the JVM TdsClientPerfTest and is annotated @Ignore (manual run only) so CI doesn't execute it — kdoc on the class explains how to run it and capture logcat.

### Steps to test this PR

1/ `precompileRegex` flag ON (internal build, default INTERNAL)

- install from this branch (the flag is ON for internal)
- browse a few tracker-heavy sites (e.g. news / shopping pages). 
- confirm tracker blocking and the privacy dashboard counts match what you see in Prod.
- confirm no crashes on launch: the precompile step now runs eagerly when the TDS client is built during TrackerDataLoader.

2/ `precompileRegex` flag OFF 

- install from this branch and ensure you have the `precompileRegex`flag OFF 
- browse a few tracker-heavy sites (e.g. news / shopping pages). 
- confirm tracker blocking and the privacy dashboard counts match what you see in Prod.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tracker-matching behavior in `TdsClient` and adds a new remote-config-controlled optimization path; while gated and covered by tests, mistakes could impact tracker blocking accuracy or startup cost due to eager regex compilation.
> 
> **Overview**
> Introduces an optional **regex precompilation** path in `TdsClient` that compiles each tracker rule’s regex once during client construction and reuses it during `matches`, skipping (and logging) rules that fail to compile.
> 
> Wires this behavior behind a new `androidBrowserConfig.precompileTdsRegex` toggle via `PrecompileTdsRegexRCWrapper`, and passes the flag from `TrackerDataLoader` when building the TDS client (*effective only when `optimizeTrackerEvaluationV3` is enabled*).
> 
> Updates unit/reference tests to exercise both `precompileRegex` modes and adds an `@Ignore`d on-device microbenchmark (`TdsClientPerfAndroidTest`) to compare construction and match throughput.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48da3db05e9d3cad03d89a95525c78e82ecf0795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->