### PR TITLE
Add getEntitlements API method

### DIFF
--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/Subscriptions.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/Subscriptions.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.api
 
 import android.content.Context
 import android.net.Uri
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import kotlinx.coroutines.flow.Flow
 
 interface Subscriptions {
@@ -42,6 +43,7 @@ interface Subscriptions {
      * This method returns a [true] if a  given [product] can be found in the entitlements list or [false] otherwise
      * @return [Boolean]
      */
+    @Deprecated("Use getEntitlements() instead.", ReplaceWith("getEntitlements()"))
     fun getEntitlementStatus(): Flow<List<Product>>
 
     /**
@@ -83,6 +85,12 @@ interface Subscriptions {
      * @return `true` if a Free Trial offer is available for the user, `false` otherwise
      */
     suspend fun isFreeTrialEligible(): Boolean
+
+    /**
+     * Emits the set of [Entitlement]s granted by the current active subscription, and re-emits when it changes.
+     * Emits an empty set when there is no active subscription.
+     */
+    fun getEntitlements(): Flow<Set<Entitlement>>
 }
 
 enum class Product(val value: String) {

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/model/Entitlement.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/model/Entitlement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 DuckDuckGo
+ * Copyright (c) 2026 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.subscriptions.impl.model
+package com.duckduckgo.subscriptions.api.model
 
 data class Entitlement(
     /**

--- a/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
+++ b/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -56,4 +57,6 @@ class SubscriptionsDummy @Inject constructor() : Subscriptions {
     override fun isSubscriptionUrl(uri: Uri): Boolean = false
 
     override suspend fun isFreeTrialEligible(): Boolean = false
+
+    override fun getEntitlements(): Flow<Set<Entitlement>> = flowOf(emptySet())
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Product.DuckAiPlus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_SUBSCRIPTIONS_PATH
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_ETLD
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.SUBSCRIPTIONS_PATH
@@ -163,6 +164,10 @@ class RealSubscriptions @Inject constructor(
 
     override suspend fun isFreeTrialEligible(): Boolean {
         return subscriptionsManager.isFreeTrialEligible()
+    }
+
+    override fun getEntitlements(): Flow<Set<Entitlement>> {
+        return subscriptionsManager.entitlementSet
     }
 
     private fun buildSubscriptionUrl(uri: Uri?): String {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -20,10 +20,10 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ADVANCED_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BASIC_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.billing.PlayBillingManager
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 import com.duckduckgo.subscriptions.impl.services.SubscriptionsCachedService
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.RealSubscriptionsManager.RecoverSubscriptionResult
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ADVANCED_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BASIC_SUBSCRIPTION
@@ -54,7 +55,6 @@ import com.duckduckgo.subscriptions.impl.billing.PurchaseState
 import com.duckduckgo.subscriptions.impl.billing.RetryPolicy
 import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
 import com.duckduckgo.subscriptions.impl.billing.retry
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.notification.VpnReminderNotificationScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionFailureErrorType
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
@@ -213,6 +213,12 @@ interface SubscriptionsManager {
     val entitlements: Flow<List<Product>>
 
     /**
+     * Flow returning the live entitlement set with both [Entitlement.name] and [Entitlement.product].
+     * Same trigger points as [entitlements].
+     */
+    val entitlementSet: Flow<Set<Entitlement>>
+
+    /**
      * Flow to know the state of the current purchase
      */
     val currentPurchaseState: Flow<CurrentPurchase>
@@ -315,6 +321,12 @@ class RealSubscriptionsManager @Inject constructor(
     )
     override val entitlements = _entitlements.onSubscription { emitEntitlementsValues() }
 
+    private val _entitlementSet: MutableSharedFlow<Set<Entitlement>> = MutableSharedFlow(
+        replay = 1,
+        onBufferOverflow = DROP_OLDEST,
+    )
+    override val entitlementSet = _entitlementSet.onSubscription { emitEntitlementsValues() }
+
     private var purchaseStateJob: Job? = null
 
     private var removeExpiredSubscriptionOnCancelledPurchase: Boolean = false
@@ -340,12 +352,10 @@ class RealSubscriptionsManager @Inject constructor(
 
     private fun emitEntitlementsValues() {
         coroutineScope.launch(dispatcherProvider.io()) {
-            val entitlements = if (authRepository.getSubscription()?.status?.isActiveOrWaiting() == true) {
-                authRepository.getEntitlements().toProductList()
-            } else {
-                emptyList()
-            }
-            _entitlements.emit(entitlements)
+            val active = authRepository.getSubscription()?.status?.isActiveOrWaiting() == true
+            val rawEntitlements = if (active) authRepository.getEntitlements() else emptyList()
+            _entitlements.emit(rawEntitlements.toProductList())
+            _entitlementSet.emit(rawEntitlements.toSet())
         }
     }
 
@@ -552,6 +562,7 @@ class RealSubscriptionsManager @Inject constructor(
         _isSignedIn.emit(false)
         _subscriptionStatus.emit(UNKNOWN)
         _entitlements.emit(emptyList())
+        _entitlementSet.emit(emptySet())
     }
 
     private suspend fun checkPurchase(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidator.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidator.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.subscriptions.impl.auth2
 
-import com.duckduckgo.subscriptions.impl.model.Entitlement
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import java.time.Instant
 
 /**

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidatorImpl.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidatorImpl.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.subscriptions.impl.auth2
 
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.subscriptions.impl.model.Entitlement
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.squareup.anvil.annotations.ContributesBinding
 import io.jsonwebtoken.Claims
 import java.util.*

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/repository/AuthRepository.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/repository/AuthRepository.kt
@@ -29,9 +29,9 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionTier
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.serp_promo.SerpPromo
 import com.duckduckgo.subscriptions.impl.store.SubscriptionsDataStore
 import com.duckduckgo.subscriptions.impl.store.SubscriptionsEncryptedDataStore

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/AuthService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/AuthService.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.subscriptions.impl.services
 
 import com.duckduckgo.anvil.annotations.ContributesNonCachingServiceApi
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.subscriptions.impl.model.Entitlement
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.squareup.moshi.Json
 import retrofit2.http.Body
 import retrofit2.http.GET

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.subscriptions.impl.services
 
 import com.duckduckgo.anvil.annotations.ContributesNonCachingServiceApi
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.auth.AuthRequired
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealProductSubscriptionManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealProductSubscriptionManagerTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.subscriptions.api.Product.*
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.*
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.ProductSubscriptionManager.ProductStatus.ACTIVE
 import com.duckduckgo.subscriptions.impl.ProductSubscriptionManager.ProductStatus.EXPIRED
 import com.duckduckgo.subscriptions.impl.ProductSubscriptionManager.ProductStatus.INELIGIBLE
@@ -281,4 +282,6 @@ private class FakeSubscriptions(
     override fun isSubscriptionUrl(uri: Uri): Boolean = false
 
     override suspend fun isFreeTrialEligible(): Boolean = false
+
+    override fun getEntitlements(): Flow<Set<Entitlement>> = flowOf(emptySet())
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.RealSubscriptionsManager.RecoverSubscriptionResult
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ADVANCED_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
@@ -46,7 +47,6 @@ import com.duckduckgo.subscriptions.impl.billing.PurchaseState.Canceled
 import com.duckduckgo.subscriptions.impl.billing.PurchaseState.Failure
 import com.duckduckgo.subscriptions.impl.billing.PurchaseState.Purchased
 import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.notification.VpnReminderNotificationScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.Account
@@ -1669,6 +1669,61 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         subscriptionsManager.entitlements.test {
             val entitlements = expectMostRecentItem()
             assertTrue(entitlements.isEmpty())
+        }
+    }
+
+    @Test
+    fun whenSubscriptionIsActiveThenEntitlementSetEmitsRawEntitlements() = runTest {
+        givenSubscriptionExists()
+
+        subscriptionsManager.entitlementSet.test {
+            assertEquals(
+                setOf(Entitlement(name = "subscriber", product = NetP.value)),
+                expectMostRecentItem(),
+            )
+        }
+    }
+
+    @Test
+    fun whenSubscriptionIsInactiveThenEntitlementSetEmitsEmpty() = runTest {
+        givenSubscriptionExists(status = INACTIVE)
+
+        subscriptionsManager.entitlementSet.test {
+            assertTrue(expectMostRecentItem().isEmpty())
+        }
+    }
+
+    @Test
+    fun whenSignOutThenEntitlementSetReEmitsEmpty() = runTest {
+        givenSubscriptionExists()
+        givenUserIsSignedIn()
+
+        subscriptionsManager.entitlementSet.test {
+            assertFalse(expectMostRecentItem().isEmpty())
+            subscriptionsManager.signOut()
+            assertTrue(expectMostRecentItem().isEmpty())
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenMultipleEntitlementsExistThenAllAreEmittedInSet() = runTest {
+        givenSubscriptionExists()
+        authRepository.setEntitlements(
+            listOf(
+                Entitlement(name = "plus", product = NetP.value),
+                Entitlement(name = "pro", product = "Duck.ai"),
+            ),
+        )
+
+        subscriptionsManager.entitlementSet.test {
+            assertEquals(
+                setOf(
+                    Entitlement(name = "plus", product = NetP.value),
+                    Entitlement(name = "pro", product = "Duck.ai"),
+                ),
+                expectMostRecentItem(),
+            )
         }
     }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -34,9 +34,9 @@ import com.duckduckgo.subscriptions.api.Product.NetP
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.internal.DefaultSubscriptionsBaseUrl
 import com.duckduckgo.subscriptions.impl.internal.RealSubscriptionsUrlProvider
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import kotlinx.coroutines.flow.flowOf

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
@@ -12,13 +12,13 @@ import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.DUCK_AI
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.NETP
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.billing.PlayBillingManager
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 import com.duckduckgo.subscriptions.impl.services.FeaturesResponse
 import com.duckduckgo.subscriptions.impl.services.FeaturesV2Response

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidatorImplTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/auth2/AuthJwtValidatorImplTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.subscriptions.impl.auth2
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.utils.CurrentTimeProvider
-import com.duckduckgo.subscriptions.impl.model.Entitlement
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
@@ -11,9 +11,9 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionTier
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.serp_promo.FakeSerpPromo
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
@@ -7,10 +7,10 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.SubscriptionOffer
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command.OpenBuyScreen
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command.OpenRestoreScreen

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -16,6 +16,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import com.duckduckgo.subscriptions.impl.CurrentPurchase
 import com.duckduckgo.subscriptions.impl.JSONObjectAdapter
 import com.duckduckgo.subscriptions.impl.PricingPhase
@@ -34,7 +35,6 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
-import com.duckduckgo.subscriptions.impl.model.Entitlement
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.Subscription
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214808964012146?focus=true

### Description

Adds `Subscriptions.getEntitlements(): Flow<Set<Entitlement>>` to the public API so consumers can read the live entitlement set (each carrying both `name` and `product`).

Changes:
- New `getEntitlements()` method on the `Subscriptions` interface, backed by a new `entitlementSet: Flow<Set<Entitlement>>` on `SubscriptionsManager`. Emits alongside the existing `entitlements: Flow<List<Product>>` from the same trigger points (`emitEntitlementsValues()`).
- `Entitlement` data class moved from `subscriptions-impl/model/` to `subscriptions-api/model/` so it's part of the public surface. All impl-side imports repointed.
- `getEntitlementStatus()` annotated `@Deprecated`.
- Unit tests added in `RealSubscriptionsManagerTest` covering the active-subscription and inactive-subscription emissions.

Design and API proposal:
- [Tech Design](https://app.asana.com/1/137249556945/project/481882893211075/task/1214784714729690)
- [API Proposal](https://app.asana.com/1/137249556945/project/1202552961248957/task/1214804968952054?focus=true)

### Steps to test this PR
- [ ] Smoke: Sign in with a Plus or Pro account, confirm subscription status and features renders as before (existing `getEntitlementStatus()` callers unchanged).
- [ ] Sign out, confirm no regressions on the subscription settings screen.

### UI changes
No UI changes - public API only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands the public `Subscriptions` API (interface method addition + deprecation) and changes entitlement emission plumbing, which could affect downstream implementers/consumers and flow behavior if mismatched.
> 
> **Overview**
> Adds a new public `Subscriptions.getEntitlements(): Flow<Set<Entitlement>>` API that exposes the live *raw* entitlement set (including both `name` and `product`) and deprecates `getEntitlementStatus()`.
> 
> Moves the `Entitlement` model into `subscriptions-api` and wires a new `SubscriptionsManager.entitlementSet` flow through `RealSubscriptions`/`SubscriptionsDummy`, emitting alongside the existing `entitlements` list and resetting to empty on sign-out; updates imports across impl/services/auth and adds unit tests covering entitlement-set emission scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab125ced40a44a2172750b9b947aa5c5c5beabc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->