### PR TITLE
Make NativeInputState.tabId non-null

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -20,7 +20,7 @@ data class NativeInputState(
     val inputMode: InputMode,
     val inputContext: InputContext,
     val inputPosition: InputPosition = InputPosition.TOP,
-    val tabId: String? = null,
+    val tabId: String,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,
@@ -48,11 +48,8 @@ data class NativeInputState(
          * Placeholder state used by [NativeInputStateProvider] for a tab that has not yet been
          * published to. Observers should not rely on these values: the native input widget overwrites
          * them via [NativeInputStatePublisher.publish] as soon as it is configured for the tab.
-         *
-         * TODO: once the widget is wired to publish on configure (follow-up PR), tighten [tabId] to
-         * non-null and remove this default; the store will key off the publisher-supplied state.
          */
-        fun zero(tabId: String? = null): NativeInputState = NativeInputState(
+        fun zero(tabId: String): NativeInputState = NativeInputState(
             inputMode = InputMode.SEARCH_AND_DUCK_AI,
             inputContext = InputContext.BROWSER,
             inputPosition = InputPosition.TOP,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -56,9 +56,8 @@ class RealNativeInputStateStore @Inject constructor() :
     }
 
     // Seed unpublished tabs with [NativeInputState.zero] only because StateFlow requires an initial
-    // value. The native input widget overwrites it on configure; see the TODO on zero() — once the
-    // widget is wired to publish first, this seed becomes unreachable and can be replaced with a
-    // first-publish gate.
+    // value. The native input widget overwrites it on configure, so observers should never see this
+    // placeholder in practice.
     private fun flowFor(tabId: String): MutableStateFlow<NativeInputState> =
         flows.computeIfAbsent(tabId) { MutableStateFlow(NativeInputState.zero(tabId)) }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -165,11 +165,13 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
         widgetConfig,
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, config ->
+        activeTabId.filterNotNull(),
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, config, tabId ->
         NativeInputState(
             inputMode = getInputMode(isFeatureEnabled && isUserEnabled, isInputScreenUserSettingEnabled),
             inputContext = config.inputContext,
             inputPosition = config.inputPosition,
+            tabId = tabId,
         )
     }.shareIn(
         scope = viewModelScope,
@@ -179,11 +181,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            combine(state, activeTabId) { current, tabId ->
-                tabId?.let { it to current.copy(tabId = it) }
-            }
-                .filterNotNull()
-                .collect { (tabId, published) -> nativeInputStatePublisher.publish(tabId, published) }
+            state.collect { nativeInputStatePublisher.publish(it.tabId, it) }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -204,10 +204,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var attachmentLimitExceeded: Boolean = false
     private var hasAttachments: Boolean = false
     private var supportsUpload: Boolean = true
-    private var nativeInputState: NativeInputState = NativeInputState(
-        inputMode = NativeInputState.InputMode.SEARCH_ONLY,
-        inputContext = NativeInputState.InputContext.BROWSER,
-    )
+    private var nativeInputState: NativeInputState? = null
     private var chatSuggestionsBinding: NativeInputChatSuggestionsBinder.Binding? = null
     private var onShowSuggestions: ((RecyclerView.Adapter<*>) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
@@ -430,7 +427,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateToggleVisibilityForState() {
         if (isDuckAiPageContext()) return
-        applyToggleVisibility(nativeInputState.toggleVisible)
+        applyToggleVisibility(nativeInputState?.toggleVisible ?: false)
     }
 
     private fun applyToggleVisibility(visible: Boolean) {
@@ -441,8 +438,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // 4dp when minimized, 8dp when expanded on focus. The browser omnibar with the toggle
         // disabled stays minimized regardless of focus; everywhere else (duck.ai omnibar,
         // duck.ai contextual, browser omnibar with toggle enabled) expands on focus.
-        val isBrowserOmnibarMinimized =
-            nativeInputState.inputContext == NativeInputState.InputContext.BROWSER && !nativeInputState.toggleVisible
+        val isBrowserOmnibarMinimized = nativeInputState?.let {
+            it.inputContext == NativeInputState.InputContext.BROWSER && !it.toggleVisible
+        } ?: true
         val expanded = !isBrowserOmnibarMinimized && inputField.hasFocus()
         val verticalPadAttr = if (expanded) {
             com.duckduckgo.mobile.android.R.dimen.keyline_2
@@ -453,9 +451,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         setPadding(paddingLeft, verticalPad, paddingRight, verticalPad)
     }
 
-    private fun isDuckAiPageContext(): Boolean =
-        nativeInputState.inputContext == NativeInputState.InputContext.DUCK_AI ||
-            nativeInputState.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL
+    private fun isDuckAiPageContext(): Boolean = nativeInputState?.let {
+        it.inputContext == NativeInputState.InputContext.DUCK_AI ||
+            it.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL
+    } ?: false
 
     override fun setVoiceSearchAvailable(available: Boolean) {
         voiceSearchAvailable = available
@@ -485,14 +484,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateNewLineButtonVisibility() {
-        val isBrowserContext = nativeInputState.inputContext == NativeInputState.InputContext.BROWSER
+        val isBrowserContext = nativeInputState?.inputContext == NativeInputState.InputContext.BROWSER
         val hasText = inputField.text.isNotBlank()
         val visible = isBrowserContext && isChatTabSelected() && hasText && !isStreaming
         floatingButtons?.setNewLineButtonVisible(visible)
     }
 
     private fun applyState(state: NativeInputState) {
-        val contextChanged = nativeInputState.inputContext != state.inputContext
+        val contextChanged = nativeInputState?.inputContext != state.inputContext
         nativeInputState = state
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
@@ -678,7 +677,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun setToggleVisible(visible: Boolean) {
-        val isVisible = visible && nativeInputState.toggleVisible
+        val isVisible = visible && (nativeInputState?.toggleVisible ?: false)
         suspendLayoutTransitions {
             applyToggleVisibility(isVisible)
         }
@@ -758,7 +757,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    override fun isWidgetBottom(): Boolean = nativeInputState.isBottom
+    override fun isWidgetBottom(): Boolean = nativeInputState?.isBottom ?: false
 
     override fun setWidgetPosition(isBottom: Boolean) {
         doOnAttach {
@@ -767,9 +766,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyOmnibarShape() {
-        if (nativeInputState.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) return
-        if (nativeInputState.isBottom) return
-        if (nativeInputState.toggleVisible) return
+        val state = nativeInputState ?: return
+        if (state.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) return
+        if (state.isBottom) return
+        if (state.toggleVisible) return
         val card = parent as? MaterialCardView ?: return
         card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
         val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
@@ -988,7 +988,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun getInputState(): NativeInputState =
-        activeTabId?.let { nativeInputStateProvider.stateForTab(it).value } ?: nativeInputState
+        activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }
+            ?: error("getInputState called before widget was configured")
 
     private fun configureSubmitButtons() {
         if (submitButtons == null) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -90,5 +90,5 @@ class NativeInputModeWidgetBackButtonsTest {
     }
 
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
-        NativeInputState(inputMode = inputMode, inputContext = inputContext)
+        NativeInputState(inputMode = inputMode, inputContext = inputContext, tabId = "test-tab")
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -118,6 +118,7 @@ class NativeInputModeWidgetViewModelTest {
         whenever(inputScreenConfigResolver.shouldShowInstalledApps()).thenReturn(false)
 
         testee = createViewModel()
+        testee.configure(tabId = "test-tab", isDuckAiMode = false, isBottom = false)
     }
 
     private fun createViewModel(plugins: List<NativeInputPlugin> = emptyList()): NativeInputModeWidgetViewModel {
@@ -151,6 +152,7 @@ class NativeInputModeWidgetViewModelTest {
         inputScreenUserSettingFlow.value = true
 
         val freshTestee = createViewModel()
+        freshTestee.configure(tabId = "test-tab", isDuckAiMode = false, isBottom = false)
 
         assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, freshTestee.state.firstOrNull()!!.inputMode)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214802223978853?focus=true

Stacked on #8550. Until that merges, the diff here shows PR 2's commits too; review the top commit (`7d57719`) for the PR 2.5 change in isolation.

### Description

Small follow-up to PR 2. Now that the widget publishes on configure, every `NativeInputState` in the per-tab store is provably associated with a `tabId`, so we tighten the type.

- Drop the `String? = null` default on `NativeInputState.tabId` and `NativeInputState.zero()`.
- ViewModel `state` flow combines `activeTabId.filterNotNull()` so the emitted state carries the active tabId. The publish init block simplifies to a direct collect-and-publish — the separate combine that re-attached the tabId is gone.
- Widget local cache becomes nullable (`NativeInputState?`). Read sites use null-safe access with the same defaults the previous field initializer carried.
- `getInputState()` throws if called pre-configure instead of returning a stale placeholder; the publish-on-configure invariant ensures plugins only reach it after configure.
- Tests: `@Before` calls `configure()` so the state flow has a tabId; the back-buttons test passes an explicit tabId.

### Steps to test this PR

_Native input widget regressions_
- [x] Open the app on a NTP, type a search query, submit — search works as before
- [x] Open a website, focus the omnibar, switch between Search and Duck.ai tabs — toggle works, no flicker
- [x] Open a Duck.ai contextual session from a long-press menu — contextual UI renders correctly
- [x] Toggle "Address bar position" between top and bottom in Settings — widget reshapes correctly on next omnibar focus
- [x] Delete a tab, then the fire button — no leaked state, next tab renders fresh

### UI changes

No UI changes — refactor only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens a core UI/state model contract and changes initialization/placeholder behavior; mis-ordered widget configuration could now throw or suppress UI updates until `tabId` is set.
> 
> **Overview**
> Makes `NativeInputState.tabId` mandatory by removing the nullable/default value and updating `zero(tabId)` accordingly.
> 
> Updates `NativeInputModeWidgetViewModel` to only emit `state` once `activeTabId` is non-null (via `activeTabId.filterNotNull()`), embedding the `tabId` in every emitted `NativeInputState` and simplifying publishing to a direct collect-and-publish.
> 
> Adjusts `NativeInputModeWidget` to treat its cached `NativeInputState` as nullable (null-safe reads with safe defaults) and makes `getInputState()` fail fast if called before `configure()`. Tests are updated to pass explicit `tabId`/call `configure()` up front.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d5ee16626003cd2a116b5c64b03cbbf8550c8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->