### PR TITLE
Fix wide_page-load and m_app_startup_time pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_page_load.json5
+++ b/PixelDefinitions/pixels/definitions/wide_page_load.json5
@@ -76,8 +76,8 @@
                 "type": "boolean"
             },
             {
-                "key": "feature.data.ext.step.page_visible.progress",
-                "description": "True if page became visible at or after fixed progress threshold (50%), false if before",
+                "key": "feature.data.ext.progress",
+                "description": "True if page became visible at or after fixed progress threshold (50%), false if before. Recorded during the page_visible step.",
                 "type": "boolean"
             },
             {
@@ -91,13 +91,18 @@
                 "type": "boolean"
             },
             {
-                "key": "feature.data.ext.step.page_finish.outcome",
-                "description": "Final outcome of the page load",
+                "key": "feature.data.ext.outcome",
+                "description": "Final outcome of the page load. Recorded during the page_finish step.",
                 "enum": ["success", "error"]
             },
             {
-                "key": "feature.data.ext.step.page_finish.error_code",
+                "key": "feature.data.ext.error_code",
                 "description": "WebViewClient error constant name (e.g., ERROR_HOST_LOOKUP, ERROR_CONNECT). Only present on error outcomes.",
+                "type": "string"
+            },
+            {
+                "key": "feature.data.ext.failure_reason",
+                "description": "Failure reason auto-attached by the wide event client when the flow finishes with FlowStatus.Failure. Mirrors error_code for page-load failures.",
                 "type": "string"
             }
         ]

--- a/app/src/main/java/com/duckduckgo/app/startup/StartupMetricsPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/startup/StartupMetricsPixelParamRemovalPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.startup
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class StartupMetricsPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return StartupMetricsPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1214864368580602?focus=true 

### Description

Resolves two pixel validation errors reported by the automated live-validation report: `wide_page-load` and `m_app_startup_time`

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to telemetry schema/validation and a plugin that removes the `ATB` parameter from `m_app_startup_time` pixels before sending.
> 
> **Overview**
> Fixes `wide_page-load` pixel schema to match the emitted wide-event fields by renaming step-scoped keys to `feature.data.ext.progress`, `feature.data.ext.outcome`, and `feature.data.ext.error_code`, and by adding `feature.data.ext.failure_reason`.
> 
> Adds `StartupMetricsPixelParamRemovalPlugin`, which registers all `StartupMetricsPixelName` pixels (e.g., `m_app_startup_time`) for automatic removal of the `ATB` parameter prior to sending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ec21f1428dd45af4cef3101f8efd740a09fae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->