### PR TITLE
fix incorrect overlap in duck.ai webview below the widget

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -150,8 +150,6 @@ class NativeInputLayoutCoordinator(
         if (targets.isEmpty()) return
         val anchor = widgetView.findViewById(R.id.inputModeWidgetCard) ?: widgetView
 
-        val overlap = widgetView.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_5)
-
         // Animate child reflows when the widget toggles Search ↔ DuckAI changes our padding.
         // The transition is staged here but only assigned to the parent once the enter animation
         // completes (see enableContentLayoutTransition). Otherwise the per-frame setPadding
@@ -198,11 +196,7 @@ class NativeInputLayoutCoordinator(
 
         fun computeDeltaBottom(): Int {
             if (!isBottom) return 0
-            return if (omnibarState.isOmnibarBottom()) {
-                maxOf(0, overlap)
-            } else {
-                maxOf(0, anchor.height - overlap)
-            }
+            return maxOf(0, widgetView.height)
         }
 
         fun applyOffsetWithBottom(anchorBottomInWindow: Int) {


### PR DESCRIPTION

Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214598987399330?focus=true, https://app.asana.com/1/137249556945/project/1212608036467427/task/1214707942438120?focus=true

### Description
Widget and duck.ai webview now don't have an extra overlap.

### Steps to test this PR
- open duck.ai in native-input widget mode.
- observe terms and conditions are shown without a cutoff.
- observe a long conversation not cutoff at the end.

### UI changes
<img width="400" height="900" alt="test" src="https://github.com/user-attachments/assets/1879ff7f-1868-4612-8438-a400045bab72" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts padding/offset calculations; main risk is minor layout regressions on bottom-positioned widget modes across devices.
> 
> **Overview**
> Fixes an incorrect extra overlap beneath the native-input DuckAI widget by removing the hardcoded `overlap` dimension and simplifying `computeDeltaBottom()` to use the current `widgetView.height` when the widget is bottom-aligned.
> 
> This changes how bottom padding is applied to `browserLayout`/NTP content so web content (e.g., DuckAI WebView terms and long conversations) is no longer cut off under the widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f175d6c5cd095466bdc53a3363d0a4c4e9502792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->