### PR TITLE
Migrate StartChat plugin to NativeInputStateProvider

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -20,7 +20,7 @@ data class NativeInputState(
     val inputMode: InputMode,
     val inputContext: InputContext,
     val inputPosition: InputPosition = InputPosition.TOP,
-    val tabId: String,
+    val toggleSelection: ToggleSelection = defaultToggleFor(inputContext),
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,
@@ -37,23 +37,21 @@ data class NativeInputState(
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 
-    val defaultToggleSelection: ToggleSelection
-        get() = when (inputContext) {
+    companion object {
+        fun defaultToggleFor(context: InputContext): ToggleSelection = when (context) {
             InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ToggleSelection.DUCK_AI
             InputContext.BROWSER -> ToggleSelection.SEARCH
         }
 
-    companion object {
         /**
          * Placeholder state used by [NativeInputStateProvider] for a tab that has not yet been
          * published to. Observers should not rely on these values: the native input widget overwrites
          * them via [NativeInputStatePublisher.publish] as soon as it is configured for the tab.
          */
-        fun zero(tabId: String): NativeInputState = NativeInputState(
+        fun zero(): NativeInputState = NativeInputState(
             inputMode = InputMode.SEARCH_AND_DUCK_AI,
             inputContext = InputContext.BROWSER,
             inputPosition = InputPosition.TOP,
-            tabId = tabId,
         )
     }
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStateProvider.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputStateProvider.kt
@@ -16,15 +16,22 @@
 
 package com.duckduckgo.duckchat.api.nativeinput
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Read-only access to the per-tab native input state. Components that need to react to input state
- * changes (toggle visibility, model selection, etc.) observe the flow for their tab.
+ * changes (toggle visibility, model selection, etc.) observe [state], which follows the currently
+ * selected browser tab and re-emits both when the tab changes and when the active tab's state is
+ * republished.
+ *
+ * [stateForTab] is for callers that already know a specific tabId and need synchronous keyed access
+ * — primarily the native input widget itself; plugins should observe [state].
  *
  * The writer-side counterpart is [NativeInputStatePublisher], which is reserved for the native input
  * widget; plugins must not depend on it.
  */
 interface NativeInputStateProvider {
+    val state: Flow<NativeInputState>
     fun stateForTab(tabId: String): StateFlow<NativeInputState>
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -21,7 +21,6 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 
 sealed class PromptContribution {
     data class ModelSelection(val modelId: String) : PromptContribution()
@@ -31,8 +30,8 @@ sealed class PromptContribution {
 
 /**
  * Communication surface from a plugin back to the host widget. Plugins use it to act on the host
- * (e.g. [submit]) and to read the host's current [NativeInputState] when their behaviour depends on it,
- * without coupling to the widget class directly.
+ * (e.g. [submit]) without coupling to the widget class directly. State that depends on the active
+ * tab is observed via `NativeInputStateProvider.state` rather than reached for through the host.
  */
 interface NativeInputHost {
     /** Submit the current input as a chat message; opens a new chat session if the input is empty. */
@@ -43,9 +42,6 @@ interface NativeInputHost {
     fun showReasoningPicker(showing: Boolean)
 
     fun attachmentChanged(hasAttachments: Boolean, limitExceeded: Boolean, supportsUpload: Boolean)
-
-    /** Current input state of the host widget (mode, context, position). */
-    fun getInputState(): NativeInputState
 }
 
 interface NativeInputPlugin : ActivePlugin {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -16,26 +16,49 @@
 
 package com.duckduckgo.duckchat.impl.nativeinput
 
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.Lazy
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class, boundType = NativeInputStateProvider::class)
 @ContributesBinding(AppScope::class, boundType = NativeInputStatePublisher::class)
-class RealNativeInputStateStore @Inject constructor() :
+class RealNativeInputStateStore @Inject constructor(
+    // Lazy avoids a Dagger cycle: TabRepository's impl (TabDataRepository) injects
+    // NativeInputStatePublisher to clearTab on tab eviction. Resolving TabRepository
+    // lazily lets Dagger construct both without circularity. The lazy is only
+    // dereferenced when `state` is collected for the first time.
+    private val tabRepository: Lazy<TabRepository>,
+) :
     NativeInputStateProvider,
     NativeInputStatePublisher {
 
     private val flows = ConcurrentHashMap<String, MutableStateFlow<NativeInputState>>()
+
+    override val state: Flow<NativeInputState> by lazy {
+        tabRepository.get().flowSelectedTab
+            .filterNotNull()
+            .map { it.tabId }
+            .distinctUntilChanged()
+            .flatMapLatest { flowFor(it) }
+    }
 
     override fun stateForTab(tabId: String): StateFlow<NativeInputState> = flowFor(tabId)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -82,5 +82,5 @@ class RealNativeInputStateStore @Inject constructor(
     // value. The native input widget overwrites it on configure, so observers should never see this
     // placeholder in practice.
     private fun flowFor(tabId: String): MutableStateFlow<NativeInputState> =
-        flows.computeIfAbsent(tabId) { MutableStateFlow(NativeInputState.zero(tabId)) }
+        flows.computeIfAbsent(tabId) { MutableStateFlow(NativeInputState.zero()) }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -160,6 +160,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private data class WidgetConfig(
         val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
         val inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP,
+        // null = follow the context-derived default; non-null = user (or widget) has set it explicitly
+        // via setToggleSelection. Reset to null on every configure(), then driven by the widget's
+        // TabLayout listener.
+        val toggleSelection: NativeInputState.ToggleSelection? = null,
     )
 
     private val widgetConfig = MutableStateFlow(WidgetConfig())
@@ -172,12 +176,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         duckChatInternal.observeInputScreenUserSettingEnabled(),
         widgetConfig,
         activeTabId.filterNotNull(),
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, config, tabId ->
+    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, config, _ ->
         NativeInputState(
             inputMode = getInputMode(isFeatureEnabled && isUserEnabled, isInputScreenUserSettingEnabled),
             inputContext = config.inputContext,
             inputPosition = config.inputPosition,
-            tabId = tabId,
+            toggleSelection = config.toggleSelection ?: NativeInputState.defaultToggleFor(config.inputContext),
         )
     }.shareIn(
         scope = viewModelScope,
@@ -190,17 +194,22 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         // later by typed host methods) untouched across widget emissions. This keeps the widget VM
         // the single writer for its fields without clobbering anything the publisher.update path
         // wrote on behalf of a plugin.
+        //
+        // Pair each state with the active tabId via combine so the publish target is captured at
+        // emission time rather than read separately from activeTabId.value (which could shift
+        // between emission and read on a fast tab switch).
         viewModelScope.launch {
-            state.collect { snapshot ->
-                nativeInputStatePublisher.update(snapshot.tabId) { current ->
-                    current.copy(
-                        inputMode = snapshot.inputMode,
-                        inputContext = snapshot.inputContext,
-                        inputPosition = snapshot.inputPosition,
-                        tabId = snapshot.tabId,
-                    )
+            combine(state, activeTabId.filterNotNull()) { snapshot, tabId -> tabId to snapshot }
+                .collect { (tabId, snapshot) ->
+                    nativeInputStatePublisher.update(tabId) { current ->
+                        current.copy(
+                            inputMode = snapshot.inputMode,
+                            inputContext = snapshot.inputContext,
+                            inputPosition = snapshot.inputPosition,
+                            toggleSelection = snapshot.toggleSelection,
+                        )
+                    }
                 }
-            }
         }
     }
 
@@ -231,6 +240,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     fun setWidgetPosition(isBottom: Boolean) {
         val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
         widgetConfig.update { it.copy(inputPosition = position) }
+    }
+
+    fun setToggleSelection(selection: NativeInputState.ToggleSelection) {
+        widgetConfig.update { it.copy(toggleSelection = selection) }
     }
 
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -186,8 +186,21 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     )
 
     init {
+        // Publish only the widget-owned fields via update, leaving plugin-owned contributions (added
+        // later by typed host methods) untouched across widget emissions. This keeps the widget VM
+        // the single writer for its fields without clobbering anything the publisher.update path
+        // wrote on behalf of a plugin.
         viewModelScope.launch {
-            state.collect { nativeInputStatePublisher.publish(it.tabId, it) }
+            state.collect { snapshot ->
+                nativeInputStatePublisher.update(snapshot.tabId) { current ->
+                    current.copy(
+                        inputMode = snapshot.inputMode,
+                        inputContext = snapshot.inputContext,
+                        inputPosition = snapshot.inputPosition,
+                        tabId = snapshot.tabId,
+                    )
+                }
+            }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
@@ -78,14 +79,21 @@ class ModelPickerView @JvmOverloads constructor(
 
     @Inject lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject lateinit var nativeInputStateProvider: NativeInputStateProvider
+
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[ModelPickerViewModel::class.java]
     }
     private val chip: Chip by lazy { findViewById(R.id.modelPickerChip) }
     private var stateJob: Job? = null
+    private var inputContextJob: Job? = null
     private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastObservedModelId: String? = null
+
+    // Mirrors the input context from the per-tab native input state so currentSurface() can be
+    // read synchronously from popup callbacks. Updated by observeInputContext().
+    private var lastInputContext: InputContext = InputContext.BROWSER
     private lateinit var host: NativeInputHost
     override var onMenuShown: (() -> Unit)? = null
     override var onMenuDismissed: (() -> Unit)? = null
@@ -131,6 +139,15 @@ class ModelPickerView @JvmOverloads constructor(
 
         viewModel.fetchModels()
         observeState()
+        observeInputContext()
+    }
+
+    private fun observeInputContext() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        inputContextJob?.cancel()
+        inputContextJob = nativeInputStateProvider.state
+            .onEach { lastInputContext = it.inputContext }
+            .launchIn(scope)
     }
 
     private fun observeState() {
@@ -165,7 +182,7 @@ class ModelPickerView @JvmOverloads constructor(
     }
 
     private fun currentSurface(): ModelPickerViewModel.PickerSurface =
-        when (host.getInputState().inputContext) {
+        when (lastInputContext) {
             InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ModelPickerViewModel.PickerSurface.DUCK_AI_TAB
             InputContext.BROWSER -> ModelPickerViewModel.PickerSurface.ADDRESS_BAR
         }
@@ -230,6 +247,8 @@ class ModelPickerView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         stateJob?.cancel()
         stateJob = null
+        inputContextJob?.cancel()
+        inputContextJob = null
         commandJob?.cancel()
         commandJob = null
         dismissPopup()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -531,7 +531,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateSelectedTab(toggle: TabLayout, state: NativeInputState) {
-        val targetIndex = if (state.defaultToggleSelection == NativeInputState.ToggleSelection.DUCK_AI) 1 else 0
+        val targetIndex = if (state.toggleSelection == NativeInputState.ToggleSelection.DUCK_AI) 1 else 0
         if (toggle.selectedTabPosition != targetIndex) {
             toggle.getTabAt(targetIndex)?.select()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1023,9 +1023,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateVoiceButtonVisibility()
     }
 
-    override fun getInputState(): NativeInputState =
-        activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }
-            ?: error("getInputState called before widget was configured")
     override fun showModelPicker(showing: Boolean) {
         findViewById<FrameLayout?>(R.id.modelPickerContainer)?.isVisible = showing
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -257,9 +257,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
-        // observeNativeInputState() is started from configure()/configureContextual() once
-        // the tabId is known — the widget reads its state from NativeInputStateProvider per-tab.
-        if (activeTabId != null) observeNativeInputState()
+        observeNativeInputState()
         if (onPaidTierChanged != null) observeTier()
     }
 
@@ -538,9 +536,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateToggleVisibility(toggle: TabLayout, state: NativeInputState) {
-        if (!state.toggleVisible) {
-            updateSelectedTab(toggle, state)
-        }
+        // Always sync the TabLayout selection to state.toggleSelection so a tab switch (which
+        // resets the stored selection via configure()) doesn't leave the previous tab's position
+        // showing. updateSelectedTab is a no-op when current and target match; the resulting
+        // onTabSelected listener call is gated by pushToggleSelectionIfUserDriven which guards
+        // against feedback loops.
+        updateSelectedTab(toggle, state)
         updateToggleVisibilityForState()
     }
 
@@ -605,15 +606,32 @@ class NativeInputModeWidget @JvmOverloads constructor(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     applyTabUi()
+                    pushToggleSelectionIfUserDriven()
                     viewModel.updatePluginContainerVisibility(isChatTabSelected())
                 }
                 override fun onTabUnselected(tab: TabLayout.Tab) {}
                 override fun onTabReselected(tab: TabLayout.Tab) {
                     applyTabUi()
+                    pushToggleSelectionIfUserDriven()
                     viewModel.updatePluginContainerVisibility(isChatTabSelected())
                 }
             },
         )
+    }
+
+    // Only propagate the TabLayout selection into NativeInputState when the toggle row is actually
+    // visible — i.e. the change came from a user tap. Programmatic selections from paths like
+    // applyDefaultTogglePosition() can run for SEARCH_ONLY users (toggle hidden); pushing those
+    // would make the chat-tab selection sticky in state and prevent updateSelectedTab() from
+    // reverting it to the context-derived default when applyState() next fires.
+    private fun pushToggleSelectionIfUserDriven() {
+        if (nativeInputState?.toggleVisible != true) return
+        val selection = if (isChatTabSelected()) {
+            NativeInputState.ToggleSelection.DUCK_AI
+        } else {
+            NativeInputState.ToggleSelection.SEARCH
+        }
+        viewModel.setToggleSelection(selection)
     }
 
     override fun EditText.applyChatInputType() {
@@ -673,6 +691,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         doOnAttach {
             if (!duckChatFeature.rememberTogglePosition().isEnabled()) return@doOnAttach
             findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+                // Wait for the first state emission so we know whether the toggle row is even shown.
+                // For SEARCH_ONLY users (input-screen setting off) the toggle is hidden, and flipping
+                // selectedTabPosition to 1 would leak chat-tab UI (plugin containers, chat styling)
+                // into the search-only experience.
+                val state = viewModel.state.firstOrNull() ?: return@launch
+                if (!state.toggleVisible) return@launch
                 val position = viewModel.defaultTogglePosition.firstOrNull() ?: return@launch
                 val resolved = if (position == DefaultTogglePosition.LAST_USED) {
                     DefaultTogglePosition.fromName(viewModel.lastUsedTogglePosition.firstOrNull())
@@ -769,7 +793,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         pendingIsDuckAiMode = isDuckAiMode
         doOnAttach {
             viewModel.configure(tabId, isDuckAiMode, isBottom)
-            observeNativeInputState()
             if (isDuckAiMode) selectChatTab()
             attachmentView?.setDuckAiMode(isDuckAiMode)
         }
@@ -781,7 +804,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         isContextualWidget = true
         doOnAttach {
             viewModel.configureContextual(tabId)
-            observeNativeInputState()
             selectChatTab()
             attachmentView?.setDuckAiMode(true)
         }
@@ -917,9 +939,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun observeNativeInputState() {
         nativeInputStateJob?.cancel()
-        val tabId = activeTabId ?: return
         val lifecycleOwner = findViewTreeLifecycleOwner() ?: return
-        nativeInputStateJob = nativeInputStateProvider.stateForTab(tabId)
+        // Use viewModel.state for the widget's own UI rather than the provider: the provider's
+        // per-tab StateFlow is seeded with NativeInputState.zero() so a subscriber that attaches
+        // before the widget VM has published the real state would briefly receive the placeholder
+        // (SEARCH_AND_DUCK_AI by default) and render the wrong UI for users in SEARCH_ONLY mode.
+        // viewModel.state combines activeTabId.filterNotNull() and only emits real values.
+        nativeInputStateJob = viewModel.state
             .onEach(::applyState)
             .launchIn(lifecycleOwner.lifecycleScope)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -20,8 +20,9 @@ import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
-import com.duckduckgo.duckchat.api.DuckChatInputModeState
-import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -31,22 +32,23 @@ import javax.inject.Inject
 class StartChatViewModel @Inject constructor(
     duckAiFeatureState: DuckAiFeatureState,
     duckChatInternal: DuckChatInternal,
-    duckChatInputModeState: DuckChatInputModeState,
+    nativeInputStateProvider: NativeInputStateProvider,
 ) : ViewModel() {
 
     /**
      * Show the start-chat icon only when Duck.ai is available (feature enabled +
      * user setting on) but the input-screen toggle is off — i.e. the user has Duck.ai
-     * but is in `SEARCH_ONLY` mode. Mapping `inputMode == SEARCH_ONLY` directly would
-     * also match the case where Duck.ai is entirely disabled, which would let the icon
-     * navigate to a Duck.ai URL the user has opted out of.
+     * but is in `SEARCH_ONLY` mode. The feature + user-setting gate is needed because
+     * `inputMode == SEARCH_ONLY` also covers the case where Duck.ai is entirely
+     * disabled, which would let the icon navigate to a Duck.ai URL the user has opted out of.
      */
     val isVisible: Flow<Boolean> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
-        duckChatInternal.observeInputScreenUserSettingEnabled(),
-        duckChatInputModeState.displayedMode,
-    ) { isFeatureEnabled, isUserEnabled, isInputScreenUserSettingEnabled, displayedMode ->
-        isFeatureEnabled && isUserEnabled && !isInputScreenUserSettingEnabled && displayedMode == InputMode.SEARCH
+        nativeInputStateProvider.state,
+    ) { isFeatureEnabled, isUserEnabled, state ->
+        isFeatureEnabled && isUserEnabled &&
+            state.inputMode == InputMode.SEARCH_ONLY &&
+            state.toggleSelection == ToggleSelection.SEARCH
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
@@ -16,17 +16,37 @@
 
 package com.duckduckgo.duckchat.impl.nativeinput
 
+import app.cash.turbine.test
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
+import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RealNativeInputStateStoreTest {
 
-    private val testee = RealNativeInputStateStore()
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val tabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
+    }
+    private val lazyTabRepository: dagger.Lazy<TabRepository> = dagger.Lazy { tabRepository }
+
+    private val testee = RealNativeInputStateStore(lazyTabRepository)
 
     @Test
     fun whenStateForTabCalledTwiceForSameTabThenSameFlowReturned() {
@@ -158,4 +178,78 @@ class RealNativeInputStateStoreTest {
         assertEquals(NativeInputState.zero("tab-a"), testee.stateForTab("tab-a").value)
         assertEquals(NativeInputState.zero("tab-b"), testee.stateForTab("tab-b").value)
     }
+
+    @Test
+    fun whenSelectedTabPublishedThenStateEmitsItsValue() = runTest {
+        val published = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+            tabId = "tab-a",
+        )
+        testee.publish("tab-a", published)
+        selectedTabFlow.value = tabEntity("tab-a")
+
+        testee.state.test {
+            assertEquals(published, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSelectedTabChangesThenStateReEmitsForNewTab() = runTest {
+        val stateA = NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = InputContext.BROWSER,
+            tabId = "tab-a",
+        )
+        val stateB = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+            tabId = "tab-b",
+        )
+        testee.publish("tab-a", stateA)
+        testee.publish("tab-b", stateB)
+        selectedTabFlow.value = tabEntity("tab-a")
+
+        testee.state.test {
+            assertEquals(stateA, awaitItem())
+
+            selectedTabFlow.value = tabEntity("tab-b")
+
+            assertEquals(stateB, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSelectedTabsStateUpdatedThenStateReEmits() = runTest {
+        val initial = NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = InputContext.BROWSER,
+            tabId = "tab-a",
+        )
+        testee.publish("tab-a", initial)
+        selectedTabFlow.value = tabEntity("tab-a")
+
+        testee.state.test {
+            assertEquals(initial, awaitItem())
+
+            testee.update("tab-a") { it.copy(inputMode = InputMode.SEARCH_ONLY) }
+
+            assertEquals(initial.copy(inputMode = InputMode.SEARCH_ONLY), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSelectedTabIsNullThenStateDoesNotEmit() = runTest {
+        selectedTabFlow.value = null
+
+        testee.state.test {
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun tabEntity(tabId: String): TabEntity = TabEntity(tabId = tabId, position = 0)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
@@ -68,7 +68,7 @@ class RealNativeInputStateStoreTest {
     fun whenStateForTabCalledWithoutPriorPublishThenZeroStateReturned() {
         val state = testee.stateForTab("tab-a").value
 
-        assertEquals(NativeInputState.zero("tab-a"), state)
+        assertEquals(NativeInputState.zero(), state)
     }
 
     @Test
@@ -76,7 +76,6 @@ class RealNativeInputStateStoreTest {
         val published = NativeInputState(
             inputMode = InputMode.SEARCH_ONLY,
             inputContext = InputContext.DUCK_AI,
-            tabId = "tab-a",
         )
 
         testee.publish("tab-a", published)
@@ -93,7 +92,6 @@ class RealNativeInputStateStoreTest {
             NativeInputState(
                 inputMode = InputMode.SEARCH_ONLY,
                 inputContext = InputContext.DUCK_AI,
-                tabId = "tab-a",
             ),
         )
 
@@ -107,7 +105,6 @@ class RealNativeInputStateStoreTest {
             NativeInputState(
                 inputMode = InputMode.SEARCH_ONLY,
                 inputContext = InputContext.BROWSER,
-                tabId = "tab-a",
             ),
         )
 
@@ -131,13 +128,12 @@ class RealNativeInputStateStoreTest {
             NativeInputState(
                 inputMode = InputMode.SEARCH_ONLY,
                 inputContext = InputContext.DUCK_AI,
-                tabId = "tab-a",
             ),
         )
 
         testee.clearTab("tab-a")
 
-        assertEquals(NativeInputState.zero("tab-a"), testee.stateForTab("tab-a").value)
+        assertEquals(NativeInputState.zero(), testee.stateForTab("tab-a").value)
     }
 
     @Test
@@ -145,7 +141,6 @@ class RealNativeInputStateStoreTest {
         val stateB = NativeInputState(
             inputMode = InputMode.SEARCH_ONLY,
             inputContext = InputContext.DUCK_AI,
-            tabId = "tab-b",
         )
         testee.publish("tab-b", stateB)
 
@@ -161,7 +156,6 @@ class RealNativeInputStateStoreTest {
             NativeInputState(
                 inputMode = InputMode.SEARCH_ONLY,
                 inputContext = InputContext.DUCK_AI,
-                tabId = "tab-a",
             ),
         )
         testee.publish(
@@ -169,14 +163,13 @@ class RealNativeInputStateStoreTest {
             NativeInputState(
                 inputMode = InputMode.SEARCH_ONLY,
                 inputContext = InputContext.DUCK_AI,
-                tabId = "tab-b",
             ),
         )
 
         testee.clearAll()
 
-        assertEquals(NativeInputState.zero("tab-a"), testee.stateForTab("tab-a").value)
-        assertEquals(NativeInputState.zero("tab-b"), testee.stateForTab("tab-b").value)
+        assertEquals(NativeInputState.zero(), testee.stateForTab("tab-a").value)
+        assertEquals(NativeInputState.zero(), testee.stateForTab("tab-b").value)
     }
 
     @Test
@@ -184,7 +177,6 @@ class RealNativeInputStateStoreTest {
         val published = NativeInputState(
             inputMode = InputMode.SEARCH_ONLY,
             inputContext = InputContext.DUCK_AI,
-            tabId = "tab-a",
         )
         testee.publish("tab-a", published)
         selectedTabFlow.value = tabEntity("tab-a")
@@ -200,12 +192,10 @@ class RealNativeInputStateStoreTest {
         val stateA = NativeInputState(
             inputMode = InputMode.SEARCH_AND_DUCK_AI,
             inputContext = InputContext.BROWSER,
-            tabId = "tab-a",
         )
         val stateB = NativeInputState(
             inputMode = InputMode.SEARCH_ONLY,
             inputContext = InputContext.DUCK_AI,
-            tabId = "tab-b",
         )
         testee.publish("tab-a", stateA)
         testee.publish("tab-b", stateB)
@@ -226,7 +216,6 @@ class RealNativeInputStateStoreTest {
         val initial = NativeInputState(
             inputMode = InputMode.SEARCH_AND_DUCK_AI,
             inputContext = InputContext.BROWSER,
-            tabId = "tab-a",
         )
         testee.publish("tab-a", initial)
         selectedTabFlow.value = tabEntity("tab-a")

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -90,5 +90,5 @@ class NativeInputModeWidgetBackButtonsTest {
     }
 
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
-        NativeInputState(inputMode = inputMode, inputContext = inputContext, tabId = "test-tab")
+        NativeInputState(inputMode = inputMode, inputContext = inputContext)
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
@@ -235,12 +236,12 @@ class NativeInputModeWidgetViewModelTest {
     fun whenContextIsDuckAiThenDefaultToggleSelectionIsDuckAi() = runTest {
         testee.setDuckAiMode(true)
 
-        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.toggleSelection)
     }
 
     @Test
     fun whenContextIsBrowserThenDefaultToggleSelectionIsSearch() = runTest {
-        assertEquals(NativeInputState.ToggleSelection.SEARCH, testee.state.firstOrNull()!!.defaultToggleSelection)
+        assertEquals(NativeInputState.ToggleSelection.SEARCH, testee.state.firstOrNull()!!.toggleSelection)
     }
 
     @Test
@@ -272,7 +273,7 @@ class NativeInputModeWidgetViewModelTest {
     fun whenContextIsDuckAiContextualThenDefaultToggleSelectionIsDuckAi() = runTest {
         testee.configureContextual(tabId = "test-tab")
 
-        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.defaultToggleSelection)
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, testee.state.firstOrNull()!!.toggleSelection)
     }
 
     @Test
@@ -777,6 +778,30 @@ class NativeInputModeWidgetViewModelTest {
         verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT)
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY, type = Daily())
+    }
+
+    // endregion
+
+    // region setToggleSelection
+
+    @Test
+    fun whenSetToggleSelectionThenStateReflectsTheSelection() = runTest {
+        testee.setToggleSelection(NativeInputState.ToggleSelection.DUCK_AI)
+
+        val emitted = testee.state.first()
+
+        assertEquals(NativeInputState.ToggleSelection.DUCK_AI, emitted.toggleSelection)
+    }
+
+    @Test
+    fun whenConfigureCalledThenToggleSelectionFallsBackToContextDefault() = runTest {
+        testee.setToggleSelection(NativeInputState.ToggleSelection.DUCK_AI)
+        testee.state.first { it.toggleSelection == NativeInputState.ToggleSelection.DUCK_AI }
+
+        testee.configure(tabId = "test-tab", isDuckAiMode = false, isBottom = false)
+
+        val emitted = testee.state.first()
+        assertEquals(NativeInputState.ToggleSelection.SEARCH, emitted.toggleSelection)
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import com.duckduckgo.duckchat.impl.DuckChatInternal
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StartChatViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val featureShowSettingsFlow = MutableStateFlow(true)
+    private val enableDuckChatFlow = MutableStateFlow(true)
+    private val providerStateFlow = MutableSharedFlow<NativeInputState>(replay = 1)
+
+    private val duckAiFeatureState: DuckAiFeatureState = mock<DuckAiFeatureState>().also {
+        whenever(it.showSettings).thenReturn(featureShowSettingsFlow)
+    }
+    private val duckChatInternal: DuckChatInternal = mock<DuckChatInternal>().also {
+        whenever(it.observeEnableDuckChatUserSetting()).thenReturn(enableDuckChatFlow)
+    }
+    private val nativeInputStateProvider: NativeInputStateProvider = mock<NativeInputStateProvider>().also {
+        whenever(it.state).thenReturn(providerStateFlow)
+    }
+
+    private val testee = StartChatViewModel(duckAiFeatureState, duckChatInternal, nativeInputStateProvider)
+
+    @Test
+    fun whenSearchOnlyModeAndSearchToggleAndDuckAiEnabledThenVisible() = runTest {
+        featureShowSettingsFlow.value = true
+        enableDuckChatFlow.value = true
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFeatureDisabledThenNotVisible() = runTest {
+        featureShowSettingsFlow.value = false
+        enableDuckChatFlow.value = true
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserSettingDisabledThenNotVisible() = runTest {
+        featureShowSettingsFlow.value = true
+        enableDuckChatFlow.value = false
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInputModeIsSearchAndDuckAiThenNotVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_AND_DUCK_AI, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenToggleSelectionIsDuckAiThenNotVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.DUCK_AI))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenStateLaterChangesToVisibleThenIsVisibleEmitsTrue() = runTest {
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_AND_DUCK_AI, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+
+            providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
+
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun stateOf(mode: InputMode, toggle: ToggleSelection): NativeInputState = NativeInputState(
+        inputMode = mode,
+        inputContext = InputContext.BROWSER,
+        toggleSelection = toggle,
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214802413219916?focus=true

Stacked on #8556 — base is `feature/david/native_input_tabid_non_null` until that merges.

### Description

First plugin migration onto the per-tab push model. `StartChatViewModel` drops `DuckChatInputModeState` and observes the tab's `NativeInputState` via `NativeInputStateProvider`.

- `NativeInputState` gets a stored `toggleSelection: ToggleSelection` field (defaults to today's context-derived value via `NativeInputState.defaultToggleFor`). `toggleSelection` is distinct from `inputContext`: the context says where the widget lives, the selection says which tab the user tapped — they can diverge inside a browser omnibar.
- `NativeInputHost` exposes `val tabId: String`. The widget implements it from `activeTabId`; reads pre-configure throw, mirroring `getInputState()`.
- Widget's `configureMainButtonsVisibility` calls `viewModel.setToggleSelection(...)` on every `onTabSelected` / `onTabReselected`, before the existing `updatePluginContainerVisibility` call. `WidgetConfig` carries a nullable `toggleSelection` override; `configure()` resets it (null = follow context default).
- `StartChatViewModel` injects `NativeInputStateProvider` and exposes `bindTabId(tabId)`; the combined `isVisible` flow `flatMapLatest`s on `stateForTab(tabId)` and gates on `toggleSelection == SEARCH`.
- `StartChatView` stashes the host's tabId before attach and forwards it to the VM from `onAttachedToWindow`; the plugin's `createView` calls `bindTabId(host.tabId)` alongside the existing `onIconClicked` wiring.

`DuckChatInputModeState` stays in place — still consumed by ambient UI (NTP background logo). Removal happens once nothing reads it. `updatePluginContainerVisibility` carries a TODO: it becomes redundant once every plugin reads `toggleSelection` from `NativeInputStateProvider` and decides its own visibility.

### Steps to test this PR

_StartChat icon visibility_
- [ ] Enable Duck.ai feature + user setting on; disable input-screen setting (search omnibar mode). On a website, focus the omnibar — StartChat icon visible.
- [ ] Same setup, tap the Duck.ai tab in the toggle — icon hides.
- [ ] Tap back to the Search tab — icon reappears.
- [ ] Disable Duck.ai user setting — icon hides regardless of tab.
- [ ] Enable input-screen setting (SEARCH_AND_DUCK_AI mode) — icon hides.

_Toggle / tab switching across tabs_
- [ ] Open a website on tab A, tap the Duck.ai toggle. Switch to a fresh tab B in the browser. The widget should reflect tab B's selection independently from tab A.

### UI changes

No visual change to existing UI; refactor of how the StartChat icon's visibility is wired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors how native-input state is derived and propagated across tabs, which can affect toggle selection, plugin visibility, and SEARCH_ONLY vs SEARCH_AND_DUCK_AI UI rendering during tab switches.
> 
> **Overview**
> **Native input state is reworked to be active-tab driven.** `NativeInputState` drops `tabId`, adds a stored `toggleSelection` (defaulted via `defaultToggleFor`), and `NativeInputStateProvider` now exposes a `state: Flow<NativeInputState>` that follows the selected browser tab.
> 
> **State propagation and UI syncing are updated.** `RealNativeInputStateStore` now derives `state` from `TabRepository.flowSelectedTab` (with a lazy injection to avoid a Dagger cycle), while `NativeInputModeWidgetViewModel` publishes widget-owned fields via `publisher.update` and tracks per-tab `toggleSelection`, resetting it on `configure()`. `NativeInputModeWidget` always observes `viewModel.state` (avoiding placeholder `zero()` emissions), keeps `TabLayout` selection synchronized to `toggleSelection`, and only writes selection back to state when the toggle row is user-visible.
> 
> **Plugins are migrated off host state reads.** `NativeInputHost.getInputState()` is removed; `ModelPickerView` and `StartChatViewModel` now observe `NativeInputStateProvider.state` to drive surface/visibility logic, with new tests covering active-tab emissions and StartChat visibility gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d8c0dcef7be2f2b8c46f6547260df4e15c0090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->