### PR TITLE
Add per-tab NativeInputStateProvider/Publisher

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -361,6 +361,7 @@ class TabDataRepository @Inject constructor(
             clearAllSiteData(listOf(tabId))
         }
         tabVisitedSitesRepository.clearTab(tabId)
+        nativeInputStatePublisher.clearTab(tabId)
     }
 
     private fun clearAllSiteData(tabIds: List<String>) {
@@ -404,7 +405,10 @@ class TabDataRepository @Inject constructor(
     override suspend fun purgeDeletableTabs() = withContext(dispatchers.io()) {
         val deletableTabIds = getDeletableTabIds()
         clearAllSiteData(deletableTabIds)
-        deletableTabIds.forEach { tabVisitedSitesRepository.clearTab(it) }
+        deletableTabIds.forEach {
+            tabVisitedSitesRepository.clearTab(it)
+            nativeInputStatePublisher.clearTab(it)
+        }
 
         purgeDeletableTabsJob += appCoroutineScope.launch(dispatchers.io()) {
             tabsDao.purgeDeletableTabsAndUpdateSelection()
@@ -449,6 +453,7 @@ class TabDataRepository @Inject constructor(
         siteData.clear()
         duckChatContextualDataStore.clearAll()
         tabVisitedSitesRepository.clearAll()
+        nativeInputStatePublisher.clearAll()
     }
 
     override suspend fun getSelectedTab(): TabEntity? =

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import dagger.SingleInstanceIn
 import io.reactivex.Scheduler
@@ -72,6 +73,7 @@ class TabDataRepository @Inject constructor(
     private val tabManagerFeatureFlags: TabManagerFeatureFlags,
     private val duckChatContextualDataStore: DuckChatContextualDataStore,
     private val tabVisitedSitesRepository: TabVisitedSitesRepository,
+    private val nativeInputStatePublisher: NativeInputStatePublisher,
 ) : TabRepository, TabAtomicOperations {
 
     override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs().distinctUntilChanged()
@@ -338,6 +340,7 @@ class TabDataRepository @Inject constructor(
         }
         siteData.remove(tab.tabId)
         tabVisitedSitesRepository.clearTab(tab.tabId)
+        nativeInputStatePublisher.clearTab(tab.tabId)
     }
 
     override suspend fun deleteTabs(tabIds: List<String>) {
@@ -345,7 +348,10 @@ class TabDataRepository @Inject constructor(
             tabsDao.deleteTabsAndUpdateSelection(tabIds)
             clearAllSiteData(tabIds)
         }
-        tabIds.forEach { tabVisitedSitesRepository.clearTab(it) }
+        tabIds.forEach {
+            tabVisitedSitesRepository.clearTab(it)
+            nativeInputStatePublisher.clearTab(it)
+        }
     }
 
     override suspend fun replaceTabWithNewTab(tabId: String, url: String?) {
@@ -430,6 +436,7 @@ class TabDataRepository @Inject constructor(
             }
         }
         tabVisitedSitesRepository.clearTab(tabId)
+        nativeInputStatePublisher.clearTab(tabId)
     }
 
     override suspend fun deleteAll() {

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.common.test.blockingObserve
 import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -108,6 +109,8 @@ class TabDataRepositoryTest {
     private val mockDuckChatContextualDataStore: DuckChatContextualDataStore = mock()
 
     private val mockTabVisitedSitesRepository: TabVisitedSitesRepository = mock()
+
+    private val mockNativeInputStatePublisher: NativeInputStatePublisher = mock()
 
     @After
     fun after() {
@@ -771,6 +774,7 @@ class TabDataRepositoryTest {
         timeProvider: CurrentTimeProvider = FakeTimeProvider(),
         contextualDataStore: DuckChatContextualDataStore = mockDuckChatContextualDataStore,
         tabVisitedSitesRepository: TabVisitedSitesRepository = mockTabVisitedSitesRepository,
+        nativeInputStatePublisher: NativeInputStatePublisher = mockNativeInputStatePublisher,
     ): TabDataRepository {
         return TabDataRepository(
             dao,
@@ -796,6 +800,7 @@ class TabDataRepositoryTest {
             tabManagerFeatureFlags,
             contextualDataStore,
             tabVisitedSitesRepository,
+            nativeInputStatePublisher,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -249,6 +249,7 @@ class TabDataRepositoryTest {
         verify(mockWebViewSessionStorage).deleteAllSessions()
         verify(mockDuckChatContextualDataStore).clearAll()
         verify(mockTabVisitedSitesRepository).clearAll()
+        verify(mockNativeInputStatePublisher).clearAll()
         assertNotSame(siteData, testee.retrieveSiteData(addedTabId))
     }
 
@@ -650,6 +651,7 @@ class TabDataRepositoryTest {
             verify(mockAdClickManager).clearTabId(tabId)
             verify(mockDuckChatContextualDataStore).clearTabChatUrl(tabId)
             verify(mockTabVisitedSitesRepository).clearTab(tabId)
+            verify(mockNativeInputStatePublisher).clearTab(tabId)
         }
     }
 
@@ -668,6 +670,7 @@ class TabDataRepositoryTest {
             verify(mockAdClickManager).clearTabId(tabId)
             verify(mockDuckChatContextualDataStore).clearTabChatUrl(tabId)
             verify(mockTabVisitedSitesRepository).clearTab(tabId)
+            verify(mockNativeInputStatePublisher).clearTab(tabId)
         }
     }
 
@@ -759,6 +762,7 @@ class TabDataRepositoryTest {
         }
         verify(mockWebViewSessionStorage).deleteSession(TAB_ID)
         verify(mockTabVisitedSitesRepository).clearTab(TAB_ID)
+        verify(mockNativeInputStatePublisher).clearTab(TAB_ID)
     }
 
     private fun tabDataRepository(

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.ui
+package com.duckduckgo.duckchat.api.nativeinput
 
 data class NativeInputState(
     val inputMode: InputMode,
     val inputContext: InputContext,
     val inputPosition: InputPosition = InputPosition.TOP,
+    val tabId: String? = null,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,
@@ -41,4 +42,21 @@ data class NativeInputState(
             InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ToggleSelection.DUCK_AI
             InputContext.BROWSER -> ToggleSelection.SEARCH
         }
+
+    companion object {
+        /**
+         * Placeholder state used by [NativeInputStateProvider] for a tab that has not yet been
+         * published to. Observers should not rely on these values: the native input widget overwrites
+         * them via [NativeInputStatePublisher.publish] as soon as it is configured for the tab.
+         *
+         * TODO: once the widget is wired to publish on configure (follow-up PR), tighten [tabId] to
+         * non-null and remove this default; the store will key off the publisher-supplied state.
+         */
+        fun zero(tabId: String? = null): NativeInputState = NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = InputContext.BROWSER,
+            inputPosition = InputPosition.TOP,
+            tabId = tabId,
+        )
+    }
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStateProvider.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStateProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api.nativeinput
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Read-only access to the per-tab native input state. Components that need to react to input state
+ * changes (toggle visibility, model selection, etc.) observe the flow for their tab.
+ *
+ * The writer-side counterpart is [NativeInputStatePublisher], which is reserved for the native input
+ * widget; plugins must not depend on it.
+ */
+interface NativeInputStateProvider {
+    fun stateForTab(tabId: String): StateFlow<NativeInputState>
+}

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStatePublisher.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStatePublisher.kt
@@ -24,4 +24,5 @@ interface NativeInputStatePublisher {
     fun publish(tabId: String, state: NativeInputState)
     fun update(tabId: String, transform: (NativeInputState) -> NativeInputState)
     fun clearTab(tabId: String)
+    fun clearAll()
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStatePublisher.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStatePublisher.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api.nativeinput
+
+/**
+ * Write-side of the native input state store. Only the native input widget (and its ViewModel) should
+ * publish; everything else observes via [NativeInputStateProvider].
+ */
+interface NativeInputStatePublisher {
+    fun publish(tabId: String, state: NativeInputState)
+    fun update(tabId: String, transform: (NativeInputState) -> NativeInputState)
+    fun clearTab(tabId: String)
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -21,7 +21,7 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.impl.ui.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 
 sealed class PromptContribution {
     data class ModelSelection(val modelId: String) : PromptContribution()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -51,6 +51,10 @@ class RealNativeInputStateStore @Inject constructor() :
         flows.remove(tabId)
     }
 
+    override fun clearAll() {
+        flows.clear()
+    }
+
     // Seed unpublished tabs with [NativeInputState.zero] only because StateFlow requires an initial
     // value. The native input widget overwrites it on configure; see the TODO on zero() — once the
     // widget is wired to publish first, this seed becomes unreachable and can be replaced with a

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = NativeInputStateProvider::class)
+@ContributesBinding(AppScope::class, boundType = NativeInputStatePublisher::class)
+class RealNativeInputStateStore @Inject constructor() :
+    NativeInputStateProvider,
+    NativeInputStatePublisher {
+
+    private val flows = ConcurrentHashMap<String, MutableStateFlow<NativeInputState>>()
+
+    override fun stateForTab(tabId: String): StateFlow<NativeInputState> = flowFor(tabId)
+
+    override fun publish(tabId: String, state: NativeInputState) {
+        flowFor(tabId).value = state
+    }
+
+    override fun update(tabId: String, transform: (NativeInputState) -> NativeInputState) {
+        flowFor(tabId).update(transform)
+    }
+
+    override fun clearTab(tabId: String) {
+        flows.remove(tabId)
+    }
+
+    // Seed unpublished tabs with [NativeInputState.zero] only because StateFlow requires an initial
+    // value. The native input widget overwrites it on configure; see the TODO on zero() — once the
+    // widget is wired to publish first, this seed becomes unreachable and can be replaced with a
+    // first-publish gate.
+    private fun flowFor(tabId: String): MutableStateFlow<NativeInputState> =
+        flows.computeIfAbsent(tabId) { MutableStateFlow(NativeInputState.zero(tabId)) }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
 import com.duckduckgo.duckchat.impl.DuckChatInternal

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -60,7 +61,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
-import com.duckduckgo.duckchat.impl.ui.NativeInputState
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.CoroutineScope

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class RealNativeInputStateStoreTest {
+
+    private val testee = RealNativeInputStateStore()
+
+    @Test
+    fun whenStateForTabCalledTwiceForSameTabThenSameFlowReturned() {
+        val first = testee.stateForTab("tab-a")
+        val second = testee.stateForTab("tab-a")
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun whenStateForTabCalledForDifferentTabsThenDifferentFlowsReturned() {
+        val a = testee.stateForTab("tab-a")
+        val b = testee.stateForTab("tab-b")
+
+        assertNotSame(a, b)
+    }
+
+    @Test
+    fun whenStateForTabCalledWithoutPriorPublishThenZeroStateReturned() {
+        val state = testee.stateForTab("tab-a").value
+
+        assertEquals(NativeInputState.zero("tab-a"), state)
+    }
+
+    @Test
+    fun whenPublishCalledThenStateForTabReturnsPublishedValue() {
+        val published = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+            tabId = "tab-a",
+        )
+
+        testee.publish("tab-a", published)
+
+        assertEquals(published, testee.stateForTab("tab-a").value)
+    }
+
+    @Test
+    fun whenPublishCalledForOneTabThenOtherTabStateIsUnchanged() {
+        val initialB = testee.stateForTab("tab-b").value
+
+        testee.publish(
+            "tab-a",
+            NativeInputState(
+                inputMode = InputMode.SEARCH_ONLY,
+                inputContext = InputContext.DUCK_AI,
+                tabId = "tab-a",
+            ),
+        )
+
+        assertEquals(initialB, testee.stateForTab("tab-b").value)
+    }
+
+    @Test
+    fun whenUpdateCalledThenTransformAppliedToExistingState() {
+        testee.publish(
+            "tab-a",
+            NativeInputState(
+                inputMode = InputMode.SEARCH_ONLY,
+                inputContext = InputContext.BROWSER,
+                tabId = "tab-a",
+            ),
+        )
+
+        testee.update("tab-a") { it.copy(inputContext = InputContext.DUCK_AI) }
+
+        assertEquals(InputContext.DUCK_AI, testee.stateForTab("tab-a").value.inputContext)
+        assertEquals(InputMode.SEARCH_ONLY, testee.stateForTab("tab-a").value.inputMode)
+    }
+
+    @Test
+    fun whenUpdateCalledOnUnpublishedTabThenTransformAppliedToZeroState() {
+        testee.update("tab-a") { it.copy(inputMode = InputMode.SEARCH_ONLY) }
+
+        assertEquals(InputMode.SEARCH_ONLY, testee.stateForTab("tab-a").value.inputMode)
+    }
+
+    @Test
+    fun whenClearTabCalledThenSubsequentStateForTabReturnsZero() {
+        testee.publish(
+            "tab-a",
+            NativeInputState(
+                inputMode = InputMode.SEARCH_ONLY,
+                inputContext = InputContext.DUCK_AI,
+                tabId = "tab-a",
+            ),
+        )
+
+        testee.clearTab("tab-a")
+
+        assertEquals(NativeInputState.zero("tab-a"), testee.stateForTab("tab-a").value)
+    }
+
+    @Test
+    fun whenClearTabCalledThenOtherTabsAreUntouched() {
+        val stateB = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+            tabId = "tab-b",
+        )
+        testee.publish("tab-b", stateB)
+
+        testee.clearTab("tab-a")
+
+        assertEquals(stateB, testee.stateForTab("tab-b").value)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
@@ -133,4 +133,29 @@ class RealNativeInputStateStoreTest {
 
         assertEquals(stateB, testee.stateForTab("tab-b").value)
     }
+
+    @Test
+    fun whenClearAllCalledThenAllTabsAreEvicted() {
+        testee.publish(
+            "tab-a",
+            NativeInputState(
+                inputMode = InputMode.SEARCH_ONLY,
+                inputContext = InputContext.DUCK_AI,
+                tabId = "tab-a",
+            ),
+        )
+        testee.publish(
+            "tab-b",
+            NativeInputState(
+                inputMode = InputMode.SEARCH_ONLY,
+                inputContext = InputContext.DUCK_AI,
+                tabId = "tab-b",
+            ),
+        )
+
+        testee.clearAll()
+
+        assertEquals(NativeInputState.zero("tab-a"), testee.stateForTab("tab-a").value)
+        assertEquals(NativeInputState.zero("tab-b"), testee.stateForTab("tab-b").value)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -16,8 +16,9 @@
 
 package com.duckduckgo.duckchat.impl.ui
 
-import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputContext
-import com.duckduckgo.duckchat.impl.ui.NativeInputState.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowCardRowBack
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowToggleRowBack
 import org.junit.Assert.assertFalse

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214788735007211?focus=true

### Description

First PR in a series moving native input state from `NativeInputHost.getInputState()` (pull-based, single in-memory snapshot in the widget) to a per-tab, push-based store that any consumer can observe.

This PR is **pure plumbing** — no behavior change. No widget or plugin writes or reads through the new interfaces yet.

What lands here:

- **`duck-chat-api`** gets two new interfaces under `com.duckduckgo.duckchat.api.nativeinput`:
  - `NativeInputStateProvider` — read side, exposes `stateForTab(tabId: String): StateFlow<NativeInputState>`.
  - `NativeInputStatePublisher` — write side, with `publish(tabId, state)`, `update(tabId, transform)`, and `clearTab(tabId)`.
  Only the native input widget should depend on the publisher; everything else observes via the provider.
- **`NativeInputState`** (and its nested `InputMode` / `InputContext` / `InputPosition` / `ToggleSelection`) moves from `duckchat-impl` to `duck-chat-api`. A new `NativeInputState.zero(tabId)` factory documents the placeholder default; a TODO marks that the widget will overwrite it once wired to publish on configure (next PR).
- **`RealNativeInputStateStore`** in `duckchat-impl` binds both interfaces at `AppScope`, backed by a `ConcurrentHashMap<String, MutableStateFlow<NativeInputState>>`.
- **`TabDataRepository`** injects the publisher and calls `clearTab(tabId)` at the three delete sites (`delete`, `deleteTabs`, `deleteTabAndSelectSource`) so per-tab state does not leak after a tab closes.

Follow-up PRs:
1. Wire the widget's ViewModel to publish through `NativeInputStatePublisher` and read its own state from the provider; tighten `tabId` to non-null.
2. Migrate the 5 `NativeInputPlugin` ViewModels to observe `stateForTab(tabId)`; route any plugin contributions through new typed `NativeInputHost` methods that the widget translates into publisher updates.
3. Remove `NativeInputHost.getInputState()` and `NativeInputPlugin.getPromptContribution()`.

### Steps to test this PR

_Plumbing only — no user-visible change._
- [ ] CI green: `:duckchat-api:compileDebugKotlin`, `:duckchat-impl:testDebugUnitTest`, `:app:testPlayDebugUnitTest`
- [ ] New `RealNativeInputStateStoreTest` passes (9 cases covering per-tab isolation, `update` atomicity, `clearTab`, zero default).
- [ ] Existing `TabDataRepositoryTest` still passes after constructor signature update.
- [ ] Smoke-test the app: open Duck.ai input on the NTP and on a browser tab — input behaves exactly as on `develop`.

### UI changes
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new state-store plumbing and updates tab-deletion paths to clear per-tab native input state; risk is mainly around DI wiring and ensuring state is properly evicted on tab lifecycle events.
> 
> **Overview**
> Adds a new per-tab, push-based native input state API (`NativeInputStateProvider`/`NativeInputStatePublisher`) backed by an `AppScope` `RealNativeInputStateStore` that maintains a `StateFlow` per tab.
> 
> Moves `NativeInputState` into `duckchat-api`, extends it with an optional `tabId` and a `zero()` placeholder factory, and updates existing widget/plugin/viewmodel/test imports to reference the new API package.
> 
> Updates `TabDataRepository` tab cleanup (`delete`, `deleteTabs`, `replaceTabWithNewTab`, `purgeDeletableTabs`, `deleteTabAndSelectSource`, `deleteAll`) to evict native input state via the publisher, with corresponding test assertions and new unit coverage for the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a038cf8e7e10de1aeca9cdfa1c41fda5dab622ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->