### PR TITLE
[Android] Make RealSubscriptionsUrlProvider a singleton

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/SubscriptionsUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/SubscriptionsUrlProvider.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.impl.internal
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface SubscriptionsUrlProvider {
@@ -29,6 +30,7 @@ interface SubscriptionsUrlProvider {
     val upgradeToProUrl: String
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealSubscriptionsUrlProvider @Inject constructor(
     private val subscriptionsBaseUrl: SubscriptionsBaseUrl,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1214779175586447?focus=true

### Description

Add Dagger scope annotation `SingleInstanceIn` for `RealSubscriptionsUrlProvider`.

### Steps to test this PR

Code review only.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Dagger scoping change; main impact is lifecycle/instance reuse, which could surface only if callers relied on per-injection instantiation.
> 
> **Overview**
> Marks `RealSubscriptionsUrlProvider` as a Dagger `@SingleInstanceIn(AppScope::class)` and adds the needed import, ensuring the `SubscriptionsUrlProvider` implementation is provided as a single app-scoped instance instead of being recreated per injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d9248d76ef76d49f9450f6fc51710bceb66cb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->