### PR TITLE
Hide toggle in contextual sheet native input widget

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -237,6 +237,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var pendingFilePickerCallback: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
     private var pendingIsDuckAiMode: Boolean = false
 
+    // True when this widget instance hosts the contextual sheet. Set in configureContextual();
+    // never reset. Used to prevent the shared per-tab NativeInputStateProvider from leaking
+    // BROWSER-state mutations from the main widget into the contextual UI: both widgets
+    // observe the same `tabId` slot, so the contextual widget can briefly receive a state
+    // with inputContext=BROWSER and toggleVisible=true/false that would otherwise show the
+    // toggle row and reset the parent card's corners.
+    private var isContextualWidget: Boolean = false
+
     private var attachmentView: AttachmentView? = null
 
     override fun onAttachedToWindow() {
@@ -431,7 +439,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyToggleVisibility(visible: Boolean) {
-        findViewById<View?>(R.id.inputModeSwitchRow)?.visibility = if (visible) VISIBLE else GONE
+        // Contextual sheet always hides the toggle row, regardless of what state the per-tab
+        // store emits — the main widget can publish toggleVisible=true for the same tabId.
+        val effective = visible && !isContextualWidget
+        findViewById<View?>(R.id.inputModeSwitchRow)?.visibility = if (effective) VISIBLE else GONE
     }
 
     private fun applyVerticalPaddingForFocus() {
@@ -749,6 +760,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun configureContextual(tabId: String) {
         activeTabId = tabId
         pendingIsDuckAiMode = true
+        isContextualWidget = true
         doOnAttach {
             viewModel.configureContextual(tabId)
             observeNativeInputState()
@@ -766,6 +778,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyOmnibarShape() {
+        // The contextual sheet's parent card has a top-only rounded shape applied by
+        // ContextualNativeInputManager.applyCardShape(); never overwrite it from here. The
+        // shared per-tab state store can briefly emit a BROWSER state with toggleVisible=false
+        // (e.g. SEARCH_ONLY users when the main widget publishes first), which would otherwise
+        // fall through and reset card.radius to largeShapeCornerRadius on all four corners.
+        if (isContextualWidget) return
         val state = nativeInputState ?: return
         if (state.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) return
         if (state.isBottom) return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214837570101572

### Description

When the contextual Duck.ai sheet opens with the native input widget enabled, the Search/Duck.ai toggle row briefly shows before being hidden — and on some users (typically `SEARCH_ONLY` mode) it stays visible. Regression after the per-tab `NativeInputStateProvider` landed: the contextual widget subscribes to the same `tabId` slot as the main browser widget, so it observes a state with `inputContext = BROWSER` and `toggleVisible = true/false` published by the main widget.

This change adds a `private var isContextualWidget: Boolean` on `NativeInputModeWidget`, set from `configureContextual()`. It is then used to:
- Force `applyToggleVisibility` to GONE, regardless of the observed state.
- Short-circuit `applyOmnibarShape` so it does not mutate the parent `contextualNativeInputCard`'s shape (otherwise a `BROWSER`/`toggleVisible=false` emission would override `ContextualNativeInputManager.applyCardShape`'s top-only rounded corners).

The underlying shared-store race and the contextual sheet's outer visual treatment are not in scope here — this is the minimal scoped fix to get the toggle hidden.

### Steps to test this PR

_Toggle hidden in contextual sheet_
- [x] Install internal build with native input enabled.
- [x] Open the browser, navigate to a page.
- [x] Open the Duck.ai contextual sheet (e.g. from the page-context entry point).
- [x] Verify the Search/Duck.ai toggle row is **not** visible inside the sheet.
- [x] Switch the input-screen setting off (`SEARCH_ONLY` mode) and repeat. Toggle still hidden.
- [x] Close the sheet and reopen it. Toggle still hidden.

_No regression in browser / full-screen Duck.ai_
- [x] In the main browser omnibar with native input, verify the toggle still appears as before (when applicable).
- [ ] Open full-screen Duck.ai mode, verify the toggle still appears as before.

### UI changes
| Before  | After |
| ------ | ----- |
| Toggle row briefly/persistently visible inside the contextual sheet | Toggle row hidden, sheet shows only the Duck.ai input |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UI-only change that gates toggle visibility and shape mutations when the widget is used in the contextual sheet; main risk is unintended suppression of the toggle if the contextual flag is set incorrectly.
> 
> **Overview**
> Prevents the Search/Duck.ai toggle row from appearing in the Duck.ai contextual sheet by marking `NativeInputModeWidget` instances created via `configureContextual()` and forcing `applyToggleVisibility` to hide the toggle regardless of per-tab state emissions.
> 
> Also skips `applyOmnibarShape()` for contextual widgets so shared `NativeInputStateProvider` updates from the main browser widget can’t override the contextual sheet card’s rounded-corner styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5465aabb5921d6779f7ea7378d6118058f6c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->