### PR TITLE
Update content scope scripts to version 14.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.7.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.8.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.78.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.78.0.tgz",
-      "integrity": "sha512-8nAG08z78eRkXUKososdbJYKoz7FS0St8LiZmyIoCHpMLb/rOZHJIlPR521wmc3y7yUQcywHl8+dIOnI3f/a9A==",
+      "version": "14.81.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.81.0.tgz",
+      "integrity": "sha512-7YgGDCFGCvc+OIjvmjrfhAOgQpyXjGntU3TSWeJYZv7XYTqUYBrcsVNEGC8yg9vekg0m9BrHZZqPvPIWzlDnVA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4d35a8c3e8e613bc4f5217c9ff3238e6857e1ad7",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d3e17cb6e45b15420637d9d689c45bff81df1a4a",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.15.0.tgz",
-      "integrity": "sha512-t64ecjJOeFyNHbxyYY2r1WA7aMFx8Pf94hXsYVbTKoCIiMjcOl4SlvMQ3obMlvNrj2QLNpByCD9f7Vq+7z45bQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.0.tgz",
+      "integrity": "sha512-gob5BGY9kKwC4YAK15wlUlG5OwOr+woLU0ZaJ+uHaiib1+IkVBkhWgrsuDDd8Y1wILjumsVCPpSdDxNqno3zIg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.15.0",
-        "@ghostery/adblocker-extended-selectors": "^2.15.0",
+        "@ghostery/adblocker-content": "^2.17.0",
+        "@ghostery/adblocker-extended-selectors": "^2.17.0",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.28"
+        "tldts-experimental": "^7.0.30"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.15.0.tgz",
-      "integrity": "sha512-CgQDRvpbqVQYEKveffFilUgy0QNRIYNxv64dTuuThZd0gTWebfg4LZF4H/lagow5GSoiDyXnZXzhSOTonkOZvg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.0.tgz",
+      "integrity": "sha512-HkGWrG6iQ11L1A9t5FpaPRK8YV6mYVmrWvElQtgUrXMUq1LT10fWZ+mAwnkgpLvRi1vR+wyPbzcjN3BI02MI4g==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.15.0"
+        "@ghostery/adblocker-extended-selectors": "^2.17.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.15.0.tgz",
-      "integrity": "sha512-exdYY2eKOXSyyd3cwfOjE2iq/8rOdkNgdkZ1Mm33361GkB2HzSrQWMczyGIlAc4CAviNV1aWu7Mlqph12WVTrg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.0.tgz",
+      "integrity": "sha512-7wvKsn/X0mtNOzYXDV+LZU1kvOstJcNvsOWViAaisRK6Wo2PPgKIvfmcVB5P9yGr4nC/xffadjyhhqc+aN04pg==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,13 +280,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.7.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.8.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1214796955580837/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core web content/consent-related dependencies via `package.json`/`package-lock.json`, which could subtly change injected script or blocking behavior at runtime. Risk is limited to dependency version bumps with no direct application code changes.
> 
> **Overview**
> Updates `@duckduckgo/content-scope-scripts` from `14.7.0` to `14.8.0` in `package.json` and updates `package-lock.json` to the new git commit.
> 
> The lockfile refresh also pulls newer resolved versions for `@duckduckgo/autoconsent` and its dependency chain (notably `@ghostery/adblocker` packages, plus `@types/node`/`undici-types`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9f658fd1d1b8de789a8d0ec59d199672376bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->