### PR TITLE
Use software render mode for trackers blocked shield animation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt
@@ -33,4 +33,8 @@ interface AddressBarTrackersAnimationFeatureToggle {
     @Toggle.InternalAlwaysEnabled
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun feature(): Toggle
+
+    @Toggle.InternalAlwaysEnabled
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun softwareRenderingMode(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationManager.kt
@@ -39,6 +39,12 @@ interface AddressBarTrackersAnimationManager {
     suspend fun isFeatureEnabled(): Boolean
 
     /**
+     * Returns the cached software rendering mode state if available, otherwise fetches and caches it.
+     * @return true if the shield animation should use Lottie's SOFTWARE render mode, false otherwise
+     */
+    suspend fun isSoftwareRenderingModeEnabled(): Boolean
+
+    /**
      * Determines if the tracker animation should be shown based on the current URL
      * and the URL where the animation was last shown.
      *
@@ -60,16 +66,24 @@ class RealAddressBarTrackersAnimationManager @Inject constructor(
 ) : AddressBarTrackersAnimationManager {
 
     private var cachedFeatureState: Boolean? = null
+    private var cachedSoftwareRenderingMode: Boolean? = null
 
     override suspend fun fetchFeatureState() {
         withContext(dispatcherProvider.io()) {
             cachedFeatureState = addressBarTrackersAnimationFeatureToggle.feature().isEnabled()
+            cachedSoftwareRenderingMode = addressBarTrackersAnimationFeatureToggle.softwareRenderingMode().isEnabled()
         }
     }
 
     override suspend fun isFeatureEnabled(): Boolean = withContext(dispatcherProvider.io()) {
         cachedFeatureState ?: addressBarTrackersAnimationFeatureToggle.feature().isEnabled().also {
             cachedFeatureState = it
+        }
+    }
+
+    override suspend fun isSoftwareRenderingModeEnabled(): Boolean = withContext(dispatcherProvider.io()) {
+        cachedSoftwareRenderingMode ?: addressBarTrackersAnimationFeatureToggle.softwareRenderingMode().isEnabled().also {
+            cachedSoftwareRenderingMode = it
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -709,7 +709,12 @@ class OmnibarLayout @JvmOverloads constructor(
             }
 
             is StartTrackersAnimation -> {
-                startTrackersAnimation(command.entities, command.isCustomTab, command.isAddressBarTrackersAnimationEnabled)
+                startTrackersAnimation(
+                    command.entities,
+                    command.isCustomTab,
+                    command.isAddressBarTrackersAnimationEnabled,
+                    command.useSoftwareRenderingMode,
+                )
             }
 
             is LaunchInputScreen -> {
@@ -1093,6 +1098,7 @@ class OmnibarLayout @JvmOverloads constructor(
         events: List<Entity>?,
         isCustomTab: Boolean,
         isAddressBarTrackersAnimationEnabled: Boolean,
+        useSoftwareRenderingMode: Boolean,
     ) {
         if (!isCustomTab) {
             if (isAddressBarTrackersAnimationEnabled) {
@@ -1104,6 +1110,7 @@ class OmnibarLayout @JvmOverloads constructor(
                     omnibarViews = omnibarViews(),
                     shieldViews = shieldViews(),
                     entities = events,
+                    useSoftwareRenderingMode = useSoftwareRenderingMode,
                 )
             } else {
                 animatorHelper.startTrackersAnimation(
@@ -1126,6 +1133,7 @@ class OmnibarLayout @JvmOverloads constructor(
                     shieldViews = customTabShieldViews(),
                     entities = events,
                     customBackgroundColor = animationBackgroundColor,
+                    useSoftwareRenderingMode = useSoftwareRenderingMode,
                 )
             } else {
                 animatorHelper.startTrackersAnimation(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -141,8 +141,9 @@ class OmnibarLayoutViewModel @Inject constructor(
             _viewState,
             tabRepository.flowTabs,
             flow { emit(addressBarTrackersAnimationManager.isFeatureEnabled()) },
+            flow { emit(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()) },
             browserMenuHighlight.shouldShowHighlightForMode(mode),
-        ) { state, tabs, isAddressBarTrackersAnimationEnabled, showHighlight ->
+        ) { state, tabs, isAddressBarTrackersAnimationEnabled, useSoftwareRenderingMode, showHighlight ->
             state.copy(
                 shouldUpdateTabsCount = tabs.size != state.tabCount && tabs.isNotEmpty(),
                 tabCount = tabs.size,
@@ -150,6 +151,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                 showBrowserMenuHighlight = showHighlight,
                 viewMode = getViewMode(state),
                 isAddressBarTrackersAnimationEnabled = isAddressBarTrackersAnimationEnabled,
+                useSoftwareRenderingMode = useSoftwareRenderingMode,
             )
         }
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.Eagerly, _viewState.value)
@@ -256,6 +258,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val isDuckAiBackAvailable: Boolean = false,
         val isNativeInputEnabled: Boolean = false,
         val isAddressBarTrackersAnimationEnabled: Boolean = false,
+        val useSoftwareRenderingMode: Boolean = false,
         val isProgressBarUpgradeEnabled: Boolean = false,
         val enabledState: EnabledState = EnabledState.ALL,
     ) {
@@ -282,6 +285,7 @@ class OmnibarLayoutViewModel @Inject constructor(
             val entities: List<Entity>?,
             val isCustomTab: Boolean,
             val isAddressBarTrackersAnimationEnabled: Boolean,
+            val useSoftwareRenderingMode: Boolean,
         ) : Command()
 
         data class StartCookiesAnimation(val isCosmetic: Boolean) : Command()
@@ -1054,6 +1058,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                                     entities = decoration.entities,
                                     isCustomTab = viewState.value.viewMode is CustomTab,
                                     isAddressBarTrackersAnimationEnabled = viewState.value.isAddressBarTrackersAnimationEnabled,
+                                    useSoftwareRenderingMode = viewState.value.useSoftwareRenderingMode,
                                 ),
                             )
                         }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
@@ -32,6 +32,7 @@ import androidx.core.animation.addListener
 import androidx.core.graphics.ColorUtils
 import androidx.core.transition.addListener
 import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.RenderMode
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -80,6 +81,7 @@ class AddressBarTrackersAnimator @Inject constructor(
         this.onAnimationComplete = onAnimationComplete
         this.customBackgroundColor = customBackgroundColor
 
+        addressBarTrackersBlockedAnimationShieldIcon.renderMode = RenderMode.SOFTWARE
         addressBarTrackersBlockedAnimationShieldIcon.show()
         addressBarTrackersBlockedAnimationShieldIcon.progress = 0F
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
@@ -64,6 +64,7 @@ class AddressBarTrackersAnimator @Inject constructor(
         shieldViews: List<View>,
         entities: List<Entity>?,
         customBackgroundColor: Int?,
+        useSoftwareRenderingMode: Boolean,
         onAnimationComplete: () -> Unit,
     ) {
         if (isAnimationRunning) return
@@ -81,7 +82,9 @@ class AddressBarTrackersAnimator @Inject constructor(
         this.onAnimationComplete = onAnimationComplete
         this.customBackgroundColor = customBackgroundColor
 
-        addressBarTrackersBlockedAnimationShieldIcon.renderMode = RenderMode.SOFTWARE
+        if (useSoftwareRenderingMode) {
+            addressBarTrackersBlockedAnimationShieldIcon.renderMode = RenderMode.SOFTWARE
+        }
         addressBarTrackersBlockedAnimationShieldIcon.show()
         addressBarTrackersBlockedAnimationShieldIcon.progress = 0F
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -143,6 +143,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
         shieldViews: List<View>,
         entities: List<Entity>?,
         customBackgroundColor: Int?,
+        useSoftwareRenderingMode: Boolean,
     ) {
         if (isCookiesAnimationRunning || addressBarTrackersAnimator.isAnimationRunning) return
 
@@ -155,6 +156,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
             shieldViews = shieldViews,
             entities = entities,
             customBackgroundColor = customBackgroundColor,
+            useSoftwareRenderingMode = useSoftwareRenderingMode,
             onAnimationComplete = {
                 conflatedJob +=
                     coroutineScope.launch {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserTrackersAnimatorHelper.kt
@@ -57,6 +57,7 @@ interface BrowserTrackersAnimatorHelper {
      * @param shieldViews are the views that should be hidden while the animation is running.
      * @param entities are the tracker entities detected on the current site
      * @param customBackgroundColor if specified, the background color to use for the animation text container.
+     * @param useSoftwareRenderingMode if true, forces Lottie SOFTWARE render mode on the shield icon to avoid hardware compositor issues on some devices.
      */
     fun startAddressBarTrackersAnimation(
         context: Context,
@@ -67,6 +68,7 @@ interface BrowserTrackersAnimatorHelper {
         shieldViews: List<View>,
         entities: List<Entity>?,
         customBackgroundColor: Int? = null,
+        useSoftwareRenderingMode: Boolean = false,
     )
 
     /**

--- a/app/src/test/java/com/duckduckgo/app/browser/animations/RealAddressBarTrackersAnimationManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/animations/RealAddressBarTrackersAnimationManagerTest.kt
@@ -107,6 +107,48 @@ class RealAddressBarTrackersAnimationManagerTest {
     }
 
     @Test
+    fun whenSoftwareRenderingModeEnabledThenIsSoftwareRenderingModeEnabledReturnsTrue() = runTest {
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
+
+        val result = testee.isSoftwareRenderingModeEnabled()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenSoftwareRenderingModeDisabledThenIsSoftwareRenderingModeEnabledReturnsFalse() = runTest {
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
+
+        val result = testee.isSoftwareRenderingModeEnabled()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun whenFetchFeatureStateCalledThenCachesSoftwareRenderingModeState() = runTest {
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
+
+        testee.fetchFeatureState()
+
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
+
+        val result = testee.isSoftwareRenderingModeEnabled()
+        assertTrue(result)
+    }
+
+    @Test
+    fun whenIsSoftwareRenderingModeEnabledCalledMultipleTimesThenUseCachedValue() = runTest {
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
+
+        assertTrue(testee.isSoftwareRenderingModeEnabled())
+
+        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
+
+        assertTrue(testee.isSoftwareRenderingModeEnabled())
+        assertTrue(testee.isSoftwareRenderingModeEnabled())
+    }
+
+    @Test
     fun whenCurrentUrlIsNullThenShouldShowAnimationReturnsFalse() {
         val result = testee.shouldShowAnimation(currentUrl = null, lastAnimatedUrl = null)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -147,6 +147,7 @@ class OmnibarLayoutViewModelTest {
         whenever(serpEasterEggLogosToggles.setFavourite().enabled()).thenReturn(setFavouriteFeatureEnabledFlow)
         runBlocking {
             whenever(addressBarTrackersAnimationManager.isFeatureEnabled()).thenReturn(false)
+            whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(false)
         }
 
         fakeStandardizedLeadingIconToggle = FeatureToggles.Builder(
@@ -1181,6 +1182,48 @@ class OmnibarLayoutViewModelTest {
 
         testee.commands().test {
             awaitItem().assertCommand(Command.StartTrackersAnimation::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSoftwareRenderingModeEnabledThenStartTrackersAnimationCommandForwardsFlag() = runTest {
+        whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(true)
+        initializeViewModel()
+
+        testee.viewState.test {
+            awaitItem()
+        }
+
+        testee.onOmnibarFocusChanged(false, SERP_URL)
+        val trackers = givenSomeTrackers()
+        testee.onAnimationStarted(Decoration.LaunchTrackersAnimation(trackers))
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is Command.StartTrackersAnimation)
+            assertTrue((command as Command.StartTrackersAnimation).useSoftwareRenderingMode)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSoftwareRenderingModeDisabledThenStartTrackersAnimationCommandForwardsFlag() = runTest {
+        whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(false)
+        initializeViewModel()
+
+        testee.viewState.test {
+            awaitItem()
+        }
+
+        testee.onOmnibarFocusChanged(false, SERP_URL)
+        val trackers = givenSomeTrackers()
+        testee.onAnimationStarted(Decoration.LaunchTrackersAnimation(trackers))
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is Command.StartTrackersAnimation)
+            assertFalse((command as Command.StartTrackersAnimation).useSoftwareRenderingMode)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1214885010072811?focus=true

### Description

Follow-up to the previous attempt at fixing intermittent WebView flashing while the trackers blocked shield animation plays (reported by Samsung users, not locally reproducible).

The previous attempt reduced the Lottie asset's complexity (fewer layers, lower frame rate). Feedback indicates the flashing is still occurring.

This change switches the trackers blocked shield Lottie to software render mode, mirroring the pattern already used for the fire animation (`FireAnimationActivity`, `NonGranularFireDialog`, `GranularFireDialog`, `SingleTabFireDialog`). Theory: the flashing is caused by GPU pipeline contention between the WebView's hardware compositor and the omnibar's hardware-accelerated Lottie repaints inside the MaterialCardView. Software mode renders each frame as a CPU-rasterised bitmap and uploads a single texture per frame, eliminating GPU-side competition with the WebView surface.

The render mode is set programmatically in `AddressBarTrackersAnimator.startAnimation()` rather than in the layout XML, so it only applies when the trackers blocked animation actually runs (which itself only happens when the feature flag is on — see the gate at `OmnibarLayout.startTrackersAnimation`). If the feature is off, no software-rendering setting is ever applied.

Software rendering is itself gated behind a separate `softwareRenderingMode` toggle (default on) so it can be disabled remotely if it causes problems on any device. The toggle is resolved on a background thread and threaded through the existing animation pipeline.

For a 44×44dp animation at 30fps the CPU cost is negligible, and the visual output should be pixel-identical to the hardware-rendered version.

### Steps to test this PR

_Trackers blocked shield animation_
- [ ] Open a site that loads trackers (e.g. cnn.com, theguardian.com, espn.com) in a new tab
- [ ] Confirm the shield in the omnibar plays the trackers blocked animation
- [ ] Confirm the animation completes smoothly and returns to the resting state
- [ ] Confirm there is no visible difference to how the animation looked before this change
- [ ] Load a few different tracker-heavy sites in succession to make sure repeated plays still work e.g. cnn.com -> theguardian.com -> espn.com

_Feature flag off (no behaviour change)_
- [ ] Disable the trackers blocked animation feature flag (`addressBarTrackersAnimation.feature`) via dev settings
- [ ] Visit tracker-heavy sites and confirm the legacy shield/trackers animation path is unchanged

_Software rendering mode flag_
- [ ] Ensure both `addressBarTrackersAnimation.feature` and `addressBarTrackersAnimation.softwareRenderingMode` are enabled (defaults)
- [ ] Open a tracker-heavy site (e.g. cnn.com) in a new tab
- [ ] Confirm the shield plays the trackers blocked animation as expected
- [ ] Disable only `addressBarTrackersAnimation.softwareRenderingMode` via dev settings and restart the app
- [ ] Open another tracker-heavy site in a new tab
- [ ] Confirm the shield animation still plays correctly
- [ ] Re-enable `addressBarTrackersAnimation.softwareRenderingMode` and restart the app
- [ ] Open a tracker-heavy site once more and confirm the shield animation plays as expected

_Multi-device verification_
- [ ] Test on a Samsung device if available (Mali/Exynos GPU) — this is the device family the original flashing reports came from; watch the WebView area while the animation plays
- [ ] Test on a non-Samsung Android device (e.g. Pixel, OnePlus) to confirm no regression
- [ ] If possible, test on an older / lower-end device to check the omnibar animation does not stutter under main-thread pressure

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that only affects how the trackers-blocked shield Lottie is rendered; main potential impact is minor CPU/perf differences during the animation.
> 
> **Overview**
> For the omnibar trackers-blocked shield animation, `AddressBarTrackersAnimator.startAnimation()` now forces the `LottieAnimationView` to use `RenderMode.SOFTWARE` before playing.
> 
> This is intended to reduce intermittent WebView flashing/graphics contention during the animation by avoiding hardware-accelerated Lottie rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb423c870eca480aaf4f1d1b3b46c754ca38a41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
