### PR TITLE
Widget publishes native input state per tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1332,6 +1332,7 @@ class BrowserTabFragment :
 
     private fun showNativeInput(query: String = "") {
         nativeInputManager.showNativeInput(
+            tabId = tabId,
             layoutInflater = layoutInflater,
             lifecycleOwner = viewLifecycleOwner,
             tabs = viewModel.tabs,

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -87,6 +87,7 @@ interface NativeInputManager {
     fun isChatTabSelected(): Boolean
 
     fun showNativeInput(
+        tabId: String,
         layoutInflater: LayoutInflater,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
@@ -300,6 +301,7 @@ class RealNativeInputManager @Inject constructor(
     }
 
     override fun showNativeInput(
+        tabId: String,
         layoutInflater: LayoutInflater,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
@@ -332,7 +334,7 @@ class RealNativeInputManager @Inject constructor(
                 selectAllText()
             }
         }
-        attachWidget(widgetView, isBottom)
+        attachWidget(widgetView, isBottom, tabId)
         val isNewTab = query.isEmpty() && omnibarController.getText().isEmpty()
         applyInitialTabSelection(widgetView, isNewTab)
         if (omnibarController.isDuckAiMode()) {
@@ -570,13 +572,13 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun attachWidget(widgetView: View, isBottom: Boolean) {
+    private fun attachWidget(widgetView: View, isBottom: Boolean, tabId: String) {
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom))
         widgetRoot = widgetView
 
         widgetFrom(widgetView)?.apply {
             setWidgetRootView(widgetView)
-            configure(isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
+            configure(tabId = tabId, isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
         applyWindowChrome(widgetView, isBottom)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -38,6 +38,7 @@ import javax.inject.Inject
 
 interface ContextualNativeInputManager {
     fun init(
+        tabId: String,
         card: MaterialCardView,
         widget: NativeInputModeWidget,
         jsMessaging: JsMessaging,
@@ -62,6 +63,7 @@ class RealContextualNativeInputManager @Inject constructor(
     private var widget: NativeInputModeWidget? = null
 
     override fun init(
+        tabId: String,
         card: MaterialCardView,
         widget: NativeInputModeWidget,
         jsMessaging: JsMessaging,
@@ -75,7 +77,7 @@ class RealContextualNativeInputManager @Inject constructor(
         this.widget = widget
 
         applyCardShape(card)
-        setupWidget(widget, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
+        setupWidget(tabId, widget, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
         observeNativeInputSetting(lifecycleOwner)
     }
 
@@ -105,12 +107,13 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     private fun setupWidget(
+        tabId: String,
         widget: NativeInputModeWidget,
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
     ) {
-        widget.configureContextual()
+        widget.configureContextual(tabId)
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.bindAttachmentCallbacks(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -424,7 +424,9 @@ class DuckChatContextualFragment :
 
         configureBottomSheet(view)
         setupBackPressHandling()
+        val tabId = requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)
         contextualNativeInputManager.init(
+            tabId = tabId.orEmpty(),
             card = binding.contextualNativeInputCard,
             widget = binding.contextualNativeInputWidget,
             jsMessaging = contentScopeScripts,
@@ -442,8 +444,8 @@ class DuckChatContextualFragment :
         )
         observeViewModel()
 
-        requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)?.let { tabId ->
-            viewModel.onSheetOpened(tabId)
+        tabId?.let {
+            viewModel.onSheetOpened(it)
             setupKeyboardVisibilityListener()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -424,9 +424,11 @@ class DuckChatContextualFragment :
 
         configureBottomSheet(view)
         setupBackPressHandling()
-        val tabId = requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)
+        val tabId = requireNotNull(requireArguments().getString(KEY_DUCK_AI_CONTEXTUAL_TAB_ID)) {
+            "DuckChatContextualFragment requires $KEY_DUCK_AI_CONTEXTUAL_TAB_ID argument"
+        }
         contextualNativeInputManager.init(
-            tabId = tabId.orEmpty(),
+            tabId = tabId,
             card = binding.contextualNativeInputCard,
             widget = binding.contextualNativeInputWidget,
             jsMessaging = contentScopeScripts,
@@ -444,10 +446,8 @@ class DuckChatContextualFragment :
         )
         observeViewModel()
 
-        tabId?.let {
-            viewModel.onSheetOpened(it)
-            setupKeyboardVisibilityListener()
-        }
+        viewModel.onSheetOpened(tabId)
+        setupKeyboardVisibilityListener()
     }
 
     private fun configureBottomSheet(view: View) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatConstants.CHAT_ID_PARAM
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -66,6 +67,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -93,6 +95,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val inputScreenConfigResolver: InputScreenConfigResolver,
     private val pixel: Pixel,
+    private val nativeInputStatePublisher: NativeInputStatePublisher,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -155,6 +158,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     private val widgetConfig = MutableStateFlow(WidgetConfig())
 
+    private val activeTabId = MutableStateFlow<String?>(null)
+
     val state: SharedFlow<NativeInputState> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
@@ -171,6 +176,16 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         started = SharingStarted.Eagerly,
         replay = 1,
     )
+
+    init {
+        viewModelScope.launch {
+            combine(state, activeTabId) { current, tabId ->
+                tabId?.let { it to current.copy(tabId = it) }
+            }
+                .filterNotNull()
+                .collect { (tabId, published) -> nativeInputStatePublisher.publish(tabId, published) }
+        }
+    }
 
     val chatState: Flow<ChatState> = duckChatInternal.chatState
 
@@ -201,7 +216,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         widgetConfig.update { it.copy(inputPosition = position) }
     }
 
-    fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {
+    fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {
+        activeTabId.value = tabId
         val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
         val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
         widgetConfig.value = WidgetConfig(inputContext = context, inputPosition = position)
@@ -217,7 +233,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         pendingNativePromptStore.store(query, modelId, reasoningEffort, images, files)
     }
 
-    fun configureContextual() {
+    fun configureContextual(tabId: String) {
+        activeTabId.value = tabId
         widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -765,6 +765,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyOmnibarShape() {
+        if (nativeInputState.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) return
         if (nativeInputState.isBottom) return
         if (nativeInputState.toggleVisible) return
         val card = parent as? MaterialCardView ?: return

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -122,8 +123,8 @@ interface NativeInputWidget {
     fun getFileAttachmentsJson(): JSONArray?
     fun clearAttachments()
     fun storePendingPrompt(query: String)
-    fun configure(isDuckAiMode: Boolean, isBottom: Boolean)
-    fun configureContextual()
+    fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean)
+    fun configureContextual(tabId: String)
     fun isWidgetBottom(): Boolean
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
@@ -178,6 +179,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     @Inject
     lateinit var chatSuggestionsBinder: NativeInputChatSuggestionsBinder
+
+    @Inject
+    lateinit var nativeInputStateProvider: NativeInputStateProvider
+
+    private var activeTabId: String? = null
 
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
@@ -243,7 +249,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
-        observeNativeInputState()
+        // observeNativeInputState() is started from configure()/configureContextual() once
+        // the tabId is known — the widget reads its state from NativeInputStateProvider per-tab.
+        if (activeTabId != null) observeNativeInputState()
         if (onPaidTierChanged != null) observeTier()
     }
 
@@ -725,21 +733,24 @@ class NativeInputModeWidget @JvmOverloads constructor(
         attachmentView?.clearAttachmentsForNewChat()
     }
 
-    override fun configure(isDuckAiMode: Boolean, isBottom: Boolean) {
+    override fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {
+        activeTabId = tabId
         pendingIsDuckAiMode = isDuckAiMode
         doOnAttach {
-            viewModel.configure(isDuckAiMode, isBottom)
-            viewModel.state.replayCache.lastOrNull()?.let { nativeInputState = it }
+            viewModel.configure(tabId, isDuckAiMode, isBottom)
+            observeNativeInputState()
             if (isDuckAiMode) selectChatTab()
             applyOmnibarShape(isBottom)
             attachmentView?.setDuckAiMode(isDuckAiMode)
         }
     }
 
-    override fun configureContextual() {
+    override fun configureContextual(tabId: String) {
+        activeTabId = tabId
         pendingIsDuckAiMode = true
         doOnAttach {
-            viewModel.configureContextual()
+            viewModel.configureContextual(tabId)
+            observeNativeInputState()
             selectChatTab()
             attachmentView?.setDuckAiMode(true)
         }
@@ -867,8 +878,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun observeNativeInputState() {
         nativeInputStateJob?.cancel()
+        val tabId = activeTabId ?: return
         val lifecycleOwner = findViewTreeLifecycleOwner() ?: return
-        nativeInputStateJob = viewModel.state
+        nativeInputStateJob = nativeInputStateProvider.stateForTab(tabId)
             .onEach(::applyState)
             .launchIn(lifecycleOwner.lifecycleScope)
     }
@@ -972,7 +984,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateVoiceButtonVisibility()
     }
 
-    override fun getInputState(): NativeInputState = nativeInputState
+    override fun getInputState(): NativeInputState =
+        activeTabId?.let { nativeInputStateProvider.stateForTab(it).value } ?: nativeInputState
 
     private fun configureSubmitButtons() {
         if (submitButtons == null) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -502,6 +502,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
         updateNewLineButtonVisibility()
+        applyOmnibarShape()
         if (contextChanged && isChatTabSelected()) {
             inputField.applyChatInputType()
             (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(inputField)
@@ -740,7 +741,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             viewModel.configure(tabId, isDuckAiMode, isBottom)
             observeNativeInputState()
             if (isDuckAiMode) selectChatTab()
-            applyOmnibarShape(isBottom)
             attachmentView?.setDuckAiMode(isDuckAiMode)
         }
     }
@@ -764,8 +764,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    private fun applyOmnibarShape(isBottom: Boolean) {
-        if (isBottom) return
+    private fun applyOmnibarShape() {
+        if (nativeInputState.isBottom) return
         if (nativeInputState.toggleVisible) return
         val card = parent as? MaterialCardView ?: return
         card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
@@ -88,6 +89,7 @@ class NativeInputModeWidgetViewModelTest {
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private val pixel: Pixel = mock()
+    private val nativeInputStatePublisher: NativeInputStatePublisher = mock()
 
     private val showSettingsFlow = MutableStateFlow(false)
     private val duckChatUserEnabledFlow = MutableStateFlow(false)
@@ -133,6 +135,7 @@ class NativeInputModeWidgetViewModelTest {
             dispatchers = coroutineRule.testDispatcherProvider,
             inputScreenConfigResolver = inputScreenConfigResolver,
             pixel = pixel,
+            nativeInputStatePublisher = nativeInputStatePublisher,
             appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
@@ -249,7 +252,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenConfigureContextualThenContextIsDuckAiContextual() = runTest {
-        testee.configureContextual()
+        testee.configureContextual(tabId = "test-tab")
 
         assertEquals(NativeInputState.InputContext.DUCK_AI_CONTEXTUAL, testee.state.firstOrNull()!!.inputContext)
     }
@@ -258,14 +261,14 @@ class NativeInputModeWidgetViewModelTest {
     fun whenContextIsDuckAiContextualAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true
-        testee.configureContextual()
+        testee.configureContextual(tabId = "test-tab")
 
         assertFalse(testee.state.firstOrNull()!!.toggleVisible)
     }
 
     @Test
     fun whenContextIsDuckAiContextualThenDefaultToggleSelectionIsDuckAi() = runTest {
-        testee.configureContextual()
+        testee.configureContextual(tabId = "test-tab")
 
         assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
     }
@@ -326,7 +329,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenConfigureThenBothContextAndPositionSetAtomically() = runTest {
-        testee.configure(isDuckAiMode = true, isBottom = true)
+        testee.configure(tabId = "test-tab", isDuckAiMode = true, isBottom = true)
 
         val state = testee.state.firstOrNull()!!
         assertEquals(NativeInputState.InputContext.DUCK_AI, state.inputContext)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1214790107756091?focus=true

Stacked on top of #8549.

### Description

PR 2 of the native input state refactor — see the parent task for the full plan.

The native input widget is now the single publisher of `NativeInputState` and reads its own state from the per-tab store (`NativeInputStateProvider`) instead of keeping it as a widget-local field. Plugins still won't see this change until PR 3.

Concretely:

- `NativeInputModeWidgetViewModel` injects `NativeInputStatePublisher`. A new `init { … }` block collects `combine(state, activeTabId)` and pushes each value through `publisher.publish(tabId, state.copy(tabId = tabId))` whenever a tabId is set.
- `NativeInputModeWidget` injects `NativeInputStateProvider`. `observeNativeInputState()` now subscribes to `provider.stateForTab(tabId)` instead of `viewModel.state`. `getInputState()` reads `provider.stateForTab(activeTabId).value`.
- `configure()` and `configureContextual()` take a `tabId: String` parameter and start the observation once the tabId is known.
- `tabId` is threaded:
  - `BrowserTabFragment.tabId` → `NativeInputManager.showNativeInput(tabId, …)` → `attachWidget(widgetView, isBottom, tabId)` → `widget.configure(tabId, …)`.
  - `DuckChatContextualFragment` reads its `KEY_DUCK_AI_CONTEXTUAL_TAB_ID` argument once and passes it to `ContextualNativeInputManager.init(tabId, …)` → `widget.configureContextual(tabId)`.
- `viewModel.state` stays as a `SharedFlow<NativeInputState>` so existing ViewModel-level tests can keep asserting on its values; the widget no longer consumes it.

What this PR intentionally does **not** do:

- `NativeInputState.tabId` stays nullable. Tightening to non-null will follow once the publish-on-configure invariant is verified in practice (and we can drop the `zero("__init__")`-style placeholder).
- `NativeInputHost.getInputState()` is still exposed — its implementation now reads from the provider, but the surface remains until plugins are migrated in PR 3 and it's removed in PR 4.
- Plugins still receive the widget as their `NativeInputHost`; nothing about their behaviour changes here.

### Steps to test this PR

- [x] CI green: `:duckchat-impl:testDebugUnitTest`, `:app:testPlayDebugUnitTest`, `spotlessCheck`.
- [x] Existing `NativeInputModeWidgetViewModelTest` cases still pass after the `configure`/`configureContextual` signature changes and the added publisher mock.
- [x] Smoke-test on device:
  - Open Duck.ai input from the NTP, type, switch to the chat tab, submit — behaviour matches develop.
  - Open the omnibar on a browser tab, switch between Search and Duck.ai modes — toggle/position/context behave as before.
  - Open Duck.ai contextual chat from a browser tab — keyboard, attachments, and submit all still work.
  - Background a tab and reopen it — input state for that tab is restored correctly.

### UI changes
None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the native input widget publishes/consumes state by keying everything on `tabId`, which could cause cross-tab state leaks or missing updates if tab IDs aren’t consistently threaded through all entry points.
> 
> **Overview**
> The native input widget now **publishes `NativeInputState` per tab** and **reads state from `NativeInputStateProvider`** instead of relying on widget-local/ViewModel flow state.
> 
> This threads `tabId` through `BrowserTabFragment` → `NativeInputManager.showNativeInput`/`attachWidget` → `NativeInputModeWidget.configure`, and through contextual chat via `DuckChatContextualFragment`/`ContextualNativeInputManager.init` → `configureContextual`. The ViewModel now injects `NativeInputStatePublisher` to push updates for the active tab, and tests are updated for the new `tabId`-required `configure` APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dc03e88539734c8b38f69c431450364f355bb2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->