### PR TITLE
Update floating buttons and keyboard actions for native-widget

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -312,7 +312,7 @@ open class InputModeWidget @JvmOverloads constructor(
                     (keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER || keyEvent?.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) &&
                         keyEvent.action == KeyEvent.ACTION_DOWN
 
-                if (actionId == EditorInfo.IME_ACTION_GO || isHardwareEnter) {
+                if (actionId == EditorInfo.IME_ACTION_GO || (isHardwareEnter && shouldSubmitOnHardwareEnter())) {
                     submitMessage()
 
                     val params = inputScreenPixelsModeParam(isSearchMode = inputModeSwitch.selectedTabPosition == 0)
@@ -425,6 +425,8 @@ open class InputModeWidget @JvmOverloads constructor(
         }
         (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(inputField)
     }
+
+    protected open fun shouldSubmitOnHardwareEnter(): Boolean = true
 
     protected open fun EditText.applyChatInputType() {
         imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -27,6 +27,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.webkit.ValueCallback
 import android.widget.EditText
 import android.widget.FrameLayout
@@ -173,6 +174,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
     private var submitButtons: InputScreenButtons? = null
+    private var floatingButtons: InputScreenButtons? = null
     private var floatingSubmitContainer: ViewGroup? = null
     private var chatStateJob: Job? = null
     private var chatSuggestionsSettingJob: Job? = null
@@ -200,13 +202,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override var onVoiceSearchClick: (() -> Unit)? = null
         set(value) {
             field = value
-            submitButtons?.onVoiceSearchClick = value
+            voiceHostButtons()?.onVoiceSearchClick = value
             onVoiceClick = value
         }
     override var onVoiceChatClick: (() -> Unit)? = null
         set(value) {
             field = value
-            submitButtons?.onVoiceChatClick = value
+            voiceHostButtons()?.onVoiceChatClick = value
         }
     override var onPaidTierChanged: ((Boolean) -> Unit)? = null
         set(value) {
@@ -355,6 +357,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         inputField.doOnTextChanged { _, _, _, _ ->
             updateSendButtonVisibility()
             updateVoiceButtonVisibility()
+            updateNewLineButtonVisibility()
         }
     }
 
@@ -387,11 +390,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateBottomRowVisibility() {
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
-        val rowSpacer = findViewById<View?>(R.id.rowSpacer)
-        val chatActive = isDuckAiPageContext() || (nativeInputState.toggleVisible && isChatTabSelected())
-        val visible = chatActive && (inputField.hasFocus() || isStreaming)
-        bottomRow.isVisible = visible
-        rowSpacer?.isVisible = visible
+        val visible = isChatTabSelected() && (inputField.hasFocus() || isStreaming)
+        bottomRow.visibility = if (visible) VISIBLE else GONE
     }
 
     private fun updateToggleVisibilityForState() {
@@ -436,8 +436,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun updateVoiceButtonVisibility() {
         val isBlank = inputField.text.isNullOrBlank() && !hasAttachments
         setVoiceButtonVisible(voiceSearchAvailable && isBlank)
-        submitButtons?.setVoiceSearchVisible(false)
-        submitButtons?.setVoiceChatVisible(voiceChatAvailable && isBlank && !isStreaming)
+        val host = voiceHostButtons()
+        host?.setVoiceSearchVisible(false)
+        host?.setVoiceChatVisible(voiceChatAvailable && isBlank && !isStreaming)
     }
 
     private fun updateSendButtonVisibility() {
@@ -449,7 +450,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
+    private fun updateNewLineButtonVisibility() {
+        val isBrowserContext = nativeInputState.inputContext == NativeInputState.InputContext.BROWSER
+        val hasText = inputField.text.isNotBlank()
+        val visible = isBrowserContext && isChatTabSelected() && hasText && !isStreaming
+        floatingButtons?.setNewLineButtonVisible(visible)
+    }
+
     private fun applyState(state: NativeInputState) {
+        val contextChanged = nativeInputState.inputContext != state.inputContext
         nativeInputState = state
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
@@ -458,6 +467,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateBackButtons(state)
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
+        updateNewLineButtonVisibility()
+        if (contextChanged && isChatTabSelected()) {
+            inputField.applyChatInputType()
+            (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(inputField)
+        }
     }
 
     private fun updateSelectedTab(toggle: TabLayout, state: NativeInputState) {
@@ -548,13 +562,19 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun EditText.applyChatInputType() {
         hint = context.getString(R.string.native_input_chat_hint)
-        imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO
+        val isDuckAiChat = isDuckAiPageContext()
+        val actionFlag = if (isDuckAiChat) EditorInfo.IME_ACTION_NONE else EditorInfo.IME_ACTION_GO
+        imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or actionFlag
+        val baseInputType = InputType.TYPE_CLASS_TEXT or
+            InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
         setRawInputType(
-            InputType.TYPE_CLASS_TEXT or
-                InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES,
+            if (isDuckAiChat) baseInputType or InputType.TYPE_TEXT_FLAG_MULTI_LINE else baseInputType,
         )
         setHorizontallyScrolling(false)
     }
+
+    override fun shouldSubmitOnHardwareEnter(): Boolean =
+        !(isDuckAiPageContext() && isChatTabSelected())
 
     override fun submitMessage(message: String?) {
         if (message == null && isChatTabSelected() && attachmentLimitExceeded) {
@@ -855,6 +875,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateBottomRowVisibility()
         updateSendButtonVisibility()
         updateVoiceButtonVisibility()
+        updateNewLineButtonVisibility()
     }
 
     private fun applyTabUi() {
@@ -867,6 +888,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             inputField.maxLines = MAX_LINES
         }
         updateSendButtonVisibility()
+        updateNewLineButtonVisibility()
         updateBottomRowVisibility()
     }
 
@@ -908,29 +930,42 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getInputState(): NativeInputState = nativeInputState
 
     private fun configureSubmitButtons() {
-        if (submitButtons != null) return
+        if (submitButtons == null) {
+            val bottomContainer = findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer) ?: return
+            val buttons = InputScreenButtons(
+                context = context,
+                useTopBar = false,
+                layoutResId = R.layout.view_native_input_screen_buttons,
+            ).apply {
+                onSendClick = { submitMessage() }
+                onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
+                setSendButtonVisible(false)
+                setNewLineButtonVisible(false)
+            }
+            bottomContainer.addView(buttons)
+            submitButtons = buttons
+        }
+
         val floating = floatingSubmitContainer
-        val (container, useTopBar) = if (floating != null) {
-            floating to true
-        } else {
-            (findViewById<FrameLayout?>(R.id.inputScreenButtonsContainer) ?: return) to false
+        if (floating != null && floatingButtons == null) {
+            val buttons = InputScreenButtons(
+                context = context,
+                useTopBar = true,
+                layoutResId = R.layout.view_native_input_screen_buttons,
+            ).apply {
+                onNewLineClick = { printNewLine() }
+                onVoiceSearchClick = this@NativeInputModeWidget.onVoiceSearchClick
+                onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
+                setSendButtonVisible(false)
+                setNewLineButtonVisible(false)
+            }
+            floating.addView(buttons)
+            floatingButtons = buttons
         }
-        val buttons = InputScreenButtons(
-            context = context,
-            useTopBar = useTopBar,
-            layoutResId = R.layout.view_native_input_screen_buttons,
-        ).apply {
-            onSendClick = { submitMessage() }
-            onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
-            onVoiceSearchClick = this@NativeInputModeWidget.onVoiceSearchClick
-            onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
-            setSendButtonVisible(false)
-            setNewLineButtonVisible(false)
-        }
-        container.addView(buttons)
-        submitButtons = buttons
         updateVoiceButtonVisibility()
     }
+
+    private fun voiceHostButtons(): InputScreenButtons? = floatingButtons ?: submitButtons
 
     companion object {
         private const val MAX_LINES = 5

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -63,6 +63,7 @@
                     android:id="@+id/inputModeSwitchRow"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
                     android:visibility="gone"
@@ -174,17 +175,11 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone" />
 
-                <Space
-                    android:id="@+id/rowSpacer"
-                    android:layout_width="match_parent"
-                    android:layout_height="8dp"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
-
                 <FrameLayout
                     android:id="@+id/inputModeWidgetBottomRow"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
                     android:clipChildren="false"
                     android:clipToPadding="false"
                     android:visibility="gone"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214733589467185?focus=true

### Description

### Steps to test this PR
#### In Search mode
- Search toggle selected
  - Keyboard action: Submit
  - No Floating Carriage Return
- Duck.ai toggle selected
  - No text
    - Keyboard action: Submit
    - No Floating Carriage Return
  - Text present
    - Keyboard action: Submit
    - Floating Carriage Return

#### In Duck.ai
- Search toggle selected
  - Keyboard action: Submit
  - No Floating Carriage Return
- Duck.ai toggle selected
  - With/Without text
    - Keyboard action: Carriage Return
    - Submit button present in bottom row buttons


### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/c98141c5-3c6d-4493-a4d3-9c6275c230b7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes submission semantics and IME/input-type handling across browser vs Duck.ai contexts, which can affect message sending and keyboard behavior. Also adjusts button hosting/visibility logic, so regressions are possible in chat controls across states (focus/streaming/attachments).
> 
> **Overview**
> Updates native chat input so **hardware Enter no longer always submits**: `InputModeWidget` now gates hardware-enter submission via overridable `shouldSubmitOnHardwareEnter()`, and `NativeInputModeWidget` disables it for Duck.ai chat.
> 
> Refines Duck.ai vs browser IME behavior by switching Duck.ai chat to *multiline* input with `IME_ACTION_NONE`, and forcing an `InputMethodManager.restartInput` when the input context changes.
> 
> Reworks native submit/voice controls to support a separate **floating button host** (including a new-line button shown only in browser-context chat with text and not streaming), simplifies bottom-row visibility logic, and tweaks layout spacing (removes `rowSpacer`, adds margins around toggle row/bottom row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d07d137cd541594cd55fc4759af451b31d4556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->