### PR TITLE
Notify Mattermost when Play Store build starts; fix existing messages

### DIFF
--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   release-production:
     runs-on: ubuntu-latest
-    name: Publish Bundle to Play Store Internal track
+    name: Publish Bundle to Play Store for review
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -80,6 +80,15 @@ jobs:
           fileName: api.json
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
+      - name: Notify Mattermost that Play Store build is starting
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
+          mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
+          mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
+          mattermost-message: ${{ env.emoji_info }} Building release ${{ inputs.ref }}. This will be uploaded to Play Store when complete.
+          action: 'send-mattermost-message'
+
       - name: Assemble the bundle
         env:
           MALICIOUS_SITE_PROTECTION_AUTH_TOKEN: ${{ secrets.MALICIOUS_SITE_PROTECTION_AUTH_TOKEN }}
@@ -112,7 +121,7 @@ jobs:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
           mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: ${{env.emoji_start}} Release ${{ github.event.inputs.ref }} uploaded to Play Store. See https://play.google.com/console/u/0/developers/5949020878215944484/app/4974643806384870294/releases/overview
+          mattermost-message: ${{env.emoji_info}} Release ${{ inputs.ref }} uploaded to Play Store. See https://play.google.com/console/u/0/developers/5949020878215944484/app/4974643806384870294/releases/overview
           action: 'send-mattermost-message'
 
       - name: Upload Universal APK to Github
@@ -127,7 +136,7 @@ jobs:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
           mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: ${{env.emoji_start}} Release ${{ github.event.inputs.ref }} uploaded to Github https://github.com/duckduckgo/Android/releases/tag/${{ github.event.inputs.ref }}
+          mattermost-message: ${{env.emoji_info}} Release ${{ inputs.ref }} uploaded to Github https://github.com/duckduckgo/Android/releases/tag/${{ inputs.ref }}
           action: 'send-mattermost-message'
 
       - name: Notify Mattermost of Release completed
@@ -137,7 +146,7 @@ jobs:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
           mattermost-channel-name: ${{ vars.MM_RELEASE_NOTIFY_CHANNEL }}
-          mattermost-message: ${{env.emoji_end}} Release ${{ github.event.inputs.ref }} completed successfully and is now in review.
+          mattermost-message: ${{env.emoji_end}} Release ${{ inputs.ref }} completed successfully and is now in review.
           action: 'send-mattermost-message'
 
       - name: Create Asana task when workflow failed


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1214893969211117?focus=true

### Description
Add an additional message posting during Play Store release process when app building is starting. Also fixes
- missing app version in the other messages due to incorrect reference
- incorrect title (referencing Internal track)

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds an extra notification step and corrects variables used in Mattermost messages; main risk is incorrect messaging or minor workflow YAML issues, not app behavior.
> 
> **Overview**
> Adds a new Mattermost notification at the start of the Play Store release workflow to announce the build has begun and will be uploaded when complete.
> 
> Updates existing Mattermost messages in `release_upload_play_store.yml` to consistently use `inputs.ref` (instead of `github.event.inputs.ref`) and adjusts the job name wording to reflect the “for review” Play Store upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc153fc76c72cc09762e8d62ea242aff9ae0ded. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->