### PR TITLE
Float autocomplete and focused view over legacy AppBar in duck.ai mode

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-dimensions.xml
@@ -60,6 +60,8 @@
     <dimen name="omnibarCardMarginBottom">12dp</dimen>
     <dimen name="omnibarOutlineWidth">0dp</dimen>
     <dimen name="omnibarOutlineFocusedWidth">2dp</dimen>
+    <!-- 1dp above the legacy AppBarLayout's lifted elevation (4dp) so floated overlays clear it. -->
+    <dimen name="omnibarFloatElevation">5dp</dimen>
     <dimen name="cookiesAnimationHeight">34dp</dimen>
     <dimen name="cookiesAnimationRadius">14dp</dimen>
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
 import com.duckduckgo.app.browser.R
 import com.google.android.material.card.MaterialCardView
 
@@ -85,6 +86,16 @@ class NativeInputLayoutCoordinator(
     fun configureAutocompleteLayout(widgetView: View, isBottom: Boolean) {
         val autoCompleteList = rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList) ?: return
         val focusedView = rootView.findViewById<View?>(R.id.focusedView)
+
+        // In duck.ai mode the legacy AppBar stays visible; float overlays over it so AppBar
+        // behavior/elevation doesn't push or cover them. Restored on widget detach.
+        val restoreFloats: List<() -> Unit> = if (omnibarState.isDuckAiMode()) {
+            listOfNotNull(autoCompleteList, focusedView).map { it.floatOverLegacyOmnibar() }
+        } else {
+            emptyList()
+        }
+
+        // Keep widget above the (possibly raised) overlay views.
         val baseElevation = maxOf(autoCompleteList.elevation, focusedView?.elevation ?: 0f)
         val targetElevation = baseElevation + widgetView.resources.displayMetrics.density
         widgetView.elevation = maxOf(widgetView.elevation, targetElevation)
@@ -128,6 +139,7 @@ class NativeInputLayoutCoordinator(
 
                 override fun onViewDetachedFromWindow(v: View) {
                     applyPadding(deltaTop = 0, deltaBottom = 0)
+                    restoreFloats.forEach { it() }
                     v.removeOnLayoutChangeListener(layoutListener)
                     autoCompleteList.removeOnLayoutChangeListener(layoutListener)
                     focusedView?.removeOnLayoutChangeListener(layoutListener)
@@ -135,6 +147,20 @@ class NativeInputLayoutCoordinator(
                 }
             },
         )
+    }
+
+    // Clears the CoordinatorLayout behavior and raises elevation so the view floats over
+    // the legacy AppBar. Returns a lambda that restores the previous state.
+    private fun View.floatOverLegacyOmnibar(): () -> Unit {
+        val previousBehavior = (layoutParams as? CoordinatorLayout.LayoutParams)?.behavior
+        val previousElevation = elevation
+        val raisedElevation = resources.getDimension(com.duckduckgo.mobile.android.R.dimen.omnibarFloatElevation)
+        updateLayoutParams<CoordinatorLayout.LayoutParams> { behavior = null }
+        elevation = maxOf(elevation, raisedElevation)
+        return {
+            updateLayoutParams<CoordinatorLayout.LayoutParams> { behavior = previousBehavior }
+            elevation = previousElevation
+        }
     }
 
     fun configureContentOffset(widgetView: View, isBottom: Boolean) {


### PR DESCRIPTION


Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214436349414642?focus=true

### Description
In duck.ai mode the legacy AppBar stays visible to host the DuckAi title and upgrade pill. Clear the autocomplete/focused-view CoordinatorLayout behavior and raise their elevation above the AppBar's lifted state so they overlay correctly. Restored on widget detach.

### Steps to test this PR
- open duck.ai with native input and toggle enabled.
- select search tab
- type something 
- observe autocomplete taking over omnibar area.
- switch tab or clear text and observe it reseting to normal.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1440" height="3120" alt="test" src="https://github.com/user-attachments/assets/b94a69a9-3850-4356-881b-9c288d9e0216" />|<img width="1440" height="3120" alt="test" src="https://github.com/user-attachments/assets/5c371efb-fe6a-409c-bbcd-f05c21b3c224" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change limited to duck.ai mode that tweaks view elevation/CoordinatorLayout behavior and restores it on detach; main risk is unintended z-order or behavior regressions in the omnibar overlays.
> 
> **Overview**
> Ensures the autocomplete suggestions list and `focusedView` correctly overlay the legacy AppBar when duck.ai keeps it visible by temporarily clearing their `CoordinatorLayout` behavior and raising their elevation.
> 
> Adds a shared `omnibarFloatElevation` dimension and restores the prior behavior/elevation when the native input widget detaches, while keeping the widget itself above any raised overlay views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4ab9cd08726970246170b7dff9247555bb31f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->