### PR TITLE
Fix Duck.ai model picker for Pro subscribers

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -115,6 +115,11 @@ enum class UserTier(val rawValue: String) {
     FREE("free"),
     PLUS("plus"),
     PRO("pro"),
+    ;
+
+    companion object {
+        fun from(raw: String?): UserTier? = entries.firstOrNull { it.rawValue == raw }
+    }
 }
 
 enum class ModelProvider {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -90,7 +91,7 @@ class RealDuckAiModelManager @Inject constructor(
             } catch (e: Exception) {
                 logcat { "Duck.ai Model Manager: failed to restore cached selection: ${e.message}" }
             }
-            subscriptions.getEntitlementStatus()
+            subscriptions.getEntitlements()
                 .distinctUntilChanged()
                 .collect {
                     logcat { "Duck.ai Model Manager: entitlements changed, re-fetching models" }
@@ -217,14 +218,10 @@ class RealDuckAiModelManager @Inject constructor(
 
     private suspend fun resolveUserTier(): UserTier {
         return try {
-            val status = subscriptions.getSubscriptionStatus()
-            if (!status.isActiveOrWaiting()) return UserTier.FREE
-
-            val products = subscriptions.getAvailableProducts()
-            when {
-                products.contains(Product.DuckAiPlus) -> UserTier.PLUS
-                else -> UserTier.FREE
-            }
+            if (!subscriptions.getSubscriptionStatus().isActiveOrWaiting()) return UserTier.FREE
+            val entitlements = subscriptions.getEntitlements().firstOrNull().orEmpty()
+            val duckAiTier = entitlements.firstOrNull { it.product == Product.DuckAiPlus.value }?.name
+            UserTier.from(duckAiTier) ?: UserTier.FREE
         } catch (e: Exception) {
             logcat { "Duck.ai Model Manager: failed to resolve user tier, defaulting to FREE: ${e.message}" }
             UserTier.FREE

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -20,11 +20,12 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.impl.store.DuckChatDataStore
 import com.duckduckgo.duckchat.impl.store.SelectedModel
-import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.api.model.Entitlement
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -51,13 +52,13 @@ class RealDuckAiModelManagerTest {
     private val subscriptions: Subscriptions = mock()
     private val duckAiHostProvider: DuckAiHostProvider = mock()
 
-    private val entitlementFlow = MutableSharedFlow<List<Product>>()
+    private val entitlementFlow = MutableSharedFlow<Set<Entitlement>>()
 
     private lateinit var testee: RealDuckAiModelManager
 
     @Before
     fun setUp() {
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementFlow)
+        whenever(subscriptions.getEntitlements()).thenReturn(entitlementFlow)
         whenever(duckAiHostProvider.getHost()).thenReturn("duck.ai")
     }
 
@@ -151,7 +152,7 @@ class RealDuckAiModelManagerTest {
     fun whenNonEmptyAccessTierAndTierMatchesThenAccessible() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(
             AIChatModelsResponse(
                 listOf(remoteModel("id", accessTier = listOf("plus", "pro"), entityHasAccess = false)),
@@ -221,7 +222,7 @@ class RealDuckAiModelManagerTest {
     fun whenSelectedModelStillAccessibleThenSelectionPreserved() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("id", "model"))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(
             AIChatModelsResponse(
                 listOf(remoteModel("id", accessTier = listOf("plus"), entityHasAccess = true)),
@@ -348,7 +349,7 @@ class RealDuckAiModelManagerTest {
     fun whenSubscriptionActiveWithDuckAiPlusThenTierIsPlus() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
 
         testee = createManager()
@@ -358,16 +359,75 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
+    fun whenSubscriptionActiveWithDuckAiProThenTierIsPro() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "pro", product = "Duck.ai"))))
+        whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(UserTier.PRO, testee.modelState.value.userTier)
+    }
+
+    @Test
     fun whenSubscriptionActiveWithoutDuckAiPlusThenTierIsFree() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.NetP))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "subscriber", product = "Network Protection"))))
         whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
 
         testee = createManager()
         testee.fetchModels()
 
         assertEquals(UserTier.FREE, testee.modelState.value.userTier)
+    }
+
+    @Test
+    fun whenDuckAiEntitlementHasUnknownTierNameThenTierIsFree() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "premium", product = "Duck.ai"))))
+        whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(UserTier.FREE, testee.modelState.value.userTier)
+    }
+
+    @Test
+    fun whenSubscriptionActiveWithEmptyEntitlementsThenTierIsFree() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(emptySet()))
+        whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(UserTier.FREE, testee.modelState.value.userTier)
+    }
+
+    @Test
+    fun whenMultipleEntitlementsThenDuckAiTierIsResolved() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(
+            flowOf(
+                setOf(
+                    Entitlement(name = "subscriber", product = "Network Protection"),
+                    Entitlement(name = "pro", product = "Duck.ai"),
+                ),
+            ),
+        )
+        whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(UserTier.PRO, testee.modelState.value.userTier)
     }
 
     @Test
@@ -386,7 +446,7 @@ class RealDuckAiModelManagerTest {
     fun whenSubscriptionInGracePeriodWithDuckAiPlusThenTierIsPlus() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.GRACE_PERIOD)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
 
         testee = createManager()
@@ -446,7 +506,7 @@ class RealDuckAiModelManagerTest {
 
         testee = createManager()
 
-        entitlementFlow.emit(listOf(Product.DuckAiPlus))
+        entitlementFlow.emit(setOf(Entitlement(name = "plus", product = "Duck.ai")))
 
         assertEquals(1, testee.modelState.value.models.size)
     }
@@ -509,7 +569,7 @@ class RealDuckAiModelManagerTest {
     fun whenAttachmentLimitsProvidedThenResolvedForPlusTier() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(
             AIChatModelsResponse(
                 models = listOf(remoteModel("id")),
@@ -558,7 +618,7 @@ class RealDuckAiModelManagerTest {
     fun whenAttachmentLimitsMissingTierThenDefaultsUsed() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-        whenever(subscriptions.getAvailableProducts()).thenReturn(setOf(Product.DuckAiPlus))
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
         whenever(modelsService.getModels(any())).thenReturn(
             AIChatModelsResponse(
                 models = listOf(remoteModel("id")),
@@ -702,7 +762,7 @@ class RealDuckAiModelManagerTest {
         whenever(modelsService.getModels(any())).thenReturn(AIChatModelsResponse(emptyList()))
 
         testee = createManager()
-        entitlementFlow.emit(emptyList())
+        entitlementFlow.emit(emptySet())
 
         verify(modelsService).getModels(any())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214577731172288?focus=true 

### Description

Fixes the Duck.ai model picker for Pro subscribers, who were incorrectly seeing only Plus/Free models. Migrates `DuckAiModelManager` from the old `getEntitlementStatus()` + `getAvailableProducts()` combination to the new `Subscriptions.getEntitlements()` flow added in the previous PR. The new API exposes the per-entitlement `name` (`"plus"` / `"pro"`), which is what distinguishes the two paid tiers.

Changes:
- `DuckAiModelManager.init` now collects `subscriptions.getEntitlements()` for the "entitlements changed → refresh models" trigger (same semantics as before, just the new flow).
- `resolveUserTier()` reads the current entitlement snapshot via `.first()`, finds the entitlement whose `product == Product.DuckAiPlus.value`, and resolves its `name` to a `UserTier` via `UserTier.from(raw)`.
- Tests updated

Depends on the previous PR being merged: https://github.com/duckduckgo/Android/pull/8566

### Steps to test this PR

Pro subscriber path (the bug being fixed)
- [x] Sign into a Pro account that has Duck.ai Pro entitlement.
- [x] Open the Duck.ai model picker.
- [x] Confirm Pro-tier models are listed and selectable (previously they were not).
- [x] Confirm a Plus-tier model is still selectable (Plus access should not regress).
- [x]  Select Pro model (Opus 4.6 and start chat.

Plus and Free subscriber paths (regression checks)_
- [x] Sign in with a Plus account, confirm Plus models are shown and Pro-only models are gated.
- [x] Sign out, confirm the picker shows only Free-tier models.

Reactivity
- [x] While Duck.ai is open, sign out from settings and return to Duck.ai. 
- [x] Start a new chat. 
- [x] The picker should refresh to free-tier-only without restarting the app.


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2410" alt="rn_image_picker_lib_temp_e529b4d9-6b7d-4970-8d21-49786c0a958a" src="https://github.com/user-attachments/assets/e41efd5b-b205-4fee-bdc2-2c75a895f790" />|<img width="1080" height="2410" alt="rn_image_picker_lib_temp_e34e70af-f0e7-41d1-acc8-fe6682118a24" src="https://github.com/user-attachments/assets/bdb5cf12-f65c-4044-9b79-4c415623fefc" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates tier resolution and refresh triggers to use the new `getEntitlements()` flow; mistakes here could mis-gate paid models/limits for subscribers but scope is limited to Duck.ai model selection logic.
> 
> **Overview**
> Fixes Duck.ai tier detection so **Pro subscribers** are correctly treated as `UserTier.PRO` (and thus see Pro-tier models).
> 
> `RealDuckAiModelManager` now listens to `subscriptions.getEntitlements()` for reactive model refresh, and `resolveUserTier()` derives the tier from the Duck.ai entitlement’s `name` (e.g., `plus`/`pro`) instead of inferring from available products.
> 
> Adds `UserTier.from(raw)` and updates tests to the new entitlements API, including new coverage for Pro, unknown tier names, empty/multiple entitlements, and the updated entitlement-change trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16175cffdd3df09c6b8609a9cba5fea866147dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->