### PR TITLE
Implement scriptlet download and storage

### DIFF
--- a/ad-blocking/ad-blocking-impl/build.gradle
+++ b/ad-blocking/ad-blocking-impl/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.work:work-runtime-ktx:2.11.2'
+    implementation  AndroidX.work.runtimeKtx
     implementation AndroidX.room.runtime
     ksp AndroidX.room.compiler
     ksp project(':anvil-ksp')

--- a/ad-blocking/ad-blocking-impl/build.gradle
+++ b/ad-blocking/ad-blocking-impl/build.gradle
@@ -28,16 +28,44 @@ android {
     anvil {
         generateDaggerFactories = true
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
+    implementation 'androidx.work:work-runtime-ktx:2.11.2'
+    implementation AndroidX.room.runtime
+    ksp AndroidX.room.compiler
     ksp project(':anvil-ksp')
     implementation project(path: ':anvil-annotations')
 
     implementation project(path: ':browser-api')
+    implementation project(path: ':common-utils')
+    implementation project(path: ':data-store-api')
     implementation project(path: ':di')
     implementation project(path: ':feature-toggles-api')
 
+    implementation "com.squareup.logcat:logcat:_"
     implementation Google.dagger
     implementation KotlinX.coroutines.core
+
+    testImplementation project(':common-test')
+    testImplementation project(':feature-toggles-test')
+
+    testImplementation AndroidX.test.ext.junit
+    testImplementation "androidx.test:runner:_"
+    testImplementation AndroidX.work.testing
+    testImplementation Testing.robolectric
+    testImplementation CashApp.turbine
+    testImplementation(KotlinX.coroutines.test) {
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        // conflicts with mockito due to direct inclusion of byte buddy
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+    testImplementation Testing.junit4
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
+import com.duckduckgo.adblocking.impl.store.ScriptletEntity
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface AdBlockingExtensionRepository {
+    suspend fun getStoredVersion(): String?
+    suspend fun storeScriptlets(version: String, scriptlets: Map<String, ByteArray>)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAdBlockingExtensionRepository @Inject constructor(
+    private val dao: AdBlockingExtensionDao,
+) : AdBlockingExtensionRepository {
+
+    override suspend fun getStoredVersion(): String? = dao.getVersion()
+
+    override suspend fun storeScriptlets(version: String, scriptlets: Map<String, ByteArray>) {
+        dao.replaceAll(
+            scriptlets.map { (name, content) ->
+                ScriptletEntity(name = name, version = version, content = content)
+            },
+        )
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
@@ -38,8 +38,9 @@ class RealAdBlockingExtensionRepository @Inject constructor(
 
     override suspend fun storeScriptlets(version: String, scriptlets: Map<String, ByteArray>) {
         dao.replaceAll(
-            scriptlets.map { (name, content) ->
-                ScriptletEntity(name = name, version = version, content = content)
+            version = version,
+            scriptlets = scriptlets.map { (name, content) ->
+                ScriptletEntity(name = name, content = content)
             },
         )
     }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
+import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@ContributesWorker(AppScope::class)
+class ScriptletDownloadWorker(
+    context: Context,
+    workerParameters: WorkerParameters,
+) : CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var updater: ScriptletUpdater
+
+    @Inject
+    lateinit var settingsAdapter: JsonAdapter<ScriptletsSettings>
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
+    override suspend fun doWork(): Result = withContext(dispatchers.io()) {
+        logcat { "Starting ScriptletDownloadWorker" }
+        val settingsJson = inputData.getString(KEY_SETTINGS) ?: return@withContext Result.failure()
+        val settings = runCatching { settingsAdapter.fromJson(settingsJson) }
+            .onFailure { logcat(WARN) { "ScriptletDownloadWorker: failed to parse settings input: ${it.asLog()}" } }
+            .getOrNull()
+            ?: return@withContext Result.failure()
+
+        when (updater.update(settings)) {
+            ScriptletUpdateResult.Success -> Result.success()
+            ScriptletUpdateResult.Retry -> Result.retry()
+        }
+    }
+
+    companion object {
+        const val KEY_SETTINGS = "settings"
+    }
+}
+
+@ContributesMultibinding(scope = AppScope::class, boundType = MainProcessLifecycleObserver::class)
+@SingleInstanceIn(AppScope::class)
+class ScriptletDownloadWorkerScheduler @Inject constructor(
+    private val workManager: WorkManager,
+    private val configProvider: AdBlockingExtensionConfigProvider,
+    private val settingsAdapter: JsonAdapter<ScriptletsSettings>,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appScope.launch {
+            configProvider.scriptletsSettings.filterNotNull().collect { settings ->
+                enqueue(settings)
+            }
+        }
+    }
+
+    private fun enqueue(settings: ScriptletsSettings) {
+        val json = settingsAdapter.toJson(settings)
+        val request = OneTimeWorkRequestBuilder<ScriptletDownloadWorker>()
+            .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_INITIAL_SECONDS, TimeUnit.SECONDS)
+            .setInputData(workDataOf(ScriptletDownloadWorker.KEY_SETTINGS to json))
+            .build()
+        workManager.enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+    }
+
+    companion object {
+        const val WORK_NAME = "AdBlockingExtensionScriptletDownloadWorker"
+        private const val BACKOFF_INITIAL_SECONDS = 30L
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -30,6 +30,7 @@ import androidx.work.workDataOf
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -40,6 +41,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -88,13 +90,19 @@ class ScriptletDownloadWorker(
 class ScriptletDownloadWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
     private val configProvider: AdBlockingExtensionConfigProvider,
+    private val feature: AdBlockingExtensionFeature,
     private val settingsAdapter: JsonAdapter<ScriptletsSettings>,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
         appScope.launch {
-            configProvider.scriptletsSettings.filterNotNull().collect { settings ->
+            combine(
+                feature.self().enabled(),
+                configProvider.scriptletsSettings,
+            ) { operational, settings ->
+                settings?.takeIf { operational }
+            }.filterNotNull().collect { settings ->
                 enqueue(settings)
             }
         }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -71,7 +71,7 @@ class ScriptletDownloadWorker(
     private val settingsAdapter by lazy { buildJsonAdapter() }
 
     override suspend fun doWork(): Result = withContext(dispatchers.io()) {
-        if (!feature.isDiscoverable().isEnabled()) {
+        if (!feature.self().isEnabled()) {
             logcat { "ScriptletDownloadWorker: kill-switch is off, skipping" }
             return@withContext Result.success()
         }
@@ -112,11 +112,11 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
     override fun onCreate(owner: LifecycleOwner) {
         appScope.launch {
             combine(
-                feature.isDiscoverable().enabled(),
                 feature.self().enabled(),
+                feature.enableContingencyMode().enabled(),
                 configProvider.scriptletsSettings,
-            ) { discoverable, operational, settings ->
-                settings?.takeIf { discoverable && operational }
+            ) { discoverable, contingencyMode, settings ->
+                settings?.takeIf { discoverable && !contingencyMode }
             }.filterNotNull().collect { settings ->
                 enqueue(settings)
             }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -105,10 +105,11 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
     override fun onCreate(owner: LifecycleOwner) {
         appScope.launch {
             combine(
+                feature.isDiscoverable().enabled(),
                 feature.self().enabled(),
                 configProvider.scriptletsSettings,
-            ) { operational, settings ->
-                settings?.takeIf { operational }
+            ) { discoverable, operational, settings ->
+                settings?.takeIf { discoverable && operational }
             }.filterNotNull().collect { settings ->
                 enqueue(settings)
             }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -64,9 +64,16 @@ class ScriptletDownloadWorker(
     lateinit var settingsAdapter: JsonAdapter<ScriptletsSettings>
 
     @Inject
+    lateinit var feature: AdBlockingExtensionFeature
+
+    @Inject
     lateinit var dispatchers: DispatcherProvider
 
     override suspend fun doWork(): Result = withContext(dispatchers.io()) {
+        if (!feature.isDiscoverable().isEnabled()) {
+            logcat { "ScriptletDownloadWorker: kill-switch is off, skipping" }
+            return@withContext Result.success()
+        }
         logcat { "Starting ScriptletDownloadWorker" }
         val settingsJson = inputData.getString(KEY_SETTINGS) ?: return@withContext Result.failure()
         val settings = runCatching { settingsAdapter.fromJson(settingsJson) }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
@@ -39,6 +39,8 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
@@ -61,13 +63,12 @@ class ScriptletDownloadWorker(
     lateinit var updater: ScriptletUpdater
 
     @Inject
-    lateinit var settingsAdapter: JsonAdapter<ScriptletsSettings>
-
-    @Inject
     lateinit var feature: AdBlockingExtensionFeature
 
     @Inject
     lateinit var dispatchers: DispatcherProvider
+
+    private val settingsAdapter by lazy { buildJsonAdapter() }
 
     override suspend fun doWork(): Result = withContext(dispatchers.io()) {
         if (!feature.isDiscoverable().isEnabled()) {
@@ -87,6 +88,11 @@ class ScriptletDownloadWorker(
         }
     }
 
+    private fun buildJsonAdapter(): JsonAdapter<AdBlockingExtensionSettings> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(AdBlockingExtensionSettings::class.java)
+    }
+
     companion object {
         const val KEY_SETTINGS = "settings"
     }
@@ -98,9 +104,10 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
     private val configProvider: AdBlockingExtensionConfigProvider,
     private val feature: AdBlockingExtensionFeature,
-    private val settingsAdapter: JsonAdapter<ScriptletsSettings>,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {
+
+    private val settingsAdapter by lazy { buildJsonAdapter() }
 
     override fun onCreate(owner: LifecycleOwner) {
         appScope.launch {
@@ -116,7 +123,7 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
         }
     }
 
-    private fun enqueue(settings: ScriptletsSettings) {
+    private fun enqueue(settings: AdBlockingExtensionSettings) {
         val json = settingsAdapter.toJson(settings)
         val request = OneTimeWorkRequestBuilder<ScriptletDownloadWorker>()
             .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
@@ -124,6 +131,11 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
             .setInputData(workDataOf(ScriptletDownloadWorker.KEY_SETTINGS to json))
             .build()
         workManager.enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+    }
+
+    private fun buildJsonAdapter(): JsonAdapter<AdBlockingExtensionSettings> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(AdBlockingExtensionSettings::class.java)
     }
 
     companion object {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloader.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloader.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.Lazy
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Named
+
+interface ScriptletDownloader {
+    suspend fun download(url: String): Result<ByteArray>
+}
+
+@ContributesBinding(AppScope::class)
+class RealScriptletDownloader @Inject constructor(
+    @Named("nonCaching") private val okHttpClient: Lazy<OkHttpClient>,
+    private val dispatchers: DispatcherProvider,
+) : ScriptletDownloader {
+
+    override suspend fun download(url: String): Result<ByteArray> = withContext(dispatchers.io()) {
+        runCatching {
+            val request = Request.Builder().url(url).build()
+            okHttpClient.get().newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Scriptlet download failed for $url: HTTP ${response.code}")
+                }
+                response.body?.bytes() ?: throw IOException("Scriptlet download for $url returned empty body")
+            }
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.di
+
+import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
+import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
+import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
+import com.duckduckgo.data.store.api.DatabaseProvider
+import com.duckduckgo.data.store.api.RoomDatabaseConfig
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+
+@Module
+@ContributesTo(AppScope::class)
+object AdBlockingExtensionModule {
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideAdBlockingExtensionDatabase(databaseProvider: DatabaseProvider): AdBlockingExtensionDatabase {
+        return databaseProvider.buildRoomDatabase(
+            AdBlockingExtensionDatabase::class.java,
+            "ad_blocking_extension.db",
+            config = RoomDatabaseConfig(
+                fallbackToDestructiveMigration = true,
+                migrations = AD_BLOCKING_EXTENSION_MIGRATIONS.toList(),
+            ),
+        )
+    }
+
+    @Provides
+    fun provideAdBlockingExtensionDao(database: AdBlockingExtensionDatabase): AdBlockingExtensionDao =
+        database.adBlockingExtensionDao()
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -17,12 +17,10 @@
 package com.duckduckgo.adblocking.impl.di
 
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
-import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
-import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.data.store.api.DatabaseProvider
 import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
@@ -59,7 +57,6 @@ object AdBlockingExtensionModule {
     @Provides
     fun provideAdBlockingExtensionSettingsAdapter(): JsonAdapter<AdBlockingExtensionSettings> =
         Moshi.Builder()
-            .add(Domain::class.java, DomainJsonAdapter().nullSafe())
             .add(KotlinJsonAdapterFactory())
             .build()
             .adapter(AdBlockingExtensionSettings::class.java)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.adblocking.impl.di
 
-import com.duckduckgo.adblocking.impl.domain.PublicKeyProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
@@ -34,12 +33,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
-import java.nio.charset.CharsetDecoder
-import java.nio.charset.StandardCharsets
-import java.security.KeyFactory
-import java.security.PublicKey
-import java.security.Signature
-import java.util.Base64
 
 @Module
 @ContributesTo(AppScope::class)
@@ -61,29 +54,6 @@ object AdBlockingExtensionModule {
     @Provides
     fun provideAdBlockingExtensionDao(database: AdBlockingExtensionDatabase): AdBlockingExtensionDao =
         database.adBlockingExtensionDao()
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideBase64Decoder(): Base64.Decoder =
-        Base64.getDecoder()
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideKeyFactory(): KeyFactory =
-        KeyFactory.getInstance("EC")
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideAdBlockingExtensionPublicKey(publicKeyProvider: PublicKeyProvider): PublicKey =
-        publicKeyProvider.publicKey
-
-    @Provides
-    fun provideUTF8CharsetDecoder(): CharsetDecoder =
-        StandardCharsets.UTF_8.newDecoder()
-
-    @Provides
-    fun provideSignature(): Signature =
-        Signature.getInstance("SHA256withECDSA")
 
     @SingleInstanceIn(AppScope::class)
     @Provides

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.adblocking.impl.di
 import com.duckduckgo.adblocking.impl.domain.PublicKeyProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
@@ -86,10 +87,22 @@ object AdBlockingExtensionModule {
 
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun provideAdBlockingExtensionSettingsAdapter(): JsonAdapter<AdBlockingExtensionSettings> =
-        Moshi.Builder()
+    fun provideMoshiBuilder(): Moshi.Builder = Moshi.Builder()
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideAdBlockingExtensionSettingsAdapter(moshiBuilder: Moshi.Builder): JsonAdapter<AdBlockingExtensionSettings> =
+        moshiBuilder
             .add(Domain::class.java, DomainJsonAdapter().nullSafe())
             .add(KotlinJsonAdapterFactory())
             .build()
             .adapter(AdBlockingExtensionSettings::class.java)
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideScriptletsSettingsAdapter(moshiBuilder: Moshi.Builder): JsonAdapter<ScriptletsSettings> =
+        moshiBuilder
+            .add(KotlinJsonAdapterFactory())
+            .build()
+            .adapter(ScriptletsSettings::class.java)
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.adblocking.impl.di
 
+import com.duckduckgo.adblocking.impl.domain.PublicKeyProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
 import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
@@ -32,6 +33,12 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
+import java.nio.charset.CharsetDecoder
+import java.nio.charset.StandardCharsets
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.Signature
+import java.util.Base64
 
 @Module
 @ContributesTo(AppScope::class)
@@ -53,6 +60,29 @@ object AdBlockingExtensionModule {
     @Provides
     fun provideAdBlockingExtensionDao(database: AdBlockingExtensionDatabase): AdBlockingExtensionDao =
         database.adBlockingExtensionDao()
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideBase64Decoder(): Base64.Decoder =
+        Base64.getDecoder()
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideKeyFactory(): KeyFactory =
+        KeyFactory.getInstance("EC")
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideAdBlockingExtensionPublicKey(publicKeyProvider: PublicKeyProvider): PublicKey =
+        publicKeyProvider.publicKey
+
+    @Provides
+    fun provideUTF8CharsetDecoder(): CharsetDecoder =
+        StandardCharsets.UTF_8.newDecoder()
+
+    @Provides
+    fun provideSignature(): Signature =
+        Signature.getInstance("SHA256withECDSA")
 
     @SingleInstanceIn(AppScope::class)
     @Provides

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -87,12 +87,8 @@ object AdBlockingExtensionModule {
 
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun provideMoshiBuilder(): Moshi.Builder = Moshi.Builder()
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideAdBlockingExtensionSettingsAdapter(moshiBuilder: Moshi.Builder): JsonAdapter<AdBlockingExtensionSettings> =
-        moshiBuilder
+    fun provideAdBlockingExtensionSettingsAdapter(): JsonAdapter<AdBlockingExtensionSettings> =
+        Moshi.Builder()
             .add(Domain::class.java, DomainJsonAdapter().nullSafe())
             .add(KotlinJsonAdapterFactory())
             .build()
@@ -100,8 +96,8 @@ object AdBlockingExtensionModule {
 
     @SingleInstanceIn(AppScope::class)
     @Provides
-    fun provideScriptletsSettingsAdapter(moshiBuilder: Moshi.Builder): JsonAdapter<ScriptletsSettings> =
-        moshiBuilder
+    fun provideScriptletsSettingsAdapter(): JsonAdapter<ScriptletsSettings> =
+        Moshi.Builder()
             .add(KotlinJsonAdapterFactory())
             .build()
             .adapter(ScriptletsSettings::class.java)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.adblocking.impl.di
 
-import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
@@ -25,9 +23,6 @@ import com.duckduckgo.data.store.api.DatabaseProvider
 import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -52,20 +47,4 @@ object AdBlockingExtensionModule {
     @Provides
     fun provideAdBlockingExtensionDao(database: AdBlockingExtensionDatabase): AdBlockingExtensionDao =
         database.adBlockingExtensionDao()
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideAdBlockingExtensionSettingsAdapter(): JsonAdapter<AdBlockingExtensionSettings> =
-        Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
-            .adapter(AdBlockingExtensionSettings::class.java)
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideScriptletsSettingsAdapter(): JsonAdapter<ScriptletsSettings> =
-        Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
-            .adapter(ScriptletsSettings::class.java)
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/di/AdBlockingExtensionModule.kt
@@ -16,13 +16,19 @@
 
 package com.duckduckgo.adblocking.impl.di
 
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
+import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
 import com.duckduckgo.adblocking.impl.store.AD_BLOCKING_EXTENSION_MIGRATIONS
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDao
 import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
+import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.data.store.api.DatabaseProvider
 import com.duckduckgo.data.store.api.RoomDatabaseConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -47,4 +53,13 @@ object AdBlockingExtensionModule {
     @Provides
     fun provideAdBlockingExtensionDao(database: AdBlockingExtensionDatabase): AdBlockingExtensionDao =
         database.adBlockingExtensionDao()
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    fun provideAdBlockingExtensionSettingsAdapter(): JsonAdapter<AdBlockingExtensionSettings> =
+        Moshi.Builder()
+            .add(Domain::class.java, DomainJsonAdapter().nullSafe())
+            .add(KotlinJsonAdapterFactory())
+            .build()
+            .adapter(AdBlockingExtensionSettings::class.java)
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/PublicKeyProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/PublicKeyProvider.kt
@@ -33,12 +33,10 @@ private const val KEY = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuqrhn2ztPnPt8QybIGs
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
-class RealPublicKeyProvider @Inject constructor(
-    private val keyFactory: KeyFactory,
-    private val decoder: Base64.Decoder,
-) : PublicKeyProvider {
+class RealPublicKeyProvider @Inject constructor() : PublicKeyProvider {
 
     override val publicKey: PublicKey by lazy {
-        keyFactory.generatePublic(X509EncodedKeySpec(decoder.decode(KEY)))
+        KeyFactory.getInstance("EC")
+            .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(KEY)))
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/PublicKeyProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/PublicKeyProvider.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.inject.Inject
+
+interface PublicKeyProvider {
+    val publicKey: PublicKey
+}
+
+private const val KEY = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuqrhn2ztPnPt8QybIGsLpROYR/xcJ/uw0jN85kdMQFKdCkwxOLaU70uVQ+zZ+F0B1fgx8qfAXus7mXWsJxBXrg=="
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealPublicKeyProvider @Inject constructor(
+    private val keyFactory: KeyFactory,
+    private val decoder: Base64.Decoder,
+) : PublicKeyProvider {
+
+    override val publicKey: PublicKey by lazy {
+        keyFactory.generatePublic(X509EncodedKeySpec(decoder.decode(KEY)))
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidator.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidator.kt
@@ -19,14 +19,12 @@ package com.duckduckgo.adblocking.impl.domain
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
 import java.nio.ByteBuffer
 import java.nio.charset.CharacterCodingException
-import java.nio.charset.CharsetDecoder
+import java.nio.charset.StandardCharsets
 import java.security.PublicKey
 import java.security.Signature
 import java.util.Base64
@@ -42,35 +40,32 @@ sealed interface ScriptletValidationResult {
 }
 
 interface ScriptletSignatureValidator {
-    suspend fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult
+    fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult
 }
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class RealScriptletSignatureValidator @Inject constructor(
-    private val publicKey: PublicKey,
-    private val signature: Signature,
-    private val charsetDecoder: CharsetDecoder,
-    private val base64Decoder: Base64.Decoder,
+    publicKeyProvider: PublicKeyProvider,
 ) : ScriptletSignatureValidator {
 
-    private val mutex = Mutex()
+    private val publicKey: PublicKey = publicKeyProvider.publicKey
 
-    override suspend fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult = mutex.withLock {
+    override fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult {
         try {
-            charsetDecoder.decode(ByteBuffer.wrap(content))
+            StandardCharsets.UTF_8.newDecoder().decode(ByteBuffer.wrap(content))
         } catch (e: CharacterCodingException) {
             logcat(WARN) { "Validating scriptlet failed with invalid encoding: ${e.message}" }
-            return@withLock ScriptletValidationResult.Invalid.Encoding
+            return ScriptletValidationResult.Invalid.Encoding
         }
         val signatureBytes = try {
-            base64Decoder.decode(signatureBase64)
+            Base64.getDecoder().decode(signatureBase64)
         } catch (e: IllegalArgumentException) {
             logcat(WARN) { "Validating scriptlet failed with invalid signature format: ${e.message}" }
-            return@withLock ScriptletValidationResult.Invalid.SignatureFormat
+            return ScriptletValidationResult.Invalid.SignatureFormat
         }
-        try {
-            val verified = signature.run {
+        return try {
+            val verified = Signature.getInstance(SIGNATURE_ALGORITHM).run {
                 initVerify(publicKey)
                 update(content)
                 verify(signatureBytes)
@@ -86,5 +81,9 @@ class RealScriptletSignatureValidator @Inject constructor(
             logcat(WARN) { "ScriptletSignatureValidator: verification threw: ${t.asLog()}" }
             ScriptletValidationResult.Invalid.SignatureVerificationFailed
         }
+    }
+
+    companion object {
+        const val SIGNATURE_ALGORITHM = "SHA256withECDSA"
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidator.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidator.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import java.nio.ByteBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CharsetDecoder
+import java.security.PublicKey
+import java.security.Signature
+import java.util.Base64
+import javax.inject.Inject
+
+sealed interface ScriptletValidationResult {
+    data object Valid : ScriptletValidationResult
+    sealed interface Invalid : ScriptletValidationResult {
+        data object Encoding : Invalid
+        data object SignatureFormat : Invalid
+        data object SignatureVerificationFailed : Invalid
+    }
+}
+
+interface ScriptletSignatureValidator {
+    suspend fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealScriptletSignatureValidator @Inject constructor(
+    private val publicKey: PublicKey,
+    private val signature: Signature,
+    private val charsetDecoder: CharsetDecoder,
+    private val base64Decoder: Base64.Decoder,
+) : ScriptletSignatureValidator {
+
+    private val mutex = Mutex()
+
+    override suspend fun validate(content: ByteArray, signatureBase64: String): ScriptletValidationResult = mutex.withLock {
+        try {
+            charsetDecoder.decode(ByteBuffer.wrap(content))
+        } catch (e: CharacterCodingException) {
+            logcat(WARN) { "Validating scriptlet failed with invalid encoding: ${e.message}" }
+            return@withLock ScriptletValidationResult.Invalid.Encoding
+        }
+        val signatureBytes = try {
+            base64Decoder.decode(signatureBase64)
+        } catch (e: IllegalArgumentException) {
+            logcat(WARN) { "Validating scriptlet failed with invalid signature format: ${e.message}" }
+            return@withLock ScriptletValidationResult.Invalid.SignatureFormat
+        }
+        try {
+            val verified = signature.run {
+                initVerify(publicKey)
+                update(content)
+                verify(signatureBytes)
+            }
+            if (verified) {
+                logcat { "Validating scriptlet succeeded" }
+                ScriptletValidationResult.Valid
+            } else {
+                logcat(WARN) { "Validating scriptlet failed with verification failed" }
+                ScriptletValidationResult.Invalid.SignatureVerificationFailed
+            }
+        } catch (t: Throwable) {
+            logcat(WARN) { "ScriptletSignatureValidator: verification threw: ${t.asLog()}" }
+            ScriptletValidationResult.Invalid.SignatureVerificationFailed
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -63,14 +63,19 @@ class RealScriptletUpdater @Inject constructor(
                         }
 
                         when (val validationResult = validator.validate(bytes, entry.signature)) {
-                            ScriptletValidationResult.Valid -> name to bytes
+                            ScriptletValidationResult.Valid -> if (bytes.isEmpty()) {
+                                logcat { "ScriptletUpdater: skipping empty scriptlet $name" }
+                                null
+                            } else {
+                                name to bytes
+                            }
                             is ScriptletValidationResult.Invalid -> {
                                 logcat(WARN) { "ScriptletUpdater: validation failed for $name: $validationResult" }
                                 throw ScriptletFailure()
                             }
                         }
                     }
-                }.awaitAll().toMap()
+                }.awaitAll().filterNotNull().toMap()
             }
         } catch (_: ScriptletFailure) {
             return ScriptletUpdateResult.Retry

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import com.duckduckgo.adblocking.impl.AdBlockingExtensionRepository
+import com.duckduckgo.adblocking.impl.ScriptletDownloader
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import logcat.LogPriority.WARN
+import logcat.logcat
+import javax.inject.Inject
+
+sealed interface ScriptletUpdateResult {
+    data object Success : ScriptletUpdateResult
+    data object Retry : ScriptletUpdateResult
+}
+
+interface ScriptletUpdater {
+    suspend fun update(settings: ScriptletsSettings): ScriptletUpdateResult
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealScriptletUpdater @Inject constructor(
+    private val repository: AdBlockingExtensionRepository,
+    private val downloader: ScriptletDownloader,
+    private val validator: ScriptletSignatureValidator,
+) : ScriptletUpdater {
+
+    override suspend fun update(settings: ScriptletsSettings): ScriptletUpdateResult {
+        if (settings.version == repository.getStoredVersion()) {
+            logcat { "Version matches stored. Skipping" }
+            return ScriptletUpdateResult.Success
+        }
+
+        val downloaded = try {
+            coroutineScope {
+                settings.scriptlets.map { (name, entry) ->
+                    async {
+                        logcat { "Downloading ${entry.url}" }
+                        val bytes = downloader.download(entry.url).getOrElse {
+                            logcat(WARN) { "ScriptletUpdater: download failed for $name: ${it.message}" }
+                            throw ScriptletFailure()
+                        }
+
+                        when (val validationResult = validator.validate(bytes, entry.signature)) {
+                            ScriptletValidationResult.Valid -> name to bytes
+                            is ScriptletValidationResult.Invalid -> {
+                                logcat(WARN) { "ScriptletUpdater: validation failed for $name: $validationResult" }
+                                throw ScriptletFailure()
+                            }
+                        }
+                    }
+                }.awaitAll().toMap()
+            }
+        } catch (_: ScriptletFailure) {
+            return ScriptletUpdateResult.Retry
+        }
+
+        logcat { "Storing scriptlets" }
+        repository.storeScriptlets(settings.version, downloaded)
+        return ScriptletUpdateResult.Success
+    }
+
+    private class ScriptletFailure : RuntimeException()
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.adblocking.impl.domain
 
 import com.duckduckgo.adblocking.impl.AdBlockingExtensionRepository
 import com.duckduckgo.adblocking.impl.ScriptletDownloader
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -35,7 +35,7 @@ sealed interface ScriptletUpdateResult {
 }
 
 interface ScriptletUpdater {
-    suspend fun update(settings: ScriptletsSettings): ScriptletUpdateResult
+    suspend fun update(settings: AdBlockingExtensionSettings): ScriptletUpdateResult
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -46,7 +46,7 @@ class RealScriptletUpdater @Inject constructor(
     private val validator: ScriptletSignatureValidator,
 ) : ScriptletUpdater {
 
-    override suspend fun update(settings: ScriptletsSettings): ScriptletUpdateResult {
+    override suspend fun update(settings: AdBlockingExtensionSettings): ScriptletUpdateResult {
         if (settings.version == repository.getStoredVersion()) {
             logcat { "Version matches stored. Skipping" }
             return ScriptletUpdateResult.Success

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.remoteconfig
+
+import com.duckduckgo.app.browser.Domain
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import logcat.LogPriority.WARN
+import logcat.asLog
+import logcat.logcat
+import javax.inject.Inject
+
+data class AdBlockingExtensionSettings(
+    val version: String,
+    val scriptlets: Map<String, ScriptletEntry>,
+    val domains: List<Domain> = emptyList(),
+)
+
+data class ScriptletEntry(
+    val url: String,
+    val signature: String,
+)
+
+interface AdBlockingExtensionConfigProvider {
+    val settings: StateFlow<AdBlockingExtensionSettings?>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(scope = AppScope::class, boundType = AdBlockingExtensionConfigProvider::class)
+@ContributesMultibinding(scope = AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+class RealAdBlockingExtensionConfigProvider @Inject constructor(
+    private val feature: AdBlockingExtensionFeature,
+    private val settingsAdapter: JsonAdapter<AdBlockingExtensionSettings>,
+) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
+
+    private val settingsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
+
+    init {
+        settingsFlow.value = computeSettings()
+    }
+
+    override val settings: StateFlow<AdBlockingExtensionSettings?> = settingsFlow.asStateFlow()
+
+    override fun onPrivacyConfigDownloaded() {
+        settingsFlow.value = computeSettings()
+    }
+
+    private fun computeSettings(): AdBlockingExtensionSettings? {
+        val settingsJson = feature.self().getSettings() ?: return null
+        return runCatching { settingsAdapter.fromJson(settingsJson) }
+            .onFailure { logcat(WARN) { "AdBlockingExtensionConfigProvider: failed to parse settings: ${it.asLog()}" } }
+            .getOrNull()
+            ?.takeIf { it.version.isNotEmpty() }
+    }
+}
+
+internal class DomainJsonAdapter : JsonAdapter<Domain>() {
+    override fun fromJson(reader: JsonReader): Domain = Domain(reader.nextString())
+    override fun toJson(writer: JsonWriter, value: Domain?) {
+        writer.value(value?.value)
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -44,8 +44,18 @@ data class ScriptletEntry(
     val signature: String,
 )
 
+data class ScriptletsSettings(
+    val version: String,
+    val scriptlets: Map<String, ScriptletEntry>,
+)
+
+data class DomainsSettings(
+    val domains: List<Domain>,
+)
+
 interface AdBlockingExtensionConfigProvider {
-    val settings: StateFlow<AdBlockingExtensionSettings?>
+    val scriptletsSettings: StateFlow<ScriptletsSettings?>
+    val domainsSettings: StateFlow<DomainsSettings?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -56,22 +66,31 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     private val settingsAdapter: JsonAdapter<AdBlockingExtensionSettings>,
 ) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
 
-    private val settingsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
+    private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
+    private val domainsFlow = MutableStateFlow<DomainsSettings?>(null)
 
     init {
-        settingsFlow.value = computeSettings()
+        refresh()
     }
 
-    override val settings: StateFlow<AdBlockingExtensionSettings?> = settingsFlow.asStateFlow()
+    override val scriptletsSettings: StateFlow<ScriptletsSettings?> = scriptletsFlow.asStateFlow()
+    override val domainsSettings: StateFlow<DomainsSettings?> = domainsFlow.asStateFlow()
 
     override fun onPrivacyConfigDownloaded() {
-        settingsFlow.value = computeSettings()
+        logcat { "onPrivacyConfigDownloaded" }
+        refresh()
+    }
+
+    private fun refresh() {
+        val settings = computeSettings()
+        scriptletsFlow.value = settings?.let { ScriptletsSettings(it.version, it.scriptlets) }
+        domainsFlow.value = settings?.let { DomainsSettings(it.domains) }
     }
 
     private fun computeSettings(): AdBlockingExtensionSettings? {
         val settingsJson = feature.self().getSettings() ?: return null
         return runCatching { settingsAdapter.fromJson(settingsJson) }
-            .onFailure { logcat(WARN) { "AdBlockingExtensionConfigProvider: failed to parse settings: ${it.asLog()}" } }
+            .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }
             .getOrNull()
             ?.takeIf { it.version.isNotEmpty() }
     }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -20,7 +20,10 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,22 +34,21 @@ import logcat.logcat
 import javax.inject.Inject
 
 data class AdBlockingExtensionSettings(
+    @field:Json(name = "version")
     val version: String,
+    @field:Json(name = "scriptlets")
     val scriptlets: Map<String, ScriptletEntry>,
 )
 
 data class ScriptletEntry(
+    @field:Json(name = "url")
     val url: String,
+    @field:Json(name = "signature")
     val signature: String,
 )
 
-data class ScriptletsSettings(
-    val version: String,
-    val scriptlets: Map<String, ScriptletEntry>,
-)
-
 interface AdBlockingExtensionConfigProvider {
-    val scriptletsSettings: StateFlow<ScriptletsSettings?>
+    val scriptletsSettings: StateFlow<AdBlockingExtensionSettings?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -54,16 +56,16 @@ interface AdBlockingExtensionConfigProvider {
 @ContributesMultibinding(scope = AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
 class RealAdBlockingExtensionConfigProvider @Inject constructor(
     private val feature: AdBlockingExtensionFeature,
-    private val settingsAdapter: JsonAdapter<AdBlockingExtensionSettings>,
 ) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
 
-    private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
+    private val settingsAdapter by lazy { buildJsonAdapter() }
+    private val scriptletsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
 
     init {
         refresh()
     }
 
-    override val scriptletsSettings: StateFlow<ScriptletsSettings?> = scriptletsFlow.asStateFlow()
+    override val scriptletsSettings: StateFlow<AdBlockingExtensionSettings?> = scriptletsFlow.asStateFlow()
 
     override fun onPrivacyConfigDownloaded() {
         logcat { "onPrivacyConfigDownloaded" }
@@ -71,8 +73,7 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     }
 
     private fun refresh() {
-        val raw = parseSettings()
-        scriptletsFlow.value = raw?.let { ScriptletsSettings(it.version, it.scriptlets) }
+        scriptletsFlow.value = parseSettings()
     }
 
     private fun parseSettings(): AdBlockingExtensionSettings? {
@@ -81,5 +82,10 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
             .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }
             .getOrNull()
             ?.takeIf { it.version.isNotEmpty() }
+    }
+
+    private fun buildJsonAdapter(): JsonAdapter<AdBlockingExtensionSettings> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(AdBlockingExtensionSettings::class.java)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -16,14 +16,11 @@
 
 package com.duckduckgo.adblocking.impl.remoteconfig
 
-import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonWriter
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +33,6 @@ import javax.inject.Inject
 data class AdBlockingExtensionSettings(
     val version: String,
     val scriptlets: Map<String, ScriptletEntry>,
-    val domains: List<Domain> = emptyList(),
 )
 
 data class ScriptletEntry(
@@ -49,13 +45,8 @@ data class ScriptletsSettings(
     val scriptlets: Map<String, ScriptletEntry>,
 )
 
-data class DomainsSettings(
-    val domains: List<Domain>,
-)
-
 interface AdBlockingExtensionConfigProvider {
     val scriptletsSettings: StateFlow<ScriptletsSettings?>
-    val domainsSettings: StateFlow<DomainsSettings?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -67,14 +58,12 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
 ) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
 
     private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
-    private val domainsFlow = MutableStateFlow<DomainsSettings?>(null)
 
     init {
         refresh()
     }
 
     override val scriptletsSettings: StateFlow<ScriptletsSettings?> = scriptletsFlow.asStateFlow()
-    override val domainsSettings: StateFlow<DomainsSettings?> = domainsFlow.asStateFlow()
 
     override fun onPrivacyConfigDownloaded() {
         logcat { "onPrivacyConfigDownloaded" }
@@ -84,7 +73,6 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     private fun refresh() {
         val raw = parseSettings()
         scriptletsFlow.value = raw?.let { ScriptletsSettings(it.version, it.scriptlets) }
-        domainsFlow.value = raw?.let { DomainsSettings(it.domains) }
     }
 
     private fun parseSettings(): AdBlockingExtensionSettings? {
@@ -93,12 +81,5 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
             .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }
             .getOrNull()
             ?.takeIf { it.version.isNotEmpty() }
-    }
-}
-
-internal class DomainJsonAdapter : JsonAdapter<Domain>() {
-    override fun fromJson(reader: JsonReader): Domain = Domain(reader.nextString())
-    override fun toJson(writer: JsonWriter, value: Domain?) {
-        writer.value(value?.value)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -88,6 +88,9 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     }
 
     private fun computeSettings(): AdBlockingExtensionSettings? {
+        if (!feature.self().isEnabled()) {
+            return null
+        }
         val settingsJson = feature.self().getSettings() ?: return null
         return runCatching { settingsAdapter.fromJson(settingsJson) }
             .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -88,9 +88,7 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     }
 
     private fun computeSettings(): AdBlockingExtensionSettings? {
-        if (!feature.self().isEnabled()) {
-            return null
-        }
+        if (!feature.isDiscoverable().isEnabled()) return null
         val settingsJson = feature.self().getSettings() ?: return null
         return runCatching { settingsAdapter.fromJson(settingsJson) }
             .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -82,13 +82,12 @@ class RealAdBlockingExtensionConfigProvider @Inject constructor(
     }
 
     private fun refresh() {
-        val settings = computeSettings()
-        scriptletsFlow.value = settings?.let { ScriptletsSettings(it.version, it.scriptlets) }
-        domainsFlow.value = settings?.let { DomainsSettings(it.domains) }
+        val raw = parseSettings()
+        scriptletsFlow.value = raw?.let { ScriptletsSettings(it.version, it.scriptlets) }
+        domainsFlow.value = raw?.let { DomainsSettings(it.domains) }
     }
 
-    private fun computeSettings(): AdBlockingExtensionSettings? {
-        if (!feature.isDiscoverable().isEnabled()) return null
+    private fun parseSettings(): AdBlockingExtensionSettings? {
         val settingsJson = feature.self().getSettings() ?: return null
         return runCatching { settingsAdapter.fromJson(settingsJson) }
             .onFailure { logcat(WARN) { "failed to parse settings: ${it.asLog()}" } }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
@@ -25,8 +25,18 @@ import com.duckduckgo.feature.toggles.api.Toggle
     featureName = "adBlockingExtension",
 )
 interface AdBlockingExtensionFeature {
+    /**
+     * @return `true` when the feature is operational.
+     * When false, feature is still accessible, but not working as expected.
+     */
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun self(): Toggle
+
+    /**
+     * Kill-switch. When false, the feature is completely inaccessible.
+     */
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    fun isDiscoverable(): Toggle
 
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun enabledByDefault(): Toggle

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
@@ -14,33 +14,20 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.adblocking.impl
+package com.duckduckgo.adblocking.impl.remoteconfig
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
-import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "adBlockingExtension",
 )
 interface AdBlockingExtensionFeature {
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun enabledByDefault(): Toggle
 }
-
-data class AdBlockingExtensionSettings(
-    val version: String? = null,
-    val scriptlets: Map<String, ScriptletEntry>? = null,
-    val domains: List<Domain>? = null,
-)
-
-data class ScriptletEntry(
-    val url: String,
-    val signature: String,
-)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
@@ -26,18 +26,18 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface AdBlockingExtensionFeature {
     /**
-     * @return `true` when the feature is operational.
-     * When false, feature is still accessible, but not working as expected.
+     * Kill-switch. When false, the feature is completely inaccessible.
      */
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    /**
-     * Kill-switch. When false, the feature is completely inaccessible.
-     */
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
-    fun isDiscoverable(): Toggle
-
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun enabledByDefault(): Toggle
+
+    /**
+     * When enabled, the feature settings will still be accessible, but no scripts
+     * will be injected, and a contingency message will be shown
+     */
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    fun enableContingencyMode(): Toggle
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDao.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDao.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class AdBlockingExtensionDao {
 
-    @Query("SELECT version FROM ad_blocking_scriptlets LIMIT 1")
+    @Query("SELECT version FROM ad_blocking_scriptlets_metadata WHERE id = ${ScriptletMetadataEntity.SINGLETON_ID}")
     abstract suspend fun getVersion(): String?
 
     @Query("SELECT * FROM ad_blocking_scriptlets")
@@ -38,9 +38,13 @@ abstract class AdBlockingExtensionDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertScriptlets(scriptlets: List<ScriptletEntity>)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertMetadata(metadata: ScriptletMetadataEntity)
+
     @Transaction
-    open suspend fun replaceAll(scriptlets: List<ScriptletEntity>) {
+    open suspend fun replaceAll(version: String, scriptlets: List<ScriptletEntity>) {
         deleteAllScriptlets()
         insertScriptlets(scriptlets)
+        upsertMetadata(ScriptletMetadataEntity(version = version))
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDao.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDao.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.store
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+abstract class AdBlockingExtensionDao {
+
+    @Query("SELECT version FROM ad_blocking_scriptlets LIMIT 1")
+    abstract suspend fun getVersion(): String?
+
+    @Query("SELECT * FROM ad_blocking_scriptlets")
+    abstract fun scriptletsFlow(): Flow<List<ScriptletEntity>>
+
+    @Query("DELETE FROM ad_blocking_scriptlets")
+    abstract suspend fun deleteAllScriptlets()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertScriptlets(scriptlets: List<ScriptletEntity>)
+
+    @Transaction
+    open suspend fun replaceAll(scriptlets: List<ScriptletEntity>) {
+        deleteAllScriptlets()
+        insertScriptlets(scriptlets)
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.store
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [ScriptletEntity::class],
+)
+abstract class AdBlockingExtensionDatabase : RoomDatabase() {
+    abstract fun adBlockingExtensionDao(): AdBlockingExtensionDao
+}
+
+val AD_BLOCKING_EXTENSION_MIGRATIONS = emptyArray<Migration>()

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletEntity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletEntity.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.store
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "ad_blocking_scriptlets")
+data class ScriptletEntity(
+    @PrimaryKey val name: String,
+    val version: String,
+    val content: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ScriptletEntity) return false
+        return name == other.name && version == other.version && content.contentEquals(other.content)
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + version.hashCode()
+        result = 31 * result + content.contentHashCode()
+        return result
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletEntity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletEntity.kt
@@ -22,18 +22,16 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "ad_blocking_scriptlets")
 data class ScriptletEntity(
     @PrimaryKey val name: String,
-    val version: String,
     val content: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ScriptletEntity) return false
-        return name == other.name && version == other.version && content.contentEquals(other.content)
+        return name == other.name && content.contentEquals(other.content)
     }
 
     override fun hashCode(): Int {
         var result = name.hashCode()
-        result = 31 * result + version.hashCode()
         result = 31 * result + content.contentHashCode()
         return result
     }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletMetadataEntity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/ScriptletMetadataEntity.kt
@@ -16,17 +16,15 @@
 
 package com.duckduckgo.adblocking.impl.store
 
-import androidx.room.Database
-import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-@Database(
-    exportSchema = true,
-    version = 2,
-    entities = [ScriptletEntity::class, ScriptletMetadataEntity::class],
-)
-abstract class AdBlockingExtensionDatabase : RoomDatabase() {
-    abstract fun adBlockingExtensionDao(): AdBlockingExtensionDao
+@Entity(tableName = "ad_blocking_scriptlets_metadata")
+data class ScriptletMetadataEntity(
+    @PrimaryKey val id: Int = SINGLETON_ID,
+    val version: String,
+) {
+    companion object {
+        const val SINGLETON_ID = 0
+    }
 }
-
-val AD_BLOCKING_EXTENSION_MIGRATIONS = emptyArray<Migration>()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -21,10 +21,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
-import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
 import com.duckduckgo.adblocking.impl.remoteconfig.RealAdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
-import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.squareup.moshi.Moshi
@@ -42,7 +40,6 @@ class AdBlockingExtensionConfigProviderTest {
 
     private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
     private val settingsAdapter = Moshi.Builder()
-        .add(Domain::class.java, DomainJsonAdapter().nullSafe())
         .add(KotlinJsonAdapterFactory())
         .build()
         .adapter(AdBlockingExtensionSettings::class.java)
@@ -54,8 +51,7 @@ class AdBlockingExtensionConfigProviderTest {
             "scriptlets": {
                 "scriptlets/isolated/ublock-filters.js": { "url": "https://cdn.example/isolated.js", "signature": "iso-sig" },
                 "scriptlets/main/ublock-filters.js": { "url": "https://cdn.example/main.js", "signature": "main-sig" }
-            },
-            "domains": ["youtube.com", "m.youtube.com"]
+            }
         }
     """.trimIndent()
 
@@ -65,7 +61,6 @@ class AdBlockingExtensionConfigProviderTest {
         provider.onPrivacyConfigDownloaded()
 
         assertNull(provider.scriptletsSettings.value)
-        assertNull(provider.domainsSettings.value)
     }
 
     @Test
@@ -74,29 +69,26 @@ class AdBlockingExtensionConfigProviderTest {
         provider.onPrivacyConfigDownloaded()
 
         assertNull(provider.scriptletsSettings.value)
-        assertNull(provider.domainsSettings.value)
     }
 
     @Test
     fun whenVersionIsMissingThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(
-            Toggle.State(remoteEnableState = true, settings = """{"scriptlets": {}, "domains": []}"""),
+            Toggle.State(remoteEnableState = true, settings = """{"scriptlets": {}}"""),
         )
         provider.onPrivacyConfigDownloaded()
 
         assertNull(provider.scriptletsSettings.value)
-        assertNull(provider.domainsSettings.value)
     }
 
     @Test
     fun whenScriptletsIsMissingThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(
-            Toggle.State(remoteEnableState = true, settings = """{"version": "1.0", "domains": []}"""),
+            Toggle.State(remoteEnableState = true, settings = """{"version": "1.0"}"""),
         )
         provider.onPrivacyConfigDownloaded()
 
         assertNull(provider.scriptletsSettings.value)
-        assertNull(provider.domainsSettings.value)
     }
 
     @Test
@@ -115,30 +107,6 @@ class AdBlockingExtensionConfigProviderTest {
             ScriptletEntry(url = "https://cdn.example/isolated.js", signature = "iso-sig"),
             scriptlets?.scriptlets?.get("scriptlets/isolated/ublock-filters.js"),
         )
-    }
-
-    @Test
-    fun whenSettingsAreValidThenDomainsSettingsReflectsParsedConfig() = runTest {
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        provider.onPrivacyConfigDownloaded()
-
-        assertEquals(
-            listOf(Domain("youtube.com"), Domain("m.youtube.com")),
-            provider.domainsSettings.value?.domains,
-        )
-    }
-
-    @Test
-    fun whenDomainsFieldIsAbsentThenDomainsSettingsHasEmptyDomains() = runTest {
-        feature.self().setRawStoredState(
-            Toggle.State(
-                remoteEnableState = true,
-                settings = """{"version": "1.0", "scriptlets": {}}""",
-            ),
-        )
-        provider.onPrivacyConfigDownloaded()
-
-        assertEquals(emptyList<Domain>(), provider.domainsSettings.value?.domains)
     }
 
     @Test

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -58,6 +59,11 @@ class AdBlockingExtensionConfigProviderTest {
             "domains": ["youtube.com", "m.youtube.com"]
         }
     """.trimIndent()
+
+    @Before
+    fun setup() {
+        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = true))
+    }
 
     @Test
     fun whenSettingsAreMissingThenSettingsAreNull() = runTest {
@@ -183,5 +189,15 @@ class AdBlockingExtensionConfigProviderTest {
             expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenKillSwitchIsOffThenSettingsAreNull() = runTest {
+        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = false))
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+
+        assertNull(freshProvider.scriptletsSettings.value)
+        assertNull(freshProvider.domainsSettings.value)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -60,62 +60,76 @@ class AdBlockingExtensionConfigProviderTest {
     """.trimIndent()
 
     @Test
-    fun `settings is null when settings are missing`() = runTest {
+    fun whenSettingsAreMissingThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = null))
         provider.onPrivacyConfigDownloaded()
 
-        assertNull(provider.settings.value)
+        assertNull(provider.scriptletsSettings.value)
+        assertNull(provider.domainsSettings.value)
     }
 
     @Test
-    fun `settings is null when settings JSON is malformed`() = runTest {
+    fun whenSettingsJsonIsMalformedThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = "{ not valid json"))
         provider.onPrivacyConfigDownloaded()
 
-        assertNull(provider.settings.value)
+        assertNull(provider.scriptletsSettings.value)
+        assertNull(provider.domainsSettings.value)
     }
 
     @Test
-    fun `settings is null when version is missing`() = runTest {
+    fun whenVersionIsMissingThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(
             Toggle.State(remoteEnableState = true, settings = """{"scriptlets": {}, "domains": []}"""),
         )
         provider.onPrivacyConfigDownloaded()
 
-        assertNull(provider.settings.value)
+        assertNull(provider.scriptletsSettings.value)
+        assertNull(provider.domainsSettings.value)
     }
 
     @Test
-    fun `settings is null when scriptlets is missing`() = runTest {
+    fun whenScriptletsIsMissingThenSettingsAreNull() = runTest {
         feature.self().setRawStoredState(
             Toggle.State(remoteEnableState = true, settings = """{"version": "1.0", "domains": []}"""),
         )
         provider.onPrivacyConfigDownloaded()
 
-        assertNull(provider.settings.value)
+        assertNull(provider.scriptletsSettings.value)
+        assertNull(provider.domainsSettings.value)
     }
 
     @Test
-    fun `settings reflects parsed config for valid settings`() = runTest {
+    fun whenSettingsAreValidThenScriptletsSettingsReflectsParsedConfig() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         provider.onPrivacyConfigDownloaded()
 
-        val config = provider.settings.value
+        val scriptlets = provider.scriptletsSettings.value
 
-        assertEquals("2026.3.9", config?.version)
+        assertEquals("2026.3.9", scriptlets?.version)
         assertEquals(
             setOf("scriptlets/isolated/ublock-filters.js", "scriptlets/main/ublock-filters.js"),
-            config?.scriptlets?.keys,
+            scriptlets?.scriptlets?.keys,
         )
         assertEquals(
             ScriptletEntry(url = "https://cdn.example/isolated.js", signature = "iso-sig"),
-            config?.scriptlets?.get("scriptlets/isolated/ublock-filters.js"),
+            scriptlets?.scriptlets?.get("scriptlets/isolated/ublock-filters.js"),
         )
-        assertEquals(listOf(Domain("youtube.com"), Domain("m.youtube.com")), config?.domains)
     }
 
     @Test
-    fun `settings has empty domains when domains field is absent`() = runTest {
+    fun whenSettingsAreValidThenDomainsSettingsReflectsParsedConfig() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        provider.onPrivacyConfigDownloaded()
+
+        assertEquals(
+            listOf(Domain("youtube.com"), Domain("m.youtube.com")),
+            provider.domainsSettings.value?.domains,
+        )
+    }
+
+    @Test
+    fun whenDomainsFieldIsAbsentThenDomainsSettingsHasEmptyDomains() = runTest {
         feature.self().setRawStoredState(
             Toggle.State(
                 remoteEnableState = true,
@@ -124,28 +138,26 @@ class AdBlockingExtensionConfigProviderTest {
         )
         provider.onPrivacyConfigDownloaded()
 
-        val config = provider.settings.value
-
-        assertEquals(emptyList<Domain>(), config?.domains)
+        assertEquals(emptyList<Domain>(), provider.domainsSettings.value?.domains)
     }
 
     @Test
-    fun `settings emits initial value when settings are valid at construction`() = runTest {
+    fun whenSettingsAreValidAtConstructionThenScriptletsSettingsEmitsInitialValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
 
-        freshProvider.settings.filterNotNull().test {
+        freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `settings emits new value when onPrivacyConfigDownloaded fires after a settings change`() = runTest {
+    fun whenOnPrivacyConfigDownloadedFiresAfterSettingsChangeThenScriptletsSettingsEmitsNewValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
 
-        freshProvider.settings.filterNotNull().test {
+        freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
 
             val newSettingsJson = validSettingsJson.replace("2026.3.9", "2026.4.0")
@@ -158,11 +170,11 @@ class AdBlockingExtensionConfigProviderTest {
     }
 
     @Test
-    fun `settings does not emit duplicates when onPrivacyConfigDownloaded fires with unchanged settings`() = runTest {
+    fun whenOnPrivacyConfigDownloadedFiresWithUnchangedSettingsThenScriptletsSettingsDoesNotEmitDuplicates() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
 
-        freshProvider.settings.filterNotNull().test {
+        freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
 
             freshProvider.onPrivacyConfigDownloaded()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -59,11 +58,6 @@ class AdBlockingExtensionConfigProviderTest {
             "domains": ["youtube.com", "m.youtube.com"]
         }
     """.trimIndent()
-
-    @Before
-    fun setup() {
-        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = true))
-    }
 
     @Test
     fun whenSettingsAreMissingThenSettingsAreNull() = runTest {
@@ -189,15 +183,5 @@ class AdBlockingExtensionConfigProviderTest {
             expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
-    }
-
-    @Test
-    fun whenKillSwitchIsOffThenSettingsAreNull() = runTest {
-        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = false))
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
-
-        assertNull(freshProvider.scriptletsSettings.value)
-        assertNull(freshProvider.domainsSettings.value)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
+import com.duckduckgo.adblocking.impl.remoteconfig.DomainJsonAdapter
+import com.duckduckgo.adblocking.impl.remoteconfig.RealAdBlockingExtensionConfigProvider
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
+import com.duckduckgo.app.browser.Domain
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SuppressLint("DenyListedApi") // setRawStoredState
+@RunWith(AndroidJUnit4::class)
+class AdBlockingExtensionConfigProviderTest {
+
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val settingsAdapter = Moshi.Builder()
+        .add(Domain::class.java, DomainJsonAdapter().nullSafe())
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(AdBlockingExtensionSettings::class.java)
+    private val provider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+
+    private val validSettingsJson = """
+        {
+            "version": "2026.3.9",
+            "scriptlets": {
+                "scriptlets/isolated/ublock-filters.js": { "url": "https://cdn.example/isolated.js", "signature": "iso-sig" },
+                "scriptlets/main/ublock-filters.js": { "url": "https://cdn.example/main.js", "signature": "main-sig" }
+            },
+            "domains": ["youtube.com", "m.youtube.com"]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `settings is null when settings are missing`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = null))
+        provider.onPrivacyConfigDownloaded()
+
+        assertNull(provider.settings.value)
+    }
+
+    @Test
+    fun `settings is null when settings JSON is malformed`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = "{ not valid json"))
+        provider.onPrivacyConfigDownloaded()
+
+        assertNull(provider.settings.value)
+    }
+
+    @Test
+    fun `settings is null when version is missing`() = runTest {
+        feature.self().setRawStoredState(
+            Toggle.State(remoteEnableState = true, settings = """{"scriptlets": {}, "domains": []}"""),
+        )
+        provider.onPrivacyConfigDownloaded()
+
+        assertNull(provider.settings.value)
+    }
+
+    @Test
+    fun `settings is null when scriptlets is missing`() = runTest {
+        feature.self().setRawStoredState(
+            Toggle.State(remoteEnableState = true, settings = """{"version": "1.0", "domains": []}"""),
+        )
+        provider.onPrivacyConfigDownloaded()
+
+        assertNull(provider.settings.value)
+    }
+
+    @Test
+    fun `settings reflects parsed config for valid settings`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        provider.onPrivacyConfigDownloaded()
+
+        val config = provider.settings.value
+
+        assertEquals("2026.3.9", config?.version)
+        assertEquals(
+            setOf("scriptlets/isolated/ublock-filters.js", "scriptlets/main/ublock-filters.js"),
+            config?.scriptlets?.keys,
+        )
+        assertEquals(
+            ScriptletEntry(url = "https://cdn.example/isolated.js", signature = "iso-sig"),
+            config?.scriptlets?.get("scriptlets/isolated/ublock-filters.js"),
+        )
+        assertEquals(listOf(Domain("youtube.com"), Domain("m.youtube.com")), config?.domains)
+    }
+
+    @Test
+    fun `settings has empty domains when domains field is absent`() = runTest {
+        feature.self().setRawStoredState(
+            Toggle.State(
+                remoteEnableState = true,
+                settings = """{"version": "1.0", "scriptlets": {}}""",
+            ),
+        )
+        provider.onPrivacyConfigDownloaded()
+
+        val config = provider.settings.value
+
+        assertEquals(emptyList<Domain>(), config?.domains)
+    }
+
+    @Test
+    fun `settings emits initial value when settings are valid at construction`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+
+        freshProvider.settings.filterNotNull().test {
+            assertEquals("2026.3.9", awaitItem().version)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `settings emits new value when onPrivacyConfigDownloaded fires after a settings change`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+
+        freshProvider.settings.filterNotNull().test {
+            assertEquals("2026.3.9", awaitItem().version)
+
+            val newSettingsJson = validSettingsJson.replace("2026.3.9", "2026.4.0")
+            feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = newSettingsJson))
+            freshProvider.onPrivacyConfigDownloaded()
+
+            assertEquals("2026.4.0", awaitItem().version)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `settings does not emit duplicates when onPrivacyConfigDownloaded fires with unchanged settings`() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+
+        freshProvider.settings.filterNotNull().test {
+            assertEquals("2026.3.9", awaitItem().version)
+
+            freshProvider.onPrivacyConfigDownloaded()
+            freshProvider.onPrivacyConfigDownloaded()
+
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -20,13 +20,10 @@ import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
-import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.RealAdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -39,11 +36,7 @@ import org.junit.runner.RunWith
 class AdBlockingExtensionConfigProviderTest {
 
     private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
-    private val settingsAdapter = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-        .adapter(AdBlockingExtensionSettings::class.java)
-    private val provider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+    private val provider = RealAdBlockingExtensionConfigProvider(feature)
 
     private val validSettingsJson = """
         {
@@ -112,7 +105,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenSettingsAreValidAtConstructionThenScriptletsSettingsEmitsInitialValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -123,7 +116,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenOnPrivacyConfigDownloadedFiresAfterSettingsChangeThenScriptletsSettingsEmitsNewValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -140,7 +133,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenOnPrivacyConfigDownloadedFiresWithUnchangedSettingsThenScriptletsSettingsDoesNotEmitDuplicates() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, settingsAdapter)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepositoryTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepositoryTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.adblocking.impl.store.AdBlockingExtensionDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AdBlockingExtensionRepositoryTest {
+
+    private lateinit var database: AdBlockingExtensionDatabase
+    private lateinit var repository: AdBlockingExtensionRepository
+
+    @Before
+    fun setup() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        database = Room.inMemoryDatabaseBuilder(context, AdBlockingExtensionDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = RealAdBlockingExtensionRepository(database.adBlockingExtensionDao())
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun whenStoreIsEmptyThenGetStoredVersionReturnsNull() = runTest {
+        assertNull(repository.getStoredVersion())
+    }
+
+    @Test
+    fun whenStoreScriptletsCalledThenPersistsVersionAndScriptlets() = runTest {
+        val scriptlets = mapOf(
+            "scriptlets/isolated/ublock-filters.js" to "isolated".toByteArray(),
+            "scriptlets/main/ublock-filters.js" to "main".toByteArray(),
+        )
+
+        repository.storeScriptlets("2026.3.9", scriptlets)
+
+        assertEquals("2026.3.9", repository.getStoredVersion())
+        val stored = database.adBlockingExtensionDao().scriptletsFlow().first().associateBy { it.name }
+        assertEquals(scriptlets.keys, stored.keys)
+        assertArrayEquals("isolated".toByteArray(), stored.getValue("scriptlets/isolated/ublock-filters.js").content)
+        assertArrayEquals("main".toByteArray(), stored.getValue("scriptlets/main/ublock-filters.js").content)
+    }
+
+    @Test
+    fun whenStoreScriptletsCalledThenDeletesPreviousVersionAtomically() = runTest {
+        repository.storeScriptlets(
+            version = "1.0.0",
+            scriptlets = mapOf("old/path.js" to "old".toByteArray()),
+        )
+
+        repository.storeScriptlets(
+            version = "2.0.0",
+            scriptlets = mapOf("new/path.js" to "new".toByteArray()),
+        )
+
+        assertEquals("2.0.0", repository.getStoredVersion())
+        val stored = database.adBlockingExtensionDao().scriptletsFlow().first()
+        assertEquals(setOf("new/path.js"), stored.map { it.name }.toSet())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepositoryTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepositoryTest.kt
@@ -26,6 +26,7 @@ import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,5 +87,13 @@ class AdBlockingExtensionRepositoryTest {
         assertEquals("2.0.0", repository.getStoredVersion())
         val stored = database.adBlockingExtensionDao().scriptletsFlow().first()
         assertEquals(setOf("new/path.js"), stored.map { it.name }.toSet())
+    }
+
+    @Test
+    fun whenStoreScriptletsCalledWithEmptyMapThenVersionIsStillPersisted() = runTest {
+        repository.storeScriptlets(version = "2026.3.9", scriptlets = emptyMap())
+
+        assertEquals("2026.3.9", repository.getStoredVersion())
+        assertTrue(database.adBlockingExtensionDao().scriptletsFlow().first().isEmpty())
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import com.duckduckgo.adblocking.impl.domain.RealScriptletUpdater
+import com.duckduckgo.adblocking.impl.domain.ScriptletSignatureValidator
+import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
+import com.duckduckgo.adblocking.impl.domain.ScriptletValidationResult
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.IOException
+
+class RealScriptletUpdaterTest {
+
+    private val repository: AdBlockingExtensionRepository = mock()
+    private val downloader: ScriptletDownloader = mock()
+    private val validator: ScriptletSignatureValidator = mock()
+
+    private val updater = RealScriptletUpdater(repository, downloader, validator)
+
+    private val isolatedPath = "scriptlets/isolated/ublock-filters.js"
+    private val mainPath = "scriptlets/main/ublock-filters.js"
+    private val isolatedEntry = ScriptletEntry(url = "https://cdn.example/isolated.js", signature = "iso-sig")
+    private val mainEntry = ScriptletEntry(url = "https://cdn.example/main.js", signature = "main-sig")
+    private val isolatedBytes = "isolated-bytes".toByteArray()
+    private val mainBytes = "main-bytes".toByteArray()
+
+    private val validSettings = ScriptletsSettings(
+        version = "2026.3.9",
+        scriptlets = mapOf(isolatedPath to isolatedEntry, mainPath to mainEntry),
+    )
+
+    @Test
+    fun whenStoredVersionMatchesRemoteVersionThenUpdateReturnsSuccess() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("2026.3.9")
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(validSettings))
+        verify(downloader, never()).download(any())
+        verify(repository, never()).storeScriptlets(any(), any())
+    }
+
+    @Test
+    fun whenSingleDownloadFailsThenUpdateReturnsRetryAndDoesNotPersist() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.failure(IOException("boom")))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+
+        assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
+        verify(repository, never()).storeScriptlets(any(), any())
+    }
+
+    @Test
+    fun whenValidationFailsForAnyScriptletThenUpdateReturnsRetryAndDoesNotPersist() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature))
+            .thenReturn(ScriptletValidationResult.Invalid.SignatureVerificationFailed)
+
+        assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
+        verify(repository, never()).storeScriptlets(any(), any())
+    }
+
+    @Test
+    fun whenAllScriptletsValidThenUpdateReturnsSuccessAndStoresAllScriptlets() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(validSettings))
+        verify(repository).storeScriptlets(
+            eq("2026.3.9"),
+            check { stored ->
+                assertEquals(setOf(isolatedPath, mainPath), stored.keys)
+                assertEquals(String(isolatedBytes), String(stored.getValue(isolatedPath)))
+                assertEquals(String(mainBytes), String(stored.getValue(mainPath)))
+            },
+        )
+    }
+
+    @Test
+    fun whenSettingsHasNoScriptletsThenUpdateReturnsSuccessAndStoresEmptyMap() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(validSettings.copy(scriptlets = emptyMap())))
+        verify(downloader, never()).download(any())
+        verify(repository).storeScriptlets(eq("2026.3.9"), eq(emptyMap()))
+    }
+
+    @Test
+    fun whenOneDownloadFailsThenUpdateShortCircuitsAndCancelsInFlightDownloads() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        val isolatedDownloadStarted = CompletableDeferred<Unit>()
+        val shortCircuitingDownloader = object : ScriptletDownloader {
+            override suspend fun download(url: String): kotlin.Result<ByteArray> = when (url) {
+                isolatedEntry.url -> {
+                    isolatedDownloadStarted.complete(Unit)
+                    awaitCancellation()
+                }
+                mainEntry.url -> kotlin.Result.failure(IOException("boom"))
+                else -> error("unexpected url: $url")
+            }
+        }
+        val shortCircuitingUpdater = RealScriptletUpdater(repository, shortCircuitingDownloader, validator)
+
+        assertEquals(ScriptletUpdateResult.Retry, shortCircuitingUpdater.update(validSettings))
+        assertTrue("isolated download should have started in parallel", isolatedDownloadStarted.isCompleted)
+        verify(validator, never()).validate(any(), any())
+        verify(repository, never()).storeScriptlets(any(), any())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -20,8 +20,8 @@ import com.duckduckgo.adblocking.impl.domain.RealScriptletUpdater
 import com.duckduckgo.adblocking.impl.domain.ScriptletSignatureValidator
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletValidationResult
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
@@ -52,7 +52,7 @@ class RealScriptletUpdaterTest {
     private val isolatedBytes = "isolated-bytes".toByteArray()
     private val mainBytes = "main-bytes".toByteArray()
 
-    private val validSettings = ScriptletsSettings(
+    private val validSettings = AdBlockingExtensionSettings(
         version = "2026.3.9",
         scriptlets = mapOf(isolatedPath to isolatedEntry, mainPath to mainEntry),
     )

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -119,6 +119,25 @@ class RealScriptletUpdaterTest {
     }
 
     @Test
+    fun whenScriptletContentIsEmptyThenItIsNotStored() = runTest {
+        val emptyBytes = ByteArray(0)
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(emptyBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(emptyBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(validSettings))
+        verify(repository).storeScriptlets(
+            eq("2026.3.9"),
+            check { stored ->
+                assertEquals(setOf(mainPath), stored.keys)
+                assertEquals(String(mainBytes), String(stored.getValue(mainPath)))
+            },
+        )
+    }
+
+    @Test
     fun whenOneDownloadFailsThenUpdateShortCircuitsAndCancelsInFlightDownloads() = runTest {
         whenever(repository.getStoredVersion()).thenReturn("0.0.0")
         val isolatedDownloadStarted = CompletableDeferred<Unit>()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -22,11 +22,8 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -50,7 +47,7 @@ class ScriptletDownloadWorkerSchedulerTest {
 
     private val discoverableFlow = MutableStateFlow(true)
     private val operationalFlow = MutableStateFlow(true)
-    private val settingsFlow = MutableStateFlow<ScriptletsSettings?>(null)
+    private val settingsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
 
     private val isDiscoverableToggle: Toggle = mock {
         on { enabled() } doReturn discoverableFlow
@@ -65,14 +62,10 @@ class ScriptletDownloadWorkerSchedulerTest {
     private val configProvider: AdBlockingExtensionConfigProvider = mock {
         on { scriptletsSettings } doReturn settingsFlow
     }
-    private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
-        .adapter(ScriptletsSettings::class.java)
     private val lifecycleOwner: LifecycleOwner = mock()
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
-    private val scriptletsSettings = ScriptletsSettings(version = "2026.5.14", scriptlets = emptyMap())
+    private val scriptletsSettings = AdBlockingExtensionSettings(version = "2026.5.14", scriptlets = emptyMap())
 
     @After
     fun tearDown() {
@@ -84,7 +77,6 @@ class ScriptletDownloadWorkerSchedulerTest {
             workManager = workManager,
             configProvider = configProvider,
             feature = feature,
-            settingsAdapter = settingsAdapter,
             appScope = testScope,
         ).onCreate(lifecycleOwner)
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+@SuppressLint("DenyListedApi") // setRawStoredState
+@RunWith(AndroidJUnit4::class)
+class ScriptletDownloadWorkerSchedulerTest {
+
+    private val workManager: WorkManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
+    private val configProvider: AdBlockingExtensionConfigProvider = mock {
+        on { scriptletsSettings } doReturn scriptletsFlow
+    }
+    private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(ScriptletsSettings::class.java)
+    private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
+
+    private val scriptletsSettings = ScriptletsSettings(version = "2026.5.14", scriptlets = emptyMap())
+
+    private fun newScheduler(appScope: CoroutineScope) = ScriptletDownloadWorkerScheduler(
+        workManager = workManager,
+        configProvider = configProvider,
+        feature = feature,
+        settingsAdapter = settingsAdapter,
+        appScope = appScope,
+    )
+
+    @Test
+    fun whenFeatureIsOperationalAndSettingsAreEmittedThenWorkIsEnqueued() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+
+        scriptletsFlow.value = scriptletsSettings
+        runCurrent()
+
+        verify(workManager).enqueueUniqueWork(
+            eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
+            any(),
+            any<OneTimeWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun whenFeatureIsNotOperationalAndSettingsAreEmittedThenWorkIsNotEnqueued() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = false))
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+
+        scriptletsFlow.value = scriptletsSettings
+        runCurrent()
+
+        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+    }
+
+    @Test
+    fun whenFeatureIsOperationalAndSettingsAreNullThenWorkIsNotEnqueued() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+
+        runCurrent()
+
+        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+    }
+
+    @Test
+    fun whenFeatureFlipsFromNotOperationalToOperationalThenWorkIsEnqueued() = runTest {
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = false))
+        scriptletsFlow.value = scriptletsSettings
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+        runCurrent()
+        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        runCurrent()
+
+        verify(workManager).enqueueUniqueWork(
+            eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
+            any(),
+            any<OneTimeWorkRequest>(),
+        )
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -28,9 +28,11 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -40,51 +42,124 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ScriptletDownloadWorkerSchedulerTest {
 
     private val workManager: WorkManager = mock()
-    private val isDiscoverableEnabledFlow = MutableStateFlow(true)
-    private val selfEnabledFlow = MutableStateFlow(false)
+
+    private val discoverableFlow = MutableStateFlow(true)
+    private val operationalFlow = MutableStateFlow(true)
+    private val settingsFlow = MutableStateFlow<ScriptletsSettings?>(null)
+
     private val isDiscoverableToggle: Toggle = mock {
-        on { enabled() } doReturn isDiscoverableEnabledFlow
+        on { enabled() } doReturn discoverableFlow
     }
     private val selfToggle: Toggle = mock {
-        on { enabled() } doReturn selfEnabledFlow
+        on { enabled() } doReturn operationalFlow
     }
     private val feature: AdBlockingExtensionFeature = mock {
         on { isDiscoverable() } doReturn isDiscoverableToggle
         on { self() } doReturn selfToggle
     }
-    private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
     private val configProvider: AdBlockingExtensionConfigProvider = mock {
-        on { scriptletsSettings } doReturn scriptletsFlow
+        on { scriptletsSettings } doReturn settingsFlow
     }
     private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .build()
         .adapter(ScriptletsSettings::class.java)
     private val lifecycleOwner: LifecycleOwner = mock()
+    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private val scriptletsSettings = ScriptletsSettings(version = "2026.5.14", scriptlets = emptyMap())
 
-    private fun newScheduler(appScope: CoroutineScope) = ScriptletDownloadWorkerScheduler(
-        workManager = workManager,
-        configProvider = configProvider,
-        feature = feature,
-        settingsAdapter = settingsAdapter,
-        appScope = appScope,
-    )
+    @After
+    fun tearDown() {
+        testScope.cancel()
+    }
+
+    private fun startScheduler() {
+        ScriptletDownloadWorkerScheduler(
+            workManager = workManager,
+            configProvider = configProvider,
+            feature = feature,
+            settingsAdapter = settingsAdapter,
+            appScope = testScope,
+        ).onCreate(lifecycleOwner)
+    }
 
     @Test
-    fun whenFeatureIsOperationalAndSettingsAreEmittedThenWorkIsEnqueued() = runTest {
-        selfEnabledFlow.value = true
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
+    fun whenDiscoverableAndOperationalAndSettingsArePresentThenWorkIsEnqueued() {
+        settingsFlow.value = scriptletsSettings
 
-        scriptletsFlow.value = scriptletsSettings
-        runCurrent()
+        startScheduler()
 
+        verifyEnqueuedOnce()
+    }
+
+    @Test
+    fun whenDiscoverableIsOffThenWorkIsNotEnqueued() {
+        discoverableFlow.value = false
+        settingsFlow.value = scriptletsSettings
+
+        startScheduler()
+
+        verifyNotEnqueued()
+    }
+
+    @Test
+    fun whenOperationalIsOffThenWorkIsNotEnqueued() {
+        operationalFlow.value = false
+        settingsFlow.value = scriptletsSettings
+
+        startScheduler()
+
+        verifyNotEnqueued()
+    }
+
+    @Test
+    fun whenSettingsAreNullThenWorkIsNotEnqueued() {
+        startScheduler()
+
+        verifyNotEnqueued()
+    }
+
+    @Test
+    fun whenDiscoverableFlipsOnThenWorkIsEnqueued() {
+        discoverableFlow.value = false
+        settingsFlow.value = scriptletsSettings
+        startScheduler()
+        verifyNotEnqueued()
+
+        discoverableFlow.value = true
+
+        verifyEnqueuedOnce()
+    }
+
+    @Test
+    fun whenOperationalFlipsOnThenWorkIsEnqueued() {
+        operationalFlow.value = false
+        settingsFlow.value = scriptletsSettings
+        startScheduler()
+        verifyNotEnqueued()
+
+        operationalFlow.value = true
+
+        verifyEnqueuedOnce()
+    }
+
+    @Test
+    fun whenSettingsBecomeNonNullThenWorkIsEnqueued() {
+        startScheduler()
+        verifyNotEnqueued()
+
+        settingsFlow.value = scriptletsSettings
+
+        verifyEnqueuedOnce()
+    }
+
+    private fun verifyEnqueuedOnce() {
         verify(workManager).enqueueUniqueWork(
             eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
             any(),
@@ -92,78 +167,7 @@ class ScriptletDownloadWorkerSchedulerTest {
         )
     }
 
-    @Test
-    fun whenFeatureIsNotOperationalAndSettingsAreEmittedThenWorkIsNotEnqueued() = runTest {
-        selfEnabledFlow.value = false
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
-
-        scriptletsFlow.value = scriptletsSettings
-        runCurrent()
-
+    private fun verifyNotEnqueued() {
         verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
-    }
-
-    @Test
-    fun whenFeatureIsOperationalAndSettingsAreNullThenWorkIsNotEnqueued() = runTest {
-        selfEnabledFlow.value = true
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
-
-        runCurrent()
-
-        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
-    }
-
-    @Test
-    fun whenFeatureFlipsFromNotOperationalToOperationalThenWorkIsEnqueued() = runTest {
-        selfEnabledFlow.value = false
-        scriptletsFlow.value = scriptletsSettings
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
-        runCurrent()
-        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
-
-        selfEnabledFlow.value = true
-        runCurrent()
-
-        verify(workManager).enqueueUniqueWork(
-            eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
-            any(),
-            any<OneTimeWorkRequest>(),
-        )
-    }
-
-    @Test
-    fun whenKillSwitchIsOffThenWorkIsNotEnqueuedEvenIfOperational() = runTest {
-        isDiscoverableEnabledFlow.value = false
-        selfEnabledFlow.value = true
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
-
-        scriptletsFlow.value = scriptletsSettings
-        runCurrent()
-
-        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
-    }
-
-    @Test
-    fun whenKillSwitchFlipsOnAndAllOtherGatesAreReadyThenWorkIsEnqueued() = runTest {
-        isDiscoverableEnabledFlow.value = false
-        selfEnabledFlow.value = true
-        scriptletsFlow.value = scriptletsSettings
-        val scheduler = newScheduler(backgroundScope)
-        scheduler.onCreate(lifecycleOwner)
-        runCurrent()
-        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
-
-        isDiscoverableEnabledFlow.value = true
-        runCurrent()
-
-        verify(workManager).enqueueUniqueWork(
-            eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
-            any(),
-            any<OneTimeWorkRequest>(),
-        )
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -16,16 +16,13 @@
 
 package com.duckduckgo.adblocking.impl
 
-import android.annotation.SuppressLint
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -43,12 +40,22 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
-@SuppressLint("DenyListedApi") // setRawStoredState
 @RunWith(AndroidJUnit4::class)
 class ScriptletDownloadWorkerSchedulerTest {
 
     private val workManager: WorkManager = mock()
-    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val isDiscoverableEnabledFlow = MutableStateFlow(true)
+    private val selfEnabledFlow = MutableStateFlow(false)
+    private val isDiscoverableToggle: Toggle = mock {
+        on { enabled() } doReturn isDiscoverableEnabledFlow
+    }
+    private val selfToggle: Toggle = mock {
+        on { enabled() } doReturn selfEnabledFlow
+    }
+    private val feature: AdBlockingExtensionFeature = mock {
+        on { isDiscoverable() } doReturn isDiscoverableToggle
+        on { self() } doReturn selfToggle
+    }
     private val scriptletsFlow = MutableStateFlow<ScriptletsSettings?>(null)
     private val configProvider: AdBlockingExtensionConfigProvider = mock {
         on { scriptletsSettings } doReturn scriptletsFlow
@@ -57,7 +64,7 @@ class ScriptletDownloadWorkerSchedulerTest {
         .add(KotlinJsonAdapterFactory())
         .build()
         .adapter(ScriptletsSettings::class.java)
-    private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
+    private val lifecycleOwner: LifecycleOwner = mock()
 
     private val scriptletsSettings = ScriptletsSettings(version = "2026.5.14", scriptlets = emptyMap())
 
@@ -71,7 +78,7 @@ class ScriptletDownloadWorkerSchedulerTest {
 
     @Test
     fun whenFeatureIsOperationalAndSettingsAreEmittedThenWorkIsEnqueued() = runTest {
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        selfEnabledFlow.value = true
         val scheduler = newScheduler(backgroundScope)
         scheduler.onCreate(lifecycleOwner)
 
@@ -87,7 +94,7 @@ class ScriptletDownloadWorkerSchedulerTest {
 
     @Test
     fun whenFeatureIsNotOperationalAndSettingsAreEmittedThenWorkIsNotEnqueued() = runTest {
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = false))
+        selfEnabledFlow.value = false
         val scheduler = newScheduler(backgroundScope)
         scheduler.onCreate(lifecycleOwner)
 
@@ -99,7 +106,7 @@ class ScriptletDownloadWorkerSchedulerTest {
 
     @Test
     fun whenFeatureIsOperationalAndSettingsAreNullThenWorkIsNotEnqueued() = runTest {
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        selfEnabledFlow.value = true
         val scheduler = newScheduler(backgroundScope)
         scheduler.onCreate(lifecycleOwner)
 
@@ -110,14 +117,47 @@ class ScriptletDownloadWorkerSchedulerTest {
 
     @Test
     fun whenFeatureFlipsFromNotOperationalToOperationalThenWorkIsEnqueued() = runTest {
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = false))
+        selfEnabledFlow.value = false
         scriptletsFlow.value = scriptletsSettings
         val scheduler = newScheduler(backgroundScope)
         scheduler.onCreate(lifecycleOwner)
         runCurrent()
         verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
 
-        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
+        selfEnabledFlow.value = true
+        runCurrent()
+
+        verify(workManager).enqueueUniqueWork(
+            eq(ScriptletDownloadWorkerScheduler.WORK_NAME),
+            any(),
+            any<OneTimeWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun whenKillSwitchIsOffThenWorkIsNotEnqueuedEvenIfOperational() = runTest {
+        isDiscoverableEnabledFlow.value = false
+        selfEnabledFlow.value = true
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+
+        scriptletsFlow.value = scriptletsSettings
+        runCurrent()
+
+        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+    }
+
+    @Test
+    fun whenKillSwitchFlipsOnAndAllOtherGatesAreReadyThenWorkIsEnqueued() = runTest {
+        isDiscoverableEnabledFlow.value = false
+        selfEnabledFlow.value = true
+        scriptletsFlow.value = scriptletsSettings
+        val scheduler = newScheduler(backgroundScope)
+        scheduler.onCreate(lifecycleOwner)
+        runCurrent()
+        verify(workManager, never()).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+
+        isDiscoverableEnabledFlow.value = true
         runCurrent()
 
         verify(workManager).enqueueUniqueWork(

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -46,18 +46,18 @@ class ScriptletDownloadWorkerSchedulerTest {
     private val workManager: WorkManager = mock()
 
     private val discoverableFlow = MutableStateFlow(true)
-    private val operationalFlow = MutableStateFlow(true)
+    private val contingencyModeFlow = MutableStateFlow(false)
     private val settingsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
 
-    private val isDiscoverableToggle: Toggle = mock {
+    private val selfToggle: Toggle = mock {
         on { enabled() } doReturn discoverableFlow
     }
-    private val selfToggle: Toggle = mock {
-        on { enabled() } doReturn operationalFlow
+    private val contingencyModeToggle: Toggle = mock {
+        on { enabled() } doReturn contingencyModeFlow
     }
     private val feature: AdBlockingExtensionFeature = mock {
-        on { isDiscoverable() } doReturn isDiscoverableToggle
         on { self() } doReturn selfToggle
+        on { enableContingencyMode() } doReturn contingencyModeToggle
     }
     private val configProvider: AdBlockingExtensionConfigProvider = mock {
         on { scriptletsSettings } doReturn settingsFlow
@@ -82,7 +82,7 @@ class ScriptletDownloadWorkerSchedulerTest {
     }
 
     @Test
-    fun whenDiscoverableAndOperationalAndSettingsArePresentThenWorkIsEnqueued() {
+    fun whenDiscoverableAndContingencyModeOffAndSettingsArePresentThenWorkIsEnqueued() {
         settingsFlow.value = scriptletsSettings
 
         startScheduler()
@@ -101,8 +101,8 @@ class ScriptletDownloadWorkerSchedulerTest {
     }
 
     @Test
-    fun whenOperationalIsOffThenWorkIsNotEnqueued() {
-        operationalFlow.value = false
+    fun whenContingencyModeIsOnThenWorkIsNotEnqueued() {
+        contingencyModeFlow.value = true
         settingsFlow.value = scriptletsSettings
 
         startScheduler()
@@ -130,13 +130,13 @@ class ScriptletDownloadWorkerSchedulerTest {
     }
 
     @Test
-    fun whenOperationalFlipsOnThenWorkIsEnqueued() {
-        operationalFlow.value = false
+    fun whenContingencyModeFlipsOffThenWorkIsEnqueued() {
+        contingencyModeFlow.value = true
         settingsFlow.value = scriptletsSettings
         startScheduler()
         verifyNotEnqueued()
 
-        operationalFlow.value = true
+        contingencyModeFlow.value = false
 
         verifyEnqueuedOnce()
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
@@ -25,8 +25,8 @@ import androidx.work.workDataOf
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
-import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -56,12 +56,12 @@ class ScriptletDownloadWorkerTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val updater: ScriptletUpdater = mock()
     private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
-    private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
+    private val settingsAdapter: JsonAdapter<AdBlockingExtensionSettings> = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .build()
-        .adapter(ScriptletsSettings::class.java)
+        .adapter(AdBlockingExtensionSettings::class.java)
 
-    private val settings = ScriptletsSettings(
+    private val settings = AdBlockingExtensionSettings(
         version = "2026.3.9",
         scriptlets = mapOf(
             "scriptlets/isolated/ublock-filters.js" to ScriptletEntry("https://cdn.example/isolated.js", "iso-sig"),
@@ -124,7 +124,6 @@ class ScriptletDownloadWorkerTest {
         }
         return TestListenableWorkerBuilder<ScriptletDownloadWorker>(context, inputData = data).build().also {
             it.updater = updater
-            it.settingsAdapter = settingsAdapter
             it.feature = feature
             it.dispatchers = coroutineRule.testDispatcherProvider
         }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.ListenableWorker.Result
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
+import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
+import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class ScriptletDownloadWorkerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val updater: ScriptletUpdater = mock()
+    private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(ScriptletsSettings::class.java)
+
+    private val settings = ScriptletsSettings(
+        version = "2026.3.9",
+        scriptlets = mapOf(
+            "scriptlets/isolated/ublock-filters.js" to ScriptletEntry("https://cdn.example/isolated.js", "iso-sig"),
+        ),
+    )
+
+    @Test
+    fun whenInputDataHasNoSettingsThenDoWorkReturnsFailure() = runTest {
+        val result = newWorker(inputData = null).doWork()
+
+        assertEquals(Result.failure(), result)
+    }
+
+    @Test
+    fun whenInputDataHasMalformedSettingsJsonThenDoWorkReturnsFailure() = runTest {
+        val result = newWorker(inputData = "{ not valid json").doWork()
+
+        assertEquals(Result.failure(), result)
+    }
+
+    @Test
+    fun whenUpdaterReportsSuccessThenDoWorkPassesDeserialisedSettingsAndReturnsSuccess() = runTest {
+        whenever(updater.update(eq(settings))).thenReturn(ScriptletUpdateResult.Success)
+
+        val result = newWorker(inputData = settingsAdapter.toJson(settings)).doWork()
+
+        assertEquals(Result.success(), result)
+        verify(updater).update(eq(settings))
+    }
+
+    @Test
+    fun whenUpdaterReportsRetryThenDoWorkReturnsRetry() = runTest {
+        whenever(updater.update(any())).thenReturn(ScriptletUpdateResult.Retry)
+
+        val result = newWorker(inputData = settingsAdapter.toJson(settings)).doWork()
+
+        assertEquals(Result.retry(), result)
+    }
+
+    private fun newWorker(inputData: String?): ScriptletDownloadWorker {
+        val data = if (inputData == null) {
+            androidx.work.Data.EMPTY
+        } else {
+            workDataOf(ScriptletDownloadWorker.KEY_SETTINGS to inputData)
+        }
+        return TestListenableWorkerBuilder<ScriptletDownloadWorker>(context, inputData = data).build().also {
+            it.updater = updater
+            it.settingsAdapter = settingsAdapter
+            it.dispatchers = coroutineRule.testDispatcherProvider
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
@@ -70,7 +70,7 @@ class ScriptletDownloadWorkerTest {
 
     @Before
     fun setup() {
-        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = true))
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = true))
     }
 
     @Test
@@ -108,7 +108,7 @@ class ScriptletDownloadWorkerTest {
 
     @Test
     fun whenKillSwitchIsOffThenDoWorkReturnsSuccessWithoutCallingUpdater() = runTest {
-        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = false))
+        feature.self().setRawStoredState(Toggle.State(remoteEnableState = false))
 
         val result = newWorker(inputData = settingsAdapter.toJson(settings)).doWork()
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.adblocking.impl
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.ListenableWorker.Result
@@ -23,23 +24,29 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.workDataOf
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdater
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletsSettings
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi") // setRawStoredState
 @RunWith(AndroidJUnit4::class)
 class ScriptletDownloadWorkerTest {
 
@@ -48,6 +55,7 @@ class ScriptletDownloadWorkerTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val updater: ScriptletUpdater = mock()
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
     private val settingsAdapter: JsonAdapter<ScriptletsSettings> = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .build()
@@ -59,6 +67,11 @@ class ScriptletDownloadWorkerTest {
             "scriptlets/isolated/ublock-filters.js" to ScriptletEntry("https://cdn.example/isolated.js", "iso-sig"),
         ),
     )
+
+    @Before
+    fun setup() {
+        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = true))
+    }
 
     @Test
     fun whenInputDataHasNoSettingsThenDoWorkReturnsFailure() = runTest {
@@ -93,6 +106,16 @@ class ScriptletDownloadWorkerTest {
         assertEquals(Result.retry(), result)
     }
 
+    @Test
+    fun whenKillSwitchIsOffThenDoWorkReturnsSuccessWithoutCallingUpdater() = runTest {
+        feature.isDiscoverable().setRawStoredState(Toggle.State(remoteEnableState = false))
+
+        val result = newWorker(inputData = settingsAdapter.toJson(settings)).doWork()
+
+        assertEquals(Result.success(), result)
+        verify(updater, never()).update(any())
+    }
+
     private fun newWorker(inputData: String?): ScriptletDownloadWorker {
         val data = if (inputData == null) {
             androidx.work.Data.EMPTY
@@ -102,6 +125,7 @@ class ScriptletDownloadWorkerTest {
         return TestListenableWorkerBuilder<ScriptletDownloadWorker>(context, inputData = data).build().also {
             it.updater = updater
             it.settingsAdapter = settingsAdapter
+            it.feature = feature
             it.dispatchers = coroutineRule.testDispatcherProvider
         }
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidatorTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidatorTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.charset.StandardCharsets
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+import java.util.Base64
+
+@RunWith(AndroidJUnit4::class)
+class ScriptletSignatureValidatorTest {
+
+    private lateinit var keyPair: KeyPair
+    private lateinit var validator: ScriptletSignatureValidator
+
+    @Before
+    fun setup() {
+        keyPair = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }.generateKeyPair()
+        validator = RealScriptletSignatureValidator(
+            publicKey = keyPair.public,
+            signature = Signature.getInstance("SHA256withECDSA"),
+            charsetDecoder = StandardCharsets.UTF_8.newDecoder(),
+            base64Decoder = Base64.getDecoder(),
+        )
+    }
+
+    @Test
+    fun whenContentAndSignatureMatchThenValidateReturnsValid() = runTest {
+        val content = "console.log('hello')".toByteArray()
+        val signature = sign(content, keyPair.private)
+
+        Assert.assertEquals(ScriptletValidationResult.Valid, validator.validate(content, signature))
+    }
+
+    @Test
+    fun whenContentIsTamperedThenValidateReturnsSignatureVerificationFailed() = runTest {
+        val original = "original content".toByteArray()
+        val signature = sign(original, keyPair.private)
+        val tampered = "tampered content".toByteArray()
+
+        Assert.assertEquals(
+            ScriptletValidationResult.Invalid.SignatureVerificationFailed,
+            validator.validate(tampered, signature),
+        )
+    }
+
+    @Test
+    fun whenSignatureIsFromDifferentKeyThenValidateReturnsSignatureVerificationFailed() =
+        runTest {
+            val content = "content".toByteArray()
+            val otherKeyPair = KeyPairGenerator.getInstance("EC").apply {
+                initialize(ECGenParameterSpec("secp256r1"))
+            }.generateKeyPair()
+            val signature = sign(content, otherKeyPair.private)
+
+            Assert.assertEquals(
+                ScriptletValidationResult.Invalid.SignatureVerificationFailed,
+                validator.validate(content, signature),
+            )
+        }
+
+    @Test
+    fun whenSignatureIsMalformedBase64ThenValidateReturnsInvalidSignatureFormat() = runTest {
+        val content = "content".toByteArray()
+
+        Assert.assertEquals(
+            ScriptletValidationResult.Invalid.SignatureFormat,
+            validator.validate(content, "not!valid!base64"),
+        )
+    }
+
+    @Test
+    fun whenSignatureBytesAreNotValidEcdsaSignatureThenValidateReturnsSignatureVerificationFailed() =
+        runTest {
+            val content = "content".toByteArray()
+            val garbage = Base64.getEncoder().encodeToString(ByteArray(64) { 0x42 })
+
+            Assert.assertEquals(
+                ScriptletValidationResult.Invalid.SignatureVerificationFailed,
+                validator.validate(content, garbage),
+            )
+        }
+
+    @Test
+    fun whenContentIsNotValidUtf8ThenValidateReturnsInvalidEncoding() = runTest {
+        val invalidUtf8 = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0x80.toByte(), 0x81.toByte())
+        val signature = sign(invalidUtf8, keyPair.private)
+
+        Assert.assertEquals(
+            ScriptletValidationResult.Invalid.Encoding,
+            validator.validate(invalidUtf8, signature),
+        )
+    }
+
+    private fun sign(content: ByteArray, privateKey: PrivateKey): String {
+        val sig = Signature.getInstance("SHA256withECDSA").apply {
+            initSign(privateKey)
+            update(content)
+        }
+        return Base64.getEncoder().encodeToString(sig.sign())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidatorTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/ScriptletSignatureValidatorTest.kt
@@ -17,15 +17,14 @@
 package com.duckduckgo.adblocking.impl.domain
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
+import java.security.PublicKey
 import java.security.Signature
 import java.security.spec.ECGenParameterSpec
 import java.util.Base64
@@ -42,15 +41,14 @@ class ScriptletSignatureValidatorTest {
             initialize(ECGenParameterSpec("secp256r1"))
         }.generateKeyPair()
         validator = RealScriptletSignatureValidator(
-            publicKey = keyPair.public,
-            signature = Signature.getInstance("SHA256withECDSA"),
-            charsetDecoder = StandardCharsets.UTF_8.newDecoder(),
-            base64Decoder = Base64.getDecoder(),
+            publicKeyProvider = object : PublicKeyProvider {
+                override val publicKey: PublicKey = keyPair.public
+            },
         )
     }
 
     @Test
-    fun whenContentAndSignatureMatchThenValidateReturnsValid() = runTest {
+    fun whenContentAndSignatureMatchThenValidateReturnsValid() {
         val content = "console.log('hello')".toByteArray()
         val signature = sign(content, keyPair.private)
 
@@ -58,7 +56,7 @@ class ScriptletSignatureValidatorTest {
     }
 
     @Test
-    fun whenContentIsTamperedThenValidateReturnsSignatureVerificationFailed() = runTest {
+    fun whenContentIsTamperedThenValidateReturnsSignatureVerificationFailed() {
         val original = "original content".toByteArray()
         val signature = sign(original, keyPair.private)
         val tampered = "tampered content".toByteArray()
@@ -70,22 +68,21 @@ class ScriptletSignatureValidatorTest {
     }
 
     @Test
-    fun whenSignatureIsFromDifferentKeyThenValidateReturnsSignatureVerificationFailed() =
-        runTest {
-            val content = "content".toByteArray()
-            val otherKeyPair = KeyPairGenerator.getInstance("EC").apply {
-                initialize(ECGenParameterSpec("secp256r1"))
-            }.generateKeyPair()
-            val signature = sign(content, otherKeyPair.private)
+    fun whenSignatureIsFromDifferentKeyThenValidateReturnsSignatureVerificationFailed() {
+        val content = "content".toByteArray()
+        val otherKeyPair = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }.generateKeyPair()
+        val signature = sign(content, otherKeyPair.private)
 
-            Assert.assertEquals(
-                ScriptletValidationResult.Invalid.SignatureVerificationFailed,
-                validator.validate(content, signature),
-            )
-        }
+        Assert.assertEquals(
+            ScriptletValidationResult.Invalid.SignatureVerificationFailed,
+            validator.validate(content, signature),
+        )
+    }
 
     @Test
-    fun whenSignatureIsMalformedBase64ThenValidateReturnsInvalidSignatureFormat() = runTest {
+    fun whenSignatureIsMalformedBase64ThenValidateReturnsInvalidSignatureFormat() {
         val content = "content".toByteArray()
 
         Assert.assertEquals(
@@ -95,19 +92,18 @@ class ScriptletSignatureValidatorTest {
     }
 
     @Test
-    fun whenSignatureBytesAreNotValidEcdsaSignatureThenValidateReturnsSignatureVerificationFailed() =
-        runTest {
-            val content = "content".toByteArray()
-            val garbage = Base64.getEncoder().encodeToString(ByteArray(64) { 0x42 })
+    fun whenSignatureBytesAreNotValidEcdsaSignatureThenValidateReturnsSignatureVerificationFailed() {
+        val content = "content".toByteArray()
+        val garbage = Base64.getEncoder().encodeToString(ByteArray(64) { 0x42 })
 
-            Assert.assertEquals(
-                ScriptletValidationResult.Invalid.SignatureVerificationFailed,
-                validator.validate(content, garbage),
-            )
-        }
+        Assert.assertEquals(
+            ScriptletValidationResult.Invalid.SignatureVerificationFailed,
+            validator.validate(content, garbage),
+        )
+    }
 
     @Test
-    fun whenContentIsNotValidUtf8ThenValidateReturnsInvalidEncoding() = runTest {
+    fun whenContentIsNotValidUtf8ThenValidateReturnsInvalidEncoding() {
         val invalidUtf8 = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0x80.toByte(), 0x81.toByte())
         val signature = sign(invalidUtf8, keyPair.private)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -308,6 +308,8 @@ dependencies {
 	implementation project(":data-store-impl")
 	implementation project(":data-store-api")
 
+    implementation project (":ad-blocking-impl")
+
 	implementation project(":new-tab-page-impl")
 	implementation project(":new-tab-page-api")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214486375443736?focus=true

### Description

### Steps to test this PR

> [!TIP]
> Set logcat filter `package:mine tag~:"RealScriptletUpdater|ScriptletDownloadWorker|AdBlockingExtensionProvider|RealPrivacyConfigDownloader|ScriptletSignatureValidator|RealAdBlockingExtensionConfigProvider" `

_Feature 1_ - RC flag disabled
- [x] Install the app
- [x] Check logs for `onPrivacyConfigDownloaded`
- [x] Check no logs for files actually downloaded
- [x] Open database inspector and check `ad_blocking_extension.db` doesn't exist

_Feature 2_ - RC flag disabled with settings
- [x] Apply Patch 1 - update privacy-config
- [x] Fresh install the app
- [x] Check logs for `onPrivacyConfigDownloaded`
- [x] Check no logs for files actually downloaded
- [x] Open database inspector and check `ad_blocking_extension.db` doesn't exist

Feature 3 - Kill-switch on, contingency mode on (feature is discoverable but dormant)
- [x] From the previous scenario, enable contingecyModeEnabled from the feature flags inventory. Also enable adBlockingExtension (order is important)
- [x] Kill and reopen the app
- [x] Check logs for onPrivacyConfigDownloaded
- [x] Check no logs for files actually downloaded
- [x] Open database inspector and check ad_blocking_extension.db doesn't exist

Feature 4 - Kill-switch on, contingency mode off (full operational path)
- [x] From the previous scenario, enable adBlockingExtension from the feature flags inventory and check contingecyModeEnabled is disabled
- [x] Check logs for onPrivacyConfigDownloaded, Validating scriptlet succeeded (x4), and Storing scriptlets
- [x] Open database inspector and check ad_blocking_extension.db exists, and has the following contents:
    - [x] name: scriptlets/isolated/ublock-filters.js, version: 2026.5.12, content: {some bytes}
    - [x] name: scriptlets/main/ublock-filters.js, version: 2026.5.12, content: {some bytes}
- [x] Kill and reopen the app
- [x] Check logs for Version matches stored. Skipping

_Feature 5_ - RC flag disabled with settings
- [x] Apply Patch 1 - update privacy-config
- [x] Fresh install the app
- [x] Enable adBlockingExtension from the feature flags inventory
- [x] Kill and restart the app
- [x] Check logs for `onPrivacyConfigDownloaded`
- [x] Check no logs for files actually downloaded
- [x] Open database inspector and check `ad_blocking_extension.db` doesn't exist
- [x] Enable adBlockingExtension -> isDiscoverable from the feature flags inventory
- [x] Open database inspector and check ad_blocking_extension.db exists, and has the following contents (you might need to stop inspectors and start inspector again):
    - [x] name: scriptlets/isolated/ublock-filters.js, version: 2026.5.12, content: {some bytes}
    - [x] name: scriptlets/main/ublock-filters.js, version: 2026.5.12, content: {some bytes}

### Patches

_Patch 1 - update privacy-config_
```
Subject: [PATCH] Update privacy-config URL
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 476d1a965596de1bab6c642a9b023d708bd86f04)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1778775474685)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-5175/v4/android-config.json"
```

### UI changes
n/a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces fetching and persisting remotely supplied script bytes with signature verification—security- and ad-blocking–critical—and gates behavior on remote feature flags and WorkManager scheduling.
> 
> **Overview**
> Adds an end-to-end pipeline in **ad-blocking-impl** to fetch ad-blocking **scriptlets** from privacy-config URLs, verify them, and persist them locally for the extension feature.
> 
> **Remote config & gating:** Settings (`version`, per-scriptlet `url`/`signature`) move into `remoteconfig` with Moshi parsing via `AdBlockingExtensionConfigProvider` (refreshes on privacy config download). `AdBlockingExtensionFeature` gains **`enableContingencyMode`**; downloads run only when the kill-switch is on, contingency is off, and parsed settings exist.
> 
> **Download & trust:** `ScriptletDownloadWorker` (WorkManager, network + exponential backoff) runs `ScriptletUpdater`, which skips work when the stored version matches, downloads scriptlets in parallel, validates **UTF-8** and **SHA256withECDSA** signatures against an embedded EC public key, then atomically replaces rows in **`ad_blocking_extension.db`** (Room). Empty scriptlets are dropped; any download/validation failure yields **retry** without persisting a partial set.
> 
> **App wiring:** `app` depends on `:ad-blocking-impl`. The module adds Room/Work dependencies and broad unit tests (repository, updater, worker, scheduler, config provider, signature validator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c5f59328eace987647b93c328b00303bb17b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->