### PR TITLE
Fix UninitializedPropertyAccessException (native input)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -640,16 +640,18 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun applyDefaultTogglePosition() {
-        if (!::duckChatFeature.isInitialized || !duckChatFeature.rememberTogglePosition().isEnabled()) return
-        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
-            val position = viewModel.defaultTogglePosition.firstOrNull() ?: return@launch
-            val resolved = if (position == DefaultTogglePosition.LAST_USED) {
-                DefaultTogglePosition.fromName(viewModel.lastUsedTogglePosition.firstOrNull())
-            } else {
-                position
-            }
-            if (resolved == DefaultTogglePosition.DUCK_AI) {
-                selectChatTab()
+        doOnAttach {
+            if (!duckChatFeature.rememberTogglePosition().isEnabled()) return@doOnAttach
+            findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+                val position = viewModel.defaultTogglePosition.firstOrNull() ?: return@launch
+                val resolved = if (position == DefaultTogglePosition.LAST_USED) {
+                    DefaultTogglePosition.fromName(viewModel.lastUsedTogglePosition.firstOrNull())
+                } else {
+                    position
+                }
+                if (resolved == DefaultTogglePosition.DUCK_AI) {
+                    selectChatTab()
+                }
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -640,7 +640,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun applyDefaultTogglePosition() {
-        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
+        if (!::duckChatFeature.isInitialized || !duckChatFeature.rememberTogglePosition().isEnabled()) return
         findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             val position = viewModel.defaultTogglePosition.firstOrNull() ?: return@launch
             val resolved = if (position == DefaultTogglePosition.LAST_USED) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214832730289236?focus=true

### Description

- Fixes a crash when the native input is showing and you change to dark/light theme.

### Steps to test this PR

_With native input enabled_
- [ ] Tap on the omnibar to show the native input
- [ ] Change the system theme
- [ ] Verify that the app does not crash


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lifecycle change that delays applying the remembered toggle state until `doOnAttach`, reducing chances of accessing uninitialized/inactive view/lifecycle state during configuration changes (e.g., theme switch).
> 
> **Overview**
> Defers `applyDefaultTogglePosition` execution by wrapping the remembered-toggle lookup and tab selection in `doOnAttach`, so the coroutine only runs once the widget is attached to a window.
> 
> This avoids applying the default/last-used toggle state during transient view recreation (e.g., light/dark theme changes), preventing crashes from accessing lifecycle/view model dependencies too early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06dad72d932be975b36805014b262ef815413c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->