### PR TITLE
Fire Mode: Tab data isolation

### DIFF
--- a/app/schemas/com.duckduckgo.app.fire.db.FireModeDatabase/1.json
+++ b/app/schemas/com.duckduckgo.app.fire.db.FireModeDatabase/1.json
@@ -1,0 +1,151 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "4f9dd3deac6cf6eb73062766547fb078",
+    "entities": [
+      {
+        "tableName": "tabs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tabId` TEXT NOT NULL, `url` TEXT, `title` TEXT, `skipHome` INTEGER NOT NULL, `viewed` INTEGER NOT NULL, `position` INTEGER NOT NULL, `tabPreviewFile` TEXT, `sourceTabId` TEXT, `deletable` INTEGER NOT NULL, `lastAccessTime` TEXT, PRIMARY KEY(`tabId`), FOREIGN KEY(`sourceTabId`) REFERENCES `tabs`(`tabId`) ON UPDATE SET NULL ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "skipHome",
+            "columnName": "skipHome",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewed",
+            "columnName": "viewed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreviewFile",
+            "columnName": "tabPreviewFile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceTabId",
+            "columnName": "sourceTabId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deletable",
+            "columnName": "deletable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessTime",
+            "columnName": "lastAccessTime",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tabId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tabs_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tabs_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "SET NULL",
+            "columns": [
+              "sourceTabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tab_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tabId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`tabId`) REFERENCES `tabs`(`tabId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabId",
+            "columnName": "tabId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tab_selection_tabId",
+            "unique": false,
+            "columnNames": [
+              "tabId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tab_selection_tabId` ON `${TABLE_NAME}` (`tabId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tabs",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tabId"
+            ],
+            "referencedColumns": [
+              "tabId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4f9dd3deac6cf6eb73062766547fb078')"
+    ]
+  }
+}

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
@@ -62,6 +62,14 @@ class DevTabsActivity : DuckDuckGoActivity() {
             viewModel.clearTabs()
         }
 
+        binding.addFireTabsButton.setOnClickListener {
+            viewModel.addFireTabs(binding.fireTabCount.text.toInt())
+        }
+
+        binding.clearFireTabsButton.setOnClickListener {
+            viewModel.clearFireTabs()
+        }
+
         binding.addBookmarksButton.setOnClickListener {
             viewModel.addBookmarks(binding.bookmarksCount.text.toInt())
         }
@@ -94,6 +102,7 @@ class DevTabsActivity : DuckDuckGoActivity() {
 
     private fun render(viewState: ViewState) {
         binding.tabCountHeader.text = getString(R.string.devSettingsTabsScreenHeader, viewState.tabCount)
+        binding.fireTabCountHeader.text = getString(R.string.devSettingsFireTabsScreenHeader, viewState.fireTabCount)
         binding.bookmarksCountHeader.text = getString(R.string.devSettingsTabsBookmarksScreenHeader, viewState.bookmarkCount)
         binding.favoritesCountHeader.text = getString(R.string.devSettingsTabsFavoritesScreenHeader, viewState.favoritesCount)
     }

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForBookmarks
 import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForFavorites
 import com.duckduckgo.app.tabs.model.TabDataRepository
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -74,12 +76,14 @@ private val randomUrls = listOf(
 @ContributesViewModel(ActivityScope::class)
 class DevTabsViewModel @Inject constructor(
     private val dispatcher: DispatcherProvider,
-    private val tabDataRepository: TabDataRepository,
+    @RegularMode private val tabDataRepository: TabDataRepository,
+    @FireMode private val fireTabDataRepository: TabDataRepository,
     private val savedSitesRepository: SavedSitesRepository,
 ) : ViewModel() {
 
     data class ViewState(
         val tabCount: Int = 0,
+        val fireTabCount: Int = 0,
         val bookmarkCount: Int = 0,
         val favoritesCount: Int = 0,
     )
@@ -94,6 +98,13 @@ class DevTabsViewModel @Inject constructor(
         tabDataRepository.flowTabs
             .onEach { tabs ->
                 _viewState.update { it.copy(tabCount = tabs.count()) }
+            }
+            .flowOn(dispatcher.io())
+            .launchIn(viewModelScope)
+
+        fireTabDataRepository.flowTabs
+            .onEach { tabs ->
+                _viewState.update { it.copy(fireTabCount = tabs.count()) }
             }
             .flowOn(dispatcher.io())
             .launchIn(viewModelScope)
@@ -127,6 +138,30 @@ class DevTabsViewModel @Inject constructor(
     fun clearTabs() {
         viewModelScope.launch(dispatcher.io()) {
             tabDataRepository.deleteAll()
+        }
+    }
+
+    fun addFireTabs(count: Int) {
+        viewModelScope.launch {
+            repeat(count) {
+                val randomIndex = randomUrls.indices.random()
+                fireTabDataRepository.add(
+                    url = randomUrls[randomIndex],
+                )
+            }
+        }
+    }
+
+    fun clearFireTabs() {
+        viewModelScope.launch(dispatcher.io()) {
+            // deleteAll() on the Fire instance fans out to shared singletons that aren't
+            // mode-aware yet (sessions, duck-chat, favicons, ad-click, native-input,
+            // preview persister, visited-sites). Until the Tabs.* clearing plugin lands,
+            // use per-tab deletion so only Fire-keyed entries are cleared.
+            val fireTabIds = fireTabDataRepository.getTabs().map { it.tabId }
+            if (fireTabIds.isNotEmpty()) {
+                fireTabDataRepository.deleteTabs(fireTabIds)
+            }
         }
     }
 

--- a/app/src/internal/res/layout/activity_dev_tabs.xml
+++ b/app/src/internal/res/layout/activity_dev_tabs.xml
@@ -105,6 +105,79 @@
             android:layout_height="8dp" />
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/fireTabCountHeader"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:gravity="center"
+            android:text="@string/devSettingsFireTabsScreenHeader"
+            app:typography="caption_allCaps" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/generateFireTabsItem"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toStartOf="@id/fireTabCount"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:primaryText="@string/devSettingsFireTabsScreenTabsToAdd" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/fireTabCount"
+                style="@style/Widget.DuckDuckGo.TextInput"
+                android:layout_width="72dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:gravity="center"
+                android:inputType="number"
+                android:text="100"
+                app:layout_constraintBottom_toBottomOf="@id/generateFireTabsItem"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/generateFireTabsItem"
+                app:layout_constraintTop_toTopOf="@id/generateFireTabsItem"
+                app:type="single_line"
+                tools:ignore="HardcodedText" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/addFireTabsButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsFireTabsScreenAddTabsButtonText"
+                app:daxButtonSize="large" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/clearFireTabsButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsFireTabsScreenClearTabsButtonText"
+                app:daxButtonSize="large" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/fireTabsFlowView"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/keyline_4"
+                app:constraint_referenced_ids="addFireTabsButton,clearFireTabsButton"
+                app:flow_horizontalStyle="spread"
+                app:flow_wrapMode="chain"
+                app:layout_constraintTop_toBottomOf="@id/generateFireTabsItem" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/bookmarksCountHeader"
             android:layout_width="match_parent"
             android:layout_height="48dp"

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -51,6 +51,10 @@
     <string name="devSettingsTabsScreenTabsToAdd">Tabs to add</string>
     <string name="devSettingsTabsScreenAddTabsButtonText">Add Tabs</string>
     <string name="devSettingsTabsScreenClearTabsButtonText">Clear Tabs</string>
+    <string name="devSettingsFireTabsScreenHeader" instruction="Not translated">Current fire tab count: %1$d</string>
+    <string name="devSettingsFireTabsScreenTabsToAdd">Fire tabs to add</string>
+    <string name="devSettingsFireTabsScreenAddTabsButtonText">Add Fire Tabs</string>
+    <string name="devSettingsFireTabsScreenClearTabsButtonText">Clear Fire Tabs</string>
     <string name="devSettingsTabsBookmarksScreenHeader" instruction="Not translated">Current bookmarks count: %1$d</string>
     <string name="devSettingsTabsFavoritesScreenHeader" instruction="Not translated">Current favorites count: %1$d</string>
     <string name="devSettingsTabsScreenBookmarksToAdd">Bookmarks to add</string>

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -45,7 +45,6 @@ import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.Url
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -67,7 +66,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -101,7 +99,6 @@ class AutoCompleteApi constructor(
     private val autoCompleteScorer: AutoCompleteScorer,
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val browserModeStateHolder: BrowserModeStateHolder,
-    private val fireModeAvailability: FireModeAvailability,
     private val autocompleteTabsFeature: AutocompleteTabsFeature,
     private val duckChat: DuckChat,
     private val history: NavigationHistory,
@@ -112,12 +109,7 @@ class AutoCompleteApi constructor(
     private val config: AutoComplete.Config,
 ) : AutoComplete {
 
-    private val currentMode: StateFlow<BrowserMode> =
-        if (fireModeAvailability.isAvailable()) {
-            browserModeStateHolder.currentMode
-        } else {
-            MutableStateFlow(BrowserMode.REGULAR)
-        }
+    private val currentMode: StateFlow<BrowserMode> = browserModeStateHolder.currentMode
 
     private val tabRepository: TabRepository
         get() = tabRepositoryProvider.forMode(currentMode.value)

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -42,6 +42,10 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.Url
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -61,9 +65,13 @@ import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -85,12 +93,15 @@ class DefaultAutoComplete @Inject constructor(
     private val factory: AutoCompleteFactory,
 ) : AutoComplete by factory.create(AutoComplete.Config())
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AutoCompleteApi constructor(
     private val autoCompleteService: AutoCompleteService,
     private val savedSitesRepository: SavedSitesRepository,
     private val navigationHistory: NavigationHistory,
     private val autoCompleteScorer: AutoCompleteScorer,
-    private val tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+    private val fireModeAvailability: FireModeAvailability,
     private val autocompleteTabsFeature: AutocompleteTabsFeature,
     private val duckChat: DuckChat,
     private val history: NavigationHistory,
@@ -100,6 +111,16 @@ class AutoCompleteApi constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val config: AutoComplete.Config,
 ) : AutoComplete {
+
+    private val currentMode: StateFlow<BrowserMode> =
+        if (fireModeAvailability.isAvailable()) {
+            browserModeStateHolder.currentMode
+        } else {
+            MutableStateFlow(BrowserMode.REGULAR)
+        }
+
+    private val tabRepository: TabRepository
+        get() = tabRepositoryProvider.forMode(currentMode.value)
 
     private var isAutocompleteTabsFeatureEnabled: Boolean? = null
 
@@ -320,11 +341,11 @@ class AutoCompleteApi constructor(
     private fun getAutocompleteSwitchToTabResults(query: String): Flow<List<RankedSuggestion<AutoCompleteSwitchToTabSuggestion>>> =
         runCatching {
             if (autocompleteTabsEnabled) {
-                combine(
-                    tabRepository.flowTabs,
-                    tabRepository.flowSelectedTab,
-                ) { tabs, selectedTab ->
-                    rankTabs(query, tabs.filter { it.tabId != selectedTab?.tabId })
+                currentMode.flatMapLatest { mode ->
+                    val repo = tabRepositoryProvider.forMode(mode)
+                    combine(repo.flowTabs, repo.flowSelectedTab) { tabs, selectedTab ->
+                        rankTabs(query, tabs.filter { it.tabId != selectedTab?.tabId })
+                    }
                 }.distinctUntilChanged()
             } else {
                 flowOf(emptyList())

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
@@ -23,6 +23,9 @@ import com.duckduckgo.app.systemsearch.DeviceAppLookup
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
@@ -38,7 +41,9 @@ class AutoCompleteFactoryImpl @Inject constructor(
     private val savedSitesRepository: SavedSitesRepository,
     private val navigationHistory: NavigationHistory,
     private val autoCompleteScorer: AutoCompleteScorer,
-    private val tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+    private val fireModeAvailability: FireModeAvailability,
     private val autocompleteTabsFeature: AutocompleteTabsFeature,
     private val duckChat: DuckChat,
     private val history: NavigationHistory,
@@ -54,7 +59,9 @@ class AutoCompleteFactoryImpl @Inject constructor(
             savedSitesRepository = savedSitesRepository,
             navigationHistory = navigationHistory,
             autoCompleteScorer = autoCompleteScorer,
-            tabRepository = tabRepository,
+            tabRepositoryProvider = tabRepositoryProvider,
+            browserModeStateHolder = browserModeStateHolder,
+            fireModeAvailability = fireModeAvailability,
             autocompleteTabsFeature = autocompleteTabsFeature,
             duckChat = duckChat,
             history = history,

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
@@ -43,7 +42,6 @@ class AutoCompleteFactoryImpl @Inject constructor(
     private val autoCompleteScorer: AutoCompleteScorer,
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val browserModeStateHolder: BrowserModeStateHolder,
-    private val fireModeAvailability: FireModeAvailability,
     private val autocompleteTabsFeature: AutocompleteTabsFeature,
     private val duckChat: DuckChat,
     private val history: NavigationHistory,
@@ -61,7 +59,6 @@ class AutoCompleteFactoryImpl @Inject constructor(
             autoCompleteScorer = autoCompleteScorer,
             tabRepositoryProvider = tabRepositoryProvider,
             browserModeStateHolder = browserModeStateHolder,
-            fireModeAvailability = fireModeAvailability,
             autocompleteTabsFeature = autocompleteTabsFeature,
             duckChat = duckChat,
             history = history,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -228,6 +228,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var fireDialogProvider: FireDialogProvider
 
+    @Inject
+    lateinit var currentBrowserMode: BrowserMode
+
     private val lastActiveTabs = TabList()
 
     private var duckAiFragment: DuckChatWebViewFragment? = null
@@ -292,7 +295,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private val tabPagerAdapter by lazy {
-        TabPagerAdapter(this, viewModel.currentMode.value)
+        TabPagerAdapter(this, currentBrowserMode)
     }
 
     private lateinit var omnibarToolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
@@ -600,7 +603,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         isExternal: Boolean,
     ): BrowserTabFragment {
         logcat(INFO) { "Opening new tab, url: $url, tabId: $tabId" }
-        val mode = if (isExternal) BrowserMode.REGULAR else viewModel.currentMode.value
+        val mode = if (isExternal) BrowserMode.REGULAR else currentBrowserMode
         val fragment = BrowserTabFragment.newInstance(tabId, url, skipHome, isExternal, mode)
         addOrReplaceNewTab(fragment, tabId)
         currentTab = fragment
@@ -684,7 +687,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         // Intents stamped with LAUNCH_REQUIRES_REGULAR_MODE must reach BrowserActivity in REGULAR
         // mode. Stash the intent and carry it to the recreated REGULAR-bound instance.
         val requiresRegularBrowserMode = intent.getBooleanExtra(LAUNCH_REQUIRES_REGULAR_MODE, false)
-        if (requiresRegularBrowserMode && viewModel.currentMode.value != BrowserMode.REGULAR) {
+        if (requiresRegularBrowserMode && currentBrowserMode != BrowserMode.REGULAR) {
             logcat(INFO) { "Intent requires REGULAR mode while in a non-regular mode — switching before processing" }
             pendingFireToRegularIntent = intent
             lifecycleScope.launch {
@@ -1068,7 +1071,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         tabs: Int,
     ) {
         val wasFragmentVisible = duckAiFragment?.isVisible ?: false
-        val mode = viewModel.currentMode.value
+        val mode = currentBrowserMode
         val fragment =
             DuckChatWebViewFragment().apply {
                 arguments =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -284,6 +284,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     // we don't store isExternal in the tab model, as it's only meant for the first time the tab is loaded.
     private val externalLaunchTabIds = mutableSetOf<String>()
 
+    // prevents new Browser mode's ViewPager showing old webviews when the mode changes
     private var skipTabPagerStateSaveOnRecreate = false
 
     private lateinit var renderer: BrowserStateRenderer

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -126,7 +126,6 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment
-import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment.Companion.KEY_DUCK_AI_BROWSER_MODE
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment.Companion.KEY_DUCK_AI_TABS
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment.Companion.KEY_DUCK_AI_URL
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -1071,14 +1070,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
         tabs: Int,
     ) {
         val wasFragmentVisible = duckAiFragment?.isVisible ?: false
-        val mode = currentBrowserMode
         val fragment =
             DuckChatWebViewFragment().apply {
                 arguments =
                     Bundle().apply {
                         duckChatUrl?.let { putString(KEY_DUCK_AI_URL, it) }
                         putInt(KEY_DUCK_AI_TABS, tabs)
-                        putString(KEY_DUCK_AI_BROWSER_MODE, mode.name)
                     }
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -296,7 +296,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private val tabPagerAdapter by lazy {
-        TabPagerAdapter(this, currentBrowserMode)
+        TabPagerAdapter(this)
     }
 
     private lateinit var omnibarToolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
@@ -604,8 +604,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         isExternal: Boolean,
     ): BrowserTabFragment {
         logcat(INFO) { "Opening new tab, url: $url, tabId: $tabId" }
-        val mode = if (isExternal) BrowserMode.REGULAR else currentBrowserMode
-        val fragment = BrowserTabFragment.newInstance(tabId, url, skipHome, isExternal, mode)
+        val fragment = BrowserTabFragment.newInstance(tabId, url, skipHome, isExternal)
         addOrReplaceNewTab(fragment, tabId)
         currentTab = fragment
         return fragment

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -281,6 +281,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
     // we don't store isExternal in the tab model, as it's only meant for the first time the tab is loaded.
     private val externalLaunchTabIds = mutableSetOf<String>()
 
+    private var skipTabPagerStateSaveOnRecreate = false
+
     private lateinit var renderer: BrowserStateRenderer
 
     private val binding: ActivityBrowserBinding by viewBinding()
@@ -419,7 +421,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        if (swipingTabsFeature.isEnabled) {
+        if (swipingTabsFeature.isEnabled && !skipTabPagerStateSaveOnRecreate) {
             outState.putParcelable(KEY_TAB_PAGER_STATE, tabPagerAdapter.saveState())
         }
         pendingFireToRegularIntent?.let { outState.putParcelable(KEY_PENDING_FIRE_TO_REGULAR_INTENT, it) }
@@ -1221,10 +1223,15 @@ open class BrowserActivity : DuckDuckGoActivity() {
     /**
      * Recreates the activity whenever the user switches browser mode. The activity is built for
      * one mode at a time (single adapter, single currentTab, single lastActiveTabs).
+     *
+     * The previous mode's BrowserTabFragments must NOT be restored, otherwise the new mode's
+     * ViewPager renders the old mode's webviews on top. We flag this so onSaveInstanceState
+     * skips the tab pager bundle.
      */
     private fun observeBrowserModeChanges() {
         lifecycleScope.launch {
             viewModel.currentMode.drop(1).collect {
+                skipTabPagerStateSaveOnRecreate = true
                 recreate()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -502,8 +502,8 @@ class BrowserTabFragment :
 
     private val isLaunchedFromExternalApp get() = requireArguments().getBoolean(LAUNCH_FROM_EXTERNAL_EXTRA)
 
-    val browserMode: BrowserMode get() = requireArguments().getString(BROWSER_MODE_ARG)
-        ?.let(BrowserMode::valueOf) ?: BrowserMode.REGULAR
+    @Inject
+    lateinit var browserMode: BrowserMode
 
     @Inject
     lateinit var userAgentProvider: UserAgentProvider
@@ -5228,7 +5228,6 @@ class BrowserTabFragment :
         private const val URL_EXTRA_ARG = "URL_EXTRA_ARG"
         private const val SKIP_HOME_ARG = "SKIP_HOME_ARG"
         private const val LAUNCH_FROM_EXTERNAL_EXTRA = "LAUNCH_FROM_EXTERNAL_EXTRA"
-        private const val BROWSER_MODE_ARG = "BROWSER_MODE_ARG"
 
         const val ADD_SAVED_SITE_FRAGMENT_TAG = "ADD_SAVED_SITE"
         private const val PDF_VIEWER_FRAGMENT_TAG = "PDF_VIEWER"
@@ -5621,14 +5620,12 @@ class BrowserTabFragment :
             query: String? = null,
             skipHome: Boolean,
             isExternal: Boolean,
-            browserMode: BrowserMode = BrowserMode.REGULAR,
         ): BrowserTabFragment {
             val fragment = BrowserTabFragment()
             val args = Bundle()
             args.putString(TAB_ID_ARG, tabId)
             args.putBoolean(SKIP_HOME_ARG, skipHome)
             args.putBoolean(LAUNCH_FROM_EXTERNAL_EXTRA, isExternal)
-            args.putString(BROWSER_MODE_ARG, browserMode.name)
             query.let {
                 args.putString(URL_EXTRA_ARG, query)
             }
@@ -5650,7 +5647,6 @@ class BrowserTabFragment :
             args.putInt(CUSTOM_TAB_TOOLBAR_COLOR_ARG, toolbarColor)
             args.putBoolean(TAB_DISPLAYED_IN_CUSTOM_TAB_SCREEN_ARG, true)
             args.putBoolean(LAUNCH_FROM_EXTERNAL_EXTRA, isExternal)
-            args.putString(BROWSER_MODE_ARG, BrowserMode.REGULAR.name)
             query.let {
                 args.putString(URL_EXTRA_ARG, query)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -25,14 +25,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabFragment
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
-import com.duckduckgo.browsermode.api.BrowserMode
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class TabPagerAdapter(
     private val activity: BrowserActivity,
-    private val browserMode: BrowserMode,
 ) : FragmentStateAdapter(activity) {
     private val tabs = mutableListOf<TabModel>()
 
@@ -75,11 +73,11 @@ class TabPagerAdapter(
         pendingMessage?.cleanupJob?.cancel()
 
         return if (pendingMessage != null) {
-            BrowserTabFragment.newInstance(tab.tabId, null, false, isExternal, browserMode).apply {
+            BrowserTabFragment.newInstance(tab.tabId, null, false, isExternal).apply {
                 this.messageFromPreviousTab = pendingMessage.message
             }
         } else {
-            BrowserTabFragment.newInstance(tab.tabId, tab.url, tab.skipHome, isExternal, browserMode)
+            BrowserTabFragment.newInstance(tab.tabId, tab.url, tab.skipHome, isExternal)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -83,7 +83,7 @@ class CtaViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val onboardingStore: OnboardingStore,
     private val userStageStore: UserStageStore,
-    private val aggregateTabRepository: AggregateTabRepository,
+    private val aggregateTabProvider: AggregateTabProvider,
     private val dispatchers: DispatcherProvider,
     private val duckChat: DuckChat,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
@@ -664,7 +664,7 @@ class CtaViewModel @Inject constructor(
         return requiredDaxOnboardingCtas().all { dismissedCtaDao.exists(it) }
     }
 
-    private fun forceStopFireButtonPulseAnimationFlow() = aggregateTabRepository.flowTabs.distinctUntilChanged()
+    private fun forceStopFireButtonPulseAnimationFlow() = aggregateTabProvider.observe().distinctUntilChanged()
         .map { tabs ->
             if (tabs.size >= MAX_TABS_OPEN_FIRE_EDUCATION) return@map true
             return@map false

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -41,10 +41,9 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -84,7 +83,7 @@ class CtaViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val onboardingStore: OnboardingStore,
     private val userStageStore: UserStageStore,
-    @RegularMode private val tabRepository: TabRepository,
+    private val aggregateTabRepository: AggregateTabRepository,
     private val dispatchers: DispatcherProvider,
     private val duckChat: DuckChat,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
@@ -665,7 +664,7 @@ class CtaViewModel @Inject constructor(
         return requiredDaxOnboardingCtas().all { dismissedCtaDao.exists(it) }
     }
 
-    private fun forceStopFireButtonPulseAnimationFlow() = tabRepository.flowTabs.distinctUntilChanged()
+    private fun forceStopFireButtonPulseAnimationFlow() = aggregateTabRepository.flowTabs.distinctUntilChanged()
         .map { tabs ->
             if (tabs.size >= MAX_TABS_OPEN_FIRE_EDUCATION) return@map true
             return@map false

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -83,7 +84,7 @@ class CtaViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val onboardingStore: OnboardingStore,
     private val userStageStore: UserStageStore,
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
     private val duckChat: DuckChat,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,

--- a/app/src/main/java/com/duckduckgo/app/di/DaoModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DaoModule.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.bookmarks.db.BookmarksDao
 import com.duckduckgo.app.bookmarks.db.FavoritesDao
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsDao
 import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.fire.db.FireModeDatabase
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteDao
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.events.db.UserEventsDao
@@ -41,6 +42,8 @@ import com.duckduckgo.app.trackerdetection.db.TdsTrackerDao
 import com.duckduckgo.app.trackerdetection.db.WebTrackersBlockedDao
 import com.duckduckgo.app.usage.app.AppDaysUsedDao
 import com.duckduckgo.app.usage.search.SearchCountDao
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
@@ -80,7 +83,12 @@ object DaoModule {
     fun providesBookmarkFoldersDao(database: AppDatabase): BookmarkFoldersDao = database.bookmarkFoldersDao()
 
     @Provides
-    fun providesTabsDao(database: AppDatabase): TabsDao = database.tabsDao()
+    @RegularMode
+    fun providesRegularTabsDao(database: AppDatabase): TabsDao = database.tabsDao()
+
+    @Provides
+    @FireMode
+    fun providesFireTabsDao(database: FireModeDatabase): TabsDao = database.tabsDao()
 
     @Provides
     fun providesTabPageContextDao(database: AppDatabase): TabPageContextDao = database.tabPageContextDao()

--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -82,6 +82,7 @@ object DatabaseModule {
     fun provideFireModeDatabase(context: Context): FireModeDatabase {
         return Room.databaseBuilder(context, FireModeDatabase::class.java, "fire_mode.db")
             .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .fallbackToDestructiveMigration(true)
             .build()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/DatabaseModule.kt
@@ -22,6 +22,7 @@ import androidx.room.RoomDatabase
 import com.duckduckgo.app.bookmarks.migration.AppDatabaseBookmarksMigrationCallbackProvider
 import com.duckduckgo.app.browser.DefaultWebViewDatabaseProvider
 import com.duckduckgo.app.browser.WebViewDatabaseProvider
+import com.duckduckgo.app.fire.db.FireModeDatabase
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.db.MigrationsProvider
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -74,5 +75,13 @@ object DatabaseModule {
         settingsDataStore: SettingsDataStore,
     ): MigrationsProvider {
         return MigrationsProvider(context, settingsDataStore)
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideFireModeDatabase(context: Context): FireModeDatabase {
+        return Room.databaseBuilder(context, FireModeDatabase::class.java, "fire_mode.db")
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.location.data.LocationPermissionsRepositoryImpl
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
@@ -67,7 +68,7 @@ object PrivacyModule {
         context: Context,
         dataManager: WebDataManager,
         clearingStore: UnsentForgetAllPixelStore,
-        tabRepository: TabRepository,
+        @RegularMode tabRepository: TabRepository,
         settingsDataStore: SettingsDataStore,
         cookieManager: DuckDuckGoCookieManager,
         appCacheClearer: AppCacheClearer,
@@ -84,6 +85,8 @@ object PrivacyModule {
         duckAiHostProvider: DuckAiHostProvider,
         siteDataCleaner: SiteDataCleaner,
     ): ClearDataAction {
+        // TODO: Burns currently only clear @RegularMode tabs. Cross-mode tab clearing will be
+        // handled as part of the data-clearing fire-mode work.
         return ClearPersonalDataAction(
             context,
             dataManager,

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -41,8 +41,8 @@ import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.location.data.LocationPermissionsRepositoryImpl
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager

--- a/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/StoreModule.kt
@@ -30,9 +30,6 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.statistics.store.StatisticsSharedPreferences
 import com.duckduckgo.app.tabs.db.TabsDbSanitizer
-import com.duckduckgo.app.tabs.model.TabAtomicOperations
-import com.duckduckgo.app.tabs.model.TabDataRepository
-import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.FavoritesObserver
 import com.duckduckgo.common.ui.store.ThemingDataStore
 import com.duckduckgo.common.ui.store.ThemingSharedPreferences
@@ -56,12 +53,6 @@ abstract class StoreModule {
 
     @Binds
     abstract fun bindOnboardingStore(onboardingStore: OnboardingStoreImpl): OnboardingStore
-
-    @Binds
-    abstract fun bindTabRepository(tabRepository: TabDataRepository): TabRepository
-
-    @Binds
-    abstract fun bindTabAtomicOperations(tabRepository: TabDataRepository): TabAtomicOperations
 
     @Binds
     abstract fun bindAppInstallStore(store: AppInstallSharedPreferences): AppInstallStore

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.di.scopes.ActivityScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+
+/**
+ * Unqualified [TabRepository] and [BrowserMode] is intentionally bound only in [ActivityScope],
+ * not [AppScope].
+ *
+ * Activity- and fragment-scoped consumers (BrowserViewModel, BrowserTabViewModel,
+ * OmnibarLayoutViewModel, etc.) are recreated whenever the browser mode changes, so each new
+ * instance resolves the right repo and mode at construction time.
+ */
+@ContributesTo(ActivityScope::class)
+@Module
+class TabRepositoryActivityModule {
+    /**
+     * The activity's [BrowserMode] is captured **once** at activity-component creation
+     * (`@SingleInstanceIn(ActivityScope::class)` on [provideActivityBrowserMode]) and reused for
+     * every unqualified [TabRepository] resolution within that activity. This guarantees a frozen
+     * mode for the activity's lifetime even if [BrowserModeStateHolder.currentMode] changes
+     * mid-construction — the activity recreates on real mode changes, so the next instance
+     * captures the new value cleanly.
+     */
+    @Provides
+    @SingleInstanceIn(ActivityScope::class)
+    fun provideActivityBrowserMode(browserModeStateHolder: BrowserModeStateHolder): BrowserMode =
+        browserModeStateHolder.currentMode.value
+
+    /**
+     * AppScope-singleton consumers cannot reach this binding — they must inject the qualified
+     * [@RegularMode] or [@FireMode] variants (or both) explicitly, which is what they want anyway:
+     * cross-mode work like data clearing operates on both, and one-shot app-launch logic should
+     * pick a specific mode rather than silently follow whatever the user last toggled.
+     */
+    @Provides
+    fun provideUnqualifiedTabRepository(
+        @RegularMode regular: TabRepository,
+        @FireMode fire: TabRepository,
+        activityMode: BrowserMode,
+    ): TabRepository = when (activityMode) {
+        BrowserMode.REGULAR -> regular
+        BrowserMode.FIRE -> fire
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.app.di
 
+import androidx.appcompat.app.AppCompatActivity
+import com.duckduckgo.app.browser.customtabs.CustomTabActivity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
@@ -45,11 +47,20 @@ class TabRepositoryActivityModule {
      * mode for the activity's lifetime even if [BrowserModeStateHolder.currentMode] changes
      * mid-construction — the activity recreates on real mode changes, so the next instance
      * captures the new value cleanly.
+     *
+     * [CustomTabActivity] always resolves to [BrowserMode.REGULAR] regardless of the state holder:
+     * Custom Tabs are launched by third-party apps and must not inherit the user's Fire-mode
+     * session, nor leak Custom Tab browsing into Fire-mode storage.
      */
     @Provides
     @SingleInstanceIn(ActivityScope::class)
-    fun provideActivityBrowserMode(browserModeStateHolder: BrowserModeStateHolder): BrowserMode =
-        browserModeStateHolder.currentMode.value
+    fun provideActivityBrowserMode(
+        activity: AppCompatActivity,
+        browserModeStateHolder: BrowserModeStateHolder,
+    ): BrowserMode = when (activity) {
+        is CustomTabActivity -> BrowserMode.REGULAR
+        else -> browserModeStateHolder.currentMode.value
+    }
 
     /**
      * AppScope-singleton consumers cannot reach this binding — they must inject the qualified

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import com.duckduckgo.adclick.api.AdClickManager
+import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
+import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
+import com.duckduckgo.app.global.model.SiteFactory
+import com.duckduckgo.app.tabs.TabManagerFeatureFlags
+import com.duckduckgo.app.tabs.db.TabsDao
+import com.duckduckgo.app.tabs.model.TabDataRepository
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.store.TabSwitcherDataStore
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+
+@ContributesTo(AppScope::class)
+@Module
+abstract class TabRepositoryModule {
+
+    @Binds
+    @RegularMode
+    abstract fun bindRegularTabRepository(impl: TabDataRepository): TabRepository
+
+    companion object {
+
+        /**
+         * Fire-mode [TabRepository] singleton backed by the fire-mode [TabsDao].
+         *
+         * WARNING: [TabRepository.deleteAll] on this instance fans out to the same clearing targets
+         * as the regular-mode instance and is UNSAFE to call until the Tabs.* clearing plugin lands.
+         * Do not invoke deleteAll() from any new code in this plan.
+         */
+        @Provides
+        @FireMode
+        @SingleInstanceIn(AppScope::class)
+        fun provideFireTabRepository(
+            @FireMode tabsDao: TabsDao,
+            siteFactory: SiteFactory,
+            webViewPreviewPersister: WebViewPreviewPersister,
+            faviconManager: FaviconManager,
+            tabSwitcherDataStore: TabSwitcherDataStore,
+            timeProvider: CurrentTimeProvider,
+            @AppCoroutineScope appCoroutineScope: CoroutineScope,
+            dispatchers: DispatcherProvider,
+            adClickManager: AdClickManager,
+            webViewSessionStorage: WebViewSessionStorage,
+            tabManagerFeatureFlags: TabManagerFeatureFlags,
+            duckChatContextualDataStore: DuckChatContextualDataStore,
+            tabVisitedSitesRepository: TabVisitedSitesRepository,
+            nativeInputStatePublisher: NativeInputStatePublisher,
+        ): TabRepository = TabDataRepository(
+            tabsDao = tabsDao,
+            siteFactory = siteFactory,
+            webViewPreviewPersister = webViewPreviewPersister,
+            faviconManager = faviconManager,
+            tabSwitcherDataStore = tabSwitcherDataStore,
+            timeProvider = timeProvider,
+            appCoroutineScope = appCoroutineScope,
+            dispatchers = dispatchers,
+            adClickManager = adClickManager,
+            webViewSessionStorage = webViewSessionStorage,
+            tabManagerFeatureFlags = tabManagerFeatureFlags,
+            duckChatContextualDataStore = duckChatContextualDataStore,
+            tabVisitedSitesRepository = tabVisitedSitesRepository,
+            nativeInputStatePublisher = nativeInputStatePublisher,
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -97,14 +97,6 @@ abstract class TabRepositoryModule {
             nativeInputStatePublisher = nativeInputStatePublisher,
         )
 
-        /**
-         * Fire-mode [TabDataRepository] singleton backed by the fire-mode [TabsDao].
-         *
-         * WARNING: [TabRepository.deleteAll] on this instance shares fan-out targets with the
-         * regular-mode instance (it clears app-global singletons like sessions / duck-chat /
-         * favicons / ad-click). It is UNSAFE to call until the Tabs.* clearing plugin lands.
-         * Do not invoke deleteAll() from any new code in this plan.
-         */
         @Provides
         @SingleInstanceIn(AppScope::class)
         @FireMode

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+@file:SuppressLint("NoImplImportsInAppModule")
+
 package com.duckduckgo.app.di
 
+import android.annotation.SuppressLint
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
@@ -34,7 +37,6 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
-//noinspection NoImplImportsInAppModule
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Binds

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
 import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.db.TabsDao
+import com.duckduckgo.app.tabs.model.TabAtomicOperations
 import com.duckduckgo.app.tabs.model.TabDataRepository
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabSwitcherDataStore
@@ -47,20 +48,66 @@ abstract class TabRepositoryModule {
 
     @Binds
     @RegularMode
-    abstract fun bindRegularTabRepository(impl: TabDataRepository): TabRepository
+    abstract fun bindRegularTabRepository(@RegularMode impl: TabDataRepository): TabRepository
+
+    @Binds
+    @FireMode
+    abstract fun bindFireTabRepository(@FireMode impl: TabDataRepository): TabRepository
+
+    @Binds
+    abstract fun bindUnqualifiedTabRepository(@RegularMode impl: TabRepository): TabRepository
+
+    @Binds
+    abstract fun bindTabAtomicOperations(@RegularMode impl: TabDataRepository): TabAtomicOperations
 
     companion object {
 
+        @Provides
+        @SingleInstanceIn(AppScope::class)
+        @RegularMode
+        fun provideRegularTabRepository(
+            @RegularMode tabsDao: TabsDao,
+            siteFactory: SiteFactory,
+            webViewPreviewPersister: WebViewPreviewPersister,
+            faviconManager: FaviconManager,
+            tabSwitcherDataStore: TabSwitcherDataStore,
+            timeProvider: CurrentTimeProvider,
+            @AppCoroutineScope appCoroutineScope: CoroutineScope,
+            dispatchers: DispatcherProvider,
+            adClickManager: AdClickManager,
+            webViewSessionStorage: WebViewSessionStorage,
+            tabManagerFeatureFlags: TabManagerFeatureFlags,
+            duckChatContextualDataStore: DuckChatContextualDataStore,
+            tabVisitedSitesRepository: TabVisitedSitesRepository,
+            nativeInputStatePublisher: NativeInputStatePublisher,
+        ): TabDataRepository = TabDataRepository(
+            tabsDao = tabsDao,
+            siteFactory = siteFactory,
+            webViewPreviewPersister = webViewPreviewPersister,
+            faviconManager = faviconManager,
+            tabSwitcherDataStore = tabSwitcherDataStore,
+            timeProvider = timeProvider,
+            appCoroutineScope = appCoroutineScope,
+            dispatchers = dispatchers,
+            adClickManager = adClickManager,
+            webViewSessionStorage = webViewSessionStorage,
+            tabManagerFeatureFlags = tabManagerFeatureFlags,
+            duckChatContextualDataStore = duckChatContextualDataStore,
+            tabVisitedSitesRepository = tabVisitedSitesRepository,
+            nativeInputStatePublisher = nativeInputStatePublisher,
+        )
+
         /**
-         * Fire-mode [TabRepository] singleton backed by the fire-mode [TabsDao].
+         * Fire-mode [TabDataRepository] singleton backed by the fire-mode [TabsDao].
          *
-         * WARNING: [TabRepository.deleteAll] on this instance fans out to the same clearing targets
-         * as the regular-mode instance and is UNSAFE to call until the Tabs.* clearing plugin lands.
+         * WARNING: [TabRepository.deleteAll] on this instance shares fan-out targets with the
+         * regular-mode instance (it clears app-global singletons like sessions / duck-chat /
+         * favicons / ad-click). It is UNSAFE to call until the Tabs.* clearing plugin lands.
          * Do not invoke deleteAll() from any new code in this plan.
          */
         @Provides
-        @FireMode
         @SingleInstanceIn(AppScope::class)
+        @FireMode
         fun provideFireTabRepository(
             @FireMode tabsDao: TabsDao,
             siteFactory: SiteFactory,
@@ -76,7 +123,7 @@ abstract class TabRepositoryModule {
             duckChatContextualDataStore: DuckChatContextualDataStore,
             tabVisitedSitesRepository: TabVisitedSitesRepository,
             nativeInputStatePublisher: NativeInputStatePublisher,
-        ): TabRepository = TabDataRepository(
+        ): TabDataRepository = TabDataRepository(
             tabsDao = tabsDao,
             siteFactory = siteFactory,
             webViewPreviewPersister = webViewPreviewPersister,

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -56,9 +56,6 @@ abstract class TabRepositoryModule {
     abstract fun bindFireTabRepository(@FireMode impl: TabDataRepository): TabRepository
 
     @Binds
-    abstract fun bindUnqualifiedTabRepository(@RegularMode impl: TabRepository): TabRepository
-
-    @Binds
     abstract fun bindTabAtomicOperations(@RegularMode impl: TabDataRepository): TabAtomicOperations
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryModule.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+//noinspection NoImplImportsInAppModule
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Binds

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
@@ -64,8 +64,6 @@ class ExternalIntentProcessingStateImpl @Inject constructor(
         private set
 
     init {
-        // AppScope-singleton: re-subscribe on mode change so a fire-mode tab load can still clear
-        // hasPendingTabLaunch. A one-shot subscribe at init would lock onto the startup mode forever.
         browserModeStateHolder.currentMode
             .flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowSelectedTab }
             .filterNotNull()

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.app.dispatchers
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -42,8 +45,13 @@ interface ExternalIntentProcessingState {
 @SingleInstanceIn(AppScope::class)
 class ExternalIntentProcessingStateImpl @Inject constructor(
     @AppCoroutineScope coroutineScope: CoroutineScope,
-    tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
 ) : ExternalIntentProcessingState {
+
+    private val tabRepository: TabRepository
+        get() = tabRepositoryProvider.forMode(browserModeStateHolder.currentMode.value)
+
     @Volatile
     override var hasPendingTabLaunch: Boolean = false
         private set

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingState.kt
@@ -24,7 +24,9 @@ import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
@@ -40,16 +42,14 @@ interface ExternalIntentProcessingState {
     fun onDuckAiClosed()
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class ExternalIntentProcessingStateImpl @Inject constructor(
     @AppCoroutineScope coroutineScope: CoroutineScope,
-    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
-    private val browserModeStateHolder: BrowserModeStateHolder,
+    tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    browserModeStateHolder: BrowserModeStateHolder,
 ) : ExternalIntentProcessingState {
-
-    private val tabRepository: TabRepository
-        get() = tabRepositoryProvider.forMode(browserModeStateHolder.currentMode.value)
 
     @Volatile
     override var hasPendingTabLaunch: Boolean = false
@@ -64,12 +64,17 @@ class ExternalIntentProcessingStateImpl @Inject constructor(
         private set
 
     init {
-        tabRepository.flowSelectedTab.filterNotNull().onEach { tab ->
-            // if we are switching to a tab that already has a URL, consider tab launch processing complete
-            if (!tab.url.isNullOrBlank()) {
-                hasPendingTabLaunch = false
-            }
-        }.launchIn(coroutineScope)
+        // AppScope-singleton: re-subscribe on mode change so a fire-mode tab load can still clear
+        // hasPendingTabLaunch. A one-shot subscribe at init would lock onto the startup mode forever.
+        browserModeStateHolder.currentMode
+            .flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowSelectedTab }
+            .filterNotNull()
+            .onEach { tab ->
+                // if we are switching to a tab that already has a URL, consider tab launch processing complete
+                if (!tab.url.isNullOrBlank()) {
+                    hasPendingTabLaunch = false
+                }
+            }.launchIn(coroutineScope)
     }
 
     override fun onIntentRequestToChangeTab() {

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabAtomicOperations
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.di.scopes.AppScope
@@ -69,7 +70,7 @@ class DataClearing @Inject constructor(
     private val tabVisitedSitesRepository: TabVisitedSitesRepository,
     private val navigationHistory: NavigationHistory,
     private val tabOperations: TabAtomicOperations,
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
     private val duckChat: DuckChat,
     private val contextualDataStore: DuckChatContextualDataStore,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,

--- a/app/src/main/java/com/duckduckgo/app/fire/DuckAiTabsCleanupPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DuckAiTabsCleanupPlugin.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.fire
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingPlugin
 import com.duckduckgo.di.scopes.AppScope
@@ -30,7 +31,7 @@ import javax.inject.Inject
 /** Closes Duck.ai tabs left pointing at cleared chat URLs. Never touches non-Duck.ai tabs. */
 @ContributesMultibinding(AppScope::class)
 class DuckAiTabsCleanupPlugin @Inject constructor(
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
     private val duckChat: DuckChat,
 ) : DataClearingPlugin {
 

--- a/app/src/main/java/com/duckduckgo/app/fire/db/FireModeDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/db/FireModeDatabase.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.duckduckgo.app.tabs.db.TabsDao
+import com.duckduckgo.app.tabs.model.LocalDateTimeTypeConverter
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabSelectionEntity
+
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [
+        TabEntity::class,
+        TabSelectionEntity::class,
+    ],
+)
+@TypeConverters(LocalDateTimeTypeConverter::class)
+abstract class FireModeDatabase : RoomDatabase() {
+
+    abstract fun tabsDao(): TabsDao
+}

--- a/app/src/main/java/com/duckduckgo/app/fire/db/FireModeDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/db/FireModeDatabase.kt
@@ -24,6 +24,13 @@ import com.duckduckgo.app.tabs.model.LocalDateTimeTypeConverter
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSelectionEntity
 
+/**
+ * Standalone database used during Fire mode to retain tab state across the wipe of [AppDatabase].
+ *
+ * Shares [TabEntity] and [TabSelectionEntity] with [com.duckduckgo.app.global.db.AppDatabase].
+ * Any schema change to these entities must be accompanied by a migration in BOTH databases —
+ * forgetting one will result in a runtime crash for the affected users.
+ */
 @Database(
     exportSchema = true,
     version = 1,

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -24,7 +24,10 @@ import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
@@ -53,12 +56,16 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val dispatcherProvider: DispatcherProvider,
     private val duckChat: DuckChat,
-    private val tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val systemAutofillEngagement: SystemAutofillEngagement,
     private val customTabDetector: CustomTabDetector,
+    private val browserModeStateHolder: BrowserModeStateHolder,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : BrowserLifecycleObserver {
+
+    private val tabRepository: TabRepository
+        get() = tabRepositoryProvider.forMode(browserModeStateHolder.currentMode.value)
 
     override fun onOpen(isFreshLaunch: Boolean) {
         // Notify the NtpAfterIdleManager synchronously on a fresh launch when the currently

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandler.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.isHttpOrHttps
 import com.duckduckgo.common.utils.plugins.PluginPoint
@@ -52,7 +53,7 @@ interface ShowOnAppLaunchOptionHandler {
 class ShowOnAppLaunchOptionHandlerImpl @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val settingsDataStore: SettingsDataStore,
     private val systemAutofillEngagement: SystemAutofillEngagement,

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -73,6 +73,14 @@ import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 
+/**
+ * Main application database.
+ *
+ * [TabEntity] and [TabSelectionEntity] are also used by
+ * [com.duckduckgo.app.fire.db.FireModeDatabase]. Any schema change to these entities must be
+ * accompanied by a migration in BOTH databases — forgetting one will result in a runtime crash
+ * for the affected users.
+ */
 @Database(
     exportSchema = true,
     version = 61,

--- a/app/src/main/java/com/duckduckgo/app/pixels/campaign/params/BrowserAdditionalPixelParams.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/campaign/params/BrowserAdditionalPixelParams.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.onboarding.store.daxOnboardingActive
 import com.duckduckgo.app.tabs.db.TabsDao
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -113,7 +114,7 @@ class SearchUserAdditionalPixelParamPlugin @Inject constructor(
 
 @ContributesMultibinding(AppScope::class)
 class ValidOpenTabsCountAdditionalPixelParamPlugin @Inject constructor(
-    private val tabsDao: TabsDao,
+    @RegularMode private val tabsDao: TabsDao,
 ) : AdditionalPixelParamPlugin {
     override suspend fun params(): Pair<String, String> = Pair(
         "validOpenTabsCount",

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
@@ -30,7 +31,7 @@ import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 class TabsDbSanitizer @Inject constructor(
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
     private val adClickManager: AdClickManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.FireMode
 import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -31,7 +32,8 @@ import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 class TabsDbSanitizer @Inject constructor(
-    @RegularMode private val tabRepository: TabRepository,
+    @RegularMode private val regularTabRepository: TabRepository,
+    @FireMode private val fireTabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
     private val adClickManager: AdClickManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -39,10 +41,15 @@ class TabsDbSanitizer @Inject constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatchers.main()) {
-            tabRepository.getDeletableTabIds().forEach {
-                adClickManager.clearTabId(it)
-            }
-            tabRepository.purgeDeletableTabs()
+            sanitize(regularTabRepository)
+            sanitize(fireTabRepository)
         }
+    }
+
+    private suspend fun sanitize(tabRepository: TabRepository) {
+        tabRepository.getDeletableTabIds().forEach {
+            adClickManager.clearTabId(it)
+        }
+        tabRepository.purgeDeletableTabs()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabProvider.kt
@@ -16,28 +16,31 @@
 
 package com.duckduckgo.app.tabs.model
 
-import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.FireModeAvailability
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class RealAggregateTabRepository @Inject constructor(
-    @RegularMode regularRepo: TabRepository,
-    @FireMode fireRepo: TabRepository,
-    fireModeAvailability: FireModeAvailability,
-) : AggregateTabRepository {
+class RealAggregateTabProvider @Inject constructor(
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val fireModeAvailability: FireModeAvailability,
+) : AggregateTabProvider {
 
-    override val flowTabs: Flow<List<TabEntity>> =
-        if (fireModeAvailability.isAvailable()) {
-            combine(regularRepo.flowTabs, fireRepo.flowTabs) { regular, fire -> regular + fire }
-        } else {
-            regularRepo.flowTabs
+    override fun observe(modes: Set<BrowserMode>): Flow<List<TabEntity>> {
+        val effectiveModes = if (fireModeAvailability.isAvailable()) modes else modes - BrowserMode.FIRE
+        val flows = effectiveModes.map { tabRepositoryProvider.forMode(it).flowTabs }
+        return when {
+            flows.isEmpty() -> flowOf(emptyList())
+            flows.size == 1 -> flows.single()
+            else -> combine(flows) { lists -> lists.flatMap { it } }
         }
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.tabs.model
 
 import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -30,8 +31,13 @@ import javax.inject.Inject
 class RealAggregateTabRepository @Inject constructor(
     @RegularMode regularRepo: TabRepository,
     @FireMode fireRepo: TabRepository,
+    fireModeAvailability: FireModeAvailability,
 ) : AggregateTabRepository {
 
     override val flowTabs: Flow<List<TabEntity>> =
-        combine(regularRepo.flowTabs, fireRepo.flowTabs) { regular, fire -> regular + fire }
+        if (fireModeAvailability.isAvailable()) {
+            combine(regularRepo.flowTabs, fireRepo.flowTabs) { regular, fire -> regular + fire }
+        } else {
+            regularRepo.flowTabs
+        }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.model
+
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAggregateTabRepository @Inject constructor(
+    @RegularMode regularRepo: TabRepository,
+    @FireMode fireRepo: TabRepository,
+) : AggregateTabRepository {
+
+    override val flowTabs: Flow<List<TabEntity>> =
+        combine(regularRepo.flowTabs, fireRepo.flowTabs) { regular, fire -> regular + fire }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/RealAggregateTabRepository.kt
@@ -21,9 +21,9 @@ import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/RealTabRepositoryProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/RealTabRepositoryProvider.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.model
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Binds
+import dagger.Module
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Resolves a per-mode [TabRepository]. Delegates to the [RegularMode] or [FireMode] repository
+ * based on the active [BrowserMode].
+ */
+@SingleInstanceIn(AppScope::class)
+class RealTabRepositoryProvider @Inject constructor(
+    @RegularMode private val regularRepo: TabRepository,
+    @FireMode private val fireRepo: TabRepository,
+) : BrowserModeDataProvider<TabRepository> {
+
+    override fun forMode(mode: BrowserMode): TabRepository = when (mode) {
+        BrowserMode.REGULAR -> regularRepo
+        BrowserMode.FIRE -> fireRepo
+    }
+}
+
+@ContributesTo(AppScope::class)
+@Module
+abstract class RealTabRepositoryProviderModule {
+    @Binds
+    abstract fun bindTabRepositoryProvider(impl: RealTabRepositoryProvider): BrowserModeDataProvider<TabRepository>
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.tabs.db.TabsDao
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.model.TabSwitcherData.UserState
 import com.duckduckgo.app.tabs.store.TabSwitcherDataStore
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -60,7 +61,7 @@ import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 class TabDataRepository @Inject constructor(
-    private val tabsDao: TabsDao,
+    @RegularMode private val tabsDao: TabsDao,
     private val siteFactory: SiteFactory,
     private val webViewPreviewPersister: WebViewPreviewPersister,
     private val faviconManager: FaviconManager,

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -34,14 +34,11 @@ import com.duckduckgo.app.tabs.db.TabsDao
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.model.TabSwitcherData.UserState
 import com.duckduckgo.app.tabs.store.TabSwitcherDataStore
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
-import dagger.SingleInstanceIn
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
@@ -57,11 +54,9 @@ import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
 import java.util.UUID
-import javax.inject.Inject
 
-@SingleInstanceIn(AppScope::class)
-class TabDataRepository @Inject constructor(
-    @RegularMode private val tabsDao: TabsDao,
+class TabDataRepository(
+    private val tabsDao: TabsDao,
     private val siteFactory: SiteFactory,
     private val webViewPreviewPersister: WebViewPreviewPersister,
     private val faviconManager: FaviconManager,

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabSelectionEntity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabSelectionEntity.kt
@@ -21,6 +21,10 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
+/**
+ * Shared by `AppDatabase` and `FireModeDatabase`. Any schema change here requires a migration in
+ * BOTH databases — forgetting one will result in a runtime crash for the affected users.
+ */
 @Entity(
     tableName = "tab_selection",
     foreignKeys = [

--- a/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.tabs.store
 
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.ACTIVITY_BUCKETS
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.ONE_WEEK_IN_DAYS
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.TAB_COUNT_BUCKETS
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.THREE_WEEKS_IN_DAYS
@@ -61,7 +62,7 @@ interface TabStatsBucketing {
 
 @ContributesBinding(AppScope::class)
 class DefaultTabStatsBucketing @Inject constructor(
-    private val tabRepository: TabRepository,
+    @RegularMode private val tabRepository: TabRepository,
 ) : TabStatsBucketing {
     override suspend fun getNumberOfOpenTabs(): String {
         val count = tabRepository.getOpenTabCount()

--- a/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
@@ -18,11 +18,11 @@ package com.duckduckgo.app.tabs.store
 
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.ACTIVITY_BUCKETS
-import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.ONE_WEEK_IN_DAYS
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.TAB_COUNT_BUCKETS
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.THREE_WEEKS_IN_DAYS
 import com.duckduckgo.app.tabs.store.TabStatsBucketing.Companion.TWO_WEEKS_IN_DAYS
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -52,7 +52,6 @@ import com.duckduckgo.app.downloads.DownloadsActivity
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.DuckAiTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
@@ -710,18 +709,6 @@ class TabSwitcherActivity :
         tabsRecycler.addItemDecoration(tabItemDecorator)
     }
 
-    private fun showTabDeletedSnackbar(tab: TabEntity) {
-        DefaultSnackbar(
-            parentView = binding.root,
-            message = getString(R.string.tabClosed),
-            anchor = snackbarAnchorView,
-            action = getString(R.string.tabClosedUndo),
-            showAction = true,
-            onAction = { launch { viewModel.onUndoDeleteTab(tab) } },
-            onDismiss = { launch { viewModel.purgeDeletableTabs() } },
-        ).show()
-    }
-
     private fun showTabsDeletedSnackbar(tabIds: List<String>) {
         DefaultSnackbar(
             parentView = binding.root,
@@ -803,7 +790,6 @@ class TabSwitcherActivity :
 
     private fun removeObservers() {
         viewModel.tabSwitcherItemsLiveData.removeObservers(this)
-        viewModel.deletableTabs.removeObservers(this)
     }
 
     private fun showCloseAllTabsConfirmation(numTabs: Int) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -56,7 +56,6 @@ import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedAppRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
@@ -91,7 +90,6 @@ import kotlin.time.Duration.Companion.milliseconds
 class TabSwitcherViewModel @Inject constructor(
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val browserModeStateHolder: BrowserModeStateHolder,
-    private val fireModeAvailability: FireModeAvailability,
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
@@ -105,12 +103,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val omnibarRepository: OmnibarRepository,
 ) : ViewModel() {
 
-    private val currentMode: StateFlow<BrowserMode> =
-        if (fireModeAvailability.isAvailable()) {
-            browserModeStateHolder.currentMode
-        } else {
-            MutableStateFlow(BrowserMode.REGULAR)
-        }
+    private val currentMode: StateFlow<BrowserMode> = browserModeStateHolder.currentMode
 
     private val tabRepository: TabRepository
         get() = tabRepositoryProvider.forMode(currentMode.value)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -53,6 +53,10 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedAppRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
@@ -68,6 +72,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
@@ -84,7 +89,9 @@ import kotlin.time.Duration.Companion.milliseconds
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @ContributesViewModel(ActivityScope::class)
 class TabSwitcherViewModel @Inject constructor(
-    private val tabRepository: TabRepository,
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+    private val fireModeAvailability: FireModeAvailability,
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
@@ -97,24 +104,38 @@ class TabSwitcherViewModel @Inject constructor(
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
 ) : ViewModel() {
-    val deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
-        context = viewModelScope.coroutineContext,
-    )
+
+    private val currentMode: StateFlow<BrowserMode> =
+        if (fireModeAvailability.isAvailable()) {
+            browserModeStateHolder.currentMode
+        } else {
+            MutableStateFlow(BrowserMode.REGULAR)
+        }
+
+    private val tabRepository: TabRepository
+        get() = tabRepositoryProvider.forMode(currentMode.value)
+
+    val deletableTabs: LiveData<List<TabEntity>> =
+        currentMode.flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowDeletableTabs }
+            .asLiveData(context = viewModelScope.coroutineContext)
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
-    private val tabSwitcherItemsFlow = tabRepository.flowTabs
-        .debounce(100.milliseconds)
-        .conflate()
-        .flatMapLatest { tabEntities ->
-            combine(
-                tabRepository.flowSelectedTab,
-                _viewState,
-                tabSwitcherDataStore.isTrackersAnimationInfoTileHidden(),
-            ) { activeTab, viewState, isAnimationTileDismissed ->
-                getTabItems(tabEntities, activeTab, isAnimationTileDismissed, viewState.mode)
+    private val tabSwitcherItemsFlow = currentMode.flatMapLatest { mode ->
+        val repo = tabRepositoryProvider.forMode(mode)
+        repo.flowTabs
+            .debounce(100.milliseconds)
+            .conflate()
+            .flatMapLatest { tabEntities ->
+                combine(
+                    repo.flowSelectedTab,
+                    _viewState,
+                    tabSwitcherDataStore.isTrackersAnimationInfoTileHidden(),
+                ) { activeTab, viewState, isAnimationTileDismissed ->
+                    getTabItems(tabEntities, activeTab, isAnimationTileDismissed, viewState.mode)
+                }
             }
-        }
+    }
 
     val tabSwitcherItemsLiveData: LiveData<List<TabSwitcherItem>> = tabSwitcherItemsFlow.asLiveData()
 
@@ -126,7 +147,7 @@ class TabSwitcherViewModel @Inject constructor(
     val viewState = combine(
         _viewState,
         tabSwitcherItemsFlow,
-        tabRepository.tabSwitcherData,
+        currentMode.flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).tabSwitcherData },
         duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus,
     ) { viewState, tabSwitcherItems, tabSwitcherData, showDuckAiButton ->
         viewState.copy(
@@ -142,7 +163,7 @@ class TabSwitcherViewModel @Inject constructor(
         ),
     )
 
-    val layoutType = tabRepository.tabSwitcherData
+    val layoutType = currentMode.flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).tabSwitcherData }
         .map { it.layoutType }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -108,10 +108,6 @@ class TabSwitcherViewModel @Inject constructor(
     private val tabRepository: TabRepository
         get() = tabRepositoryProvider.forMode(currentMode.value)
 
-    val deletableTabs: LiveData<List<TabEntity>> =
-        currentMode.flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).flowDeletableTabs }
-            .asLiveData(context = viewModelScope.coroutineContext)
-
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     private val tabSwitcherItemsFlow = currentMode.flatMapLatest { mode ->

--- a/app/src/main/java/com/duckduckgo/app/userstate/UserStateReporter.kt
+++ b/app/src/main/java/com/duckduckgo/app/userstate/UserStateReporter.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabDataRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -35,7 +36,7 @@ import javax.inject.Inject
 )
 class UserStateReporter @Inject constructor(
     private val dispatchers: DispatcherProvider,
-    private val repository: TabDataRepository,
+    @RegularMode private val repository: TabDataRepository,
     private val appBuildConfig: AppBuildConfig,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -40,7 +40,6 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
@@ -100,9 +99,6 @@ class AutoCompleteApiTest {
     @Mock
     private lateinit var mockBrowserModeStateHolder: BrowserModeStateHolder
 
-    @Mock
-    private lateinit var mockFireModeAvailability: FireModeAvailability
-
     private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
 
     @Mock
@@ -137,7 +133,6 @@ class AutoCompleteApiTest {
         whenever(mockTabRepository.flowTabs).thenReturn(flowOf(listOf(TabEntity("1", position = 1))))
         whenever(mockNavigationHistory.getHistory()).thenReturn(flowOf(emptyList()))
         whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
-        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
         whenever(mockBrowserModeStateHolder.currentMode).thenReturn(currentModeFlow)
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
@@ -2088,7 +2083,6 @@ class AutoCompleteApiTest {
             RealAutoCompleteScorer(),
             mockTabRepositoryProvider,
             mockBrowserModeStateHolder,
-            mockFireModeAvailability,
             mockAutocompleteTabsFeature,
             mockDuckChat,
             mockHistory,

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -37,6 +37,10 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
@@ -49,6 +53,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -87,6 +92,20 @@ class AutoCompleteApiTest {
     private lateinit var mockTabRepository: TabRepository
 
     @Mock
+    private lateinit var mockFireTabRepository: TabRepository
+
+    @Mock
+    private lateinit var mockTabRepositoryProvider: BrowserModeDataProvider<TabRepository>
+
+    @Mock
+    private lateinit var mockBrowserModeStateHolder: BrowserModeStateHolder
+
+    @Mock
+    private lateinit var mockFireModeAvailability: FireModeAvailability
+
+    private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+
+    @Mock
     private lateinit var mockAutocompleteTabsFeature: AutocompleteTabsFeature
 
     @Mock
@@ -118,6 +137,10 @@ class AutoCompleteApiTest {
         whenever(mockTabRepository.flowTabs).thenReturn(flowOf(listOf(TabEntity("1", position = 1))))
         whenever(mockNavigationHistory.getHistory()).thenReturn(flowOf(emptyList()))
         whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        whenever(mockBrowserModeStateHolder.currentMode).thenReturn(currentModeFlow)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
         runTest {
             whenever(mockDeviceAppLookup.query(any())).thenReturn(emptyList())
         }
@@ -2063,7 +2086,9 @@ class AutoCompleteApiTest {
             mockSavedSitesRepository,
             mockNavigationHistory,
             RealAutoCompleteScorer(),
-            mockTabRepository,
+            mockTabRepositoryProvider,
+            mockBrowserModeStateHolder,
+            mockFireModeAvailability,
             mockAutocompleteTabsFeature,
             mockDuckChat,
             mockHistory,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -756,6 +756,7 @@ class BrowserTabViewModelTest {
             whenever(mockTabRepository.getTabs()).thenReturn(emptyList())
             whenever(mockTabRepository.flowSelectedTab).thenReturn(flowSelectedTab)
             whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
+            whenever(mockAggregateTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
             whenever(mockEmailManager.signedInFlow()).thenReturn(emailStateFlow.asStateFlow())
             whenever(mockSavedSitesRepository.getFavorites()).thenReturn(favoriteListFlow.consumeAsFlow())
             whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(bookmarksListFlow.consumeAsFlow())

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -216,7 +216,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_INITIAL_CTA
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_SERP_CTA
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabPageContextRepository
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -427,7 +427,7 @@ class BrowserTabViewModelTest {
 
     private val mockTabRepository: TabRepository = mock()
 
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
 
     private val webViewSessionStorage: WebViewSessionStorage = mock()
 
@@ -756,7 +756,7 @@ class BrowserTabViewModelTest {
             whenever(mockTabRepository.getTabs()).thenReturn(emptyList())
             whenever(mockTabRepository.flowSelectedTab).thenReturn(flowSelectedTab)
             whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
-            whenever(mockAggregateTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
+            whenever(mockAggregateTabProvider.observe()).thenReturn(flowOf(emptyList()))
             whenever(mockEmailManager.signedInFlow()).thenReturn(emailStateFlow.asStateFlow())
             whenever(mockSavedSitesRepository.getFavorites()).thenReturn(favoriteListFlow.consumeAsFlow())
             whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(bookmarksListFlow.consumeAsFlow())
@@ -806,7 +806,7 @@ class BrowserTabViewModelTest {
                     settingsDataStore = ctaViewModelMockSettingsStore,
                     onboardingStore = mockOnboardingStore,
                     userStageStore = mockUserStageStore,
-                    aggregateTabRepository = mockAggregateTabRepository,
+                    aggregateTabProvider = mockAggregateTabProvider,
                     dispatchers = coroutineRule.testDispatcherProvider,
                     duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
                     extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -218,6 +218,7 @@ import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabPageContextRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabStatsBucketing
 import com.duckduckgo.app.trackerdetection.EntityLookup
@@ -425,6 +426,8 @@ class BrowserTabViewModelTest {
     private val mockOmnibarConverter: OmnibarEntryConverter = mock()
 
     private val mockTabRepository: TabRepository = mock()
+
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
 
     private val webViewSessionStorage: WebViewSessionStorage = mock()
 
@@ -802,7 +805,7 @@ class BrowserTabViewModelTest {
                     settingsDataStore = ctaViewModelMockSettingsStore,
                     onboardingStore = mockOnboardingStore,
                     userStageStore = mockUserStageStore,
-                    tabRepository = mockTabRepository,
+                    aggregateTabRepository = mockAggregateTabRepository,
                     dispatchers = coroutineRule.testDispatcherProvider,
                     duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
                     extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -254,7 +254,6 @@ import com.duckduckgo.browser.ui.browsermenu.VpnMenuState
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.common.ui.store.AppTheme
@@ -722,8 +721,6 @@ class BrowserTabViewModelTest {
             whenever(tabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockTabRepository)
             val browserModeStateHolder: BrowserModeStateHolder = mock()
             whenever(browserModeStateHolder.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
-            val fireModeAvailability: FireModeAvailability = mock()
-            whenever(fireModeAvailability.isAvailable()).thenReturn(true)
 
             mockAutoCompleteApi =
                 AutoCompleteApi(
@@ -733,7 +730,6 @@ class BrowserTabViewModelTest {
                     mockAutoCompleteScorer,
                     tabRepositoryProvider,
                     browserModeStateHolder,
-                    fireModeAvailability,
                     mockAutocompleteTabsFeature,
                     mockDuckChat,
                     mockHistory,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -216,9 +216,9 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_INITIAL_CTA
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_SERP_CTA
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabPageContextRepository
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.store.TabStatsBucketing
 import com.duckduckgo.app.trackerdetection.EntityLookup

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -250,6 +250,10 @@ import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browser.ui.browsermenu.VpnMenuState
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.common.ui.store.AppTheme
@@ -710,13 +714,23 @@ class BrowserTabViewModelTest {
             fireproofWebsiteDao = db.fireproofWebsiteDao()
             locationPermissionsDao = db.locationPermissionsDao()
 
+            val tabRepositoryProvider: BrowserModeDataProvider<TabRepository> = mock()
+            whenever(tabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+            whenever(tabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockTabRepository)
+            val browserModeStateHolder: BrowserModeStateHolder = mock()
+            whenever(browserModeStateHolder.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+            val fireModeAvailability: FireModeAvailability = mock()
+            whenever(fireModeAvailability.isAvailable()).thenReturn(true)
+
             mockAutoCompleteApi =
                 AutoCompleteApi(
                     mockAutoCompleteService,
                     mockSavedSitesRepository,
                     mockNavigationHistory,
                     mockAutoCompleteScorer,
-                    mockTabRepository,
+                    tabRepositoryProvider,
+                    browserModeStateHolder,
+                    fireModeAvailability,
                     mockAutocompleteTabsFeature,
                     mockDuckChat,
                     mockHistory,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -43,8 +43,8 @@ import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.tabs.model.TabEntity
-import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
@@ -116,7 +116,7 @@ class CtaViewModelTest {
 
     private val mockUserStageStore: UserStageStore = mock()
 
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
 
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
 
@@ -171,7 +171,7 @@ class CtaViewModelTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -192,7 +192,7 @@ class CtaViewModelTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -43,7 +43,7 @@ import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
@@ -116,7 +116,7 @@ class CtaViewModelTest {
 
     private val mockUserStageStore: UserStageStore = mock()
 
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
 
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
 
@@ -171,7 +171,7 @@ class CtaViewModelTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabProvider.observe()).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -192,7 +192,7 @@ class CtaViewModelTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -40,7 +40,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_ONBOARDING_END_CTA
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -97,7 +97,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -150,7 +150,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -40,7 +40,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_ONBOARDING_END_CTA
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -97,7 +97,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -150,7 +150,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_FIRE_DIALOG_CTA
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -97,7 +97,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -147,7 +147,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_FIRE_DIALOG_CTA
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -97,7 +97,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -147,7 +147,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_NETWORK_CTA_1
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -111,7 +111,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -145,7 +145,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabProvider.observe()).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -167,7 +167,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_NETWORK_CTA_1
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -111,7 +111,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -145,7 +145,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -167,7 +167,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
@@ -103,7 +103,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -156,7 +156,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
@@ -103,7 +103,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -156,7 +156,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -104,7 +104,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -139,7 +139,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -162,7 +162,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
@@ -104,7 +104,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -139,7 +139,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabProvider.observe()).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -162,7 +162,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -50,7 +50,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_INITIAL_VISIT_SITE_CTA
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -119,7 +119,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -150,7 +150,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabProvider.observe()).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -170,7 +170,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -50,7 +50,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.CTA_SHOWN
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DAX_INITIAL_VISIT_SITE_CTA
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -119,7 +119,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -150,7 +150,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
-        whenever(mockTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
+        whenever(mockAggregateTabRepository.flowTabs).thenReturn(db.tabsDao().liveTabs().asFlow())
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
@@ -170,7 +170,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
@@ -101,7 +101,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockTabRepository: TabRepository = mock()
+    private val mockAggregateTabRepository: AggregateTabRepository = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -148,7 +148,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            tabRepository = mockTabRepository,
+            aggregateTabRepository = mockAggregateTabRepository,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
@@ -101,7 +101,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
     private val mockOnboardingStore: OnboardingStore = mock()
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockUserStageStore: UserStageStore = mock()
-    private val mockAggregateTabRepository: AggregateTabRepository = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockSubscriptions: Subscriptions = mock()
@@ -148,7 +148,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
             settingsDataStore = mockSettingsDataStore,
             onboardingStore = mockOnboardingStore,
             userStageStore = mockUserStageStore,
-            aggregateTabRepository = mockAggregateTabRepository,
+            aggregateTabProvider = mockAggregateTabProvider,
             dispatchers = coroutineRule.testDispatcherProvider,
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdat
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -81,7 +81,7 @@ class OnboardingDaxDialogTests {
     private val settingsDataStore: SettingsDataStore = mock()
     private val onboardingStore: OnboardingStore = mock()
     private val userStageStore: UserStageStore = mock()
-    private val tabRepository: TabRepository = mock()
+    private val aggregateTabRepository: AggregateTabRepository = mock()
     private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
@@ -114,7 +114,7 @@ class OnboardingDaxDialogTests {
             settingsDataStore,
             onboardingStore,
             userStageStore,
-            tabRepository,
+            aggregateTabRepository,
             coroutineRule.testDispatcherProvider,
             mockDuckChat,
             duckDuckGoUrlDetector,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdat
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -81,7 +81,7 @@ class OnboardingDaxDialogTests {
     private val settingsDataStore: SettingsDataStore = mock()
     private val onboardingStore: OnboardingStore = mock()
     private val userStageStore: UserStageStore = mock()
-    private val aggregateTabRepository: AggregateTabRepository = mock()
+    private val aggregateTabProvider: AggregateTabProvider = mock()
     private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
@@ -114,7 +114,7 @@ class OnboardingDaxDialogTests {
             settingsDataStore,
             onboardingStore,
             userStageStore,
-            aggregateTabRepository,
+            aggregateTabProvider,
             coroutineRule.testDispatcherProvider,
             mockDuckChat,
             duckDuckGoUrlDetector,

--- a/app/src/test/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/dispatchers/ExternalIntentProcessingStateTest.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.app.dispatchers
 
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -29,6 +32,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class ExternalIntentProcessingStateTest {
@@ -40,6 +46,11 @@ class ExternalIntentProcessingStateTest {
     private lateinit var mockTabRepository: TabRepository
 
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val browserModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val mockBrowserModeStateHolder: BrowserModeStateHolder = mock {
+        on { currentMode } doReturn browserModeFlow
+    }
+    private lateinit var mockTabRepositoryProvider: BrowserModeDataProvider<TabRepository>
     private lateinit var testee: ExternalIntentProcessingState
 
     @Before
@@ -47,9 +58,14 @@ class ExternalIntentProcessingStateTest {
         MockitoAnnotations.openMocks(this)
         whenever(mockTabRepository.flowSelectedTab).thenReturn(selectedTabFlow)
 
+        mockTabRepositoryProvider = mock {
+            on { forMode(any()) } doReturn mockTabRepository
+        }
+
         testee = ExternalIntentProcessingStateImpl(
             coroutineScope = TestScope(coroutineRule.testDispatcher),
-            tabRepository = mockTabRepository,
+            tabRepositoryProvider = mockTabRepositoryProvider,
+            browserModeStateHolder = mockBrowserModeStateHolder,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/fire/db/FireModeDatabaseTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/db/FireModeDatabaseTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.tabs.model.TabEntity
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FireModeDatabaseTest {
+
+    private lateinit var database: FireModeDatabase
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            FireModeDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun whenTabInsertedThenItCanBeReadBack() {
+        val tab = TabEntity(tabId = "tab-1", url = "https://duckduckgo.com", title = "DuckDuckGo", position = 0)
+
+        database.tabsDao().insertTab(tab)
+
+        val result = database.tabsDao().tab("tab-1")
+        assertNotNull(result)
+        assertEquals("tab-1", result!!.tabId)
+        assertEquals("https://duckduckgo.com", result.url)
+        assertEquals("DuckDuckGo", result.title)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -43,7 +44,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.duckchat.api.DuckChat
@@ -40,7 +43,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -61,6 +66,13 @@ class FirstScreenHandlerImplTest {
     private val appBuildConfig: AppBuildConfig = mock()
     private val duckChat: DuckChat = mock()
     private val tabRepository: TabRepository = mock()
+    private val browserModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val browserModeStateHolder: BrowserModeStateHolder = mock {
+        on { currentMode } doReturn browserModeFlow
+    }
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository> = mock {
+        on { forMode(any()) } doReturn tabRepository
+    }
     private val systemAutofillEngagement: SystemAutofillEngagement = mock()
     private val customTabDetector: CustomTabDetector = mock()
     private val idleReturnToggle: Toggle = mock()
@@ -91,7 +103,8 @@ class FirstScreenHandlerImplTest {
             showOnAppLaunchOptionDataStore = showOnAppLaunchOptionDataStore,
             appBuildConfig = appBuildConfig,
             duckChat = duckChat,
-            tabRepository = tabRepository,
+            tabRepositoryProvider = tabRepositoryProvider,
+            browserModeStateHolder = browserModeStateHolder,
             ntpAfterIdleManager = ntpAfterIdleManager,
             systemAutofillEngagement = systemAutofillEngagement,
             customTabDetector = customTabDetector,

--- a/app/src/test/java/com/duckduckgo/app/tabs/model/RealAggregateTabProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/model/RealAggregateTabProviderTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.model
+
+import com.duckduckgo.browsermode.api.BrowserMode.FIRE
+import com.duckduckgo.browsermode.api.BrowserMode.REGULAR
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.FireModeAvailability
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RealAggregateTabProviderTest {
+
+    private val regularTabs = MutableStateFlow(listOf(TabEntity(tabId = "r1", position = 0)))
+    private val fireTabs = MutableStateFlow(listOf(TabEntity(tabId = "f1", position = 0)))
+
+    private val regularRepo: TabRepository = mock()
+    private val fireRepo: TabRepository = mock()
+    private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository> = mock()
+    private val fireAvailability: FireModeAvailability = mock()
+
+    private val testee by lazy { RealAggregateTabProvider(tabRepositoryProvider, fireAvailability) }
+
+    @Before
+    fun setup() {
+        whenever(regularRepo.flowTabs).thenReturn(regularTabs)
+        whenever(fireRepo.flowTabs).thenReturn(fireTabs)
+        whenever(tabRepositoryProvider.forMode(REGULAR)).thenReturn(regularRepo)
+        whenever(tabRepositoryProvider.forMode(FIRE)).thenReturn(fireRepo)
+        whenever(fireAvailability.isAvailable()).thenReturn(true)
+    }
+
+    @Test
+    fun whenAllModesRequestedThenEmitsConcatenationOfRegularAndFire() = runTest {
+        val tabs = testee.observe(setOf(REGULAR, FIRE)).first()
+
+        assertEquals(setOf("r1", "f1"), tabs.map { it.tabId }.toSet())
+    }
+
+    @Test
+    fun whenDefaultArgsThenAggregatesAcrossAllBrowserModes() = runTest {
+        val tabs = testee.observe().first()
+
+        assertEquals(setOf("r1", "f1"), tabs.map { it.tabId }.toSet())
+    }
+
+    @Test
+    fun whenOnlyRegularRequestedThenEmitsRegularOnly() = runTest {
+        val tabs = testee.observe(setOf(REGULAR)).first()
+
+        assertEquals(listOf("r1"), tabs.map { it.tabId })
+    }
+
+    @Test
+    fun whenOnlyFireRequestedThenEmitsFireOnly() = runTest {
+        val tabs = testee.observe(setOf(FIRE)).first()
+
+        assertEquals(listOf("f1"), tabs.map { it.tabId })
+    }
+
+    @Test
+    fun whenFireUnavailableThenFireModeContributesNothing() = runTest {
+        whenever(fireAvailability.isAvailable()).thenReturn(false)
+
+        val tabs = testee.observe(setOf(REGULAR, FIRE)).first()
+
+        assertEquals(listOf("r1"), tabs.map { it.tabId })
+    }
+
+    @Test
+    fun whenFireUnavailableAndOnlyFireRequestedThenEmitsEmpty() = runTest {
+        whenever(fireAvailability.isAvailable()).thenReturn(false)
+
+        val tabs = testee.observe(setOf(FIRE)).first()
+
+        assertEquals(emptyList<String>(), tabs.map { it.tabId })
+    }
+
+    @Test
+    fun whenEmptyModeSetThenEmitsEmpty() = runTest {
+        val tabs = testee.observe(emptySet()).first()
+
+        assertEquals(emptyList<String>(), tabs.map { it.tabId })
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/tabs/model/RealTabRepositoryProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/model/RealTabRepositoryProviderTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.model
+
+import com.duckduckgo.browsermode.api.BrowserMode.FIRE
+import com.duckduckgo.browsermode.api.BrowserMode.REGULAR
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class RealTabRepositoryProviderTest {
+
+    private val regularRepo: TabRepository = mock()
+    private val fireRepo: TabRepository = mock()
+    private val provider = RealTabRepositoryProvider(regularRepo, fireRepo)
+
+    @Test
+    fun whenModeIsRegularThenReturnsRegularRepository() {
+        assertSame(regularRepo, provider.forMode(REGULAR))
+    }
+
+    @Test
+    fun whenModeIsFireThenReturnsFireRepository() {
+        assertSame(fireRepo, provider.forMode(FIRE))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -624,32 +624,6 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun whenRepositoryDeletableTabsUpdatesThenDeletableTabsEmits() = runTest {
-        val tab = TabEntity("ID", position = 0)
-
-        val expectedTabs = listOf(listOf(), listOf(tab))
-        var index = 0
-        testee.deletableTabs.observeForever {
-            assertEquals(expectedTabs[index++], it)
-        }
-
-        repoDeletableTabs.send(listOf())
-        repoDeletableTabs.send(listOf(tab))
-    }
-
-    @Test
-    fun whenRepositoryDeletableTabsEmitsSameValueThenDeletableTabsEmitsAll() = runTest {
-        val tab = TabEntity("ID", position = 0)
-
-        testee.deletableTabs.observeForever {
-            assertEquals(listOf(tab), it)
-        }
-
-        repoDeletableTabs.send(listOf(tab))
-        repoDeletableTabs.send(listOf(tab))
-    }
-
-    @Test
     fun whenOnCloseAllTabsRequestedThenEmitCommandCloseAllTabsRequest() = runTest {
         testee.onCloseAllTabsRequested()
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -55,7 +55,6 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
-import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.blockingObserve
 import com.duckduckgo.common.ui.DuckDuckGoTheme
@@ -131,8 +130,6 @@ class TabSwitcherViewModelTest {
 
     private val mockBrowserModeStateHolder: BrowserModeStateHolder = mock()
 
-    private val mockFireModeAvailability: FireModeAvailability = mock()
-
     private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
 
     private val mockPixel: Pixel = mock()
@@ -191,7 +188,6 @@ class TabSwitcherViewModelTest {
 
         whenever(duckAiFeatureStateMock.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(MutableStateFlow(false))
 
-        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
         whenever(mockBrowserModeStateHolder.currentMode).thenReturn(currentModeFlow)
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
 
@@ -210,7 +206,6 @@ class TabSwitcherViewModelTest {
         testee = TabSwitcherViewModel(
             mockTabRepositoryProvider,
             mockBrowserModeStateHolder,
-            mockFireModeAvailability,
             coroutinesTestRule.testDispatcherProvider,
             mockPixel,
             swipingTabsFeatureProvider,
@@ -2003,43 +1998,6 @@ class TabSwitcherViewModelTest {
 
         assertTrue(items.any { it is NormalTab && it.tabEntity.tabId == "fire-1" })
         verify(mockTabRepositoryProvider, atLeastOnce()).forMode(BrowserMode.FIRE)
-    }
-
-    @Test
-    fun `when fire mode unavailable then disabled viewmodel ignores state holder and only resolves regular repo`() = runTest {
-        // Use isolated mocks so the @Before viewmodel (which subscribed to currentModeFlow) does not interfere.
-        val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()
-        val isolatedStateHolder = mock<BrowserModeStateHolder>()
-        val isolatedAvailability = mock<FireModeAvailability>()
-        val isolatedStateFlow = MutableStateFlow(BrowserMode.REGULAR)
-        whenever(isolatedAvailability.isAvailable()).thenReturn(false)
-        whenever(isolatedStateHolder.currentMode).thenReturn(isolatedStateFlow)
-        whenever(isolatedProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
-
-        val isolatedViewModel = TabSwitcherViewModel(
-            isolatedProvider,
-            isolatedStateHolder,
-            isolatedAvailability,
-            coroutinesTestRule.testDispatcherProvider,
-            mockPixel,
-            swipingTabsFeatureProvider,
-            duckChatMock,
-            duckAiFeatureState = duckAiFeatureStateMock,
-            mockWebTrackersBlockedAppRepository,
-            mockTabSwitcherPrefsDataStore,
-            faviconManager,
-            savedSitesRepository,
-            mockTrackersAnimationInfoPanelPixels,
-            mockOmnibarFeatureRepository,
-        )
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            isolatedViewModel.viewState.collect()
-        }
-
-        isolatedStateFlow.value = BrowserMode.FIRE
-        advanceUntilIdle()
-
-        verify(isolatedProvider, never()).forMode(BrowserMode.FIRE)
     }
 
     private class FakeTabSwitcherDataStore : TabSwitcherDataStore {

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -52,6 +52,10 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedAppRepository
 import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.blockingObserve
 import com.duckduckgo.common.ui.DuckDuckGoTheme
@@ -89,6 +93,7 @@ import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -117,6 +122,18 @@ class TabSwitcherViewModelTest {
     private val commandCaptor = argumentCaptor<Command>()
 
     private val mockTabRepository: TabRepository = mock()
+
+    private val mockFireTabRepository: TabRepository = mock()
+
+    @Suppress("UNCHECKED_CAST")
+    private val mockTabRepositoryProvider: BrowserModeDataProvider<TabRepository> =
+        mock<BrowserModeDataProvider<TabRepository>>()
+
+    private val mockBrowserModeStateHolder: BrowserModeStateHolder = mock()
+
+    private val mockFireModeAvailability: FireModeAvailability = mock()
+
+    private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
 
     private val mockPixel: Pixel = mock()
 
@@ -174,6 +191,10 @@ class TabSwitcherViewModelTest {
 
         whenever(duckAiFeatureStateMock.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(MutableStateFlow(false))
 
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
+        whenever(mockBrowserModeStateHolder.currentMode).thenReturn(currentModeFlow)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+
         initializeMockTabEntitesData()
         initializeViewModel()
         prepareSelectionMode()
@@ -187,7 +208,9 @@ class TabSwitcherViewModelTest {
 
     private fun initializeViewModel(tabSwitcherDataStore: TabSwitcherDataStore = mockTabSwitcherPrefsDataStore) {
         testee = TabSwitcherViewModel(
-            mockTabRepository,
+            mockTabRepositoryProvider,
+            mockBrowserModeStateHolder,
+            mockFireModeAvailability,
             coroutinesTestRule.testDispatcherProvider,
             mockPixel,
             swipingTabsFeatureProvider,
@@ -1962,6 +1985,61 @@ class TabSwitcherViewModelTest {
 
         assertTrue(items.any { it is NormalTab })
         assertTrue(items.none { it is DuckAiTab })
+    }
+
+    @Test
+    fun `when fire mode available and current mode is fire then tab switcher items resolve from fire repo`() = runTest {
+        val fireTabList = listOf(TabEntity("fire-1", url = "https://fire.example", position = 1))
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(fireTabList))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTabList.first()))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        val items = testee.tabSwitcherItemsLiveData.blockingObserve() ?: listOf()
+
+        assertTrue(items.any { it is NormalTab && it.tabEntity.tabId == "fire-1" })
+        verify(mockTabRepositoryProvider, atLeastOnce()).forMode(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when fire mode unavailable then disabled viewmodel ignores state holder and only resolves regular repo`() = runTest {
+        // Use isolated mocks so the @Before viewmodel (which subscribed to currentModeFlow) does not interfere.
+        val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()
+        val isolatedStateHolder = mock<BrowserModeStateHolder>()
+        val isolatedAvailability = mock<FireModeAvailability>()
+        val isolatedStateFlow = MutableStateFlow(BrowserMode.REGULAR)
+        whenever(isolatedAvailability.isAvailable()).thenReturn(false)
+        whenever(isolatedStateHolder.currentMode).thenReturn(isolatedStateFlow)
+        whenever(isolatedProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+
+        val isolatedViewModel = TabSwitcherViewModel(
+            isolatedProvider,
+            isolatedStateHolder,
+            isolatedAvailability,
+            coroutinesTestRule.testDispatcherProvider,
+            mockPixel,
+            swipingTabsFeatureProvider,
+            duckChatMock,
+            duckAiFeatureState = duckAiFeatureStateMock,
+            mockWebTrackersBlockedAppRepository,
+            mockTabSwitcherPrefsDataStore,
+            faviconManager,
+            savedSitesRepository,
+            mockTrackersAnimationInfoPanelPixels,
+            mockOmnibarFeatureRepository,
+        )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            isolatedViewModel.viewState.collect()
+        }
+
+        isolatedStateFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        verify(isolatedProvider, never()).forMode(BrowserMode.FIRE)
     }
 
     private class FakeTabSwitcherDataStore : TabSwitcherDataStore {

--- a/browser-api/build.gradle
+++ b/browser-api/build.gradle
@@ -23,6 +23,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(path: ':navigation-api')
+    implementation project(path: ':browser-mode-api')
     implementation project(path: ':design-system')
     implementation project(path: ':common-utils')
     implementation project(':feature-toggles-api')

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/AggregateTabProvider.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/AggregateTabProvider.kt
@@ -16,21 +16,13 @@
 
 package com.duckduckgo.app.tabs.model
 
-import kotlinx.coroutines.flow.Flow
+import com.duckduckgo.browsermode.api.AggregateBrowserModeProvider
 
 /**
- * Cross-mode view over [TabRepository]. Use this when consumers need to react to tabs
- * from both regular and fire mode at once — counting, stats, or any flow-based aggregation
- * that should not be tied to a single mode.
+ * Observes tabs across one or more [com.duckduckgo.browsermode.api.BrowserMode]s. Callers pass the
+ * set of modes they want tabs from — a single mode for a per-mode view, or omit the argument for a
+ * cross-mode view.
  *
- * For everything that operates on one mode at a time, inject the mode-qualified
- * [TabRepository] directly.
+ * For mutating tab state, use the mode-qualified [TabRepository] directly.
  */
-interface AggregateTabRepository {
-
-    /**
-     * Emits the concatenation of regular-mode and fire-mode tabs. Re-emits whenever either
-     * underlying repository's [TabRepository.flowTabs] emits.
-     */
-    val flowTabs: Flow<List<TabEntity>>
-}
+interface AggregateTabProvider : AggregateBrowserModeProvider<List<TabEntity>>

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/AggregateTabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/AggregateTabRepository.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.model
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Cross-mode view over [TabRepository]. Use this when consumers need to react to tabs
+ * from both regular and fire mode at once — counting, stats, or any flow-based aggregation
+ * that should not be tied to a single mode.
+ *
+ * For everything that operates on one mode at a time, inject the mode-qualified
+ * [TabRepository] directly.
+ */
+interface AggregateTabRepository {
+
+    /**
+     * Emits the concatenation of regular-mode and fire-mode tabs. Re-emits whenever either
+     * underlying repository's [TabRepository.flowTabs] emits.
+     */
+    val flowTabs: Flow<List<TabEntity>>
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabEntitiy.kt
@@ -24,6 +24,10 @@ import androidx.room.TypeConverter
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import java.time.LocalDateTime
 
+/**
+ * Shared by `AppDatabase` and `FireModeDatabase`. Any schema change here requires a migration in
+ * BOTH databases — forgetting one will result in a runtime crash for the affected users.
+ */
 @Entity(
     tableName = "tabs",
     foreignKeys = [

--- a/browser-mode/browser-mode-api/build.gradle
+++ b/browser-mode/browser-mode-api/build.gradle
@@ -28,4 +28,6 @@ android {
 dependencies {
     implementation KotlinX.coroutines.core
     implementation AndroidX.webkit
+
+    compileOnly 'javax.inject:javax.inject:1'
 }

--- a/browser-mode/browser-mode-api/build.gradle
+++ b/browser-mode/browser-mode-api/build.gradle
@@ -29,5 +29,5 @@ dependencies {
     implementation KotlinX.coroutines.core
     implementation AndroidX.webkit
 
-    compileOnly 'javax.inject:javax.inject:1'
+    compileOnly "javax.inject:javax.inject:_"
 }

--- a/browser-mode/browser-mode-api/src/main/java/com/duckduckgo/browsermode/api/AggregateBrowserModeProvider.kt
+++ b/browser-mode/browser-mode-api/src/main/java/com/duckduckgo/browsermode/api/AggregateBrowserModeProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browsermode.api
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Emits a [T] aggregated across the requested set of [BrowserMode]s. Implementations
+ * decide how per-mode values are combined into a single [T].
+ *
+ * Sibling to [BrowserModeDataProvider]: that one resolves a single mode-bound instance
+ * point-in-time; this one composes reactive streams from one or more modes.
+ */
+interface AggregateBrowserModeProvider<T> {
+    /**
+     * Emits a [T] composed from each mode in [modes]. Re-emits when any contributing
+     * mode's underlying source emits. Passing a single mode yields that mode's flow
+     * unchanged. Omitting [modes] observes every value of [BrowserMode].
+     */
+    fun observe(modes: Set<BrowserMode> = BrowserMode.entries.toSet()): Flow<T>
+}

--- a/browser-mode/browser-mode-api/src/main/java/com/duckduckgo/browsermode/api/ModeQualifiers.kt
+++ b/browser-mode/browser-mode-api/src/main/java/com/duckduckgo/browsermode/api/ModeQualifiers.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browsermode.api
+
+import javax.inject.Qualifier
+
+/**
+ * DI qualifier for bindings that belong to the [BrowserMode.REGULAR] browsing experience.
+ *
+ * Annotate a binding or injection site with this to select the regular-mode variant when
+ * both a regular and a fire-mode binding exist for the same type.
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RegularMode
+
+/**
+ * DI qualifier for bindings that belong to the [BrowserMode.FIRE] browsing experience.
+ *
+ * Annotate a binding or injection site with this to select the fire-mode variant when
+ * both a regular and a fire-mode binding exist for the same type.
+ */
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FireMode

--- a/browser-mode/browser-mode-impl/src/main/java/com/duckduckgo/browsermode/impl/FireModeFeature.kt
+++ b/browser-mode/browser-mode-impl/src/main/java/com/duckduckgo/browsermode/impl/FireModeFeature.kt
@@ -29,6 +29,6 @@ interface FireModeFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun fireTabs(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -56,6 +56,8 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.gone
@@ -184,6 +186,12 @@ class DuckChatContextualFragment :
     @Inject
     lateinit var contextualNativeInputManager: ContextualNativeInputManager
 
+    @Inject
+    lateinit var webViewModeInitializer: WebViewModeInitializer
+
+    @Inject
+    lateinit var browserMode: BrowserMode
+
     private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     private var pendingFileDownload: FileDownloader.PendingFileDownload? = null
@@ -252,6 +260,8 @@ class DuckChatContextualFragment :
         cookieManager.setAcceptThirdPartyCookies(simpleWebview, true)
 
         simpleWebview.let {
+            webViewModeInitializer.bind(it, browserMode)
+
             it.webViewClient = webViewClient
             webViewClient
                 .onPageFinishedListener = { url ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.nativeinput
 
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
@@ -45,7 +46,11 @@ class RealNativeInputStateStore @Inject constructor(
     // NativeInputStatePublisher to clearTab on tab eviction. Resolving TabRepository
     // lazily lets Dagger construct both without circularity. The lazy is only
     // dereferenced when `state` is collected for the first time.
-    private val tabRepository: Lazy<TabRepository>,
+    //
+    // Qualified @RegularMode because the unqualified TabRepository is only bound in
+    // ActivityScope; AppScope consumers must pick a mode explicitly. Duck.ai native
+    // input state follows regular-mode tabs.
+    @RegularMode private val tabRepository: Lazy<TabRepository>,
 ) :
     NativeInputStateProvider,
     NativeInputStatePublisher {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
@@ -122,8 +123,6 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
 
     private val browseSharedViewModel: DuckChatSharedViewModel by activityViewModels()
 
-    val browserMode: BrowserMode? get() = arguments?.getString(KEY_DUCK_AI_BROWSER_MODE)?.let(BrowserMode::valueOf)
-
     @Inject
     lateinit var webViewClient: DuckChatWebViewClient
 
@@ -180,6 +179,12 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
     @Inject
     lateinit var browserAndInputScreenTransitionProvider: BrowserAndInputScreenTransitionProvider
 
+    @Inject
+    lateinit var webViewModeInitializer: WebViewModeInitializer
+
+    @Inject
+    lateinit var browserMode: BrowserMode
+
     private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     private var pendingFileDownload: PendingFileDownload? = null
@@ -208,6 +213,8 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
         cookieManager.setAcceptThirdPartyCookies(simpleWebview, true)
 
         simpleWebview.let {
+            webViewModeInitializer.bind(it, browserMode)
+
             it.webViewClient = webViewClient
             it.webChromeClient = object : WebChromeClient() {
                 override fun onCreateWindow(
@@ -748,6 +755,5 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
         private const val REQUEST_CODE_CHOOSE_FILE = 100
         const val KEY_DUCK_AI_URL: String = "KEY_DUCK_AI_URL"
         const val KEY_DUCK_AI_TABS: String = "KEY_DUCK_AI_TABS"
-        const val KEY_DUCK_AI_BROWSER_MODE: String = "KEY_DUCK_AI_BROWSER_MODE"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.duckchat.impl.voice
 
 import android.content.Context
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.AppScope
@@ -62,7 +62,7 @@ interface VoiceSessionStateManager {
 @ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
 class RealVoiceSessionStateManager @Inject constructor(
     private val context: Context,
-    private val tabRepository: TabRepository,
+    private val tabRepository: AggregateTabRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val duckChatFeature: DuckChatFeature,
 ) : VoiceSessionStateManager, BrowserLifecycleObserver {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/voice/VoiceSessionStateManager.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.duckchat.impl.voice
 
 import android.content.Context
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.AppScope
@@ -62,7 +62,7 @@ interface VoiceSessionStateManager {
 @ContributesMultibinding(AppScope::class, boundType = BrowserLifecycleObserver::class)
 class RealVoiceSessionStateManager @Inject constructor(
     private val context: Context,
-    private val tabRepository: AggregateTabRepository,
+    private val tabRepository: AggregateTabProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val duckChatFeature: DuckChatFeature,
 ) : VoiceSessionStateManager, BrowserLifecycleObserver {
@@ -128,7 +128,7 @@ class RealVoiceSessionStateManager @Inject constructor(
 
     private fun listenToTabRemoval() {
         listenJob += appCoroutineScope.launch {
-            tabRepository.flowTabs.drop(1).collect { tabs ->
+            tabRepository.observe().drop(1).collect { tabs ->
                 val existingTabIds = tabs.mapTo(mutableSetOf()) { it.tabId }
                 synchronized(this@RealVoiceSessionStateManager) {
                     _activeVoiceSessions.update { current ->

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -20,8 +20,8 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
+import com.duckduckgo.app.tabs.model.AggregateTabRepository
 import com.duckduckgo.app.tabs.model.TabEntity
-import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -48,7 +48,7 @@ class RealVoiceSessionStateManagerTest {
     val coroutineTestRule = CoroutineTestRule()
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val tabRepository: TabRepository = mock()
+    private val tabRepository: AggregateTabRepository = mock()
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
     private val duckChatFeature: DuckChatFeature = mock()
     private val voiceChatServiceToggle: Toggle = mock()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/voice/RealVoiceSessionStateManagerTest.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
-import com.duckduckgo.app.tabs.model.AggregateTabRepository
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -48,7 +48,7 @@ class RealVoiceSessionStateManagerTest {
     val coroutineTestRule = CoroutineTestRule()
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val tabRepository: AggregateTabRepository = mock()
+    private val tabRepository: AggregateTabProvider = mock()
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
     private val duckChatFeature: DuckChatFeature = mock()
     private val voiceChatServiceToggle: Toggle = mock()
@@ -63,7 +63,7 @@ class RealVoiceSessionStateManagerTest {
 
     @Before
     fun setup() {
-        whenever(tabRepository.flowTabs).thenReturn(tabsFlow)
+        whenever(tabRepository.observe()).thenReturn(tabsFlow)
         whenever(duckChatFeature.duckAiVoiceChatService()).thenReturn(voiceChatServiceToggle)
         whenever(voiceChatServiceToggle.isEnabled()).thenReturn(true)
         testee = RealVoiceSessionStateManager(

--- a/versions.properties
+++ b/versions.properties
@@ -195,3 +195,5 @@ version.com.google.zxing..core=3.5.4
 version.android.tools.desugar_jdk_libs=2.1.5
 
 version.de.siegmar..fastcsv=2.2.2
+
+version.javax.inject..javax.inject=1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214821628980689?focus=true

API Proposal: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215098408642711?focus=true

### Description

1. **Isolated tab storage per mode.** Fire-mode tabs persist in their own Room database, separate from regular tabs. Other tab-scoped state stays shared and will be cleaned per-mode later by the data-clearing plugin.

2. **Mode-aware tab consumers.** The tab switcher and autocomplete react to mode changes at runtime, reading from whichever mode is currently active. All behavior is gated behind the `fireTabs` feature flag — when disabled, the app behaves exactly as before.

3. **No public API or burn-flow changes.** The `TabRepository` interface is untouched and the existing burn (clear-all-data) path is untouched. This lays the data foundation; Fire-tab UI lands in a separate workstream.


### DI changes for fire-mode tab isolation

To support per-mode tab repositories without forcing every existing consumer to choose a side upfront, this PR introduces three coordinated bindings:

#### 1. Unqualified `TabRepository` — ActivityScope only

Previously `bindUnqualifiedTabRepository(@RegularMode impl)` made every plain `tabRepository: TabRepository` injection silently resolve to the regular repo — a footgun once fire mode exists. The unqualified binding now lives in `UnqualifiedTabRepositoryActivityModule` and is contributed **only to `ActivityScope`**. AppScope consumers can no longer resolve unqualified `TabRepository` (the build fails with `MissingBinding`), forcing them to declare `@RegularMode`, `@FireMode`, both, `BrowserModeDataProvider<TabRepository>`, or `AggregateTabRepository`. Activity- and fragment-scoped consumers transparently get whichever repo matches the activity's current browser mode.

#### 2. Activity-scoped `BrowserMode`

`provideActivityBrowserMode` is `@SingleInstanceIn(ActivityScope::class)` so it captures `browserModeStateHolder.currentMode.value` **once** at activity component creation. The unqualified repo binding and `BrowserActivity` itself both read from this frozen value, so the whole activity instance is locked to one mode for its lifetime. Mode changes trigger `recreate()`, which builds a fresh activity component that captures the new value cleanly — the two readers can never disagree mid-render.

#### 3. `AggregateTabRepository`

New interface in `browser-api` and impl in `:app` (`@ContributesBinding(AppScope)`) exposing `flowTabs: Flow<List<TabEntity>>` that combines both repos. For consumers that span modes (voice session lifecycle, "user has interacted" CTA hints), this is cleaner than injecting both qualifiers separately.

#### Injection-point inventory

| Consumer | Choice | Why |
|---|---|---|
| `BrowserViewModel` | Current mode | Frozen to the activity's mode; activity recreates on mode change |
| `BrowserTabViewModel` | Current mode | Per-tab VM follows the activity's mode |
| `DefaultTabManager` | Current mode | Manages the active mode's tabs |
| `OmnibarLayoutViewModel` | Current mode | Omnibar shows the activity's mode |
| `BrowserNavigationBarViewModel` | Current mode | Nav-bar chip is per-mode |
| `GranularFireDialogViewModel` | Current mode | Per-mode dialog; cross-mode handling deferred to data-clearing work |
| `SingleTabFireDialogViewModel` | Current mode | Same as above |
| `InputScreenViewModel` | Current mode | Duck-AI input screen uses current-mode repo |
| `NewTabReturnHatchViewModel` | Current mode | Hot-start case correct; cold-start cross-mode is future work |
| `TabSwitcherViewModel` | `BrowserModeDataProvider<TabRepository>` | The toggle lives in this screen; needs reactive resolution without recreate |
| `AutoComplete` | `BrowserModeDataProvider<TabRepository>` | Reactive `flatMapLatest` since instances can outlive a mode change |
| `BrowserViewModel` mode-change observer | StateFlow from state holder | Reactive observation drives `recreate()` |
| `FirstScreenHandler` | `BrowserModeDataProvider<TabRepository>` + state holder | App-scope singleton, lookup at call time |
| `ExternalIntentProcessingState` | `BrowserModeDataProvider<TabRepository>` + `flatMapLatest` | AppScope subscriber must re-subscribe on mode change |
| `VoiceSessionStateManager` | `AggregateTabRepository` | Listens to tab removal across both modes to end voice sessions |
| `CtaViewModel` | `AggregateTabRepository` | "User has any tabs" is mode-independent |
| `ShowOnAppLaunchOptionHandler` | `@RegularMode` | App-launch path is regular-only |
| `TabStatsBucketing` | `@RegularMode` | Long-term stats reflect persistent tabs only |
| `TabsDbSanitizer` | `@RegularMode` + `@FireMode` | Sanitizes both databases |
| `DataClearing` | `@RegularMode` | Cross-mode tab clearing deferred to data-clearing fire-mode work |
| `PrivacyModule.clearDataAction` → `ClearPersonalDataAction` | `@RegularMode` | Same as above; burn currently clears regular only |


### Steps to test this PR

Smoke testing the existing functionality with the FF off is sufficient for now.

- [ ] Open the app and open a few tabs
- [ ] Smoke test that everything works normally in the browser
- [ ] Open the tab switcher
- [ ] Verify the correct number of tabs is displayed
- [ ] Create and close some tabs and check that it behaves as expected



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tab persistence, activity recreation on mode change, and many injection sites; burn/clear still regular-only, and dual-database schema drift is a documented footgun.
> 
> **Overview**
> Introduces **separate tab persistence for Fire mode** via a new `FireModeDatabase` (`fire_mode.db`) that mirrors the regular tab schema, with `@RegularMode` / `@FireMode` DAO and dual `TabDataRepository` instances wired through new DI modules.
> 
> **Mode-aware resolution:** `BrowserModeDataProvider<TabRepository>` and `AggregateTabProvider` let app-scope code pick or combine repos by mode; unqualified `TabRepository` and `BrowserMode` are bound only in **ActivityScope** (frozen at activity creation, Custom Tabs forced to REGULAR). `BrowserActivity` recreates on mode switch and skips saving tab pager state so old webviews are not restored.
> 
> **Runtime behavior updates:** Autocomplete and the tab switcher use `flatMapLatest` on current mode; CTAs and voice sessions use aggregated tab flows; data clearing / burn paths still target `@RegularMode` only (noted TODOs). Browser mode is injected into tab fragments instead of bundle args; Duck Chat WebViews bind via `WebViewModeInitializer`. `fireTabs` remote toggle default moves to **false**; internal dev screen can seed/clear fire tabs.
> 
> Shared `TabEntity` / `TabSelectionEntity` docs warn that schema changes need migrations in **both** databases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f813c7bffc359c744ac1e384a466f0230ba3171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->