### PR TITLE
Add create image and web search to native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -390,6 +390,7 @@ import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
 import okio.ByteString.Companion.encode
+import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONTokener
 import java.io.File
@@ -1362,7 +1363,7 @@ class BrowserTabFragment :
                     binding.focusedView.gone()
                 },
                 onSearchSubmitted = { query -> onUserSubmittedText(query) },
-                onDuckAiChatSubmitted = { query, modelId, reasoningEffort, imagesJson, filesJson ->
+                onDuckAiChatSubmitted = { query, modelId, reasoningEffort, selectedTool, imagesJson, filesJson ->
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(
                             featureName = "aiChat",
@@ -1380,6 +1381,9 @@ class BrowserTabFragment :
                                         }
                                         if (reasoningEffort != null) {
                                             put("reasoningEffort", reasoningEffort)
+                                        }
+                                        if (selectedTool != null) {
+                                            put("toolChoice", JSONArray().apply { put(selectedTool) })
                                         }
                                         if (imagesJson != null) {
                                             put("images", imagesJson)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -382,6 +382,7 @@ class RealNativeInputManager @Inject constructor(
                         imagesJson,
                         filesJson,
                     )
+                    widget.clearSelectedTool()
                 } else {
                     widget.saveLastUsedTogglePosition(isChat = true)
                     widget.storePendingPrompt(query)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -61,6 +61,7 @@ class NativeInputCallbacks(
         query: String,
         modelId: String?,
         reasoningEffort: String?,
+        selectedTool: String?,
         imagesJson: JSONArray?,
         filesJson: JSONArray?,
     ) -> Unit,
@@ -377,6 +378,7 @@ class RealNativeInputManager @Inject constructor(
                         query,
                         widget.getSelectedModelId(),
                         widget.getResolvedReasoningEffort(),
+                        widget.getSelectedTool(),
                         imagesJson,
                         filesJson,
                     )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -131,6 +131,7 @@ class RealContextualNativeInputManager @Inject constructor(
                 val filesJson = widget.getFileAttachmentsJson()
                 widget.clearAttachments()
                 sendPrompt(prompt, widget.getSelectedModelId(), widget.getResolvedReasoningEffort(), widget.getSelectedTool(), imagesJson, filesJson)
+                widget.clearSelectedTool()
                 widget.text = ""
             },
         )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -130,7 +130,7 @@ class RealContextualNativeInputManager @Inject constructor(
                 val imagesJson = widget.getImageAttachmentsJson()
                 val filesJson = widget.getFileAttachmentsJson()
                 widget.clearAttachments()
-                sendPrompt(prompt, widget.getSelectedModelId(), widget.getResolvedReasoningEffort(), imagesJson, filesJson)
+                sendPrompt(prompt, widget.getSelectedModelId(), widget.getResolvedReasoningEffort(), widget.getSelectedTool(), imagesJson, filesJson)
                 widget.text = ""
             },
         )
@@ -146,6 +146,7 @@ class RealContextualNativeInputManager @Inject constructor(
         prompt: String,
         modelId: String? = null,
         reasoningEffort: String? = null,
+        selectedTool: String? = null,
         imagesJson: JSONArray? = null,
         filesJson: JSONArray? = null,
     ) {
@@ -162,6 +163,9 @@ class RealContextualNativeInputManager @Inject constructor(
                     }
                     if (reasoningEffort != null) {
                         put("reasoningEffort", reasoningEffort)
+                    }
+                    if (selectedTool != null) {
+                        put("toolChoice", JSONArray().apply { put(selectedTool) })
                     }
                     if (imagesJson != null) {
                         put("images", imagesJson)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -411,6 +411,9 @@ class RealDuckChatJSHelper @Inject constructor(
                         if (pending.reasoningEffort != null) {
                             put("reasoningEffort", pending.reasoningEffort)
                         }
+                        if (pending.selectedTool != null) {
+                            put("toolChoice", JSONArray().apply { put(pending.selectedTool) })
+                        }
                         if (pending.images.isNotEmpty()) {
                             put(
                                 "images",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/PendingNativePromptStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/PendingNativePromptStore.kt
@@ -37,6 +37,7 @@ data class PendingNativePrompt(
     val prompt: String,
     val modelId: String?,
     val reasoningEffort: String?,
+    val selectedTool: String? = null,
     val images: List<PendingNativeImage> = emptyList(),
     val files: List<PendingNativeFile> = emptyList(),
 )
@@ -46,6 +47,7 @@ interface PendingNativePromptStore {
         prompt: String,
         modelId: String?,
         reasoningEffort: String?,
+        selectedTool: String? = null,
         images: List<PendingNativeImage> = emptyList(),
         files: List<PendingNativeFile> = emptyList(),
     )
@@ -62,10 +64,11 @@ class RealPendingNativePromptStore @Inject constructor() : PendingNativePromptSt
         prompt: String,
         modelId: String?,
         reasoningEffort: String?,
+        selectedTool: String?,
         images: List<PendingNativeImage>,
         files: List<PendingNativeFile>,
     ) {
-        pending.set(PendingNativePrompt(prompt, modelId, reasoningEffort, images, files))
+        pending.set(PendingNativePrompt(prompt, modelId, reasoningEffort, selectedTool, images, files))
     }
 
     override fun consume(): PendingNativePrompt? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -34,6 +34,7 @@ data class RemoteAIChatModel(
     @field:Json(name = "supportsImageUpload") val supportsImageUpload: Boolean = false,
     @field:Json(name = "supportedFileTypes") val supportedFileTypes: List<String>? = null,
     @field:Json(name = "supportedReasoningEffort") val supportedReasoningEffort: List<String>? = null,
+    @field:Json(name = "supportedTools") val supportedTools: List<String>? = null,
 )
 
 data class RemoteTierAttachmentLimits(
@@ -90,6 +91,16 @@ data class AIChatAttachmentUsage(
     val fileSizeBytesUsed: Long = 0L,
 )
 
+enum class SupportedTool(val rawValue: String) {
+    WEB_SEARCH("WebSearch"),
+    IMAGE_GENERATION("GenerateImage"),
+    ;
+
+    companion object {
+        fun from(raw: String): SupportedTool? = entries.firstOrNull { it.rawValue == raw }
+    }
+}
+
 data class AIChatModel(
     val id: String,
     val name: String,
@@ -102,9 +113,12 @@ data class AIChatModel(
     val supportedImageFormats: List<String> = emptyList(),
     val supportedFileTypes: List<String> = emptyList(),
     val supportedReasoningEfforts: List<ReasoningEffort> = emptyList(),
+    val supportedTools: List<SupportedTool> = emptyList(),
 ) {
     val supportsFileUpload: Boolean
         get() = supportedFileTypes.isNotEmpty()
+
+    fun supportsTool(tool: SupportedTool): Boolean = supportedTools.contains(tool)
 
     companion object {
         val NATIVE_SUPPORTED_IMAGE_FORMATS = listOf("png", "jpeg", "webp")

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -91,16 +91,6 @@ data class AIChatAttachmentUsage(
     val fileSizeBytesUsed: Long = 0L,
 )
 
-enum class SupportedTool(val rawValue: String) {
-    WEB_SEARCH("WebSearch"),
-    IMAGE_GENERATION("GenerateImage"),
-    ;
-
-    companion object {
-        fun from(raw: String): SupportedTool? = entries.firstOrNull { it.rawValue == raw }
-    }
-}
-
 data class AIChatModel(
     val id: String,
     val name: String,
@@ -113,12 +103,12 @@ data class AIChatModel(
     val supportedImageFormats: List<String> = emptyList(),
     val supportedFileTypes: List<String> = emptyList(),
     val supportedReasoningEfforts: List<ReasoningEffort> = emptyList(),
-    val supportedTools: List<SupportedTool> = emptyList(),
+    val supportedTools: List<Tool> = emptyList(),
 ) {
     val supportsFileUpload: Boolean
         get() = supportedFileTypes.isNotEmpty()
 
-    fun supportsTool(tool: SupportedTool): Boolean = supportedTools.contains(tool)
+    fun supportsTool(tool: Tool): Boolean = supportedTools.contains(tool)
 
     companion object {
         val NATIVE_SUPPORTED_IMAGE_FORMATS = listOf("png", "jpeg", "webp")

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -276,6 +276,7 @@ class RealDuckAiModelManager @Inject constructor(
             supportedImageFormats = if (remote.supportsImageUpload) AIChatModel.NATIVE_SUPPORTED_IMAGE_FORMATS else emptyList(),
             supportedFileTypes = remote.supportedFileTypes.orEmpty(),
             supportedReasoningEfforts = remote.supportedReasoningEffort.orEmpty().mapNotNull(ReasoningEffort::from),
+            supportedTools = remote.supportedTools.orEmpty().mapNotNull(SupportedTool::from),
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -276,7 +276,7 @@ class RealDuckAiModelManager @Inject constructor(
             supportedImageFormats = if (remote.supportsImageUpload) AIChatModel.NATIVE_SUPPORTED_IMAGE_FORMATS else emptyList(),
             supportedFileTypes = remote.supportedFileTypes.orEmpty(),
             supportedReasoningEfforts = remote.supportedReasoningEffort.orEmpty().mapNotNull(ReasoningEffort::from),
-            supportedTools = remote.supportedTools.orEmpty().mapNotNull(SupportedTool::from),
+            supportedTools = remote.supportedTools.orEmpty().mapNotNull(Tool::from),
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Tool.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Tool.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.models
+
+enum class Tool(val rawValue: String) {
+    WEB_SEARCH("WebSearch"),
+    IMAGE_GENERATION("GenerateImage"),
+    ;
+
+    companion object {
+        fun from(raw: String): Tool? = entries.firstOrNull { it.rawValue == raw }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 sealed class PromptContribution {
     data class ModelSelection(val modelId: String) : PromptContribution()
     data class ReasoningEffortSelection(val effort: String) : PromptContribution()
+    data class ToolSelection(val tool: String) : PromptContribution()
 }
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -39,10 +39,10 @@ interface NativeInputHost {
     fun submit()
 
     fun showAttachmentChooser(showing: Boolean)
-    fun attachmentChanged(hasAttachments: Boolean, limitExceeded: Boolean, supportsUpload: Boolean)
-
     fun showModelPicker(showing: Boolean)
     fun showReasoningPicker(showing: Boolean)
+
+    fun attachmentChanged(hasAttachments: Boolean, limitExceeded: Boolean, supportsUpload: Boolean)
 
     /** Current input state of the host widget (mode, context, position). */
     fun getInputState(): NativeInputState

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -40,6 +40,9 @@ interface NativeInputHost {
     fun showAttachmentChooser(showing: Boolean)
     fun attachmentChanged(hasAttachments: Boolean, limitExceeded: Boolean, supportsUpload: Boolean)
 
+    fun showModelPicker(showing: Boolean)
+    fun showReasoningPicker(showing: Boolean)
+
     /** Current input state of the host widget (mode, context, position). */
     fun getInputState(): NativeInputState
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -151,6 +151,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
     }
 
+    fun getSelectedTool(): String? {
+        return _plugins.value.firstNotNullOfOrNull { plugin ->
+            (plugin.getPromptContribution() as? PromptContribution.ToolSelection)?.tool
+        }
+    }
+
     private data class WidgetConfig(
         val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
         val inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP,
@@ -225,10 +231,11 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         query: String,
         modelId: String?,
         reasoningEffort: String?,
+        selectedTool: String? = null,
         images: List<PendingNativeImage> = emptyList(),
         files: List<PendingNativeFile> = emptyList(),
     ) {
-        pendingNativePromptStore.store(query, modelId, reasoningEffort, images, files)
+        pendingNativePromptStore.store(query, modelId, reasoningEffort, selectedTool, images, files)
     }
 
     fun configureContextual(tabId: String) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsView
+import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -37,7 +38,14 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.optionsButtonContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
+    private var optionsView: WeakReference<OptionsView> = WeakReference(null)
 
-    override fun getPromptContribution(): PromptContribution? = null
+    override fun createView(context: Context, host: NativeInputHost): View {
+        return OptionsView(context, host).also { optionsView = WeakReference(it) }
+    }
+
+    override fun getPromptContribution(): PromptContribution? {
+        val tool = optionsView.get()?.getSelectedTool() ?: return null
+        return PromptContribution.ToolSelection(tool.rawValue)
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -37,7 +37,7 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.optionsButtonContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context)
+    override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
 
     override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.models.SupportedTool
 import com.google.android.material.chip.Chip
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
@@ -55,6 +56,8 @@ interface ModelPicker {
     var onMenuDismissed: (() -> Unit)?
     var onModelSelected: (() -> Unit)?
     fun getSelectedModelId(): String?
+    fun isImageGenerationSupported(): Boolean
+    fun isWebSearchSupported(): Boolean
     fun setPickerEnabled(enabled: Boolean)
 }
 
@@ -82,7 +85,20 @@ class ModelPickerView @JvmOverloads constructor(
         inflate(context, R.layout.view_model_picker, this)
     }
 
+    private val selectedModel: AIChatModel?
+        get() {
+            if (!::viewModelFactory.isInitialized) return null
+            val state = viewModel.state.value
+            return state.models.find { it.id == state.selectedModelId }
+        }
+
     override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
+
+    override fun isImageGenerationSupported(): Boolean =
+        selectedModel?.supportsTool(SupportedTool.IMAGE_GENERATION) ?: true
+
+    override fun isWebSearchSupported(): Boolean =
+        selectedModel?.supportsTool(SupportedTool.WEB_SEARCH) ?: true
 
     private var pickerEnabled = false
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -43,7 +43,6 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.ModelState
-import com.duckduckgo.duckchat.impl.models.Tool
 import com.google.android.material.chip.Chip
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
@@ -85,20 +84,17 @@ class ModelPickerView @JvmOverloads constructor(
         inflate(context, R.layout.view_model_picker, this)
     }
 
-    private val selectedModel: AIChatModel?
-        get() {
-            if (!::viewModelFactory.isInitialized) return null
-            val state = viewModel.state.value
-            return state.models.find { it.id == state.selectedModelId }
-        }
-
     override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
 
-    override fun isImageGenerationSupported(): Boolean =
-        selectedModel?.supportsTool(Tool.IMAGE_GENERATION) ?: true
+    override fun isImageGenerationSupported(): Boolean {
+        if (!isAttachedToWindow) return true
+        return viewModel.isImageGenerationSupported()
+    }
 
-    override fun isWebSearchSupported(): Boolean =
-        selectedModel?.supportsTool(Tool.WEB_SEARCH) ?: true
+    override fun isWebSearchSupported(): Boolean {
+        if (!isAttachedToWindow) return true
+        return viewModel.isWebSearchSupported()
+    }
 
     private var pickerEnabled = false
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -43,7 +43,7 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.ModelState
-import com.duckduckgo.duckchat.impl.models.SupportedTool
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.google.android.material.chip.Chip
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
@@ -95,10 +95,10 @@ class ModelPickerView @JvmOverloads constructor(
     override fun getSelectedModelId(): String? = viewModel.getSelectedModelId()
 
     override fun isImageGenerationSupported(): Boolean =
-        selectedModel?.supportsTool(SupportedTool.IMAGE_GENERATION) ?: true
+        selectedModel?.supportsTool(Tool.IMAGE_GENERATION) ?: true
 
     override fun isWebSearchSupported(): Boolean =
-        selectedModel?.supportsTool(SupportedTool.WEB_SEARCH) ?: true
+        selectedModel?.supportsTool(Tool.WEB_SEARCH) ?: true
 
     private var pickerEnabled = false
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.UserTier
@@ -44,6 +45,12 @@ class ModelPickerViewModel @Inject constructor(
     var menuShowing = false
 
     fun getSelectedModelId(): String? = modelManager.getSelectedModelId()
+
+    fun getSelectedModel(): AIChatModel? = state.value.run { models.find { it.id == selectedModelId } }
+
+    fun isImageGenerationSupported(): Boolean = getSelectedModel()?.supportsTool(Tool.IMAGE_GENERATION) ?: true
+
+    fun isWebSearchSupported(): Boolean = getSelectedModel()?.supportsTool(Tool.WEB_SEARCH) ?: true
 
     fun fetchModels() {
         viewModelScope.launch {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -25,9 +25,9 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
-import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -113,6 +113,7 @@ interface NativeInputWidget {
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
     fun getResolvedReasoningEffort(): String?
+    fun getSelectedTool(): String?
     fun setModelPickerEnabled(enabled: Boolean)
 
     /**
@@ -199,6 +200,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var modelPickerEnabledJob: Job? = null
     private var modelPickerEnabledSource: Flow<Boolean>? = null
     private var modelPickerView: ModelPicker? = null
+    private var optionsView: OptionsView? = null
     private var chatSuggestionsUserEnabled: Boolean = true
     private var isStreaming: Boolean = false
     private var attachmentLimitExceeded: Boolean = false
@@ -272,8 +274,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
                             // before plugins were created.
                             pluginView.setPickerEnabled(viewModel.modelPickerEnabled.value)
                         }
+                        if (pluginView is OptionsView) {
+                            optionsView = pluginView
+                        }
                         wirePluginView(pluginView, scope)
                     }
+                    optionsView?.updateCapabilitiesFrom(modelPickerView)
                 }
             }
             launch {
@@ -310,6 +316,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
             picker.onMenuDismissed = { isModelMenuVisible = false }
+            picker.onModelSelected = {
+                optionsView?.updateCapabilitiesFrom(picker)
+            }
         }
     }
 
@@ -338,6 +347,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         modelPickerEnabledJob?.cancel()
         modelPickerEnabledJob = null
         modelPickerView = null
+        optionsView = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -697,6 +707,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun getResolvedReasoningEffort(): String? = viewModel.getResolvedReasoningEffort()
 
+    override fun getSelectedTool(): String? = viewModel.getSelectedTool()
+
     override fun setModelPickerEnabled(enabled: Boolean) {
         viewModel.setModelPickerEnabled(enabled)
     }
@@ -731,7 +743,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val files = attachmentView?.getFileAttachments()?.map {
             PendingNativeFile(base64Data = it.base64Data, fileName = it.fileName, mimeType = it.mimeType)
         } ?: emptyList()
-        viewModel.storePendingPrompt(query, getSelectedModelId(), getResolvedReasoningEffort(), images, files)
+        viewModel.storePendingPrompt(query, getSelectedModelId(), getResolvedReasoningEffort(), getSelectedTool(), images, files)
         attachmentView?.clearAttachmentsForNewChat()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -114,6 +114,7 @@ interface NativeInputWidget {
     fun getSelectedModelId(): String?
     fun getResolvedReasoningEffort(): String?
     fun getSelectedTool(): String?
+    fun clearSelectedTool()
     fun setModelPickerEnabled(enabled: Boolean)
 
     /**
@@ -709,6 +710,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun getSelectedTool(): String? = viewModel.getSelectedTool()
 
+    override fun clearSelectedTool() {
+        optionsView?.clearSelection()
+    }
+
     override fun setModelPickerEnabled(enabled: Boolean) {
         viewModel.setModelPickerEnabled(enabled)
     }
@@ -745,6 +750,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         } ?: emptyList()
         viewModel.storePendingPrompt(query, getSelectedModelId(), getResolvedReasoningEffort(), getSelectedTool(), images, files)
         attachmentView?.clearAttachmentsForNewChat()
+        optionsView?.clearSelection()
     }
 
     override fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -990,6 +990,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getInputState(): NativeInputState =
         activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }
             ?: error("getInputState called before widget was configured")
+    override fun showModelPicker(showing: Boolean) {
+        findViewById<FrameLayout?>(R.id.modelPickerContainer)?.isVisible = showing
+    }
+
+    override fun showReasoningPicker(showing: Boolean) {
+        findViewById<FrameLayout?>(R.id.reasoningModePickerContainer)?.isVisible = showing
+    }
 
     private fun configureSubmitButtons() {
         if (submitButtons == null) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -28,7 +28,7 @@ import android.widget.ScrollView
 import androidx.core.view.isVisible
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.models.SupportedTool
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 
 @SuppressLint("ViewConstructor")
@@ -70,11 +70,11 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         addView(optionsButton)
     }
 
-    fun getSelectedTool(): SupportedTool? {
+    fun getSelectedTool(): Tool? {
         val index = tappedIndices.firstOrNull() ?: return null
         return when (menuItems[index].option) {
-            Option.CREATE_IMAGE -> SupportedTool.IMAGE_GENERATION
-            Option.WEB_SEARCH -> SupportedTool.WEB_SEARCH
+            Option.CREATE_IMAGE -> Tool.IMAGE_GENERATION
+            Option.WEB_SEARCH -> Tool.WEB_SEARCH
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -175,7 +175,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
                 trailingIcons.values.forEach { it.visibility = GONE }
                 if (nowSelected) trailingIcon.visibility = VISIBLE
                 onOptionTapped(item)
-                row.postDelayed({ popup.dismiss() }, 150)
+                row.postDelayed({ popup.dismiss() }, MENU_DISMISS_DELAY_MS)
             }
             container.addView(row)
         }
@@ -223,5 +223,9 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
             if (it.isShowing) it.dismiss()
         }
         popupWindow = null
+    }
+
+    companion object {
+        private const val MENU_DISMISS_DELAY_MS = 150L
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -27,14 +27,18 @@ import android.widget.PopupWindow
 import android.widget.ScrollView
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 
 @SuppressLint("ViewConstructor")
-class OptionsView(context: Context) : LinearLayout(context) {
+class OptionsView(context: Context, private val host: NativeInputHost) : LinearLayout(context) {
+
+    private enum class Option { CREATE_IMAGE, WEB_SEARCH }
 
     private data class MenuItem(
         val iconRes: Int,
         val titleRes: Int,
         val subtitleRes: Int,
+        val option: Option,
     )
 
     private val menuItems = listOf(
@@ -42,11 +46,13 @@ class OptionsView(context: Context) : LinearLayout(context) {
             iconRes = R.drawable.ic_images_24,
             titleRes = R.string.duckChatOptionsMenuCreateImage,
             subtitleRes = R.string.duckChatOptionsMenuCreateImageSubtitle,
+            option = Option.CREATE_IMAGE,
         ),
         MenuItem(
             iconRes = com.duckduckgo.mobile.android.R.drawable.ic_globe_24,
             titleRes = R.string.duckChatOptionsMenuWebSearch,
             subtitleRes = R.string.duckChatOptionsMenuWebSearchSubtitle,
+            option = Option.WEB_SEARCH,
         ),
     )
 
@@ -124,6 +130,8 @@ class OptionsView(context: Context) : LinearLayout(context) {
         if (tappedIndices.contains(index)) {
             tappedIndices.remove(index)
             removeChipForIndex(index)
+            host.showModelPicker(true)
+            host.showReasoningPicker(true)
         } else {
             tappedIndices.firstOrNull()?.let { other ->
                 tappedIndices.remove(other)
@@ -131,6 +139,9 @@ class OptionsView(context: Context) : LinearLayout(context) {
             }
             tappedIndices.add(index)
             addView(buildChip(index, menuItems[index]), 1)
+            val show = menuItems[index].option != Option.CREATE_IMAGE
+            host.showModelPicker(show)
+            host.showReasoningPicker(show)
         }
     }
 
@@ -146,6 +157,8 @@ class OptionsView(context: Context) : LinearLayout(context) {
         view.setOnClickListener {
             tappedIndices.remove(index)
             removeView(view)
+            host.showModelPicker(true)
+            host.showReasoningPicker(true)
         }
         return view
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -20,7 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.widget.FrameLayout
+import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
@@ -29,13 +29,12 @@ import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
 
 @SuppressLint("ViewConstructor")
-class OptionsView(context: Context) : FrameLayout(context) {
+class OptionsView(context: Context) : LinearLayout(context) {
 
     private data class MenuItem(
         val iconRes: Int,
         val titleRes: Int,
         val subtitleRes: Int,
-        val showTick: Boolean = false,
     )
 
     private val menuItems = listOf(
@@ -43,13 +42,11 @@ class OptionsView(context: Context) : FrameLayout(context) {
             iconRes = R.drawable.ic_images_24,
             titleRes = R.string.duckChatOptionsMenuCreateImage,
             subtitleRes = R.string.duckChatOptionsMenuCreateImageSubtitle,
-            showTick = true,
         ),
         MenuItem(
             iconRes = com.duckduckgo.mobile.android.R.drawable.ic_globe_24,
             titleRes = R.string.duckChatOptionsMenuWebSearch,
             subtitleRes = R.string.duckChatOptionsMenuWebSearchSubtitle,
-            showTick = true,
         ),
     )
 
@@ -57,8 +54,9 @@ class OptionsView(context: Context) : FrameLayout(context) {
     private var popupWindow: PopupWindow? = null
 
     init {
+        orientation = HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
         addView(buildOptionsButton())
-        setOnClickListener { showMenu() }
     }
 
     override fun onDetachedFromWindow() {
@@ -74,6 +72,7 @@ class OptionsView(context: Context) : FrameLayout(context) {
             contentDescription = context.getString(R.string.duckChatOptionsButtonContentDescription)
             scaleType = ImageView.ScaleType.CENTER
             setImageResource(R.drawable.ic_options_24)
+            setOnClickListener { showMenu() }
         }
     }
 
@@ -101,30 +100,59 @@ class OptionsView(context: Context) : FrameLayout(context) {
     }
 
     private fun populate(container: LinearLayout, popup: PopupWindow) {
+        val trailingIcons = mutableMapOf<Int, ImageView>()
         menuItems.forEachIndexed { index, item ->
             val row = LayoutInflater.from(context).inflate(R.layout.view_options_menu_item, container, false)
             val trailingIcon = row.findViewById<ImageView>(R.id.optionsMenuItemTrailingIcon)
+            trailingIcons[index] = trailingIcon
             row.findViewById<ImageView>(R.id.optionsMenuItemIcon).setImageResource(item.iconRes)
             row.findViewById<DaxTextView>(R.id.optionsMenuItemTitle).setText(item.titleRes)
             row.findViewById<DaxTextView>(R.id.optionsMenuItemSubtitle).setText(item.subtitleRes)
-            trailingIcon.visibility = if (item.showTick && index in tappedIndices) VISIBLE else GONE
+            trailingIcon.visibility = if (index in tappedIndices) VISIBLE else GONE
             row.setOnClickListener {
-                if (item.showTick) {
-                    if (tappedIndices.add(index)) {
-                        trailingIcon.visibility = VISIBLE
-                    } else {
-                        tappedIndices.remove(index)
-                        trailingIcon.visibility = GONE
-                    }
-                }
+                val nowSelected = index !in tappedIndices
+                trailingIcons.values.forEach { it.visibility = GONE }
+                if (nowSelected) trailingIcon.visibility = VISIBLE
+                toggleOption(index)
                 row.postDelayed({ popup.dismiss() }, 150)
             }
             container.addView(row)
         }
     }
 
+    private fun toggleOption(index: Int) {
+        if (tappedIndices.contains(index)) {
+            tappedIndices.remove(index)
+            removeChipForIndex(index)
+        } else {
+            tappedIndices.firstOrNull()?.let { other ->
+                tappedIndices.remove(other)
+                removeChipForIndex(other)
+            }
+            tappedIndices.add(index)
+            addView(buildChip(index, menuItems[index]), 1)
+        }
+    }
+
+    private fun removeChipForIndex(index: Int) {
+        (0 until childCount).map { getChildAt(it) }.firstOrNull { it.tag == index }?.let { removeView(it) }
+    }
+
+    private fun buildChip(index: Int, item: MenuItem): View {
+        val view = LayoutInflater.from(context).inflate(R.layout.view_options_chip, this, false)
+        view.tag = index
+        view.findViewById<ImageView>(R.id.optionsChipIcon).setImageResource(item.iconRes)
+        view.contentDescription = context.getString(R.string.duckChatOptionsChipDismissContentDescription, context.getString(item.titleRes))
+        view.setOnClickListener {
+            tappedIndices.remove(index)
+            removeView(view)
+        }
+        return view
+    }
+
     private fun showAtPosition(popup: PopupWindow) {
-        val loc = IntArray(2).also { getLocationOnScreen(it) }
+        val button = getChildAt(0) ?: this
+        val loc = IntArray(2).also { button.getLocationOnScreen(it) }
         popup.showAtLocation(rootView, Gravity.TOP or Gravity.START, loc[0], loc[1])
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -78,6 +78,16 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         }
     }
 
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (visibility == VISIBLE && tappedIndices.any { menuItems[it].option == Option.CREATE_IMAGE }) {
+            post {
+                host.showModelPicker(false)
+                host.showReasoningPicker(false)
+            }
+        }
+    }
+
     fun updateCapabilitiesFrom(picker: ModelPicker?) {
         val supportsImageGeneration = picker?.isImageGenerationSupported() ?: true
         val supportsWebSearch = picker?.isWebSearchSupported() ?: true

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -83,6 +83,14 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     override fun onAttachedToWindow() {
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
+        restoreChip()
+    }
+
+    private fun restoreChip() {
+        val tool = viewModel.selectedTool.value ?: return
+        val item = menuItems.firstOrNull { it.tool == tool } ?: return
+        addView(buildChip(item), 1)
+        applyPickerVisibility()
     }
 
     fun getSelectedTool(): Tool? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -26,21 +26,33 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.ScrollView
 import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
 
+@InjectWith(ViewScope::class)
 @SuppressLint("ViewConstructor")
 class OptionsView(context: Context, private val host: NativeInputHost) : LinearLayout(context) {
 
-    private enum class Option { CREATE_IMAGE, WEB_SEARCH }
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    private val viewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[OptionsViewModel::class.java]
+    }
 
     private data class MenuItem(
         val iconRes: Int,
         val titleRes: Int,
         val subtitleRes: Int,
-        val option: Option,
+        val tool: Tool,
     )
 
     private val menuItems = listOf(
@@ -48,19 +60,17 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
             iconRes = R.drawable.ic_images_24,
             titleRes = R.string.duckChatOptionsMenuCreateImage,
             subtitleRes = R.string.duckChatOptionsMenuCreateImageSubtitle,
-            option = Option.CREATE_IMAGE,
+            tool = Tool.IMAGE_GENERATION,
         ),
         MenuItem(
             iconRes = com.duckduckgo.mobile.android.R.drawable.ic_globe_24,
             titleRes = R.string.duckChatOptionsMenuWebSearch,
             subtitleRes = R.string.duckChatOptionsMenuWebSearchSubtitle,
-            option = Option.WEB_SEARCH,
+            tool = Tool.WEB_SEARCH,
         ),
     )
 
-    private val tappedIndices = mutableSetOf<Int>()
     private var popupWindow: PopupWindow? = null
-    private var visibleMenuItems = menuItems.withIndex().toList()
     private var optionsButton: ImageView
 
     init {
@@ -70,17 +80,19 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         addView(optionsButton)
     }
 
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+    }
+
     fun getSelectedTool(): Tool? {
-        val index = tappedIndices.firstOrNull() ?: return null
-        return when (menuItems[index].option) {
-            Option.CREATE_IMAGE -> Tool.IMAGE_GENERATION
-            Option.WEB_SEARCH -> Tool.WEB_SEARCH
-        }
+        if (!isAttachedToWindow) return null
+        return viewModel.selectedTool.value
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
-        if (visibility == VISIBLE && tappedIndices.any { menuItems[it].option == Option.CREATE_IMAGE }) {
+        if (visibility == VISIBLE && !viewModel.shouldShowPickers) {
             post {
                 host.showModelPicker(false)
                 host.showReasoningPicker(false)
@@ -89,34 +101,20 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     }
 
     fun updateCapabilitiesFrom(picker: ModelPicker?) {
-        val supportsImageGeneration = picker?.isImageGenerationSupported() ?: true
-        val supportsWebSearch = picker?.isWebSearchSupported() ?: true
+        val visibleTools = buildSet {
+            if (picker?.isImageGenerationSupported() ?: true) add(Tool.IMAGE_GENERATION)
+            if (picker?.isWebSearchSupported() ?: true) add(Tool.WEB_SEARCH)
+        }
 
-        visibleMenuItems = menuItems.withIndex()
-            .filter { (_, item) ->
-                when (item.option) {
-                    Option.CREATE_IMAGE -> supportsImageGeneration
-                    Option.WEB_SEARCH -> supportsWebSearch
-                }
-            }
-            .toList()
-
-        menuItems.forEachIndexed { index, item ->
-            val supported = when (item.option) {
-                Option.CREATE_IMAGE -> supportsImageGeneration
-                Option.WEB_SEARCH -> supportsWebSearch
-            }
-            if (!supported && index in tappedIndices) {
-                tappedIndices.remove(index)
-                removeChipForIndex(index)
-                if (item.option == Option.CREATE_IMAGE) {
-                    host.showModelPicker(true)
-                    host.showReasoningPicker(true)
-                }
+        if (isAttachedToWindow) {
+            val selectionCleared = viewModel.updateVisibleTools(visibleTools)
+            if (selectionCleared) {
+                removeChip()
+                applyPickerVisibility()
             }
         }
 
-        optionsButton.isVisible = visibleMenuItems.isNotEmpty()
+        optionsButton.isVisible = visibleTools.isNotEmpty()
     }
 
     override fun onDetachedFromWindow() {
@@ -160,59 +158,55 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     }
 
     private fun populate(container: LinearLayout, popup: PopupWindow) {
-        val trailingIcons = mutableMapOf<Int, ImageView>()
-        for ((index, item) in visibleMenuItems) {
+        val selectedTool = viewModel.selectedTool.value
+        val trailingIcons = mutableMapOf<Tool, ImageView>()
+        for (item in menuItems.filter { it.tool in viewModel.visibleTools.value }) {
             val row = LayoutInflater.from(context).inflate(R.layout.view_options_menu_item, container, false)
             val trailingIcon = row.findViewById<ImageView>(R.id.optionsMenuItemTrailingIcon)
-            trailingIcons[index] = trailingIcon
+
+            trailingIcons[item.tool] = trailingIcon
             row.findViewById<ImageView>(R.id.optionsMenuItemIcon).setImageResource(item.iconRes)
             row.findViewById<DaxTextView>(R.id.optionsMenuItemTitle).setText(item.titleRes)
             row.findViewById<DaxTextView>(R.id.optionsMenuItemSubtitle).setText(item.subtitleRes)
-            trailingIcon.visibility = if (index in tappedIndices) VISIBLE else GONE
+            trailingIcon.visibility = if (item.tool == selectedTool) VISIBLE else GONE
+
             row.setOnClickListener {
-                val nowSelected = index !in tappedIndices
+                val nowSelected = item.tool != viewModel.selectedTool.value
                 trailingIcons.values.forEach { it.visibility = GONE }
                 if (nowSelected) trailingIcon.visibility = VISIBLE
-                toggleOption(index)
+                onOptionTapped(item)
                 row.postDelayed({ popup.dismiss() }, 150)
             }
             container.addView(row)
         }
     }
 
-    private fun toggleOption(index: Int) {
-        if (tappedIndices.contains(index)) {
-            tappedIndices.remove(index)
-            removeChipForIndex(index)
-            host.showModelPicker(true)
-            host.showReasoningPicker(true)
-        } else {
-            tappedIndices.firstOrNull()?.let { other ->
-                tappedIndices.remove(other)
-                removeChipForIndex(other)
-            }
-            tappedIndices.add(index)
-            addView(buildChip(index, menuItems[index]), 1)
-            val show = menuItems[index].option != Option.CREATE_IMAGE
-            host.showModelPicker(show)
-            host.showReasoningPicker(show)
-        }
+    private fun onOptionTapped(item: MenuItem) {
+        val hadChip = viewModel.selectedTool.value != null
+        viewModel.toggleTool(item.tool)
+        if (hadChip) removeChip()
+        if (viewModel.selectedTool.value != null) addView(buildChip(item), 1)
+        applyPickerVisibility()
     }
 
-    private fun removeChipForIndex(index: Int) {
-        (0 until childCount).map { getChildAt(it) }.firstOrNull { it.tag == index }?.let { removeView(it) }
+    private fun applyPickerVisibility() {
+        val show = viewModel.shouldShowPickers
+        host.showModelPicker(show)
+        host.showReasoningPicker(show)
     }
 
-    private fun buildChip(index: Int, item: MenuItem): View {
+    private fun removeChip() {
+        if (childCount > 1) removeViewAt(1)
+    }
+
+    private fun buildChip(item: MenuItem): View {
         val view = LayoutInflater.from(context).inflate(R.layout.view_options_chip, this, false)
-        view.tag = index
         view.findViewById<ImageView>(R.id.optionsChipIcon).setImageResource(item.iconRes)
         view.contentDescription = context.getString(R.string.duckChatOptionsChipDismissContentDescription, context.getString(item.titleRes))
         view.setOnClickListener {
-            tappedIndices.remove(index)
+            viewModel.clearTool()
             removeView(view)
-            host.showModelPicker(true)
-            host.showReasoningPicker(true)
+            applyPickerVisibility()
         }
         return view
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -90,8 +90,16 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         return viewModel.selectedTool.value
     }
 
+    fun clearSelection() {
+        if (!isAttachedToWindow) return
+        viewModel.clearTool()
+        removeChip()
+        applyPickerVisibility()
+    }
+
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
+        if (!isAttachedToWindow) return
         if (visibility == VISIBLE && !viewModel.shouldShowPickers) {
             post {
                 host.showModelPicker(false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -25,8 +25,10 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.ScrollView
+import androidx.core.view.isVisible
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.models.SupportedTool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 
 @SuppressLint("ViewConstructor")
@@ -58,11 +60,53 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
 
     private val tappedIndices = mutableSetOf<Int>()
     private var popupWindow: PopupWindow? = null
+    private var visibleMenuItems = menuItems.withIndex().toList()
+    private var optionsButton: ImageView
 
     init {
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
-        addView(buildOptionsButton())
+        optionsButton = buildOptionsButton()
+        addView(optionsButton)
+    }
+
+    fun getSelectedTool(): SupportedTool? {
+        val index = tappedIndices.firstOrNull() ?: return null
+        return when (menuItems[index].option) {
+            Option.CREATE_IMAGE -> SupportedTool.IMAGE_GENERATION
+            Option.WEB_SEARCH -> SupportedTool.WEB_SEARCH
+        }
+    }
+
+    fun updateCapabilitiesFrom(picker: ModelPicker?) {
+        val supportsImageGeneration = picker?.isImageGenerationSupported() ?: true
+        val supportsWebSearch = picker?.isWebSearchSupported() ?: true
+
+        visibleMenuItems = menuItems.withIndex()
+            .filter { (_, item) ->
+                when (item.option) {
+                    Option.CREATE_IMAGE -> supportsImageGeneration
+                    Option.WEB_SEARCH -> supportsWebSearch
+                }
+            }
+            .toList()
+
+        menuItems.forEachIndexed { index, item ->
+            val supported = when (item.option) {
+                Option.CREATE_IMAGE -> supportsImageGeneration
+                Option.WEB_SEARCH -> supportsWebSearch
+            }
+            if (!supported && index in tappedIndices) {
+                tappedIndices.remove(index)
+                removeChipForIndex(index)
+                if (item.option == Option.CREATE_IMAGE) {
+                    host.showModelPicker(true)
+                    host.showReasoningPicker(true)
+                }
+            }
+        }
+
+        optionsButton.isVisible = visibleMenuItems.isNotEmpty()
     }
 
     override fun onDetachedFromWindow() {
@@ -84,7 +128,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
 
     private fun showMenu() {
         val container = LinearLayout(context).apply {
-            orientation = LinearLayout.VERTICAL
+            orientation = VERTICAL
             setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.popup_menu_bg)
         }
         val popup = PopupWindow(
@@ -107,7 +151,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
 
     private fun populate(container: LinearLayout, popup: PopupWindow) {
         val trailingIcons = mutableMapOf<Int, ImageView>()
-        menuItems.forEachIndexed { index, item ->
+        for ((index, item) in visibleMenuItems) {
             val row = LayoutInflater.from(context).inflate(R.layout.view_options_menu_item, container, false)
             val trailingIcon = row.findViewById<ImageView>(R.id.optionsMenuItemTrailingIcon)
             trailingIcons[index] = trailingIcon

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.models.Tool
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class OptionsViewModel @Inject constructor() : ViewModel() {
+
+    private val _selectedTool = MutableStateFlow<Tool?>(null)
+    val selectedTool: StateFlow<Tool?> = _selectedTool.asStateFlow()
+
+    private val _visibleTools = MutableStateFlow(Tool.entries.toSet())
+    val visibleTools: StateFlow<Set<Tool>> = _visibleTools.asStateFlow()
+
+    val shouldShowPickers: Boolean get() = _selectedTool.value != Tool.IMAGE_GENERATION
+
+    fun toggleTool(tool: Tool) {
+        _selectedTool.value = if (tool == _selectedTool.value) null else tool
+    }
+
+    fun clearTool() {
+        _selectedTool.value = null
+    }
+
+    fun updateVisibleTools(tools: Set<Tool>): Boolean {
+        _visibleTools.value = tools
+        return if (_selectedTool.value != null && _selectedTool.value !in tools) {
+            _selectedTool.value = null
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/drawable/background_options_chip.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/background_options_chip.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="?attr/daxColorBlack" />
+            <corners android:radius="100dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="?attr/daxColorContainer" />
+            <corners android:radius="100dp" />
+            <stroke
+                android:width="@dimen/modelPickerChipStrokeWidth"
+                android:color="?attr/daxColorLines" />
+        </shape>
+    </item>
+</ripple>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
@@ -24,23 +24,23 @@
     android:focusable="true"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingStart="@dimen/keyline_4"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingTop="@dimen/keyline_2"
+    android:paddingBottom="@dimen/keyline_2">
 
     <ImageView
         android:id="@+id/optionsChipIcon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:importantForAccessibility="no"
         android:scaleType="center" />
 
     <ImageView
         android:id="@+id/optionsChipClose"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/keyline_4"
+        android:layout_height="@dimen/keyline_4"
+        android:layout_marginStart="@dimen/keyline_2"
         android:importantForAccessibility="no"
         android:scaleType="center"
         app:srcCompat="@drawable/ic_close_16" />

--- a/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/keyline_1"
+    android:background="@drawable/background_options_chip"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <ImageView
+        android:id="@+id/optionsChipIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:importantForAccessibility="no"
+        android:scaleType="center" />
+
+    <ImageView
+        android:id="@+id/optionsChipClose"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_marginStart="8dp"
+        android:importantForAccessibility="no"
+        android:scaleType="center"
+        app:srcCompat="@drawable/ic_close_16" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_options_menu_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_options_menu_item.xml
@@ -14,47 +14,41 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
-    android:minHeight="@dimen/popupMenuItemHeight"
-    android:paddingTop="@dimen/keyline_2"
-    android:paddingBottom="@dimen/keyline_2">
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/keyline_4"
+    android:paddingTop="@dimen/keyline_1"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingBottom="@dimen/keyline_1">
 
     <ImageView
         android:id="@+id/optionsMenuItemIcon"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
-        android:layout_marginStart="@dimen/keyline_4"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:srcCompat="@drawable/ic_settings_ai_16" />
+        tools:srcCompat="@drawable/ic_images_24" />
 
     <LinearLayout
         android:id="@+id/optionsMenuItemTextContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_2"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/optionsMenuItemTrailingIcon"
-        app:layout_constraintStart_toEndOf="@id/optionsMenuItemIcon"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_marginStart="@dimen/keyline_3"
+        android:layout_weight="1"
+        android:orientation="vertical">
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/optionsMenuItemTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:singleLine="true"
+            android:lineSpacingExtra="0sp"
+            android:textColor="?attr/daxColorPrimaryText"
             app:typography="body1"
             tools:text="Create Image" />
 
@@ -73,16 +67,14 @@
 
     <ImageView
         android:id="@+id/optionsMenuItemTrailingIcon"
-        android:layout_width="@dimen/keyline_4"
-        android:layout_height="@dimen/keyline_4"
-        android:layout_marginEnd="@dimen/keyline_3"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
+        android:layout_marginStart="@dimen/keyline_2"
         android:importantForAccessibility="no"
+        android:scaleType="centerInside"
         android:src="@drawable/ic_check_24"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         tools:ignore="ContentDescription"
         tools:visibility="visible" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -67,7 +67,7 @@
 
     <!-- Options button -->
     <string name="duckChatOptionsButtonContentDescription">Duck.ai options</string>
-    <string name="duckChatOptionsChipDismissContentDescription">Remove %1$s</string>
+    <string name="duckChatOptionsChipDismissContentDescription" instruction="%1$s is the name of the option being removed (e.g. Create Image).">Remove %1$s</string>
     <string name="duckChatOptionsMenuCreateImage">Create Image</string>
     <string name="duckChatOptionsMenuCreateImageSubtitle">Turn text into images</string>
     <string name="duckChatOptionsMenuWebSearch">Web Search</string>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -67,6 +67,7 @@
 
     <!-- Options button -->
     <string name="duckChatOptionsButtonContentDescription">Duck.ai options</string>
+    <string name="duckChatOptionsChipDismissContentDescription">Remove %1$s</string>
     <string name="duckChatOptionsMenuCreateImage">Create Image</string>
     <string name="duckChatOptionsMenuCreateImageSubtitle">Turn text into images</string>
     <string name="duckChatOptionsMenuWebSearch">Web Search</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1815,6 +1815,55 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenGetAIChatNativePromptWithSelectedToolThenToolChoiceIncluded() = runTest {
+        val pending = PendingNativePrompt(
+            prompt = "test prompt",
+            modelId = "model-id",
+            reasoningEffort = null,
+            selectedTool = "WebSearch",
+        )
+        whenever(mockPendingNativePromptStore.consume()).thenReturn(pending)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativePrompt",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertNotNull(result)
+        val query = result!!.params.getJSONObject("query")
+        assertTrue(query.has("toolChoice"))
+        val toolChoice = query.getJSONArray("toolChoice")
+        assertEquals(1, toolChoice.length())
+        assertEquals("WebSearch", toolChoice.getString(0))
+    }
+
+    @Test
+    fun whenGetAIChatNativePromptWithNoSelectedToolThenToolChoiceAbsent() = runTest {
+        val pending = PendingNativePrompt(
+            prompt = "test prompt",
+            modelId = "model-id",
+            reasoningEffort = null,
+            selectedTool = null,
+        )
+        whenever(mockPendingNativePromptStore.consume()).thenReturn(pending)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativePrompt",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertNotNull(result)
+        val query = result!!.params.getJSONObject("query")
+        assertFalse(query.has("toolChoice"))
+    }
+
+    @Test
     fun whenGetAIChatNativePromptWithNoImagesThenImagesKeyAbsent() = runTest {
         val pending = PendingNativePrompt(
             prompt = "test prompt",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealPendingNativePromptStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealPendingNativePromptStoreTest.kt
@@ -80,4 +80,22 @@ class RealPendingNativePromptStoreTest {
 
         assertNull(result?.reasoningEffort)
     }
+
+    @Test
+    fun whenPromptStoredWithSelectedToolThenConsumeReturnsTool() {
+        testee.store("hello", "model", null, selectedTool = "WebSearch")
+
+        val result = testee.consume()
+
+        assertEquals("WebSearch", result?.selectedTool)
+    }
+
+    @Test
+    fun whenPromptStoredWithoutSelectedToolThenConsumeReturnsNullTool() {
+        testee.store("hello", "model", null)
+
+        val result = testee.consume()
+
+        assertNull(result?.selectedTool)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -255,7 +256,81 @@ class ModelPickerViewModelTest {
         assertNull(testee.getIconResForModel(model))
     }
 
-    private fun freeModel(id: String, shortName: String, provider: ModelProvider = ModelProvider.UNKNOWN) = AIChatModel(
+    @Test
+    fun whenNoModelSelectedThenGetSelectedModelReturnsNull() {
+        stateFlow.value = ModelState(models = listOf(freeModel("id1", "model1")), selectedModelId = null)
+
+        assertNull(testee.getSelectedModel())
+    }
+
+    @Test
+    fun whenModelSelectedThenGetSelectedModelReturnsIt() {
+        val model = freeModel("id1", "model1")
+        stateFlow.value = ModelState(models = listOf(model), selectedModelId = "id1")
+
+        assertEquals(model, testee.getSelectedModel())
+    }
+
+    @Test
+    fun whenSelectedModelSupportsImageGenerationThenIsImageGenerationSupportedIsTrue() {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel("id1", "model1", supportedTools = listOf(Tool.IMAGE_GENERATION))),
+            selectedModelId = "id1",
+        )
+
+        assertTrue(testee.isImageGenerationSupported())
+    }
+
+    @Test
+    fun whenSelectedModelDoesNotSupportImageGenerationThenIsImageGenerationSupportedIsFalse() {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel("id1", "model1", supportedTools = emptyList())),
+            selectedModelId = "id1",
+        )
+
+        assertFalse(testee.isImageGenerationSupported())
+    }
+
+    @Test
+    fun whenNoModelSelectedThenIsImageGenerationSupportedDefaultsToTrue() {
+        stateFlow.value = ModelState(models = emptyList(), selectedModelId = null)
+
+        assertTrue(testee.isImageGenerationSupported())
+    }
+
+    @Test
+    fun whenSelectedModelSupportsWebSearchThenIsWebSearchSupportedIsTrue() {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel("id1", "model1", supportedTools = listOf(Tool.WEB_SEARCH))),
+            selectedModelId = "id1",
+        )
+
+        assertTrue(testee.isWebSearchSupported())
+    }
+
+    @Test
+    fun whenSelectedModelDoesNotSupportWebSearchThenIsWebSearchSupportedIsFalse() {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel("id1", "model1", supportedTools = emptyList())),
+            selectedModelId = "id1",
+        )
+
+        assertFalse(testee.isWebSearchSupported())
+    }
+
+    @Test
+    fun whenNoModelSelectedThenIsWebSearchSupportedDefaultsToTrue() {
+        stateFlow.value = ModelState(models = emptyList(), selectedModelId = null)
+
+        assertTrue(testee.isWebSearchSupported())
+    }
+
+    private fun freeModel(
+        id: String,
+        shortName: String,
+        provider: ModelProvider = ModelProvider.UNKNOWN,
+        supportedTools: List<Tool> = emptyList(),
+    ) = AIChatModel(
         id = id,
         name = id,
         displayName = id,
@@ -263,6 +338,7 @@ class ModelPickerViewModelTest {
         accessTier = listOf("free"),
         isAccessible = true,
         provider = provider,
+        supportedTools = supportedTools,
     )
 
     private fun premiumModel(id: String, shortName: String) = AIChatModel(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -345,7 +345,7 @@ class NativeInputModeWidgetViewModelTest {
 
         viewModel.storePendingPrompt("hello", "model-1", null)
 
-        verify(pendingNativePromptStore).store("hello", "model-1", null, emptyList(), emptyList())
+        verify(pendingNativePromptStore).store("hello", "model-1", null, null, emptyList(), emptyList())
     }
 
     @Test
@@ -354,7 +354,7 @@ class NativeInputModeWidgetViewModelTest {
 
         viewModel.storePendingPrompt("hello", null, null)
 
-        verify(pendingNativePromptStore).store("hello", null, null, emptyList(), emptyList())
+        verify(pendingNativePromptStore).store("hello", null, null, null, emptyList(), emptyList())
     }
 
     @Test
@@ -363,7 +363,7 @@ class NativeInputModeWidgetViewModelTest {
 
         viewModel.storePendingPrompt("hello", "model-1", "low")
 
-        verify(pendingNativePromptStore).store("hello", "model-1", "low", emptyList(), emptyList())
+        verify(pendingNativePromptStore).store("hello", "model-1", "low", null, emptyList(), emptyList())
     }
 
     @Test
@@ -525,12 +525,53 @@ class NativeInputModeWidgetViewModelTest {
         assertNull(viewModel.getResolvedReasoningEffort())
     }
 
+    @Test
+    fun whenNoPluginsThenGetSelectedToolReturnsNull() = runTest {
+        val viewModel = createViewModel(plugins = emptyList())
+
+        assertNull(viewModel.getSelectedTool())
+    }
+
+    @Test
+    fun whenPluginReturnsToolSelectionThenGetSelectedToolReturnsIt() = runTest {
+        val plugin = fakeToolPlugin(containerId = 3, tool = "WebSearch")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+
+        assertEquals("WebSearch", viewModel.getSelectedTool())
+    }
+
+    @Test
+    fun whenNoPluginContributesToolSelectionThenGetSelectedToolReturnsNull() = runTest {
+        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
+        val viewModel = createViewModel(plugins = listOf(plugin))
+
+        assertNull(viewModel.getSelectedTool())
+    }
+
+    @Test
+    fun whenStorePendingPromptWithSelectedToolThenForwardsTool() = runTest {
+        val viewModel = createViewModel(plugins = emptyList())
+
+        viewModel.storePendingPrompt("hello", "model-1", null, selectedTool = "GenerateImage")
+
+        verify(pendingNativePromptStore).store("hello", "model-1", null, "GenerateImage", emptyList(), emptyList())
+    }
+
     private fun fakeReasoningPlugin(containerId: Int, effort: String?): NativeInputPlugin {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
             override fun getPromptContribution(): PromptContribution? =
                 effort?.let { PromptContribution.ReasoningEffortSelection(it) }
+        }
+    }
+
+    private fun fakeToolPlugin(containerId: Int, tool: String?): NativeInputPlugin {
+        return object : NativeInputPlugin {
+            override val containerId: Int = containerId
+            override fun createView(context: Context, host: NativeInputHost): View = View(context)
+            override fun getPromptContribution(): PromptContribution? =
+                tool?.let { PromptContribution.ToolSelection(it) }
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/OptionsViewModelTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.impl.models.Tool
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class OptionsViewModelTest {
+
+    private lateinit var testee: OptionsViewModel
+
+    @Before
+    fun setUp() {
+        testee = OptionsViewModel()
+    }
+
+    @Test
+    fun whenCreatedThenNoToolSelected() {
+        assertNull(testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenCreatedThenAllToolsVisible() {
+        assertEquals(Tool.entries.toSet(), testee.visibleTools.value)
+    }
+
+    @Test
+    fun whenCreatedThenShouldShowPickersIsTrue() {
+        assertTrue(testee.shouldShowPickers)
+    }
+
+    @Test
+    fun whenToolToggledThenItBecomesSelected() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+
+        assertEquals(Tool.WEB_SEARCH, testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenSelectedToolToggledAgainThenSelectionIsCleared() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+        testee.toggleTool(Tool.WEB_SEARCH)
+
+        assertNull(testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenDifferentToolToggledThenSelectionSwitches() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+        testee.toggleTool(Tool.IMAGE_GENERATION)
+
+        assertEquals(Tool.IMAGE_GENERATION, testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenToolClearedThenNoToolSelected() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+        testee.clearTool()
+
+        assertNull(testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenToolClearedWithNoSelectionThenNoToolSelected() {
+        testee.clearTool()
+
+        assertNull(testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenNoToolSelectedThenShouldShowPickersIsTrue() {
+        assertTrue(testee.shouldShowPickers)
+    }
+
+    @Test
+    fun whenWebSearchSelectedThenShouldShowPickersIsTrue() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+
+        assertTrue(testee.shouldShowPickers)
+    }
+
+    @Test
+    fun whenImageGenerationSelectedThenShouldShowPickersIsFalse() {
+        testee.toggleTool(Tool.IMAGE_GENERATION)
+
+        assertFalse(testee.shouldShowPickers)
+    }
+
+    @Test
+    fun whenImageGenerationClearedThenShouldShowPickersIsTrue() {
+        testee.toggleTool(Tool.IMAGE_GENERATION)
+        testee.clearTool()
+
+        assertTrue(testee.shouldShowPickers)
+    }
+
+    @Test
+    fun whenVisibleToolsUpdatedThenVisibleToolsReflectNewSet() {
+        testee.updateVisibleTools(setOf(Tool.WEB_SEARCH))
+
+        assertEquals(setOf(Tool.WEB_SEARCH), testee.visibleTools.value)
+    }
+
+    @Test
+    fun whenVisibleToolsUpdatedAndNoSelectionThenReturnsFalse() {
+        val selectionCleared = testee.updateVisibleTools(setOf(Tool.WEB_SEARCH))
+
+        assertFalse(selectionCleared)
+    }
+
+    @Test
+    fun whenVisibleToolsUpdatedAndSelectionStillSupportedThenReturnsFalse() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+
+        val selectionCleared = testee.updateVisibleTools(setOf(Tool.WEB_SEARCH))
+
+        assertFalse(selectionCleared)
+        assertEquals(Tool.WEB_SEARCH, testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenVisibleToolsUpdatedAndSelectionNoLongerSupportedThenReturnsTrue() {
+        testee.toggleTool(Tool.IMAGE_GENERATION)
+
+        val selectionCleared = testee.updateVisibleTools(setOf(Tool.WEB_SEARCH))
+
+        assertTrue(selectionCleared)
+    }
+
+    @Test
+    fun whenSelectionClearedByUpdateVisibleToolsThenSelectedToolIsNull() {
+        testee.toggleTool(Tool.IMAGE_GENERATION)
+
+        testee.updateVisibleTools(setOf(Tool.WEB_SEARCH))
+
+        assertNull(testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenVisibleToolsUpdatedWithEmptySetAndToolSelectedThenSelectionCleared() {
+        testee.toggleTool(Tool.WEB_SEARCH)
+
+        val selectionCleared = testee.updateVisibleTools(emptySet())
+
+        assertTrue(selectionCleared)
+        assertNull(testee.selectedTool.value)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214776295472425?focus=true

### Description

- Adds create image and web search tools to the native input

### Steps to test this PR

_With the native input enabled_
- [x] Tap the options button
- [x] Select create image
- [x] Verify that the pickers are hidden
- [x] Toggle to Search and back to Duck.ai
- [x] Verify that the option stays selected
- [x] Type something and submit
- [x] Verify that the image generated
- [x] Do the same in Duck.ai
- [x] Go back
- [x] Tap the options button
- [x] Select web search
- [x] Type something and submit
- [x] Verify that a web search is completed in Duck.ai
- [x] Do the same in Duck.ai


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tool-selection path that alters AI chat prompt payloads and UI state across native input, which could affect prompt handling and model capability gating if mismatched with backend/JS expectations.
> 
> **Overview**
> Adds native input *tool selection* for Duck.ai prompts (e.g. **Create Image** and **Web Search**) and threads it through submission and pending-prompt flows.
> 
> The selected tool is contributed via the options plugin/UI, persisted while navigating, cleared after submit/store, and sent to JS as a new `toolChoice` array in the `submitAIChatNativePrompt`/pending prompt payloads.
> 
> Model capabilities are extended with `supportedTools` (new `Tool` enum) and used to show/hide available options; selecting image generation also hides the model/reasoning pickers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6e8679d3b9219a4b0b33bae3594b81026f94ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->