### PR TITLE
Fix: Input box hint ANR

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -129,7 +129,6 @@ import com.duckduckgo.serp.logos.api.SerpEasterEggLogosToggles
 import com.duckduckgo.serp.logos.api.SerpLogos
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.card.MaterialCardView
-import com.google.android.material.color.MaterialColors.isColorLight
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
@@ -920,8 +919,6 @@ class OmnibarLayout @JvmOverloads constructor(
         renderPulseAnimation(viewState)
 
         renderLeadingIconState(viewState)
-
-        omnibarTextInput.hint = context.getString(R.string.search)
     }
 
     private fun renderDuckAiMode(viewState: ViewState) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214787767029879?focus=true

### Description

Fixes an ANR regression when a hint was set programmatically even though it was already set in XML.

### Steps to test this PR

- [x] Start the app
- [x] Open a NTP
- [x] Verify there is a "Search" as a hint in the address bar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that removes a redundant `hint` assignment in `OmnibarLayout`, reducing the chance of an ANR without altering navigation, security, or data handling logic.
> 
> **Overview**
> Stops setting `omnibarTextInput.hint` programmatically in `OmnibarLayout.renderBrowserMode`, relying on the XML `android:hint` instead to avoid an ANR regression. Cleans up the now-unused Material import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e92639ba52eabd44d6dbf997fdc18fbb8221d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->