### PR TITLE
PIR: Add email polling mechanism

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOut
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.RealBrokerStepsParser
+import com.duckduckgo.pir.impl.common.RealEmailDataResolver
 import com.duckduckgo.pir.impl.common.RealPirRunStateHandler
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler
 import com.duckduckgo.pir.impl.common.actions.BrokerStepCompletedEventHandler
@@ -314,6 +315,7 @@ class PirEndToEndTest {
             pirDetachedWebViewProvider = fakePirDetachedWebViewProvider,
             brokerActionProcessor = brokerActionProcessor,
             nativeBrokerActionHandler = fakeNativeBrokerActionHandler,
+            emailDataResolver = RealEmailDataResolver(fakeDbpService, dispatcherProvider, moshi),
             engineFactory = engineFactory,
             coroutineScope = testScope,
         )

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/TestPirActionsRunnerFactory.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/TestPirActionsRunnerFactory.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl.integration.fakes
 
 import android.content.Context
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.pir.impl.common.EmailDataResolver
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.common.actions.RealPirActionsRunnerStateEngineFactory
@@ -32,6 +33,7 @@ class TestPirActionsRunnerFactory(
     private val pirDetachedWebViewProvider: FakePirDetachedWebViewProvider,
     private val brokerActionProcessor: RealBrokerActionProcessor,
     private val nativeBrokerActionHandler: FakeNativeBrokerActionHandler,
+    private val emailDataResolver: EmailDataResolver,
     private val engineFactory: RealPirActionsRunnerStateEngineFactory,
     private val coroutineScope: CoroutineScope,
 ) : RealPirActionsRunner.Factory {
@@ -45,6 +47,7 @@ class TestPirActionsRunnerFactory(
             pirDetachedWebViewProvider = pirDetachedWebViewProvider,
             brokerActionProcessor = brokerActionProcessor,
             nativeBrokerActionHandler = nativeBrokerActionHandler,
+            emailDataResolver = emailDataResolver,
             engineFactory = engineFactory,
             coroutineScope = coroutineScope,
             runType = runType,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/EmailDataResolver.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/EmailDataResolver.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.common.EmailDataResolver.EmailDataResolverResult
+import com.duckduckgo.pir.impl.common.EmailDataResolver.EmailDataResolverResult.Failure
+import com.duckduckgo.pir.impl.common.EmailDataResolver.EmailDataResolverResult.Pending
+import com.duckduckgo.pir.impl.common.EmailDataResolver.EmailDataResolverResult.Success
+import com.duckduckgo.pir.impl.service.DbpService
+import com.duckduckgo.pir.impl.service.DbpService.PirEmailConfirmationDataRequest
+import com.duckduckgo.pir.impl.service.DbpService.PirEmailConfirmationDataRequest.RequestEmailData
+import com.duckduckgo.pir.impl.service.ResponseError
+import com.duckduckgo.pir.impl.service.parseError
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import retrofit2.HttpException
+import javax.inject.Inject
+
+interface EmailDataResolver {
+    /**
+     * Polls the backend for email-extracted data (e.g. verification codes) for the given email/attempt pair.
+     *
+     * @param emailAddress - the generated email address whose inbox is being polled
+     * @param attemptId - identifies the scan or opt-out attempt
+     */
+    suspend fun poll(
+        emailAddress: String,
+        attemptId: String,
+    ): EmailDataResolverResult
+
+    sealed class EmailDataResolverResult {
+        /** Backend returned status "ready" with the extracted data map. */
+        data class Success(
+            val extractedData: Map<String, String>,
+        ) : EmailDataResolverResult()
+
+        /** Backend has not yet received the email — caller should poll again. */
+        data object Pending : EmailDataResolverResult()
+
+        data class Failure(
+            val code: Int,
+            val message: String,
+        ) : EmailDataResolverResult()
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class RealEmailDataResolver @Inject constructor(
+    private val dbpService: DbpService,
+    private val dispatcherProvider: DispatcherProvider,
+    moshi: Moshi,
+) : EmailDataResolver {
+    private val adapter = moshi.adapter(ResponseError::class.java)
+
+    override suspend fun poll(
+        emailAddress: String,
+        attemptId: String,
+    ): EmailDataResolverResult = withContext(dispatcherProvider.io()) {
+        runCatching {
+            dbpService.getEmailConfirmationLinkStatus(
+                PirEmailConfirmationDataRequest(
+                    items = listOf(
+                        RequestEmailData(
+                            email = emailAddress,
+                            attemptId = attemptId,
+                        ),
+                    ),
+                ),
+            ).run {
+                logcat { "PIR-EMAIL-DATA: RESULT -> $this" }
+                val item = items.firstOrNull()
+                    ?: return@run Failure(
+                        code = 0,
+                        message = PREFIX_EMAIL_DATA_ERROR + "Empty response items",
+                    )
+
+                when (item.status.lowercase()) {
+                    STATUS_READY -> Success(
+                        extractedData = item.data.associate { it.name to it.value },
+                    )
+
+                    STATUS_PENDING -> Pending
+
+                    else -> Failure(
+                        code = 0,
+                        message = "$PREFIX_EMAIL_DATA_ERROR${item.errorCode.orEmpty()} ${item.error ?: item.status}",
+                    )
+                }
+            }
+        }.getOrElse { error ->
+            logcat { "PIR-EMAIL-DATA: Failure -> $error" }
+            if (error is HttpException) {
+                val errorMessage = adapter.parseError(error)?.message.orEmpty()
+                Failure(
+                    code = error.code(),
+                    message = "$PREFIX_EMAIL_DATA_ERROR${error.code()} $errorMessage",
+                )
+            } else {
+                Failure(
+                    code = 0,
+                    message = PREFIX_EMAIL_DATA_ERROR + (error.message ?: "Unknown error"),
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val PREFIX_EMAIL_DATA_ERROR = "Email data poll error: "
+        private const val STATUS_READY = "ready"
+        private const val STATUS_PENDING = "pending"
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.CaptchaInfoReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailDataReceived
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailReceived
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ErrorReceived
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
@@ -42,10 +43,12 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.LoadUrlComplete
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.LoadUrlFailed
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryAwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryAwaitEmailData
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryGetCaptchaSolution
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.Started
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitEmailData
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.CompleteExecution
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.EvaluateJs
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.GetCaptchaSolution
@@ -117,6 +120,7 @@ class RealPirActionsRunner @AssistedInject constructor(
     private val pirDetachedWebViewProvider: PirDetachedWebViewProvider,
     private val brokerActionProcessor: BrokerActionProcessor,
     private val nativeBrokerActionHandler: NativeBrokerActionHandler,
+    private val emailDataResolver: EmailDataResolver,
     private val engineFactory: PirActionsRunnerStateEngineFactory,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     @Assisted private val runType: RunType,
@@ -271,7 +275,7 @@ class RealPirActionsRunner @AssistedInject constructor(
                 }
 
             is AwaitCaptchaSolution -> handleAwaitCaptchaSolution(effect)
-            is SideEffect.AwaitEmailData -> handleAwaitEmailData(effect)
+            is AwaitEmailData -> handleAwaitEmailData(effect)
         }
     }
 
@@ -359,9 +363,77 @@ class RealPirActionsRunner @AssistedInject constructor(
             }
         }
 
-    private suspend fun handleAwaitEmailData(effect: SideEffect.AwaitEmailData) {
-        // TODO: Implement in step 5 — poll for email data via EmailDataResolver
-    }
+    private suspend fun handleAwaitEmailData(effect: AwaitEmailData) =
+        withContext(dispatcherProvider.io()) {
+            if (effect.emailAddress.isEmpty() || effect.attemptId.isEmpty()) {
+                onError(
+                    ClientError(
+                        actionID = effect.actionId,
+                        message = "Invalid state: missing email address or attempt id for email data poll",
+                    ),
+                )
+                return@withContext
+            }
+
+            val maxAttempts = if (effect.pollingIntervalSeconds > 0) {
+                effect.maxTimeoutSeconds / effect.pollingIntervalSeconds
+            } else {
+                0
+            }
+
+            when (val result = emailDataResolver.poll(effect.emailAddress, effect.attemptId)) {
+                is EmailDataResolver.EmailDataResolverResult.Success -> {
+                    if (effect.extractFields.all { result.extractedData.containsKey(it) }) {
+                        engine?.dispatch(
+                            EmailDataReceived(
+                                emailExtractedData = result.extractedData,
+                            ),
+                        )
+                    } else {
+                        onError(
+                            ClientError(
+                                actionID = effect.actionId,
+                                message = "Email data ready but missing required fields: ${effect.extractFields - result.extractedData.keys}",
+                            ),
+                        )
+                    }
+                }
+
+                is EmailDataResolver.EmailDataResolverResult.Pending -> {
+                    if (effect.attempt >= maxAttempts) {
+                        onError(
+                            ClientError(
+                                actionID = effect.actionId,
+                                message = "Email data poll timeout after ${effect.maxTimeoutSeconds}s",
+                            ),
+                        )
+                    } else {
+                        delay(effect.pollingIntervalSeconds * 1000L)
+                        engine?.dispatch(
+                            RetryAwaitEmailData(
+                                actionId = effect.actionId,
+                                brokerName = effect.brokerName,
+                                emailAddress = effect.emailAddress,
+                                attemptId = effect.attemptId,
+                                extractFields = effect.extractFields,
+                                pollingIntervalSeconds = effect.pollingIntervalSeconds,
+                                maxTimeoutSeconds = effect.maxTimeoutSeconds,
+                                attempt = effect.attempt,
+                            ),
+                        )
+                    }
+                }
+
+                is EmailDataResolver.EmailDataResolverResult.Failure -> {
+                    onError(
+                        ClientError(
+                            actionID = effect.actionId,
+                            message = result.message,
+                        ),
+                    )
+                }
+            }
+        }
 
     private suspend fun handleGetCaptchaSolution(effect: GetCaptchaSolution) =
         withContext(dispatcherProvider.io()) {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailDataReceivedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/EmailDataReceivedEventHandler.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailDataReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = EventHandler::class,
+)
+class EmailDataReceivedEventHandler @Inject constructor() : EventHandler {
+    override val event: KClass<out Event> = EmailDataReceived::class
+
+    override suspend fun invoke(
+        state: State,
+        event: Event,
+    ): Next {
+        val actualEvent = event as EmailDataReceived
+        return Next(
+            nextState = state.copy(
+                currentActionIndex = state.currentActionIndex + 1,
+                emailExtractedData = actualEvent.emailExtractedData,
+            ),
+            nextEvent = ExecuteBrokerStepAction(
+                actionRequestData = UserProfile(
+                    userProfile = state.profileQuery,
+                ),
+            ),
+        )
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitEmailData
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.GetEmailForProfile
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.LoadUrl
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.PushJsAction
@@ -48,6 +49,7 @@ import com.duckduckgo.pir.impl.scripts.models.BrokerAction.Expectation
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.FillForm
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GenerateEmail
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GetCaptchaInfo
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GetEmailData
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.SolveCaptcha
 import com.duckduckgo.pir.impl.scripts.models.DataSource.EXTRACTED_PROFILE
 import com.duckduckgo.pir.impl.scripts.models.PirError
@@ -123,6 +125,23 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
                     sideEffect = GetEmailForProfile(
                         actionId = actionToExecute.id,
                         brokerName = currentBrokerStep.broker.name,
+                    ),
+                )
+            } else if (actionToExecute is GetEmailData) {
+                Next(
+                    nextState = state.copy(
+                        stageStatus = PirStageStatus(
+                            currentStage = PirStage.EMAIL_DATA_POLL,
+                            stageStartMs = currentTimeProvider.currentTimeMillis(),
+                        ),
+                    ),
+                    sideEffect = AwaitEmailData(
+                        actionId = actionToExecute.id,
+                        brokerName = currentBrokerStep.broker.name,
+                        emailAddress = state.generatedEmailData?.emailAddress.orEmpty(),
+                        attemptId = state.attemptId,
+                        extractFields = actionToExecute.extract,
+                        pollingIntervalSeconds = actionToExecute.pollingTime.toIntOrNull() ?: DEFAULT_EMAIL_DATA_POLL_INTERVAL_SECONDS,
                     ),
                 )
             } else {
@@ -304,5 +323,9 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
         } else {
             requestData
         }
+    }
+
+    companion object {
+        private const val DEFAULT_EMAIL_DATA_POLL_INTERVAL_SECONDS = 5
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/RetryAwaitEmailDataEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/RetryAwaitEmailDataEventHandler.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryAwaitEmailData
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitEmailData
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = EventHandler::class,
+)
+class RetryAwaitEmailDataEventHandler @Inject constructor() : EventHandler {
+    override val event: KClass<out Event> = RetryAwaitEmailData::class
+
+    override suspend fun invoke(
+        state: State,
+        event: Event,
+    ): Next {
+        val actualEvent = event as RetryAwaitEmailData
+        return Next(
+            nextState = state,
+            sideEffect = AwaitEmailData(
+                actionId = actualEvent.actionId,
+                brokerName = actualEvent.brokerName,
+                emailAddress = actualEvent.emailAddress,
+                attemptId = actualEvent.attemptId,
+                extractFields = actualEvent.extractFields,
+                pollingIntervalSeconds = actualEvent.pollingIntervalSeconds,
+                maxTimeoutSeconds = actualEvent.maxTimeoutSeconds,
+                attempt = actualEvent.attempt + 1,
+            ),
+        )
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirStage.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirStage.kt
@@ -69,6 +69,11 @@ enum class PirStage(val stageName: String) {
     FILL_FORM("fill-form"),
 
     /**
+     * Stage starts: when getEmailData polling begins, waiting for email-extracted data (e.g. verification codes) to arrive.
+     */
+    EMAIL_DATA_POLL("email-data-poll"),
+
+    /**
      * Catch-all stage
      */
     OTHER("other"),

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealEmailDataResolverTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealEmailDataResolverTest.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.EmailDataResolver.EmailDataResolverResult
+import com.duckduckgo.pir.impl.service.DbpService
+import com.duckduckgo.pir.impl.service.DbpService.PirEmailConfirmationDataRequest
+import com.duckduckgo.pir.impl.service.DbpService.PirEmailConfirmationDataRequest.RequestEmailData
+import com.duckduckgo.pir.impl.service.DbpService.PirGetEmailConfirmationLinkResponse
+import com.duckduckgo.pir.impl.service.DbpService.PirGetEmailConfirmationLinkResponse.ResponseItem
+import com.duckduckgo.pir.impl.service.DbpService.PirGetEmailConfirmationLinkResponse.ResponseItemData
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.HttpException
+import retrofit2.Response
+
+class RealEmailDataResolverTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: RealEmailDataResolver
+
+    private val mockDbpService: DbpService = mock()
+    private val moshi = Moshi.Builder().build()
+
+    private val testEmail = "generated@example.com"
+    private val testAttemptId = "attempt-123"
+
+    private fun expectedRequest() = PirEmailConfirmationDataRequest(
+        items = listOf(
+            RequestEmailData(
+                email = testEmail,
+                attemptId = testAttemptId,
+            ),
+        ),
+    )
+
+    private fun responseItem(
+        status: String,
+        data: List<ResponseItemData> = emptyList(),
+        errorCode: String? = null,
+        error: String? = null,
+    ) = ResponseItem(
+        email = testEmail,
+        attemptId = testAttemptId,
+        status = status,
+        emailAddressCreatedAt = 0L,
+        emailReceivedAt = 0L,
+        data = data,
+        errorCode = errorCode,
+        error = error,
+    )
+
+    @Before
+    fun setUp() {
+        testee = RealEmailDataResolver(
+            dbpService = mockDbpService,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            moshi = moshi,
+        )
+    }
+
+    @Test
+    fun whenStatusIsReadyThenReturnsSuccessWithExtractedData() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(
+            items = listOf(
+                responseItem(
+                    status = "ready",
+                    data = listOf(
+                        ResponseItemData(name = "verificationCode", value = "123456"),
+                        ResponseItemData(name = "magicLink", value = "https://example.com/x"),
+                    ),
+                ),
+            ),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Success)
+        val success = result as EmailDataResolverResult.Success
+        assertEquals("123456", success.extractedData["verificationCode"])
+        assertEquals("https://example.com/x", success.extractedData["magicLink"])
+        verify(mockDbpService).getEmailConfirmationLinkStatus(eq(expectedRequest()))
+    }
+
+    @Test
+    fun whenStatusIsReadyWithEmptyDataThenReturnsSuccessWithEmptyMap() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(
+            items = listOf(responseItem(status = "ready", data = emptyList())),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Success)
+        assertTrue((result as EmailDataResolverResult.Success).extractedData.isEmpty())
+    }
+
+    @Test
+    fun whenStatusIsReadyUppercaseThenStillReturnsSuccess() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(
+            items = listOf(
+                responseItem(
+                    status = "READY",
+                    data = listOf(ResponseItemData(name = "verificationCode", value = "999")),
+                ),
+            ),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Success)
+    }
+
+    @Test
+    fun whenStatusIsPendingThenReturnsPending() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(
+            items = listOf(responseItem(status = "pending")),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertEquals(EmailDataResolverResult.Pending, result)
+    }
+
+    @Test
+    fun whenStatusIsUnknownThenReturnsFailure() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(
+            items = listOf(
+                responseItem(
+                    status = "error",
+                    errorCode = "boom",
+                    error = "Something went wrong",
+                ),
+            ),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Failure)
+        val failure = result as EmailDataResolverResult.Failure
+        assertEquals(0, failure.code)
+        assertTrue(failure.message.contains("boom"))
+        assertTrue(failure.message.contains("Something went wrong"))
+    }
+
+    @Test
+    fun whenResponseHasNoItemsThenReturnsFailure() = runTest {
+        val response = PirGetEmailConfirmationLinkResponse(items = emptyList())
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenReturn(response)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Failure)
+        val failure = result as EmailDataResolverResult.Failure
+        assertEquals(0, failure.code)
+        assertTrue(failure.message.contains("Empty response items"))
+    }
+
+    @Test
+    fun whenHttpExceptionThenReturnsFailureWithHttpCode() = runTest {
+        val errorBody = """{"message":"Server error"}""".toResponseBody("application/json".toMediaType())
+        val httpException = HttpException(
+            Response.error<PirGetEmailConfirmationLinkResponse>(500, errorBody),
+        )
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest()))).thenThrow(httpException)
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Failure)
+        val failure = result as EmailDataResolverResult.Failure
+        assertEquals(500, failure.code)
+        assertTrue(failure.message.contains("500"))
+        assertTrue(failure.message.contains("Server error"))
+    }
+
+    @Test
+    fun whenNonHttpExceptionThenReturnsFailureWithZeroCode() = runTest {
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest())))
+            .thenThrow(RuntimeException("Network timeout"))
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Failure)
+        val failure = result as EmailDataResolverResult.Failure
+        assertEquals(0, failure.code)
+        assertTrue(failure.message.contains("Network timeout"))
+    }
+
+    @Test
+    fun whenNonHttpExceptionWithNoMessageThenReturnsFailureWithUnknownError() = runTest {
+        whenever(mockDbpService.getEmailConfirmationLinkStatus(eq(expectedRequest())))
+            .thenThrow(RuntimeException())
+
+        val result = testee.poll(testEmail, testAttemptId)
+
+        assertTrue(result is EmailDataResolverResult.Failure)
+        val failure = result as EmailDataResolverResult.Failure
+        assertEquals(0, failure.code)
+        assertTrue(failure.message.contains("Unknown error"))
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
@@ -63,6 +63,7 @@ class RealPirActionsRunnerTest {
     private val mockPirDetachedWebViewProvider: PirDetachedWebViewProvider = mock()
     private val mockBrokerActionProcessor: BrokerActionProcessor = mock()
     private val mockNativeBrokerActionHandler: NativeBrokerActionHandler = mock()
+    private val mockEmailDataResolver: EmailDataResolver = mock()
     private val mockEngineFactory: PirActionsRunnerStateEngineFactory = mock()
     private val mockEngine: PirActionsRunnerStateEngine = mock()
     private val mockWebView: WebView = mock()
@@ -123,6 +124,7 @@ class RealPirActionsRunnerTest {
             pirDetachedWebViewProvider = mockPirDetachedWebViewProvider,
             brokerActionProcessor = mockBrokerActionProcessor,
             nativeBrokerActionHandler = mockNativeBrokerActionHandler,
+            emailDataResolver = mockEmailDataResolver,
             engineFactory = mockEngineFactory,
             coroutineScope = coroutineRule.testScope,
             runType = testRunType,

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailDataReceivedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/EmailDataReceivedEventHandlerTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.EmailDataReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EmailDataReceivedEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: EmailDataReceivedEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val baseState =
+        State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = emptyList(),
+            profileQuery = testProfileQuery,
+            currentActionIndex = 2,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_DATA_POLL,
+                stageStartMs = 1000L,
+            ),
+        )
+
+    @Before
+    fun setUp() {
+        testee = EmailDataReceivedEventHandler()
+    }
+
+    @Test
+    fun whenEventIsEmailDataReceivedThenEventTypeIsCorrect() {
+        assertEquals(EmailDataReceived::class, testee.event)
+    }
+
+    @Test
+    fun whenEmailDataReceivedThenStoresExtractedDataInState() = runTest {
+        val extractedData = mapOf("verificationCode" to "123456")
+        val event = EmailDataReceived(emailExtractedData = extractedData)
+
+        val result = testee.invoke(baseState, event)
+
+        assertEquals(extractedData, result.nextState.emailExtractedData)
+    }
+
+    @Test
+    fun whenEmailDataReceivedThenAdvancesActionIndex() = runTest {
+        val event = EmailDataReceived(emailExtractedData = mapOf("verificationCode" to "abc"))
+
+        val result = testee.invoke(baseState, event)
+
+        assertEquals(3, result.nextState.currentActionIndex)
+    }
+
+    @Test
+    fun whenEmailDataReceivedThenDispatchesExecuteBrokerStepActionWithProfileQuery() = runTest {
+        val event = EmailDataReceived(emailExtractedData = mapOf("verificationCode" to "abc"))
+
+        val result = testee.invoke(baseState, event)
+
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        val userProfile = nextEvent.actionRequestData as UserProfile
+        assertEquals(testProfileQuery, userProfile.userProfile)
+        assertNull(userProfile.extractedProfile)
+        assertNull(result.sideEffect)
+    }
+
+    @Test
+    fun whenEmailDataReceivedWithMultipleFieldsThenStoresAllFields() = runTest {
+        val extractedData = mapOf(
+            "verificationCode" to "123456",
+            "magicLink" to "https://example.com/verify?token=abc",
+        )
+        val event = EmailDataReceived(emailExtractedData = extractedData)
+
+        val result = testee.invoke(baseState, event)
+
+        assertEquals(extractedData, result.nextState.emailExtractedData)
+        assertEquals(2, result.nextState.emailExtractedData.size)
+    }
+
+    @Test
+    fun whenEmailDataReceivedThenPreservesOtherStateFields() = runTest {
+        val state = baseState.copy(
+            currentBrokerStepIndex = 4,
+            actionRetryCount = 1,
+            attemptId = "test-attempt",
+        )
+        val event = EmailDataReceived(emailExtractedData = mapOf("verificationCode" to "abc"))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(4, result.nextState.currentBrokerStepIndex)
+        assertEquals(1, result.nextState.actionRetryCount)
+        assertEquals("test-attempt", result.nextState.attemptId)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitCaptchaSolution
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitEmailData
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.GetEmailForProfile
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.LoadUrl
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.PushJsAction
@@ -894,5 +895,170 @@ class ExecuteBrokerStepActionEventHandlerTest {
         val sideEffect = result.sideEffect as PushJsAction
         val userData = sideEffect.requestParamsData as UserProfile
         assertEquals("generated@example.com", userData.extractedProfile?.email)
+    }
+
+    @Test
+    fun whenScanStepGetEmailDataActionThenEmitsAwaitEmailDataSideEffect() = runTest {
+        val action = BrokerAction.GetEmailData(
+            id = "get-email-data-1",
+            pollingTime = "5",
+            extract = listOf("verificationCode"),
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "generated@example.com",
+                pattern = "pattern-123",
+            ),
+            attemptId = "scan-attempt-1",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_DATA_POLL, result.nextState.stageStatus.currentStage)
+        assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals("get-email-data-1", sideEffect.actionId)
+        assertEquals(testBrokerName, sideEffect.brokerName)
+        assertEquals("generated@example.com", sideEffect.emailAddress)
+        assertEquals("scan-attempt-1", sideEffect.attemptId)
+        assertEquals(listOf("verificationCode"), sideEffect.extractFields)
+        assertEquals(5, sideEffect.pollingIntervalSeconds)
+        assertEquals(60, sideEffect.maxTimeoutSeconds)
+        assertEquals(0, sideEffect.attempt)
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenOptOutStepGetEmailDataActionThenEmitsAwaitEmailDataSideEffect() = runTest {
+        val action = BrokerAction.GetEmailData(
+            id = "get-email-data-1",
+            pollingTime = "10",
+            extract = listOf("verificationCode", "magicLink"),
+        )
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(action),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "generated@example.com",
+                pattern = "pattern-123",
+            ),
+            attemptId = "optout-attempt-1",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        assertEquals(PirStage.EMAIL_DATA_POLL, result.nextState.stageStatus.currentStage)
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals(listOf("verificationCode", "magicLink"), sideEffect.extractFields)
+        assertEquals(10, sideEffect.pollingIntervalSeconds)
+    }
+
+    @Test
+    fun whenGetEmailDataActionWithInvalidPollingTimeThenFallsBackToDefault() = runTest {
+        val action = BrokerAction.GetEmailData(
+            id = "get-email-data-1",
+            pollingTime = "not-a-number",
+            extract = listOf("verificationCode"),
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "generated@example.com",
+                pattern = "pattern-123",
+            ),
+            attemptId = "scan-attempt-1",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals(5, sideEffect.pollingIntervalSeconds)
+    }
+
+    @Test
+    fun whenGetEmailDataActionWithoutGeneratedEmailDataThenEmitsEmptyEmailAddress() = runTest {
+        val action = BrokerAction.GetEmailData(
+            id = "get-email-data-1",
+            pollingTime = "5",
+            extract = listOf("verificationCode"),
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = null,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals("", sideEffect.emailAddress)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryAwaitEmailDataEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/RetryAwaitEmailDataEventHandlerTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common.actions
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.RetryAwaitEmailData
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.SideEffect.AwaitEmailData
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
+import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.pixels.PirStage
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RetryAwaitEmailDataEventHandlerTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: RetryAwaitEmailDataEventHandler
+
+    private val testProfileQuery =
+        ProfileQuery(
+            id = 123L,
+            firstName = "John",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = emptyList(),
+            birthYear = 1990,
+            fullName = "John Doe",
+            age = 33,
+            deprecated = false,
+        )
+
+    private val baseState =
+        State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = emptyList(),
+            profileQuery = testProfileQuery,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.EMAIL_DATA_POLL,
+                stageStartMs = 0,
+            ),
+        )
+
+    private val baseEvent =
+        RetryAwaitEmailData(
+            actionId = "get-email-data-1",
+            brokerName = "test-broker",
+            emailAddress = "test@example.com",
+            attemptId = "attempt-1",
+            extractFields = listOf("verificationCode"),
+            pollingIntervalSeconds = 5,
+            maxTimeoutSeconds = 60,
+            attempt = 0,
+        )
+
+    @Before
+    fun setUp() {
+        testee = RetryAwaitEmailDataEventHandler()
+    }
+
+    @Test
+    fun whenEventIsRetryAwaitEmailDataThenEventTypeIsCorrect() {
+        assertEquals(RetryAwaitEmailData::class, testee.event)
+    }
+
+    @Test
+    fun whenRetryAwaitEmailDataThenReturnsAwaitEmailDataSideEffectWithIncrementedAttempt() = runTest {
+        val result = testee.invoke(baseState, baseEvent)
+
+        assertEquals(baseState, result.nextState)
+        assertEquals(
+            AwaitEmailData(
+                actionId = "get-email-data-1",
+                brokerName = "test-broker",
+                emailAddress = "test@example.com",
+                attemptId = "attempt-1",
+                extractFields = listOf("verificationCode"),
+                pollingIntervalSeconds = 5,
+                maxTimeoutSeconds = 60,
+                attempt = 1,
+            ),
+            result.sideEffect,
+        )
+        assertNull(result.nextEvent)
+    }
+
+    @Test
+    fun whenRetryAwaitEmailDataWithHigherAttemptThenIncrementsAttempt() = runTest {
+        val event = baseEvent.copy(attempt = 5)
+
+        val result = testee.invoke(baseState, event)
+
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals(6, sideEffect.attempt)
+    }
+
+    @Test
+    fun whenRetryAwaitEmailDataThenPreservesAllOtherFields() = runTest {
+        val event = baseEvent.copy(
+            actionId = "custom-action-id",
+            brokerName = "another-broker",
+            emailAddress = "another@example.com",
+            attemptId = "another-attempt",
+            extractFields = listOf("verificationCode", "magicLink"),
+            pollingIntervalSeconds = 10,
+            maxTimeoutSeconds = 120,
+            attempt = 3,
+        )
+
+        val result = testee.invoke(baseState, event)
+
+        val sideEffect = result.sideEffect as AwaitEmailData
+        assertEquals("custom-action-id", sideEffect.actionId)
+        assertEquals("another-broker", sideEffect.brokerName)
+        assertEquals("another@example.com", sideEffect.emailAddress)
+        assertEquals("another-attempt", sideEffect.attemptId)
+        assertEquals(listOf("verificationCode", "magicLink"), sideEffect.extractFields)
+        assertEquals(10, sideEffect.pollingIntervalSeconds)
+        assertEquals(120, sideEffect.maxTimeoutSeconds)
+        assertEquals(4, sideEffect.attempt)
+    }
+
+    @Test
+    fun whenRetryAwaitEmailDataThenStateRemainsUnchanged() = runTest {
+        val state = baseState.copy(
+            currentBrokerStepIndex = 3,
+            currentActionIndex = 5,
+            actionRetryCount = 2,
+        )
+
+        val result = testee.invoke(state, baseEvent)
+
+        assertEquals(state, result.nextState)
+        assertEquals(3, result.nextState.currentBrokerStepIndex)
+        assertEquals(5, result.nextState.currentActionIndex)
+        assertEquals(2, result.nextState.actionRetryCount)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213993026941871?focus=true

### Description
Adds polling mechanism for getEmailData action.

### Steps to test this PR
Will be testable later when feature is complete.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async polling path on opt-out/scan flows with timeouts and backend dependency; behavior is covered by unit tests and mirrors existing captcha polling patterns.
> 
> **Overview**
> Adds end-to-end support for the broker **`getEmailData`** action: when a step requests inbox-derived fields (e.g. verification codes), the runner polls the DBP API instead of pushing JS immediately.
> 
> A new **`EmailDataResolver`** calls `getEmailConfirmationLinkStatus` and maps **ready** / **pending** / error responses into success, retry, or failure. **`RealPirActionsRunner`** implements the former stub **`handleAwaitEmailData`**: validates email + attempt id, polls on an interval with a max timeout, checks required **`extract`** fields, then dispatches **`EmailDataReceived`** or **`RetryAwaitEmailData`**.
> 
> **`ExecuteBrokerStepActionEventHandler`** routes **`GetEmailData`** to an **`AwaitEmailData`** side effect (generated email, attempt id, polling interval with a 5s default). **`EmailDataReceivedEventHandler`** stores **`emailExtractedData`**, bumps the action index, and resumes **`ExecuteBrokerStepAction`**. **`PirStage.EMAIL_DATA_POLL`** is added for telemetry. Tests and the integration test factory wire **`RealEmailDataResolver`** into the runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88e05a5f171e10af4d56ec2e71a5536af19095c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->