### PR TITLE
Position reasoning dialog to button

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -138,7 +138,8 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     private fun showAtPosition(popup: PopupWindow) {
         val loc = IntArray(2).also { button.getLocationOnScreen(it) }
-        popup.showAtLocation(rootView, Gravity.TOP or Gravity.START, loc[0], loc[1])
+        val menuWidth = resources.getDimensionPixelSize(R.dimen.reasoningModePickerMenuWidth)
+        popup.showAtLocation(rootView, Gravity.TOP or Gravity.START, loc[0] + button.width - menuWidth, loc[1])
     }
 
     private fun dismissPopup() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -138,10 +138,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     private fun showAtPosition(popup: PopupWindow) {
         val loc = IntArray(2).also { button.getLocationOnScreen(it) }
-        val x = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_4)
-        val y = resources.displayMetrics.heightPixels - loc[1] +
-            resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
-        popup.showAtLocation(rootView, Gravity.BOTTOM or Gravity.END, x, y)
+        popup.showAtLocation(rootView, Gravity.TOP or Gravity.START, loc[0], loc[1])
     }
 
     private fun dismissPopup() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214803420088478?focus=true

### Description

- Places the top left hand corner of the reasoning dialog to the button position (to match the options dialog)

### Steps to test this PR

_With native input enabled_
- [ ] Tap the reasoning button
- [ ] Verify that the dialog is properly positioned

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="594" alt="Screenshot_20260515_110826" src="https://github.com/user-attachments/assets/473e36f1-6834-49e2-8846-8dd3d83ee465" />|<img width="1080" height="670" alt="Screenshot_20260515_133852" src="https://github.com/user-attachments/assets/812e8311-6a58-47e9-b6e2-097e0e2c4bea" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts `PopupWindow` positioning; potential issues limited to layout/coordinates across screen sizes and RTL.
> 
> **Overview**
> Updates the reasoning mode picker popup positioning to align the menu with the triggering button, matching the behavior of the options dialog.
> 
> Replaces the previous bottom/end offset calculation with a screen-coordinate based placement using `button.getLocationOnScreen` and the configured `reasoningModePickerMenuWidth` to right-align the popup to the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24cd89098269bb25597b901598a80d3be0e3066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->