### PR TITLE
Fix Figma sign-in Custom Tab issue

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -70,7 +70,7 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
         startActivity(
             CustomTabActivity.intent(
                 context = this,
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK and Intent.FLAG_ACTIVITY_CLEAR_TASK and Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS,
                 text = intentText,
                 toolbarColor = toolbarColor,
                 isExternal = isExternal,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1200776578788342/item/1211781703927439/story/1214603116952132?focus=true

### Description

When users tapped to sign in to the Figma app, the sign-in Custom Tab wasn't opening inside of the Figma app as expected, this meant users could get stuck in our browser while trying to sign in (e.g. if they closed the sign in page).

It turned out that the Custom Tab intent flags were being cleared, since instead of combining them (with bitwise OR), we were effectively clearing them (with bitwise AND).

### Steps to test this PR

1. Open DuckDuckGo and make sure it is the default browser
    - *(Opening the browser here, even if already default might be needed.)*
2. Install Figma Android app (or sign out if already installed)
3. Open Figma app, and tap Sign In
4. Press X to close Figma sign in window.
5. Make sure you are taken back to the Figma app, instead of being left in the DuckDuckGo Browser.