### PR TITLE
Pre-compile TrackerAllowlist regex

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.httpsupgrade.api.HttpsUpgrader
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.impl.features.contentblocking.RealContentBlocking
+import com.duckduckgo.privacy.config.impl.features.trackerallowlist.OptimizeTrackerAllowListRCWrapper
 import com.duckduckgo.privacy.config.impl.features.trackerallowlist.RealTrackerAllowlist
 import com.duckduckgo.privacy.config.impl.features.trackerallowlist.TrackerAllowlistFeature
 import com.duckduckgo.privacy.config.impl.features.unprotectedtemporary.RealUnprotectedTemporary
@@ -367,7 +368,10 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
         } ?: emptyList()
 
         whenever(trackerAllowlistRepository.exceptions).thenReturn(CopyOnWriteArrayList(allowlistEntries))
-        trackerAllowlist = RealTrackerAllowlist(trackerAllowlistRepository, fakeToggle)
+        val precompileWrapper = object : OptimizeTrackerAllowListRCWrapper {
+            override val enabled: Boolean = false
+        }
+        trackerAllowlist = RealTrackerAllowlist(trackerAllowlistRepository, fakeToggle, precompileWrapper)
     }
 
     private fun setupUserAllowList() {

--- a/app/src/androidTest/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlistPerfAndroidTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlistPerfAndroidTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.trackerallowlist
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.CompiledRule
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistRepository
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.buildRulesByDomain
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.json.JSONObject
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.File
+
+/**
+ * On-device microbenchmark for [RealTrackerAllowlist].
+ *
+ * Compares the legacy read path (precompileRegexAndCacheDomains=false: linear filter over all
+ * entities + compile-on-every-call regex) against the optimized read path
+ * (precompileRegexAndCacheDomains=true: hash-keyed lookup over the repository's pre-built
+ * `rulesByDomain` view) on a real Android device or emulator.
+ *
+ * ## Data source
+ * Loads the bundled privacy-config fallback resource (`R.raw.privacy_config`).
+ *
+ * ## Running it
+ * NOTE: this class is annotated @Ignore so CI does not run it. To execute manually:
+ *   1. From Android Studio: right-click the test method or class and choose "Run". The IDE
+ *      bypasses @Ignore for explicit invocations.
+ *   2. From the CLI: temporarily comment out the @Ignore annotation, run the gradle command
+ *      below, then revert. JUnit honors @Ignore even when --tests targets the class directly.
+ *     ./gradlew :app:connectedPlayDebugAndroidTest \
+ *         -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.privacy.config.impl.features.trackerallowlist.RealTrackerAllowlistPerfAndroidTest
+ *
+ * Output is emitted to logcat under tag "TrackerAllowlistPerf"; capture with:
+ *     adb logcat -s TrackerAllowlistPerf:I *:S
+ *
+ * Numbers are observation-only — no pass/fail assertion.
+ */
+@Ignore("Performance benchmark — run manually, not in CI. See class kdoc for instructions.")
+@RunWith(AndroidJUnit4::class)
+class RealTrackerAllowlistPerfAndroidTest {
+
+    private val featureToggle: FeatureToggle = mock<FeatureToggle>().also {
+        whenever(it.isFeatureEnabled(anyString(), anyBoolean())).thenReturn(true)
+    }
+
+    @Test
+    fun benchmarkOptimizedOffVsOnUsingRealAllowlist() {
+        logRuntimeContext()
+        val source = loadAllowlistEntities()
+        val entities = source.entities
+        val totalRules = entities.sumOf { it.rules.size }
+        val urls = buildWorstCaseUrls(entities, sampleSize = URL_SAMPLE_SIZE)
+        val documentUrl = "http://example.com/index.htm"
+
+        val repository = fakeRepository(entities)
+        val testeeOff = RealTrackerAllowlist(repository, featureToggle, ToggleStub(false))
+        val testeeOn = RealTrackerAllowlist(repository, featureToggle, ToggleStub(true))
+
+        // JIT/ART warmup — both paths.
+        repeat(WARMUP_ROUNDS) {
+            urls.forEach {
+                testeeOff.isAnException(documentUrl, it)
+                testeeOn.isAnException(documentUrl, it)
+            }
+        }
+
+        // Build cost — paid once per privacy-config refresh on the repository side, regardless of
+        // toggle state. Reported here so the trade-off is visible.
+        val tStartBuild = System.nanoTime()
+        val rulesByDomain = buildRulesByDomain(entities)
+        val buildNs = System.nanoTime() - tStartBuild
+
+        // Match throughput.
+        val matchOffNs = measureMatchNs(testeeOff, urls, documentUrl)
+        val matchOnNs = measureMatchNs(testeeOn, urls, documentUrl)
+
+        val totalCalls = MEASURED_ITERATIONS.toLong() * urls.size
+        val perCallOffNs = matchOffNs / totalCalls
+        val perCallOnNs = matchOnNs / totalCalls
+        val speedup = matchOffNs.toDouble() / matchOnNs.toDouble()
+
+        log("=== RealTrackerAllowlist optimized-path benchmark (on-device) ===")
+        log(
+            "Device: ${Build.MANUFACTURER} ${Build.MODEL} | " +
+                "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT}) | " +
+                "ABI ${Build.SUPPORTED_ABIS.firstOrNull()}",
+        )
+        log("Data source: ${source.label}")
+        log("Allowlist entries: ${entities.size} (total rules across all entries: $totalRules)")
+        log("Domains in index: ${rulesByDomain.size} (entries with the same normalized key are merged)")
+        log("URL sample: ${urls.size} (each hits an allowlisted domain but no rule matches → full rule scan)")
+        log("Iterations: $MEASURED_ITERATIONS × ${urls.size} URLs = $totalCalls match calls per toggle state")
+        log("")
+        log("Repository build cost (buildRulesByDomain): ${buildNs / 1_000_000} ms — paid once per config refresh")
+        log("")
+        log("[optimized=false] total match: ${matchOffNs / 1_000_000} ms | per-call: $perCallOffNs ns")
+        log("[optimized=true ] total match: ${matchOnNs / 1_000_000} ms | per-call: $perCallOnNs ns")
+        log("Match speedup: ${"%.2f".format(speedup)}x")
+    }
+
+    private fun measureMatchNs(
+        testee: RealTrackerAllowlist,
+        urls: List<String>,
+        documentUrl: String,
+    ): Long {
+        val start = System.nanoTime()
+        repeat(MEASURED_ITERATIONS) {
+            urls.forEach { testee.isAnException(documentUrl, it) }
+        }
+        return System.nanoTime() - start
+    }
+
+    /**
+     * Build URLs that hit an allowlisted domain (so we enter the rules loop) but with paths
+     * crafted to NOT match any rule. Forces every rule's regex to be evaluated — the worst case
+     * the optimization targets. Biased toward entries with many rules to amplify the signal.
+     */
+    private fun buildWorstCaseUrls(entities: List<TrackerAllowlistEntity>, sampleSize: Int): List<String> {
+        return entities.asSequence()
+            .filter { it.rules.isNotEmpty() }
+            .sortedByDescending { it.rules.size }
+            .take(sampleSize)
+            .map { entity ->
+                val nonce = "z9q8w7e6r5t4y3u2-${entity.domain.hashCode()}"
+                "http://${entity.domain}/no-rule-match-path/$nonce/end"
+            }
+            .toList()
+    }
+
+    private fun fakeRepository(entities: List<TrackerAllowlistEntity>): TrackerAllowlistRepository {
+        val index = buildRulesByDomain(entities)
+        return object : TrackerAllowlistRepository {
+            override fun updateAll(exceptions: List<TrackerAllowlistEntity>) = Unit
+            override val exceptions: List<TrackerAllowlistEntity> = entities
+            override val rulesByDomain: Map<String, List<CompiledRule>> = index
+        }
+    }
+
+    private data class LoadedAllowlist(val entities: List<TrackerAllowlistEntity>, val label: String)
+
+    private fun loadAllowlistEntities(): LoadedAllowlist {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val jsonText = targetContext.resources
+            .openRawResource(com.duckduckgo.privacy.config.impl.R.raw.privacy_config)
+            .bufferedReader()
+            .use { it.readText() }
+
+        val trackerAllowlistJson = JSONObject(jsonText)
+            .getJSONObject("features")
+            .getJSONObject("trackerAllowlist")
+            .toString()
+        val adapter: JsonAdapter<TrackerAllowlistFeature> =
+            Moshi.Builder().build().adapter(TrackerAllowlistFeature::class.java)
+        val feature = adapter.fromJson(trackerAllowlistJson)
+            ?: error("Failed to parse trackerAllowlist feature from R.raw.privacy_config")
+
+        val entities = feature.settings.allowlistedTrackers.entries.map { (domain, value) ->
+            TrackerAllowlistEntity(domain = domain, rules = value.rules)
+        }
+        return LoadedAllowlist(entities, "R.raw.privacy_config")
+    }
+
+    /**
+     * Prints proof-of-environment up front so anyone reading the output knows this is genuinely
+     * running on the device's ART runtime and not on a JVM.
+     */
+    private fun logRuntimeContext() {
+        val rt = Runtime.getRuntime()
+        val vmName = System.getProperty("java.vm.name") ?: "?"
+        val vmVersion = System.getProperty("java.vm.version") ?: "?"
+        val mb = 1024L * 1024L
+        log("--- Runtime context ---")
+        log("PID: ${android.os.Process.myPid()} (this is the on-device app_process running ART)")
+        log("VM: $vmName $vmVersion (\"Dalvik\" = ART; not HotSpot)")
+        log("Cores available: ${rt.availableProcessors()}")
+        log("Heap: max=${rt.maxMemory() / mb} MB, total=${rt.totalMemory() / mb} MB, free=${rt.freeMemory() / mb} MB")
+        log("Build fingerprint: ${Build.FINGERPRINT}")
+        logSocDetails()
+        log("-----------------------")
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun logSocDetails() {
+        val soc = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            "${Build.SOC_MANUFACTURER} / ${Build.SOC_MODEL}"
+        } else {
+            "n/a (requires API 31+, this device is API ${Build.VERSION.SDK_INT})"
+        }
+        log("SoC: $soc")
+        log("Hardware: ${Build.HARDWARE} | Board: ${Build.BOARD} | Device: ${Build.DEVICE}")
+        runCatching {
+            val cpuinfo = File("/proc/cpuinfo").readText()
+            val processorCount = cpuinfo.lineSequence().count { it.startsWith("processor") }
+            val hardwareLine = cpuinfo.lineSequence()
+                .firstOrNull { it.startsWith("Hardware") }
+                ?.substringAfter(":")?.trim()
+            val cpuParts = cpuinfo.lineSequence()
+                .filter { it.startsWith("CPU part") }
+                .map { it.substringAfter(":").trim() }
+                .toSet()
+            log("/proc/cpuinfo: kernel-visible cores=$processorCount, hardware=\"${hardwareLine ?: "(unset)"}\", distinct CPU parts=$cpuParts")
+        }.onFailure {
+            log("/proc/cpuinfo: not readable (${it.message})")
+        }
+    }
+
+    private fun log(message: String) {
+        Log.i(LOG_TAG, message)
+    }
+
+    private class ToggleStub(override val enabled: Boolean) : OptimizeTrackerAllowListRCWrapper
+
+    companion object {
+        private const val LOG_TAG = "TrackerAllowlistPerf"
+        private const val WARMUP_ROUNDS = 5
+        private const val MEASURED_ITERATIONS = 500
+        private const val URL_SAMPLE_SIZE = 200
+    }
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/OptimizeTrackerAllowListFeatures.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/OptimizeTrackerAllowListFeatures.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.trackerallowlist
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "optimizeTrackerAllowList",
+)
+interface OptimizeTrackerAllowListFeatures {
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    /**
+     * Pre-compile tracker allowlist rule regex patterns once when the exceptions list is loaded
+     * rather than recompiling on every request. Also builds a per-domain hash map so the
+     * tracker-domain lookup is O(1) instead of a linear filter.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun precompileRegexAndCacheDomains(): Toggle
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/OptimizeTrackerAllowListRCWrapper.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/OptimizeTrackerAllowListRCWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.config.impl.features.trackerallowlist
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface OptimizeTrackerAllowListRCWrapper {
+    val enabled: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealOptimizeTrackerAllowListRCWrapper @Inject constructor(
+    private val optimizeTrackerAllowListFeatures: OptimizeTrackerAllowListFeatures,
+) : OptimizeTrackerAllowListRCWrapper {
+    override val enabled by lazy { optimizeTrackerAllowListFeatures.precompileRegexAndCacheDomains().isEnabled() }
+}

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.UriString
+import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
@@ -74,9 +75,11 @@ class RealTrackerAllowlist @Inject constructor(
         host: String,
         rulesByDomain: Map<String, List<CompiledRule>>,
     ): List<CompiledRule>? {
+        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate = host
         while (true) {
             rulesByDomain[candidate]?.let { return it }
+            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.TrackerAllowlist
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.CompiledRule
 import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -34,19 +35,51 @@ import javax.inject.Inject
 class RealTrackerAllowlist @Inject constructor(
     private val trackerAllowlistRepository: TrackerAllowlistRepository,
     private val featureToggle: FeatureToggle,
+    private val optimizeTrackerAllowList: OptimizeTrackerAllowListRCWrapper,
 ) : TrackerAllowlist {
 
     override fun isAnException(
         documentURL: String,
         url: String,
     ): Boolean {
-        return if (featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackerAllowlistFeatureName.value, true)) {
+        if (!featureToggle.isFeatureEnabled(PrivacyFeatureName.TrackerAllowlistFeatureName.value, true)) {
+            return false
+        }
+        return if (optimizeTrackerAllowList.enabled) {
+            isAnExceptionOptimized(url, documentURL)
+        } else {
             trackerAllowlistRepository.exceptions
                 .filter { UriString.sameOrSubdomain(url, it.domain) }
                 .map { matches(url, documentURL, it) }
                 .firstOrNull() ?: false
-        } else {
-            false
+        }
+    }
+
+    private fun isAnExceptionOptimized(
+        url: String,
+        documentUrl: String,
+    ): Boolean {
+        val host = UriString.host(url) ?: return false
+        val rules = findRulesForHost(host, trackerAllowlistRepository.rulesByDomain) ?: return false
+        val cleanedUrl = removePortFromUrl(url)
+        return rules.any { compiledRule ->
+            val regex = compiledRule.regex ?: return@any false
+            if (!cleanedUrl.matches(regex)) return@any false
+            val ruleDomains = compiledRule.rule.domains
+            ruleDomains.contains("<all>") || ruleDomains.any { domain -> UriString.sameOrSubdomain(documentUrl, domain) }
+        }
+    }
+
+    private fun findRulesForHost(
+        host: String,
+        rulesByDomain: Map<String, List<CompiledRule>>,
+    ): List<CompiledRule>? {
+        var candidate = host
+        while (true) {
+            rulesByDomain[candidate]?.let { return it }
+            val dot = candidate.indexOf('.')
+            if (dot < 0) return null
+            candidate = candidate.substring(dot + 1)
         }
     }
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlistTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlistTest.kt
@@ -18,8 +18,10 @@ package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.privacy.config.store.AllowlistRuleEntity
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
 import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistRepository
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.buildRulesByDomain
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -27,20 +29,21 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.util.concurrent.CopyOnWriteArrayList
 
 @RunWith(AndroidJUnit4::class)
 class RealTrackerAllowlistTest {
 
     private val mockTrackerAllowlistRepository: TrackerAllowlistRepository = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
+    private val mockOptimizeTrackerAllowListRCWrapper: OptimizeTrackerAllowListRCWrapper = mock()
     private lateinit var testee: RealTrackerAllowlist
 
     @Before
     fun setup() {
         whenever(mockFeatureToggle.isFeatureEnabled(any(), any())).thenReturn(true)
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(false)
 
-        testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle)
+        testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle, mockOptimizeTrackerAllowListRCWrapper)
     }
 
     @Test
@@ -51,10 +54,142 @@ class RealTrackerAllowlistTest {
         assertFalse(testee.isAnException("test.com", url))
     }
 
+    @Test
+    fun whenOptimizedEnabledAndUrlCannotBeParsedThenDoNotThrowAnException() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        val url = "://allowlist-tracker-1.com:5000/videos.js"
+        givenDomainIsAnException("allowlist-tracker-1.com")
+
+        assertFalse(testee.isAnException("test.com", url))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndRuleMatchesThenReturnsTrue() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("site.com"), reason = ""),
+                ),
+            ),
+        )
+
+        assertTrue(testee.isAnException("https://site.com", "https://tracker.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndSubdomainRequestThenReturnsTrue() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+
+        assertTrue(testee.isAnException("https://site.com", "https://a.b.tracker.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndDocumentDomainDoesNotMatchThenReturnsFalse() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("site.com"), reason = ""),
+                ),
+            ),
+        )
+
+        assertFalse(testee.isAnException("https://other.com", "https://tracker.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndDomainNotInListThenReturnsFalse() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+
+        assertFalse(testee.isAnException("https://site.com", "https://other-tracker.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndFeatureDisabledThenReturnsFalse() {
+        whenever(mockFeatureToggle.isFeatureEnabled(any(), any())).thenReturn(false)
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+
+        assertFalse(testee.isAnException("https://site.com", "https://tracker.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndRepositorySnapshotChangesThenReadsLatest() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/videos.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+        assertTrue(testee.isAnException("https://site.com", "https://tracker.com/videos.js"))
+        assertFalse(testee.isAnException("https://site.com", "https://tracker-2.com/videos.js"))
+
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker-2.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker-2.com/videos.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+        assertFalse(testee.isAnException("https://site.com", "https://tracker.com/videos.js"))
+        assertTrue(testee.isAnException("https://site.com", "https://tracker-2.com/videos.js"))
+    }
+
+    @Test
+    fun whenOptimizedEnabledAndRuleRegexIsInvalidThenRuleIsSkipped() {
+        whenever(mockOptimizeTrackerAllowListRCWrapper.enabled).thenReturn(true)
+        givenAllowlistContains(
+            TrackerAllowlistEntity(
+                domain = "tracker.com",
+                rules = listOf(
+                    AllowlistRuleEntity(rule = "tracker.com/[invalid", domains = listOf("<all>"), reason = ""),
+                    AllowlistRuleEntity(rule = "tracker.com/good.js", domains = listOf("<all>"), reason = ""),
+                ),
+            ),
+        )
+
+        assertTrue(testee.isAnException("https://site.com", "https://tracker.com/good.js"))
+        assertFalse(testee.isAnException("https://site.com", "https://tracker.com/bad.js"))
+    }
+
     private fun givenDomainIsAnException(domain: String) {
-        val exceptions = CopyOnWriteArrayList<TrackerAllowlistEntity>()
-        val entity = TrackerAllowlistEntity(domain, emptyList())
-        exceptions.add(entity)
-        whenever(mockTrackerAllowlistRepository.exceptions).thenReturn(exceptions)
+        givenAllowlistContains(TrackerAllowlistEntity(domain, emptyList()))
+    }
+
+    private fun givenAllowlistContains(vararg entities: TrackerAllowlistEntity) {
+        val list = entities.toList()
+        whenever(mockTrackerAllowlistRepository.exceptions).thenReturn(list)
+        whenever(mockTrackerAllowlistRepository.rulesByDomain).thenReturn(buildRulesByDomain(list))
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackerallowlist/TrackerAllowlistReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackerallowlist/TrackerAllowlistReferenceTest.kt
@@ -19,9 +19,11 @@ package com.duckduckgo.privacy.config.impl.referencetests.trackerallowlist
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
+import com.duckduckgo.privacy.config.impl.features.trackerallowlist.OptimizeTrackerAllowListRCWrapper
 import com.duckduckgo.privacy.config.impl.features.trackerallowlist.RealTrackerAllowlist
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
 import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistRepository
+import com.duckduckgo.privacy.config.store.features.trackerallowlist.buildRulesByDomain
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
@@ -40,6 +42,7 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
 
     private val mockTrackerAllowlistRepository: TrackerAllowlistRepository = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
+    private val mockPrecompileRegexWrapper: OptimizeTrackerAllowListRCWrapper = mock()
 
     companion object {
         private val moshi = Moshi.Builder().build()
@@ -69,9 +72,27 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
             ),
         )
             .thenReturn(true)
+        whenever(mockPrecompileRegexWrapper.enabled).thenReturn(false)
         mockAllowlist()
 
-        val testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle)
+        val testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle, mockPrecompileRegexWrapper)
+
+        assertEquals(testCase.isAllowlisted, testee.isAnException(testCase.site, testCase.request))
+    }
+
+    @Test
+    fun whenIsAnExceptionAnFeatureEnableAndPrecompileEnabledThenReturnCorrectValues() {
+        whenever(
+            mockFeatureToggle.isFeatureEnabled(
+                PrivacyFeatureName.TrackerAllowlistFeatureName.value,
+                true,
+            ),
+        )
+            .thenReturn(true)
+        whenever(mockPrecompileRegexWrapper.enabled).thenReturn(true)
+        mockAllowlist()
+
+        val testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle, mockPrecompileRegexWrapper)
 
         assertEquals(testCase.isAllowlisted, testee.isAnException(testCase.site, testCase.request))
     }
@@ -85,9 +106,10 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
             ),
         )
             .thenReturn(false)
+        whenever(mockPrecompileRegexWrapper.enabled).thenReturn(false)
         mockAllowlist()
 
-        val testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle)
+        val testee = RealTrackerAllowlist(mockTrackerAllowlistRepository, mockFeatureToggle, mockPrecompileRegexWrapper)
 
         assertEquals(false, testee.isAnException(testCase.site, testCase.request))
     }
@@ -95,7 +117,7 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
     private fun mockAllowlist() {
         val jsonAdapter: JsonAdapter<TrackerAllowlistEntity> =
             moshi.adapter(TrackerAllowlistEntity::class.java)
-        val exceptions = CopyOnWriteArrayList<TrackerAllowlistEntity>()
+        val exceptions = mutableListOf<TrackerAllowlistEntity>()
         val jsonObject: JSONObject =
             FileUtilities.getJsonObjectFromFile(
                 javaClass.classLoader!!,
@@ -106,7 +128,8 @@ class TrackerAllowlistReferenceTest(private val testCase: TestCase) {
             val allowlistEntity = jsonAdapter.fromJson(jsonObject.get(it).toString())
             exceptions.add(allowlistEntity!!.copy(domain = it))
         }
-        whenever(mockTrackerAllowlistRepository.exceptions).thenReturn(exceptions)
+        whenever(mockTrackerAllowlistRepository.exceptions).thenReturn(CopyOnWriteArrayList(exceptions))
+        whenever(mockTrackerAllowlistRepository.rulesByDomain).thenReturn(buildRulesByDomain(exceptions))
     }
 
     data class TestCase(

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
@@ -17,16 +17,23 @@
 package com.duckduckgo.privacy.config.store.features.trackerallowlist
 
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.privacy.config.store.AllowlistRuleEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.TrackerAllowlistEntity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.util.concurrent.CopyOnWriteArrayList
+import logcat.logcat
 
 interface TrackerAllowlistRepository {
     fun updateAll(exceptions: List<TrackerAllowlistEntity>)
-    val exceptions: CopyOnWriteArrayList<TrackerAllowlistEntity>
+    val exceptions: List<TrackerAllowlistEntity>
+    val rulesByDomain: Map<String, List<CompiledRule>>
 }
+
+data class CompiledRule(
+    val rule: AllowlistRuleEntity,
+    val regex: Regex?,
+)
 
 class RealTrackerAllowlistRepository(
     database: PrivacyConfigDatabase,
@@ -36,7 +43,12 @@ class RealTrackerAllowlistRepository(
 ) : TrackerAllowlistRepository {
 
     private val trackerAllowlistDao: TrackerAllowlistDao = database.trackerAllowlistDao()
-    override val exceptions = CopyOnWriteArrayList<TrackerAllowlistEntity>()
+
+    @Volatile
+    private var snapshot: Snapshot = Snapshot(emptyList(), emptyMap())
+
+    override val exceptions get() = snapshot.exceptions
+    override val rulesByDomain get() = snapshot.rulesByDomain
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -52,7 +64,30 @@ class RealTrackerAllowlistRepository(
     }
 
     private fun loadToMemory() {
-        exceptions.clear()
-        trackerAllowlistDao.getAll().map { exceptions.add(it) }
+        val fresh = trackerAllowlistDao.getAll()
+        snapshot = Snapshot(fresh, buildRulesByDomain(fresh))
     }
+
+    private data class Snapshot(
+        val exceptions: List<TrackerAllowlistEntity>,
+        val rulesByDomain: Map<String, List<CompiledRule>>,
+    )
+}
+
+internal fun buildRulesByDomain(exceptions: List<TrackerAllowlistEntity>): Map<String, List<CompiledRule>> {
+    val map = HashMap<String, List<CompiledRule>>(exceptions.size)
+    exceptions.forEach { entity ->
+        // Keys are www-stripped to match UriString.host(), which strips a leading "www." via
+        // Uri.baseHost. Lookups always arrive www-stripped, so entities stored as "www.foo.com"
+        // must live at key "foo.com" or they'd never be hit.
+        val key = entity.domain.removePrefix("www.")
+        val compiledRules = entity.rules.map { rule ->
+            val regex = runCatching { ".*${rule.rule}.*".toRegex() }
+                .onFailure { logcat(tag = "TrackerAllowlistRepository") { "Rule failed to compile, skipping: ${rule.rule} (${it.message})" } }
+                .getOrNull()
+            CompiledRule(rule = rule, regex = regex)
+        }
+        map.merge(key, compiledRules) { existing, new -> existing + new }
+    }
+    return map
 }

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
@@ -74,7 +74,7 @@ class RealTrackerAllowlistRepository(
     )
 }
 
-internal fun buildRulesByDomain(exceptions: List<TrackerAllowlistEntity>): Map<String, List<CompiledRule>> {
+fun buildRulesByDomain(exceptions: List<TrackerAllowlistEntity>): Map<String, List<CompiledRule>> {
     val map = HashMap<String, List<CompiledRule>>(exceptions.size)
     exceptions.forEach { entity ->
         // Keys are www-stripped to match UriString.host(), which strips a leading "www." via

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
@@ -103,6 +103,55 @@ class RealTrackerAllowlistRepositoryTest {
             assertEquals(0, testee.exceptions.size)
         }
 
+    @Test
+    fun whenUpdateAllThenRulesByDomainReflectsNewData() =
+        runTest {
+            whenever(mockTrackerAllowlistDao.getAll()).thenReturn(listOf(trackerAllowlistEntity))
+            testee.updateAll(listOf(trackerAllowlistEntity))
+
+            assertEquals(setOf("domain"), testee.rulesByDomain.keys)
+            assertEquals(1, testee.rulesByDomain["domain"]?.size)
+            assertNotNull(testee.rulesByDomain["domain"]?.first()?.regex)
+
+            val replacement = TrackerAllowlistEntity(
+                domain = "other.com",
+                rules = listOf(AllowlistRuleEntity(rule = "other.com/x", domains = listOf("<all>"), reason = "")),
+            )
+            whenever(mockTrackerAllowlistDao.getAll()).thenReturn(listOf(replacement))
+            testee.updateAll(listOf(replacement))
+
+            assertEquals(setOf("other.com"), testee.rulesByDomain.keys)
+        }
+
+    @Test
+    fun whenRuleRegexInvalidThenCompiledRuleHasNullRegex() {
+        val bad = TrackerAllowlistEntity(
+            domain = "bad.com",
+            rules = listOf(AllowlistRuleEntity(rule = "bad.com/[unterminated", domains = listOf("<all>"), reason = "")),
+        )
+
+        val result = buildRulesByDomain(listOf(bad))
+
+        assertNull(result["bad.com"]?.first()?.regex)
+    }
+
+    @Test
+    fun whenEntitiesShareNormalizedKeyThenRulesAreMerged() {
+        val a = TrackerAllowlistEntity(
+            domain = "tracker.com",
+            rules = listOf(AllowlistRuleEntity(rule = "tracker.com/a", domains = listOf("<all>"), reason = "")),
+        )
+        val b = TrackerAllowlistEntity(
+            domain = "www.tracker.com",
+            rules = listOf(AllowlistRuleEntity(rule = "tracker.com/b", domains = listOf("<all>"), reason = "")),
+        )
+
+        val result = buildRulesByDomain(listOf(a, b))
+
+        assertEquals(setOf("tracker.com"), result.keys)
+        assertEquals(2, result["tracker.com"]?.size)
+    }
+
     private fun givenHttpsDaoContainsExceptions() {
         whenever(mockTrackerAllowlistDao.getAll()).thenReturn(listOf(trackerAllowlistEntity))
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1213808460359640?focus=true

### Description  


Adds an opt-in optimized read path for RealTrackerAllowlist, gated behind a new optimizeTrackerAllowList.precompileRegexAndCacheDomains remote feature (default INTERNAL).

When the toggle is off, behavior is unchanged: linear filter over exceptions + regex compiled on every isAnException call.

When the toggle is on:

- TrackerAllowlistRepository now exposes a rulesByDomain: Map\<String, List\<CompiledRule>> view, built once per privacy-config refresh. Regexes are precompiled at build time; rules whose regex fails to compile are kept with regex = null and skipped at match time. Keys are www-stripped so entries stored as [www.foo.com](http://www.foo.com) are reachable from UriString.host() lookups.
- The repository swaps its CopyOnWriteArrayList for an immutable Snapshot. 
- RealTrackerAllowlist.isAnException does an O(1) host lookup with a subdomain fallback walk ([a.b.tracker.com](http://a.b.tracker.com) → [b.tracker.com](http://b.tracker.com) → [tracker.com](http://tracker.com)) instead of scanning the full list, and reuses precompiled regexes.

Other changes:

- OptimizeTrackerAllowListRCWrapper wraps the toggle check behind by lazy so the feature flag is read at most once per app process.
- RealTrackerAllowlist constructor gains the wrapper as a third parameter — all callers/tests updated.
- New on-device benchmark RealTrackerAllowlistPerfAndroidTest (@Ignored in CI) compares the two paths against the bundled R.raw.privacy_config allowlist on a real device. Run manually per the class kdoc.

### Steps to test this PR

Smoke test with flag ON / OFF.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new, toggle-gated matching path for tracker allowlisting and changes the repository API/storage shape, which could affect tracking exceptions behavior when enabled or during config refreshes. Default gating reduces blast radius, but correctness/performance depends on the new domain-indexing and regex compilation logic.
> 
> **Overview**
> Introduces an **opt-in optimized read path** for `RealTrackerAllowlist`, gated by the new remote feature `optimizeTrackerAllowList.precompileRegexAndCacheDomains` (via `OptimizeTrackerAllowListRCWrapper`). When enabled, allowlist lookups use a per-domain `rulesByDomain` index with **precompiled regex** and subdomain fallback instead of scanning all exceptions and compiling regex on each call.
> 
> Updates `TrackerAllowlistRepository` to expose `rulesByDomain` and replaces the in-memory `CopyOnWriteArrayList` with an immutable, volatile `Snapshot` built on each refresh; invalid regex rules are retained with `regex=null` and skipped. Call sites and reference/unit tests are updated for the new constructor/dependencies, and an `@Ignore`d on-device microbenchmark (`RealTrackerAllowlistPerfAndroidTest`) is added to compare the two paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55df6cf520ba649439f7047cedc7445e980160f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->