### PR TITLE
Data-clearing additions to delete selected Duck.ai chats

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -133,7 +133,7 @@ class DataClearing @Inject constructor(
     private suspend fun clearDuckAiChatIfNeeded(tabUrl: String?) {
         logcat { "clearDuckAiChatIfNeeded url=$tabUrl" }
         if (tabUrl == null) return
-        dataClearingTrigger.clearData(setOf(ClearableData.DuckChats.Single(tabUrl)))
+        dataClearingTrigger.clearData(setOf(ClearableData.DuckChats.Selected(setOf(tabUrl))))
     }
 
     override suspend fun clearDataUsingManualFireOptions(shouldRestartIfRequired: Boolean, wasAppUsedSinceLastClear: Boolean) {

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -785,7 +785,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=abc-123"))))
     }
 
     @Test
@@ -795,7 +795,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://example.com")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://example.com"))))
     }
 
     @Test
@@ -806,7 +806,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=abc-123"))))
     }
 
     @Test
@@ -817,7 +817,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=abc-123")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=abc-123"))))
     }
 
     @Test
@@ -841,7 +841,7 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=contextual-123")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=contextual-123"))))
         verify(mockContextualDataStore).clearTabChatUrl("tab1")
     }
 
@@ -878,8 +878,8 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=tab-chat")))
-        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Single("https://duck.ai/chat?chatID=contextual-456")))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=tab-chat"))))
+        verify(mockDataClearingTrigger).clearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai/chat?chatID=contextual-456"))))
     }
 
     // --- getNewTabUrl tests (via clearSingleTabData) ---

--- a/data-clearing/data-clearing-api/src/main/java/com/duckduckgo/dataclearing/api/plugin/ClearableData.kt
+++ b/data-clearing/data-clearing-api/src/main/java/com/duckduckgo/dataclearing/api/plugin/ClearableData.kt
@@ -39,6 +39,11 @@ sealed class ClearableData {
     /** Duck AI chats. */
     sealed class DuckChats : ClearableData() {
         data object All : DuckChats()
-        data class Single(val chatUrl: String) : DuckChats()
+
+        /**
+         * A known set of Duck.ai chats, identified by their full chat URLs.
+         * `setOf(oneUrl)` is the single-chat case; `emptySet()` is a valid no-op.
+         */
+        data class Selected(val chatUrls: Set<String>) : DuckChats()
     }
 }

--- a/data-clearing/data-clearing-impl/src/test/java/com/duckduckgo/dataclearing/impl/plugin/DataClearingOrchestratorTest.kt
+++ b/data-clearing/data-clearing-impl/src/test/java/com/duckduckgo/dataclearing/impl/plugin/DataClearingOrchestratorTest.kt
@@ -62,7 +62,7 @@ class DataClearingOrchestratorTest {
         val plugin = recordingPlugin(receivedTypes)
         val orchestrator = createOrchestrator(plugin)
 
-        val types = setOf<ClearableData>(ClearableData.Tabs.Single("tab1"), ClearableData.DuckChats.Single("url"))
+        val types = setOf<ClearableData>(ClearableData.Tabs.Single("tab1"), ClearableData.DuckChats.Selected(setOf("url")))
         orchestrator.clearData(types)
 
         assertEquals(1, receivedTypes.size)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
@@ -44,7 +44,7 @@ class DuckChatDataClearingPlugin @Inject constructor(
         types.forEach { type ->
             when (type) {
                 is ClearableData.DuckChats.All -> deleteAllChats()
-                is ClearableData.DuckChats.Single -> deleteChat(type.chatUrl)
+                is ClearableData.DuckChats.Selected -> deleteSelected(type.chatUrls)
                 else -> { /* not handled by this plugin */ }
             }
         }
@@ -69,14 +69,19 @@ class DuckChatDataClearingPlugin @Inject constructor(
         }
     }
 
-    private suspend fun deleteChat(chatUrl: String) {
-        logcat { "DuckChatDataClearingPlugin: deleting chat url=$chatUrl" }
-        val chatId = extractChatId(chatUrl) ?: return
-        val deleted = duckChatDeleter.deleteChat(chatId)
-        if (deleted) {
-            duckChatSyncRepository.recordSingleChatDeletion(chatId)
-            syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    private suspend fun deleteSelected(chatUrls: Set<String>) {
+        logcat { "DuckChatDataClearingPlugin: deleting ${chatUrls.size} selected chat(s)" }
+        if (chatUrls.isEmpty()) return
+        var anyDeleted = false
+        chatUrls.forEach { chatUrl ->
+            val chatId = extractChatId(chatUrl) ?: return@forEach
+            if (duckChatDeleter.deleteChat(chatId)) {
+                duckChatSyncRepository.recordSingleChatDeletion(chatId)
+                anyDeleted = true
+            }
         }
+        // One sync trigger per user-visible delete action, not N.
+        if (anyDeleted) syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
     }
 
     private fun extractChatId(url: String): String? {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
@@ -31,8 +31,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -104,12 +106,12 @@ class DuckChatDataClearingPluginTest {
     }
 
     @Test
-    fun `deleteSingleChat extracts chatId and deletes`() = runTest {
+    fun `Selected with one chat extracts chatId and deletes`() = runTest {
         val chatUrl = "https://duckduckgo.com/?ia=chat&chatID=abc-123"
         whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
         whenever(duckChatDeleter.deleteChat("abc-123")).thenReturn(true)
 
-        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(setOf(chatUrl))))
 
         verify(duckChatDeleter).deleteChat("abc-123")
         verify(duckChatSyncRepository).recordSingleChatDeletion("abc-123")
@@ -117,36 +119,74 @@ class DuckChatDataClearingPluginTest {
     }
 
     @Test
-    fun `deleteSingleChat does nothing when url is not a duck chat url`() = runTest {
+    fun `Selected with one chat does nothing when url is not a duck chat url`() = runTest {
         val chatUrl = "https://example.com/?chatID=abc-123"
         whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(false)
 
-        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(setOf(chatUrl))))
 
         verify(duckChatDeleter, never()).deleteChat(any())
         verify(syncEngine, never()).triggerSync(any())
     }
 
     @Test
-    fun `deleteSingleChat does nothing when chatId is missing`() = runTest {
+    fun `Selected with one chat does nothing when chatId is missing`() = runTest {
         val chatUrl = "https://duckduckgo.com/?ia=chat"
         whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
 
-        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(setOf(chatUrl))))
 
         verify(duckChatDeleter, never()).deleteChat(any())
         verify(syncEngine, never()).triggerSync(any())
     }
 
     @Test
-    fun `deleteSingleChat does not record sync when deletion fails`() = runTest {
+    fun `Selected with one chat does not record sync when deletion fails`() = runTest {
         val chatUrl = "https://duckduckgo.com/?ia=chat&chatID=abc-123"
         whenever(duckChat.isDuckChatUrl(Uri.parse(chatUrl))).thenReturn(true)
         whenever(duckChatDeleter.deleteChat("abc-123")).thenReturn(false)
 
-        plugin.onClearData(setOf(ClearableData.DuckChats.Single(chatUrl)))
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(setOf(chatUrl))))
 
         verify(duckChatDeleter).deleteChat("abc-123")
+        verify(duckChatSyncRepository, never()).recordSingleChatDeletion(any())
+        verify(syncEngine, never()).triggerSync(any())
+    }
+
+    @Test
+    fun `Selected deletes each chat in the set and records per-chat sync deletions`() = runTest {
+        whenever(duckChat.isDuckChatUrl(eq(Uri.parse("https://duck.ai?chatID=alpha")))).thenReturn(true)
+        whenever(duckChat.isDuckChatUrl(eq(Uri.parse("https://duck.ai?chatID=beta")))).thenReturn(true)
+        whenever(duckChatDeleter.deleteChat("alpha")).thenReturn(true)
+        whenever(duckChatDeleter.deleteChat("beta")).thenReturn(true)
+
+        plugin.onClearData(
+            setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai?chatID=alpha", "https://duck.ai?chatID=beta"))),
+        )
+
+        verify(duckChatDeleter).deleteChat("alpha")
+        verify(duckChatDeleter).deleteChat("beta")
+        verify(duckChatSyncRepository).recordSingleChatDeletion("alpha")
+        verify(duckChatSyncRepository).recordSingleChatDeletion("beta")
+        // Batched sync trigger — one event for the whole subset, not one per chat.
+        verify(syncEngine, times(1)).triggerSync(any())
+    }
+
+    @Test
+    fun `Selected does not call deleteAllChats`() = runTest {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        whenever(duckChatDeleter.deleteChat(any())).thenReturn(true)
+
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(setOf("https://duck.ai?chatID=x"))))
+
+        verify(duckChatDeleter, never()).deleteAllChats()
+    }
+
+    @Test
+    fun `Selected with empty url set is a no-op`() = runTest {
+        plugin.onClearData(setOf(ClearableData.DuckChats.Selected(emptySet())))
+
+        verify(duckChatDeleter, never()).deleteChat(any())
         verify(duckChatSyncRepository, never()).recordSingleChatDeletion(any())
         verify(syncEngine, never()).triggerSync(any())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214837464091621 

### Description

Merges `ClearableData.DuckChats.Single(chatUrl: String)` into a new `Selected(chatUrls: Set<String>)` variant in `:data-clearing-api`.

### Steps to test this PR

_Existing in-chat fire flow is unchanged_
- [ ] Open a Duck.ai chat tab, send a message so it has a `chatID=` URL.
- [ ] Tap the fire button → confirm. The tab should be replaced with a fresh new-chat URL, and the deleted chat should no longer appear in chat history.

_Contextual chat clear is unchanged_
- [ ] Open an input-screen contextual chat tied to a tab, then trigger a single-tab fire on that tab. Both the tab's Duck.ai URL chat and the contextual chat should be deleted.

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the data-clearing API and DuckChat clearing plugin to accept sets of chat URLs, which could affect chat deletion/sync triggering if callers pass unexpected URLs or empty sets.
> 
> **Overview**
> **Duck.ai chat clearing now supports subsets of chats instead of only a single URL.** `ClearableData.DuckChats.Single` is replaced by `ClearableData.DuckChats.Selected(Set<String>)`, and call sites (e.g., single-tab fire/contextual chat clear) now pass `setOf(tabUrl)`.
> 
> The DuckChat data-clearing plugin is updated to delete each selected chat, record per-chat deletions for sync, and **batch sync triggering to a single `DATA_CHANGE` event** for the whole selection; tests are updated/expanded to cover multi-delete and empty-set no-op behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42023af1dc0d7d8decbe565226f4679101ef9e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->