### PR TITLE
Update PIR broker bundle - 2026-05-18

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/publicdatacheck.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicdatacheck.com.json
@@ -1,9 +1,10 @@
 {
-  "name": "SpyFly",
-  "url": "spyfly.com",
-  "version": "0.8.0",
-  "addedDatetime": 1775214750818,
-  "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
+  "name": "Public Data Check",
+  "url": "publicdatacheck.com",
+  "version": "0.2.0",
+  "parent": "spyfly.com",
+  "addedDatetime": 1778777242134,
+  "optOutUrl": "https://www.publicdatacheck.com/help-center/privacy-requests",
   "steps": [
     {
       "stepType": "scan",
@@ -11,8 +12,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "192af9bf-ba6f-4fb3-9bda-c72f8b489f8e"
+          "url": "https://www.publicdatacheck.com/help-center/privacy-requests",
+          "id": "16b8ebc5-afbe-4309-8677-d50f2ddac56d"
         },
         {
           "actionType": "expectation",
@@ -22,7 +23,7 @@
               "selector": ".main"
             }
           ],
-          "id": "9423632f-b0d0-4d66-be94-4fbb23085e9d"
+          "id": "f0abc890-b94a-436a-badb-01fa5c2c022a"
         },
         {
           "actionType": "fillForm",
@@ -35,7 +36,6 @@
             },
             {
               "type": "lastName",
-              "_comment": "This input doesn't follow the same id pattern as the rest",
               "selector": ".//input[@placeholder='Last Name']"
             },
             {
@@ -55,19 +55,18 @@
               "selector": "#age"
             }
           ],
-          "id": "97679943-0b17-41e7-9916-6774a8163bc3"
+          "id": "19920e38-7265-4bc5-857e-c0cc4a33a4df"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "_comment": "Ensure the captcha checkbox is checked before proceeding",
               "selector": ".//input[@name='cf-turnstile-response' and @value and @value != '']",
               "parent": ".form__captcha"
             }
           ],
-          "id": "04d2e2c3-688c-486a-8c4d-920d31c4677f"
+          "id": "dbb50c04-48e9-4039-98fe-92880cb9a44b"
         },
         {
           "actionType": "click",
@@ -77,10 +76,9 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "b5774ac1-d743-490c-b738-f9a70b63ada5"
+          "id": "a7024123-d145-40f5-a98d-e18f444ce76d"
         },
         {
-          "_comment": "After Continue, the email verification page loads.",
           "actionType": "expectation",
           "expectations": [
             {
@@ -88,12 +86,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a5ffc9fd-1ddf-4f5f-8c91-37db9f142ab5"
+          "id": "753ab729-85cb-42c9-97e1-00ca23079920"
         },
         {
-          "_comment": "Generate a disposable email address before filling the email field",
           "actionType": "generateEmail",
-          "id": "63c07f1a-fa0c-4c64-a516-4e9701a209cc"
+          "id": "88b47f1d-af9a-46b2-be49-3151854b8557"
         },
         {
           "actionType": "fillForm",
@@ -105,10 +102,9 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a63daf34-fd46-46b9-abeb-ea54c0b65494"
+          "id": "9e16ba9a-f5f3-46b1-8afd-e1849d560c3c"
         },
         {
-          "_comment": "Wait for Turnstile on email page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -117,10 +113,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "fbe8687d-caf5-48c7-9572-4401141e1cf7"
+          "id": "56cd0d0d-22dd-43f8-a65e-1513831a77b6"
         },
         {
-          "_comment": "Submit the email",
           "actionType": "click",
           "elements": [
             {
@@ -128,17 +123,15 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "38d0e82c-5d6e-4c69-8695-17b957537854"
+          "id": "27667068-ca68-4f68-9be2-55c53d87a05c"
         },
         {
-          "_comment": "SpyFly sends a verification code to the generated email. Poll the backend until it arrives.",
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "6d78ef56-d2cb-4ba2-b521-0d0127cbfe48"
+          "id": "447885fc-609b-4a02-a45d-ea0372a02cc7"
         },
         {
-          "_comment": "Wait for the verification code page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -146,10 +139,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d25356d5-1585-40bb-99f0-b31f5b8f8558"
+          "id": "673fb221-a548-4e64-ac4e-9016555de3f1"
         },
         {
-          "_comment": "Fill the verification code from the email",
           "actionType": "fillForm",
           "selector": ".form-contact-help form",
           "dataSource": "emailData",
@@ -159,10 +151,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d032386d-3cec-4598-b154-9ebe0689bbc3"
+          "id": "3428b55b-53d8-47eb-82cc-6024601dd5a2"
         },
         {
-          "_comment": "Wait for Turnstile on verification code page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -171,10 +162,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "bd28f924-1c63-4e4b-9107-bf414a51146d"
+          "id": "bdf95164-b8e9-4043-a58e-65de0d900666"
         },
         {
-          "_comment": "Submit the verification code",
           "actionType": "click",
           "elements": [
             {
@@ -182,10 +172,9 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "386c4ff6-c057-4d8e-a587-f7de9832882c"
+          "id": "27c4e3f5-8dfa-45e3-aa6f-90b68b1f160d"
         },
         {
-          "_comment": "Wait for the results page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -194,7 +183,7 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "90deb9b3-42b1-4377-be87-f7da82c07f9d"
+          "id": "33a52736-da2d-4292-92d4-ba485711743f"
         },
         {
           "actionType": "extract",
@@ -220,7 +209,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "22b645d1-9504-4350-8031-0fa8268e4a2e"
+          "id": "a6bf4ba0-21f9-4428-a724-038e07db4cc1"
         }
       ]
     },
@@ -230,8 +219,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "bfb6652e-20d1-4b5b-9123-ae234fe1c48d"
+          "url": "https://www.publicdatacheck.com/help-center/privacy-requests",
+          "id": "24d46c0d-da23-4606-8880-9383ede6b0fb"
         },
         {
           "actionType": "expectation",
@@ -241,7 +230,7 @@
               "selector": ".main"
             }
           ],
-          "id": "928fdd3b-69c8-48f2-9d52-6f30a82a0bbc"
+          "id": "71509921-e351-4b33-a018-41e84645308b"
         },
         {
           "actionType": "fillForm",
@@ -273,7 +262,7 @@
               "selector": "#age"
             }
           ],
-          "id": "098032c0-d8c0-40b3-b9f1-d9a4883fc338"
+          "id": "30e8042e-e085-4358-bfca-82b72c8db0b8"
         },
         {
           "actionType": "expectation",
@@ -284,7 +273,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "3aa26942-a743-49a4-ad5e-277ee726ac2e"
+          "id": "7771e80f-1465-46e5-8783-0c97adb91bd1"
         },
         {
           "actionType": "click",
@@ -294,7 +283,7 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "6b012cd0-d1e7-4969-a24d-05be01123084"
+          "id": "96d21d70-729e-40e4-9d6d-6804a996272b"
         },
         {
           "actionType": "expectation",
@@ -304,11 +293,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a540257d-17ff-4c31-b0ce-6bf0934ba503"
+          "id": "95405418-3e85-4493-ac22-067d2c2ba73a"
         },
         {
           "actionType": "generateEmail",
-          "id": "82af023b-7bd8-449d-94a6-449ec2144882"
+          "id": "2a05a32e-d57d-48eb-a305-eda6204967a9"
         },
         {
           "actionType": "fillForm",
@@ -320,7 +309,7 @@
               "selector": "#email-address"
             }
           ],
-          "id": "b2129acb-6d7b-4e9a-8a15-1692f897f0a3"
+          "id": "a4cd4034-75a0-45b7-9765-2e6d18705daf"
         },
         {
           "actionType": "expectation",
@@ -331,7 +320,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "d5adefdd-b519-414a-b4d3-424000bed137"
+          "id": "7491c371-48f3-4c0b-b173-7814f4c90cb7"
         },
         {
           "actionType": "click",
@@ -341,13 +330,13 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "8056bd39-9db2-4ddf-bd7b-f138171821ca"
+          "id": "c3593195-abfa-4492-8a60-e6947777e787"
         },
         {
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "08f0eddc-1ade-4a57-85e9-d51f8175245e"
+          "id": "594bdae7-693a-42a3-8775-2622faee55e2"
         },
         {
           "actionType": "expectation",
@@ -357,7 +346,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "50ca8d93-c3b5-4cc3-a43b-5e24667df7df"
+          "id": "88e0bbd7-4779-44f5-a40b-a4feb6f18b54"
         },
         {
           "actionType": "fillForm",
@@ -369,7 +358,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "a94edfa1-9bc3-4c93-8dbe-bb98d7d25613"
+          "id": "58950ae1-62a7-4e4b-b933-bf1b4e7f79fd"
         },
         {
           "actionType": "expectation",
@@ -380,7 +369,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "66fff0ae-7f55-4560-9d54-d29404536e92"
+          "id": "8c5a9fe9-359d-4bcd-ba05-3a687ad7df39"
         },
         {
           "actionType": "click",
@@ -390,7 +379,7 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "6807275b-f28c-4c9b-afcf-4bccefc28ca5"
+          "id": "f27b0dae-cfcc-473e-be5c-a420177a8819"
         },
         {
           "actionType": "expectation",
@@ -401,10 +390,9 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "9a5f702f-2218-4090-9bf9-b9182df979b6"
+          "id": "73cc7194-1dd7-4630-b2f6-88fde48f7bcb"
         },
         {
-          "_comment": "Click Remove on the matched profile using profileMatch",
           "actionType": "click",
           "elements": [
             {
@@ -430,7 +418,7 @@
               }
             }
           ],
-          "id": "eab75fe5-15be-429d-98ce-10f206759066"
+          "id": "fafc1b71-7f82-435b-822e-1dde6689bcb8"
         },
         {
           "actionType": "expectation",
@@ -441,16 +429,14 @@
               "expect": "Request Submitted"
             }
           ],
-          "id": "798a9f5a-1e55-4541-b729-9b8544e003d6"
+          "id": "d049175b-e41a-4736-ba29-29b60d2d2788"
         },
         {
-          "_comment": "SpyFly sends a confirmation link. Decoupled: native releases the webview and picks up the link later.",
           "actionType": "emailConfirmation",
           "pollingTime": 30,
-          "id": "dce5999c-ad7a-4050-b92f-8bc4e945e68d"
+          "id": "d3bc1138-c001-49a5-a908-a8be6b0c4db3"
         },
         {
-          "_comment": "After clicking the confirmation link, verify the success page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -459,7 +445,7 @@
               "expect": "Verification Complete"
             }
           ],
-          "id": "7d78b439-ce6e-4660-b20a-04d10ca817bc"
+          "id": "355d44c5-22f4-4120-bb5d-0f4a51d05e70"
         }
       ]
     }

--- a/pir/pir-impl/src/main/assets/brokers/publicrecordreports.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicrecordreports.com.json
@@ -1,9 +1,10 @@
 {
-  "name": "SpyFly",
-  "url": "spyfly.com",
-  "version": "0.8.0",
-  "addedDatetime": 1775214750818,
-  "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
+  "name": "Public Record Reports",
+  "url": "publicrecordreports.com",
+  "version": "0.2.0",
+  "parent": "spyfly.com",
+  "addedDatetime": 1778777242134,
+  "optOutUrl": "https://www.publicrecordreports.com/help-center/privacy-requests",
   "steps": [
     {
       "stepType": "scan",
@@ -11,8 +12,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "192af9bf-ba6f-4fb3-9bda-c72f8b489f8e"
+          "url": "https://www.publicrecordreports.com/help-center/privacy-requests",
+          "id": "ffe7e4bc-b43a-44cb-a532-126a00a326ec"
         },
         {
           "actionType": "expectation",
@@ -22,7 +23,7 @@
               "selector": ".main"
             }
           ],
-          "id": "9423632f-b0d0-4d66-be94-4fbb23085e9d"
+          "id": "ee227ef6-7fa6-412d-9fc2-1ac80f8121ff"
         },
         {
           "actionType": "fillForm",
@@ -35,7 +36,6 @@
             },
             {
               "type": "lastName",
-              "_comment": "This input doesn't follow the same id pattern as the rest",
               "selector": ".//input[@placeholder='Last Name']"
             },
             {
@@ -55,19 +55,18 @@
               "selector": "#age"
             }
           ],
-          "id": "97679943-0b17-41e7-9916-6774a8163bc3"
+          "id": "8f1c1b5b-fc29-4606-9b6c-462c5ad8e962"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "_comment": "Ensure the captcha checkbox is checked before proceeding",
               "selector": ".//input[@name='cf-turnstile-response' and @value and @value != '']",
               "parent": ".form__captcha"
             }
           ],
-          "id": "04d2e2c3-688c-486a-8c4d-920d31c4677f"
+          "id": "3a1f60ab-5ca3-4743-9bd0-ce948d3b9166"
         },
         {
           "actionType": "click",
@@ -77,10 +76,9 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "b5774ac1-d743-490c-b738-f9a70b63ada5"
+          "id": "d8da8542-9913-4a27-a291-ae91a01b47ac"
         },
         {
-          "_comment": "After Continue, the email verification page loads.",
           "actionType": "expectation",
           "expectations": [
             {
@@ -88,12 +86,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a5ffc9fd-1ddf-4f5f-8c91-37db9f142ab5"
+          "id": "89f2b451-846d-46fe-8d5a-6e85f796f859"
         },
         {
-          "_comment": "Generate a disposable email address before filling the email field",
           "actionType": "generateEmail",
-          "id": "63c07f1a-fa0c-4c64-a516-4e9701a209cc"
+          "id": "6ced2fc6-0c4c-4187-8a8f-47d5283c84ea"
         },
         {
           "actionType": "fillForm",
@@ -105,10 +102,9 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a63daf34-fd46-46b9-abeb-ea54c0b65494"
+          "id": "3711bff9-3de8-401b-99cf-dc006ede18f9"
         },
         {
-          "_comment": "Wait for Turnstile on email page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -117,10 +113,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "fbe8687d-caf5-48c7-9572-4401141e1cf7"
+          "id": "254a2f5b-dc24-4efe-88c6-11666a8dfadc"
         },
         {
-          "_comment": "Submit the email",
           "actionType": "click",
           "elements": [
             {
@@ -128,17 +123,15 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "38d0e82c-5d6e-4c69-8695-17b957537854"
+          "id": "5fcf3918-c648-48f6-a897-1692234a5695"
         },
         {
-          "_comment": "SpyFly sends a verification code to the generated email. Poll the backend until it arrives.",
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "6d78ef56-d2cb-4ba2-b521-0d0127cbfe48"
+          "id": "854a3430-be71-47a7-bc67-90406d7e90cd"
         },
         {
-          "_comment": "Wait for the verification code page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -146,10 +139,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d25356d5-1585-40bb-99f0-b31f5b8f8558"
+          "id": "3047d132-bae5-4c43-81e7-889a2ead2486"
         },
         {
-          "_comment": "Fill the verification code from the email",
           "actionType": "fillForm",
           "selector": ".form-contact-help form",
           "dataSource": "emailData",
@@ -159,10 +151,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d032386d-3cec-4598-b154-9ebe0689bbc3"
+          "id": "4fc6d8f6-0b8e-4e54-b4ee-27f35d969cd0"
         },
         {
-          "_comment": "Wait for Turnstile on verification code page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -171,10 +162,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "bd28f924-1c63-4e4b-9107-bf414a51146d"
+          "id": "4368046d-2d4f-43b0-8439-a09543ab5413"
         },
         {
-          "_comment": "Submit the verification code",
           "actionType": "click",
           "elements": [
             {
@@ -182,10 +172,9 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "386c4ff6-c057-4d8e-a587-f7de9832882c"
+          "id": "ae49542f-89bb-4e5c-9fce-95c7d41d7356"
         },
         {
-          "_comment": "Wait for the results page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -194,7 +183,7 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "90deb9b3-42b1-4377-be87-f7da82c07f9d"
+          "id": "779ec355-552e-4da1-b7fb-b746bbd3d395"
         },
         {
           "actionType": "extract",
@@ -220,7 +209,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "22b645d1-9504-4350-8031-0fa8268e4a2e"
+          "id": "d82b5b92-310c-42be-b9f1-ae01c2a0e7c6"
         }
       ]
     },
@@ -230,8 +219,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "bfb6652e-20d1-4b5b-9123-ae234fe1c48d"
+          "url": "https://www.publicrecordreports.com/help-center/privacy-requests",
+          "id": "4a168bc3-8530-46f4-949d-7bddedb1b43d"
         },
         {
           "actionType": "expectation",
@@ -241,7 +230,7 @@
               "selector": ".main"
             }
           ],
-          "id": "928fdd3b-69c8-48f2-9d52-6f30a82a0bbc"
+          "id": "48c0af01-182c-49a9-a4f1-2e9caa04bfb7"
         },
         {
           "actionType": "fillForm",
@@ -273,7 +262,7 @@
               "selector": "#age"
             }
           ],
-          "id": "098032c0-d8c0-40b3-b9f1-d9a4883fc338"
+          "id": "0edc6f09-eed8-4334-9ed0-cd8848b925c3"
         },
         {
           "actionType": "expectation",
@@ -284,7 +273,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "3aa26942-a743-49a4-ad5e-277ee726ac2e"
+          "id": "9da356d2-e068-4b7c-aa66-48de9a707276"
         },
         {
           "actionType": "click",
@@ -294,7 +283,7 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "6b012cd0-d1e7-4969-a24d-05be01123084"
+          "id": "a4260025-dc5b-4728-a889-e41e902899f0"
         },
         {
           "actionType": "expectation",
@@ -304,11 +293,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a540257d-17ff-4c31-b0ce-6bf0934ba503"
+          "id": "8442cd28-1a3a-4334-add7-8149b6fdc0c9"
         },
         {
           "actionType": "generateEmail",
-          "id": "82af023b-7bd8-449d-94a6-449ec2144882"
+          "id": "97db03ed-205b-4950-b72f-19cea4652ece"
         },
         {
           "actionType": "fillForm",
@@ -320,7 +309,7 @@
               "selector": "#email-address"
             }
           ],
-          "id": "b2129acb-6d7b-4e9a-8a15-1692f897f0a3"
+          "id": "c81d58ad-7b62-451b-ab0c-b8965df42450"
         },
         {
           "actionType": "expectation",
@@ -331,7 +320,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "d5adefdd-b519-414a-b4d3-424000bed137"
+          "id": "f60bfbfd-becf-4bc9-9223-3be2b4f55c52"
         },
         {
           "actionType": "click",
@@ -341,13 +330,13 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "8056bd39-9db2-4ddf-bd7b-f138171821ca"
+          "id": "77325f49-c7d3-4cbd-b2d5-0a82978391c7"
         },
         {
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "08f0eddc-1ade-4a57-85e9-d51f8175245e"
+          "id": "07950f37-d242-424c-874a-9beea55c4a94"
         },
         {
           "actionType": "expectation",
@@ -357,7 +346,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "50ca8d93-c3b5-4cc3-a43b-5e24667df7df"
+          "id": "7506729a-2dd5-4b71-8c93-9d0c5a179609"
         },
         {
           "actionType": "fillForm",
@@ -369,7 +358,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "a94edfa1-9bc3-4c93-8dbe-bb98d7d25613"
+          "id": "a334df44-13f7-4fec-85ef-d75cc6962eba"
         },
         {
           "actionType": "expectation",
@@ -380,7 +369,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "66fff0ae-7f55-4560-9d54-d29404536e92"
+          "id": "f046b61b-c5ad-4d09-a64b-3618f34d9897"
         },
         {
           "actionType": "click",
@@ -390,7 +379,7 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "6807275b-f28c-4c9b-afcf-4bccefc28ca5"
+          "id": "bff6572f-7051-4122-a208-d5da8327cfe2"
         },
         {
           "actionType": "expectation",
@@ -401,10 +390,9 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "9a5f702f-2218-4090-9bf9-b9182df979b6"
+          "id": "33a8ae87-e54f-4ac5-8ae8-9cd2020bf249"
         },
         {
-          "_comment": "Click Remove on the matched profile using profileMatch",
           "actionType": "click",
           "elements": [
             {
@@ -430,7 +418,7 @@
               }
             }
           ],
-          "id": "eab75fe5-15be-429d-98ce-10f206759066"
+          "id": "c4e9cab3-95fb-4895-a2a5-499a04a8e3c6"
         },
         {
           "actionType": "expectation",
@@ -441,16 +429,14 @@
               "expect": "Request Submitted"
             }
           ],
-          "id": "798a9f5a-1e55-4541-b729-9b8544e003d6"
+          "id": "96d66bd9-970e-4b5a-aa9e-6c1f602d489a"
         },
         {
-          "_comment": "SpyFly sends a confirmation link. Decoupled: native releases the webview and picks up the link later.",
           "actionType": "emailConfirmation",
           "pollingTime": 30,
-          "id": "dce5999c-ad7a-4050-b92f-8bc4e945e68d"
+          "id": "5f4cfdfa-33c5-4a30-bd67-ae2244171272"
         },
         {
-          "_comment": "After clicking the confirmation link, verify the success page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -459,7 +445,7 @@
               "expect": "Verification Complete"
             }
           ],
-          "id": "7d78b439-ce6e-4660-b20a-04d10ca817bc"
+          "id": "38be83f0-c7e6-416a-87f9-5af3cee7e2f7"
         }
       ]
     }

--- a/pir/pir-impl/src/main/assets/brokers/searchpublicrecords.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/searchpublicrecords.com.json
@@ -1,9 +1,10 @@
 {
-  "name": "SpyFly",
-  "url": "spyfly.com",
-  "version": "0.8.0",
-  "addedDatetime": 1775214750818,
-  "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
+  "name": "Search Public Records",
+  "url": "searchpublicrecords.com",
+  "version": "0.2.0",
+  "parent": "spyfly.com",
+  "addedDatetime": 1778777242134,
+  "optOutUrl": "https://www.searchpublicrecords.com/help-center/privacy-requests",
   "steps": [
     {
       "stepType": "scan",
@@ -11,8 +12,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "192af9bf-ba6f-4fb3-9bda-c72f8b489f8e"
+          "url": "https://www.searchpublicrecords.com/help-center/privacy-requests",
+          "id": "9cee62c2-0d49-4502-9005-25134b2c5385"
         },
         {
           "actionType": "expectation",
@@ -22,7 +23,7 @@
               "selector": ".main"
             }
           ],
-          "id": "9423632f-b0d0-4d66-be94-4fbb23085e9d"
+          "id": "3207a4fd-45e1-4697-ae71-6e28f2cd9421"
         },
         {
           "actionType": "fillForm",
@@ -35,7 +36,6 @@
             },
             {
               "type": "lastName",
-              "_comment": "This input doesn't follow the same id pattern as the rest",
               "selector": ".//input[@placeholder='Last Name']"
             },
             {
@@ -55,19 +55,18 @@
               "selector": "#age"
             }
           ],
-          "id": "97679943-0b17-41e7-9916-6774a8163bc3"
+          "id": "6fe0aba6-b3d5-4b01-b7a1-26c44766a665"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "_comment": "Ensure the captcha checkbox is checked before proceeding",
               "selector": ".//input[@name='cf-turnstile-response' and @value and @value != '']",
               "parent": ".form__captcha"
             }
           ],
-          "id": "04d2e2c3-688c-486a-8c4d-920d31c4677f"
+          "id": "ce7a8410-4bc3-4861-ba39-8cc82257a27b"
         },
         {
           "actionType": "click",
@@ -77,10 +76,9 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "b5774ac1-d743-490c-b738-f9a70b63ada5"
+          "id": "9d25315b-0bed-485a-b47f-df7afcec931c"
         },
         {
-          "_comment": "After Continue, the email verification page loads.",
           "actionType": "expectation",
           "expectations": [
             {
@@ -88,12 +86,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a5ffc9fd-1ddf-4f5f-8c91-37db9f142ab5"
+          "id": "6454b894-34df-4008-bb23-4f99c8487b7a"
         },
         {
-          "_comment": "Generate a disposable email address before filling the email field",
           "actionType": "generateEmail",
-          "id": "63c07f1a-fa0c-4c64-a516-4e9701a209cc"
+          "id": "c8676bdf-aabd-4e6d-95c8-14bc5d60fc71"
         },
         {
           "actionType": "fillForm",
@@ -105,10 +102,9 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a63daf34-fd46-46b9-abeb-ea54c0b65494"
+          "id": "60df1331-796a-4bfa-8946-f770e672f8b6"
         },
         {
-          "_comment": "Wait for Turnstile on email page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -117,10 +113,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "fbe8687d-caf5-48c7-9572-4401141e1cf7"
+          "id": "cf01a15b-6795-4c25-85e9-ced3faf6cdc5"
         },
         {
-          "_comment": "Submit the email",
           "actionType": "click",
           "elements": [
             {
@@ -128,17 +123,15 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "38d0e82c-5d6e-4c69-8695-17b957537854"
+          "id": "99cc63dd-9800-4834-bb9a-3e43367fcfc5"
         },
         {
-          "_comment": "SpyFly sends a verification code to the generated email. Poll the backend until it arrives.",
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "6d78ef56-d2cb-4ba2-b521-0d0127cbfe48"
+          "id": "806e6680-976f-499b-9cf8-4c2c4d5e38f8"
         },
         {
-          "_comment": "Wait for the verification code page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -146,10 +139,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d25356d5-1585-40bb-99f0-b31f5b8f8558"
+          "id": "de47c115-c2cc-42cf-8952-17449764ea61"
         },
         {
-          "_comment": "Fill the verification code from the email",
           "actionType": "fillForm",
           "selector": ".form-contact-help form",
           "dataSource": "emailData",
@@ -159,10 +151,9 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "d032386d-3cec-4598-b154-9ebe0689bbc3"
+          "id": "c828d71d-c668-4418-8bdc-a0b01e863738"
         },
         {
-          "_comment": "Wait for Turnstile on verification code page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -171,10 +162,9 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "bd28f924-1c63-4e4b-9107-bf414a51146d"
+          "id": "5f679b57-8cd1-470c-a188-2b8d4cd6bfcb"
         },
         {
-          "_comment": "Submit the verification code",
           "actionType": "click",
           "elements": [
             {
@@ -182,10 +172,9 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "386c4ff6-c057-4d8e-a587-f7de9832882c"
+          "id": "c11d7d2e-7c27-4f60-8707-02365a85e855"
         },
         {
-          "_comment": "Wait for the results page to load",
           "actionType": "expectation",
           "expectations": [
             {
@@ -194,7 +183,7 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "90deb9b3-42b1-4377-be87-f7da82c07f9d"
+          "id": "360ee431-61e6-459b-b2ac-6ff20bba97d3"
         },
         {
           "actionType": "extract",
@@ -220,7 +209,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "22b645d1-9504-4350-8031-0fa8268e4a2e"
+          "id": "92a8b30b-9a34-4fac-9c7c-b455368de5e2"
         }
       ]
     },
@@ -230,8 +219,8 @@
       "actions": [
         {
           "actionType": "navigate",
-          "url": "https://www.spyfly.com/help-center/privacy-requests",
-          "id": "bfb6652e-20d1-4b5b-9123-ae234fe1c48d"
+          "url": "https://www.searchpublicrecords.com/help-center/privacy-requests",
+          "id": "ad60964e-4d3d-46d1-8b8b-e267ac0d431a"
         },
         {
           "actionType": "expectation",
@@ -241,7 +230,7 @@
               "selector": ".main"
             }
           ],
-          "id": "928fdd3b-69c8-48f2-9d52-6f30a82a0bbc"
+          "id": "377a1f93-df7e-4808-8945-3db938c7ac08"
         },
         {
           "actionType": "fillForm",
@@ -273,7 +262,7 @@
               "selector": "#age"
             }
           ],
-          "id": "098032c0-d8c0-40b3-b9f1-d9a4883fc338"
+          "id": "a1618a70-6600-4688-a9ab-d7fa11919b92"
         },
         {
           "actionType": "expectation",
@@ -284,7 +273,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "3aa26942-a743-49a4-ad5e-277ee726ac2e"
+          "id": "64da1a53-1d1f-4976-ad22-56cacbe5fbd8"
         },
         {
           "actionType": "click",
@@ -294,7 +283,7 @@
               "selector": ".//button[@type='submit']"
             }
           ],
-          "id": "6b012cd0-d1e7-4969-a24d-05be01123084"
+          "id": "9ba3b743-6d35-48b6-bffc-2e39ff89e1ed"
         },
         {
           "actionType": "expectation",
@@ -304,11 +293,11 @@
               "selector": "#email-address"
             }
           ],
-          "id": "a540257d-17ff-4c31-b0ce-6bf0934ba503"
+          "id": "71b36e7a-9b97-462a-96d4-21a6d4b14231"
         },
         {
           "actionType": "generateEmail",
-          "id": "82af023b-7bd8-449d-94a6-449ec2144882"
+          "id": "f07e52fa-c752-41e8-ae71-4582d1162663"
         },
         {
           "actionType": "fillForm",
@@ -320,7 +309,7 @@
               "selector": "#email-address"
             }
           ],
-          "id": "b2129acb-6d7b-4e9a-8a15-1692f897f0a3"
+          "id": "f8352b96-f34c-4994-af27-669a40d0fe89"
         },
         {
           "actionType": "expectation",
@@ -331,7 +320,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "d5adefdd-b519-414a-b4d3-424000bed137"
+          "id": "809b813b-5d8b-44a6-be9d-4dbed3f2a37b"
         },
         {
           "actionType": "click",
@@ -341,13 +330,13 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "8056bd39-9db2-4ddf-bd7b-f138171821ca"
+          "id": "63f1a511-0b03-4cb8-9b83-2b464004bdf4"
         },
         {
           "actionType": "getEmailData",
           "pollingTime": 3,
           "extract": ["verificationCode"],
-          "id": "08f0eddc-1ade-4a57-85e9-d51f8175245e"
+          "id": "aa5548bc-b5fe-47eb-8477-39a30ae2ad80"
         },
         {
           "actionType": "expectation",
@@ -357,7 +346,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "50ca8d93-c3b5-4cc3-a43b-5e24667df7df"
+          "id": "b0642e59-c6be-4b50-aabf-8c2bbd900f08"
         },
         {
           "actionType": "fillForm",
@@ -369,7 +358,7 @@
               "selector": "#unique-code"
             }
           ],
-          "id": "a94edfa1-9bc3-4c93-8dbe-bb98d7d25613"
+          "id": "96e5ecf8-4fe3-43c7-97cb-310a1ffda4ba"
         },
         {
           "actionType": "expectation",
@@ -380,7 +369,7 @@
               "parent": ".form__captcha"
             }
           ],
-          "id": "66fff0ae-7f55-4560-9d54-d29404536e92"
+          "id": "64680a02-20b0-4c80-95cd-7549a612e3d8"
         },
         {
           "actionType": "click",
@@ -390,7 +379,7 @@
               "selector": "#continue-button"
             }
           ],
-          "id": "6807275b-f28c-4c9b-afcf-4bccefc28ca5"
+          "id": "a1f0bd70-266f-4282-9aa7-6bfad93ba668"
         },
         {
           "actionType": "expectation",
@@ -401,10 +390,9 @@
               "expect": "Select Data for Removal"
             }
           ],
-          "id": "9a5f702f-2218-4090-9bf9-b9182df979b6"
+          "id": "7d1c1518-979d-48fa-8a75-a11092143100"
         },
         {
-          "_comment": "Click Remove on the matched profile using profileMatch",
           "actionType": "click",
           "elements": [
             {
@@ -430,7 +418,7 @@
               }
             }
           ],
-          "id": "eab75fe5-15be-429d-98ce-10f206759066"
+          "id": "88d3f6b1-2352-4ff9-9c53-7b9bdc0eec4e"
         },
         {
           "actionType": "expectation",
@@ -441,16 +429,14 @@
               "expect": "Request Submitted"
             }
           ],
-          "id": "798a9f5a-1e55-4541-b729-9b8544e003d6"
+          "id": "ee12ec5d-7938-426c-9a5d-67b4a3dbf0ad"
         },
         {
-          "_comment": "SpyFly sends a confirmation link. Decoupled: native releases the webview and picks up the link later.",
           "actionType": "emailConfirmation",
           "pollingTime": 30,
-          "id": "dce5999c-ad7a-4050-b92f-8bc4e945e68d"
+          "id": "bb9ec21c-e631-4cc6-acd2-9a8fef716259"
         },
         {
-          "_comment": "After clicking the confirmation link, verify the success page",
           "actionType": "expectation",
           "expectations": [
             {
@@ -459,7 +445,7 @@
               "expect": "Verification Complete"
             }
           ],
-          "id": "7d78b439-ce6e-4660-b20a-04d10ca817bc"
+          "id": "b7e296ca-044f-4f73-b4f2-1328163c5d6b"
         }
       ]
     }

--- a/pir/pir-impl/src/main/assets/brokers/vehiclerelatedrecords.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/vehiclerelatedrecords.com.json
@@ -1,0 +1,63 @@
+{
+  "name": "Vehicle Related Records",
+  "url": "vehiclerelatedrecords.com",
+  "version": "0.4.0",
+  "parent": "spyfly.com",
+  "addedDatetime": 1778777242134,
+  "optOutUrl": "https://www.spyfly.com/help-center/privacy-requests",
+  "steps": [
+    {
+      "stepType": "scan",
+      "scanType": "templatedUrl",
+      "actions": [
+        {
+          "actionType": "navigate",
+          "url": "https://vehiclerelatedrecords.com/results.php?sptp=Drivers&sbid=Driving&first=${firstName}&last=${lastName}&city=${city}&state=${state}",
+          "id": "16fb97aa-59d4-4113-b1f7-85aac2fbf8f9"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "table.results-table"
+            }
+          ],
+          "id": "1ed7d7fb-d6a5-44b3-8755-a62cb0021aef"
+        },
+        {
+          "actionType": "extract",
+          "selector": "table.results-table tr.odd",
+          "noResultsSelector": "//span[contains(@class, 'search_title') and contains(., 'Your search was unsuccessful')]",
+          "profile": {
+            "name": {
+              "selector": "div.name"
+            },
+            "age": {
+              "selector": "td.hidden-xs"
+            },
+            "addressCityState": {
+              "selector": ".//td[5]"
+            },
+            "profileUrl": {
+              "identifierType": "hash"
+            }
+          },
+          "id": "e6d23772-0b90-4ce3-9381-9d6d39d4a84d"
+        }
+      ]
+    },
+    {
+      "stepType": "optOut",
+      "optOutType": "parentSiteOptOut",
+      "actions": []
+    }
+  ],
+  "schedulingConfig": {
+    "retryError": 48,
+    "confirmOptOutScan": 72,
+    "maintenanceScan": 120,
+    "maxAttempts": -1
+  },
+  "removedAt": null
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214874062712778?focus=true

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Added (4):**
- publicdatacheck.com.json
- publicrecordreports.com.json
- searchpublicrecords.com.json
- vehiclerelatedrecords.com.json
**Updated (1):**
- spyfly.com.json (0.7.0 → 0.8.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes broker automation configurations (selectors/flows) and adds new broker definitions, which can break scanning/opt-out runs if site markup differs from assumptions.
> 
> **Overview**
> Updates the PIR broker bundle with **four new broker definitions** (`publicdatacheck.com`, `publicrecordreports.com`, `searchpublicrecords.com`, and `vehiclerelatedrecords.com`), all modeled as SpyFly children (three with full form-based scan/opt-out flows; one delegating opt-out to the parent site).
> 
> Bumps `spyfly.com.json` from `0.7.0` to `0.8.0` and tweaks multiple page-header expectations to use the more specific selector `.section__head h1` for results/submission/verification steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7194513b1f45e225762722b44046654329ff21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->