### PR TITLE
Update content scope scripts to version 14.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.8.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.9.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.81.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.81.0.tgz",
-      "integrity": "sha512-7YgGDCFGCvc+OIjvmjrfhAOgQpyXjGntU3TSWeJYZv7XYTqUYBrcsVNEGC8yg9vekg0m9BrHZZqPvPIWzlDnVA==",
+      "version": "14.82.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.82.0.tgz",
+      "integrity": "sha512-Q0WkYlQSQxWQq7I3I+nq+Kk+/NkQuMzJ2DUm87pdLHk8sLpJMmuM61+9F35zcMS48bfy690Pi7RGzPJBDGRx6A==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d3e17cb6e45b15420637d9d689c45bff81df1a4a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.0.tgz",
-      "integrity": "sha512-gob5BGY9kKwC4YAK15wlUlG5OwOr+woLU0ZaJ+uHaiib1+IkVBkhWgrsuDDd8Y1wILjumsVCPpSdDxNqno3zIg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.1.tgz",
+      "integrity": "sha512-IGVFdLcBhOGcvbumQPIJYPYYoV+8NlpIbehBWMoDEV/vl1OXAuDwXnj0PEFc4ogQTt7JwFUOHcyiDLn8VfaEsA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.17.0",
-        "@ghostery/adblocker-extended-selectors": "^2.17.0",
+        "@ghostery/adblocker-content": "^2.17.1",
+        "@ghostery/adblocker-extended-selectors": "^2.17.1",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.0.tgz",
-      "integrity": "sha512-HkGWrG6iQ11L1A9t5FpaPRK8YV6mYVmrWvElQtgUrXMUq1LT10fWZ+mAwnkgpLvRi1vR+wyPbzcjN3BI02MI4g==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.1.tgz",
+      "integrity": "sha512-8ljkGaO3nIDXYw5lgiu6ZH1TQyaTmUUx8z/IMpoFFuhZPPOmioMX8hUahEobcI5JzW2KQln7c1V9b60FZaFPlQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.17.0"
+        "@ghostery/adblocker-extended-selectors": "^2.17.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.0.tgz",
-      "integrity": "sha512-7wvKsn/X0mtNOzYXDV+LZU1kvOstJcNvsOWViAaisRK6Wo2PPgKIvfmcVB5P9yGr4nC/xffadjyhhqc+aN04pg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.1.tgz",
+      "integrity": "sha512-724Q/OBX8n78ga72ZPh6jUvDKNqp+IOBy9ujsqPNV9NCIgeC29+s9Axru3i1BRG6co+qGaCQxg3EUsvXH2prCw==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,13 +280,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/resolve": {
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.8.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.9.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214831375350273?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `@duckduckgo/content-scope-scripts` and transitive JS dependencies used for privacy/tracker protection, which could subtly change in-page behavior. Risk is limited to dependency bumps with no app code changes.
> 
> **Overview**
> Updates the `@duckduckgo/content-scope-scripts` dependency from `14.8.0` to `14.9.0` in `package.json` and refreshes `package-lock.json` accordingly.
> 
> The lockfile also bumps related resolved versions (notably `@duckduckgo/autoconsent`, `@ghostery/adblocker*`, and Node type packages) to match the new dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2af389698c9e673b2a12bc8d0538e24526c65da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->