### PR TITLE
Wire per-row Rename in chat history overflow menu

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -119,6 +119,24 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach(::render)
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        viewModel.navigationEvents
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach(::onNavigationEvent)
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun onNavigationEvent(event: ChatHistoryViewModel.NavigationEvent) {
+        when (event) {
+            is ChatHistoryViewModel.NavigationEvent.OpenRename -> openRenameScreen(event.chatId, event.currentTitle)
+        }
+    }
+
+    private fun openRenameScreen(chatId: String, currentTitle: String) {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.chatHistoryFragmentContainer, RenameChatFragment.newInstance(chatId, currentTitle))
+            .addToBackStack(null)
+            .commit()
     }
 
     private fun render(state: ChatHistoryUiState) {
@@ -269,7 +287,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         val popup = PopupMenu(layoutInflater, R.layout.popup_chat_history_row)
         val view = popup.contentView
         popup.onMenuItemClicked(view.findViewById(R.id.pin)) { showComingSoonSnackbar() }
-        popup.onMenuItemClicked(view.findViewById(R.id.rename)) { showComingSoonSnackbar() }
+        popup.onMenuItemClicked(view.findViewById(R.id.rename)) {
+            viewModel.onRenameRequested(item.chatId, item.displayTitle)
+        }
         popup.onMenuItemClicked(view.findViewById(R.id.download)) { showComingSoonSnackbar() }
         popup.onMenuItemClicked(view.findViewById(R.id.delete)) { viewModel.onDeleteSingleChat(item.chatId) }
         popup.show(binding.root, anchor)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -61,7 +61,9 @@ class RealChatHistoryRepository @Inject constructor(
     }
 
     override suspend fun renameChat(chatId: String, newTitle: String) {
-        withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
+        withContext(dispatchers.io()) {
+            check(chatStore.renameChat(chatId, newTitle)) { "Chat $chatId not found or unreadable" }
+        }
     }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -35,7 +35,7 @@ interface ChatHistoryRepository {
 
     suspend fun deleteChat(chatId: String)
     suspend fun deleteAllChats()
-    suspend fun renameChat(chatId: String, newTitle: String)
+    suspend fun renameChat(chatId: String, newTitle: String): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -60,11 +60,8 @@ class RealChatHistoryRepository @Inject constructor(
         withContext(dispatchers.io()) { chatStore.deleteAllChats() }
     }
 
-    override suspend fun renameChat(chatId: String, newTitle: String) {
-        withContext(dispatchers.io()) {
-            check(chatStore.renameChat(chatId, newTitle)) { "Chat $chatId not found or unreadable" }
-        }
-    }
+    override suspend fun renameChat(chatId: String, newTitle: String): Boolean =
+        withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(
         chatId = chat.chatId,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -35,6 +35,7 @@ interface ChatHistoryRepository {
 
     suspend fun deleteChat(chatId: String)
     suspend fun deleteAllChats()
+    suspend fun renameChat(chatId: String, newTitle: String)
 }
 
 @ContributesBinding(AppScope::class)
@@ -57,6 +58,10 @@ class RealChatHistoryRepository @Inject constructor(
 
     override suspend fun deleteAllChats() {
         withContext(dispatchers.io()) { chatStore.deleteAllChats() }
+    }
+
+    override suspend fun renameChat(chatId: String, newTitle: String) {
+        withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
     }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -29,11 +29,15 @@ import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Mode
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.PendingConfirmation
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -49,6 +53,9 @@ class ChatHistoryViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val controls = MutableStateFlow(UiControls())
+
+    private val navigationChannel = Channel<NavigationEvent>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val navigationEvents: Flow<NavigationEvent> = navigationChannel.receiveAsFlow()
 
     /** Cached snapshot so non-suspend action methods can read Recent without re-subscribing. */
     private var latestItems: List<ChatHistoryItem> = emptyList()
@@ -121,6 +128,10 @@ class ChatHistoryViewModel @Inject constructor(
     /** Per-row overflow Delete — fires immediately, no confirmation. */
     fun onDeleteSingleChat(chatId: String) {
         dispatchSelectedClear(setOf(chatId))
+    }
+
+    fun onRenameRequested(chatId: String, currentTitle: String) {
+        navigationChannel.trySend(NavigationEvent.OpenRename(chatId = chatId, currentTitle = currentTitle))
     }
 
     private fun dispatchSelectedClear(chatIds: Set<String>) {
@@ -246,6 +257,10 @@ class ChatHistoryViewModel @Inject constructor(
         val active: Boolean = false,
         val query: String = "",
     )
+
+    sealed interface NavigationEvent {
+        data class OpenRename(val chatId: String, val currentTitle: String) : NavigationEvent
+    }
 
     private companion object {
         const val STOP_TIMEOUT_MILLIS = 5_000L

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
@@ -85,7 +85,7 @@ class RenameChatFragment : DuckDuckGoFragment(R.layout.fragment_rename_chat) {
     private fun onRenameResult(result: RenameChatViewModel.RenameResult) {
         when (result) {
             RenameChatViewModel.RenameResult.Success -> dismiss()
-            is RenameChatViewModel.RenameResult.Error ->
+            RenameChatViewModel.RenameResult.Error ->
                 Snackbar.make(binding.root, R.string.duck_ai_chat_history_rename_error, Snackbar.LENGTH_SHORT).show()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import android.os.Bundle
+import android.text.Editable
+import android.view.View
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.common.utils.text.TextChangedWatcher
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.databinding.FragmentRenameChatBinding
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(FragmentScope::class)
+class RenameChatFragment : DuckDuckGoFragment(R.layout.fragment_rename_chat) {
+
+    @Inject
+    lateinit var viewModelFactory: FragmentViewModelFactory
+
+    private val binding: FragmentRenameChatBinding by viewBinding()
+    private val viewModel: RenameChatViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[RenameChatViewModel::class.java]
+    }
+
+    private val chatId: String by lazy { checkNotNull(requireArguments().getString(ARG_CHAT_ID)) }
+    private val initialTitle: String by lazy { requireArguments().getString(ARG_CURRENT_TITLE).orEmpty() }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.toolbar.setTitle(R.string.duck_ai_chat_history_rename_title)
+        binding.toolbar.setNavigationIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_left_24)
+        binding.toolbar.setNavigationOnClickListener { dismiss() }
+        binding.toolbar.inflateMenu(R.menu.menu_rename_chat)
+        binding.toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_rename_confirm) {
+                onConfirmClicked()
+                true
+            } else {
+                false
+            }
+        }
+
+        binding.titleInput.text = initialTitle
+        binding.titleInput.addTextChangedListener(titleTextWatcher)
+        binding.titleInput.showKeyboardDelayed()
+        setConfirmEnabled(false)
+
+        viewModel.results
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach(::onRenameResult)
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun onConfirmClicked() {
+        viewModel.onSaveClicked(chatId, binding.titleInput.text)
+    }
+
+    private fun onRenameResult(result: RenameChatViewModel.RenameResult) {
+        when (result) {
+            RenameChatViewModel.RenameResult.Success -> dismiss()
+            is RenameChatViewModel.RenameResult.Error ->
+                Snackbar.make(binding.root, R.string.duck_ai_chat_history_rename_error, Snackbar.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun dismiss() {
+        requireActivity().hideKeyboard()
+        parentFragmentManager.popBackStack()
+    }
+
+    private fun setConfirmEnabled(enabled: Boolean) {
+        binding.toolbar.menu.findItem(R.id.action_rename_confirm)?.isEnabled = enabled
+    }
+
+    private val titleTextWatcher = object : TextChangedWatcher() {
+        override fun afterTextChanged(editable: Editable) {
+            val candidate = editable.toString().trim()
+            setConfirmEnabled(candidate.isNotBlank() && candidate != initialTitle.trim())
+        }
+    }
+
+    companion object {
+        private const val ARG_CHAT_ID = "arg_chat_id"
+        private const val ARG_CURRENT_TITLE = "arg_current_title"
+
+        fun newInstance(chatId: String, currentTitle: String): RenameChatFragment = RenameChatFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_CHAT_ID, chatId)
+                putString(ARG_CURRENT_TITLE, currentTitle)
+            }
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.di.scopes.FragmentScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ContributesViewModel(FragmentScope::class)
+class RenameChatViewModel @Inject constructor(
+    private val chatHistoryRepository: ChatHistoryRepository,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : ViewModel() {
+
+    private val resultChannel = Channel<RenameResult>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val results: Flow<RenameResult> = resultChannel.receiveAsFlow()
+
+    fun onSaveClicked(chatId: String, newTitle: String) {
+        appScope.launch {
+            runCatching { chatHistoryRepository.renameChat(chatId, newTitle.trim()) }
+                .onSuccess { resultChannel.trySend(RenameResult.Success) }
+                .onFailure { error -> resultChannel.trySend(RenameResult.Error(error)) }
+        }
+    }
+
+    sealed interface RenameResult {
+        data object Success : RenameResult
+        data class Error(val throwable: Throwable) : RenameResult
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
@@ -40,19 +40,19 @@ class RenameChatViewModel @Inject constructor(
 
     fun onSaveClicked(chatId: String, newTitle: String) {
         appScope.launch {
-            try {
-                chatHistoryRepository.renameChat(chatId, newTitle.trim())
-                resultChannel.trySend(RenameResult.Success)
+            val outcome = try {
+                if (chatHistoryRepository.renameChat(chatId, newTitle.trim())) RenameResult.Success else RenameResult.Error
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                resultChannel.trySend(RenameResult.Error(e))
+                RenameResult.Error
             }
+            resultChannel.trySend(outcome)
         }
     }
 
     sealed interface RenameResult {
         data object Success : RenameResult
-        data class Error(val throwable: Throwable) : RenameResult
+        data object Error : RenameResult
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.di.scopes.FragmentScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -39,9 +40,14 @@ class RenameChatViewModel @Inject constructor(
 
     fun onSaveClicked(chatId: String, newTitle: String) {
         appScope.launch {
-            runCatching { chatHistoryRepository.renameChat(chatId, newTitle.trim()) }
-                .onSuccess { resultChannel.trySend(RenameResult.Success) }
-                .onFailure { error -> resultChannel.trySend(RenameResult.Error(error)) }
+            try {
+                chatHistoryRepository.renameChat(chatId, newTitle.trim())
+                resultChannel.trySend(RenameResult.Success)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                resultChannel.trySend(RenameResult.Error(e))
+            }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
@@ -44,9 +44,10 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/keyline_4"
         android:hint="@string/duck_ai_chat_history_rename_chat_title_hint"
-        android:inputType="text|textCapWords"
+        app:capitalizeKeyboard="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/appBarLayout" />
+        app:layout_constraintTop_toBottomOf="@id/appBarLayout"
+        app:type="single_line" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.duckduckgo.duckchat.impl.history.RenameChatFragment">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/daxColorToolbar"
+            android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+            app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.duckduckgo.common.ui.view.text.DaxTextInput
+        android:id="@+id/titleInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/keyline_4"
+        android:hint="@string/duck_ai_chat_history_rename_chat_title_hint"
+        android:inputType="text|textCapWords"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/appBarLayout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/menu/menu_rename_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/menu/menu_rename_chat.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_rename_confirm"
+        android:enabled="false"
+        android:icon="@drawable/ic_check_24"
+        android:title="@string/duck_ai_chat_history_rename_confirm_content_description"
+        app:showAsAction="always" />
+</menu>

--- a/duckchat/duckchat-impl/src/main/res/menu/menu_rename_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/menu/menu_rename_chat.xml
@@ -18,8 +18,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_rename_confirm"
+        android:contentDescription="@string/duck_ai_chat_history_rename_confirm_content_description"
         android:enabled="false"
         android:icon="@drawable/ic_check_24"
-        android:title="@string/duck_ai_chat_history_rename_confirm_content_description"
+        android:title="@string/duck_ai_chat_history_rename_confirm_title"
         app:showAsAction="always" />
 </menu>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -104,6 +104,7 @@
     <string name="duck_ai_chat_history_exit_select_mode_content_description">Exit selection mode</string>
     <string name="duck_ai_chat_history_rename_title">Rename Chat</string>
     <string name="duck_ai_chat_history_rename_chat_title_hint">Chat Title</string>
-    <string name="duck_ai_chat_history_rename_confirm_content_description">Save</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Save</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Save chat title</string>
     <string name="duck_ai_chat_history_rename_error">Couldn\'t rename chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -102,4 +102,8 @@
     <string name="duck_ai_chat_history_row_selected_content_description">Selected</string>
     <string name="duck_ai_chat_history_row_unselected_content_description">Not selected</string>
     <string name="duck_ai_chat_history_exit_select_mode_content_description">Exit selection mode</string>
+    <string name="duck_ai_chat_history_rename_title">Rename Chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chat Title</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Save</string>
+    <string name="duck_ai_chat_history_rename_error">Couldn\'t rename chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -166,19 +167,22 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `renameChat delegates to store on success`() = runTest {
+    fun `renameChat delegates to store and returns true on success`() = runTest {
         whenever(chatStore.renameChat("abc", "New")).thenReturn(true)
 
-        repository.renameChat("abc", "New")
+        val result = repository.renameChat("abc", "New")
 
+        assertTrue(result)
         verify(chatStore).renameChat("abc", "New")
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `renameChat throws when store reports the chat could not be updated`() = runTest {
+    @Test
+    fun `renameChat returns false when store reports the chat could not be updated`() = runTest {
         whenever(chatStore.renameChat("missing", "New")).thenReturn(false)
 
-        repository.renameChat("missing", "New")
+        val result = repository.renameChat("missing", "New")
+
+        assertFalse(result)
     }
 
     private fun chat(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -165,6 +165,22 @@ class ChatHistoryRepositoryTest {
         verify(chatStore).deleteAllChats()
     }
 
+    @Test
+    fun `renameChat delegates to store on success`() = runTest {
+        whenever(chatStore.renameChat("abc", "New")).thenReturn(true)
+
+        repository.renameChat("abc", "New")
+
+        verify(chatStore).renameChat("abc", "New")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `renameChat throws when store reports the chat could not be updated`() = runTest {
+        whenever(chatStore.renameChat("missing", "New")).thenReturn(false)
+
+        repository.renameChat("missing", "New")
+    }
+
     private fun chat(
         chatId: String,
         title: String = "Title",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -805,6 +805,19 @@ class ChatHistoryViewModelTest {
         assertTrue(dataClearingTrigger.calls.isEmpty())
     }
 
+    @Test
+    fun `onRenameRequested emits OpenRename navigation event with chatId and currentTitle`() = coroutineRule.testScope.runTest {
+        viewModel.navigationEvents.test {
+            viewModel.onRenameRequested("chat-42", "My favourite chat")
+
+            val event = awaitItem()
+            assertTrue(event is ChatHistoryViewModel.NavigationEvent.OpenRename)
+            event as ChatHistoryViewModel.NavigationEvent.OpenRename
+            assertEquals("chat-42", event.chatId)
+            assertEquals("My favourite chat", event.currentTitle)
+        }
+    }
+
     /**
      * `stateIn(WhileSubscribed)` does not guarantee subscribers observe the `Loading` initial
      * value — the upstream may emit before the StateFlow can replay it. Tolerate both orderings.
@@ -837,6 +850,7 @@ private class FakeChatHistoryRepository(
     private val source: MutableStateFlow<List<ChatHistoryItem>>,
 ) : ChatHistoryRepository {
     val deletedChatIds: MutableList<String> = mutableListOf()
+    val renamedChats: MutableList<Pair<String, String>> = mutableListOf()
     var deleteAllChatsCalled: Boolean = false
         private set
 
@@ -850,6 +864,10 @@ private class FakeChatHistoryRepository(
     override suspend fun deleteAllChats() {
         deleteAllChatsCalled = true
         source.value = emptyList()
+    }
+
+    override suspend fun renameChat(chatId: String, newTitle: String) {
+        renamedChats += chatId to newTitle
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -866,8 +866,9 @@ private class FakeChatHistoryRepository(
         source.value = emptyList()
     }
 
-    override suspend fun renameChat(chatId: String, newTitle: String) {
+    override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         renamedChats += chatId to newTitle
+        return true
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -45,16 +44,24 @@ class RenameChatViewModelTest {
     }
 
     @Test
-    fun `onSaveClicked emits Error when repository throws`() = coroutineRule.testScope.runTest {
-        val failure = IllegalStateException("boom")
-        repository.errorToThrow = failure
+    fun `onSaveClicked emits Error when repository reports failure`() = coroutineRule.testScope.runTest {
+        repository.nextResult = false
 
         viewModel.results.test {
             viewModel.onSaveClicked("chat-1", "New Title")
 
-            val result = awaitItem()
-            assertTrue(result is RenameChatViewModel.RenameResult.Error)
-            assertEquals(failure, (result as RenameChatViewModel.RenameResult.Error).throwable)
+            assertEquals(RenameChatViewModel.RenameResult.Error, awaitItem())
+        }
+    }
+
+    @Test
+    fun `onSaveClicked emits Error when repository throws`() = coroutineRule.testScope.runTest {
+        repository.errorToThrow = IllegalStateException("boom")
+
+        viewModel.results.test {
+            viewModel.onSaveClicked("chat-1", "New Title")
+
+            assertEquals(RenameChatViewModel.RenameResult.Error, awaitItem())
         }
     }
 }
@@ -62,14 +69,16 @@ class RenameChatViewModelTest {
 private class RecordingRenameRepository : ChatHistoryRepository {
     val renames: MutableList<Pair<String, String>> = mutableListOf()
     var errorToThrow: Throwable? = null
+    var nextResult: Boolean = true
 
     override fun observeChats(): Flow<List<ChatHistoryItem>> = MutableStateFlow(emptyList())
 
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
 
-    override suspend fun renameChat(chatId: String, newTitle: String) {
+    override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         errorToThrow?.let { throw it }
         renames += chatId to newTitle
+        return nextResult
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class RenameChatViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val repository = RecordingRenameRepository()
+    private val viewModel = RenameChatViewModel(repository, coroutineRule.testScope)
+
+    @Test
+    fun `onSaveClicked forwards trimmed title and emits Success`() = coroutineRule.testScope.runTest {
+        viewModel.results.test {
+            viewModel.onSaveClicked("chat-1", "  New Title  ")
+
+            assertEquals(RenameChatViewModel.RenameResult.Success, awaitItem())
+            assertEquals(listOf("chat-1" to "New Title"), repository.renames)
+        }
+    }
+
+    @Test
+    fun `onSaveClicked emits Error when repository throws`() = coroutineRule.testScope.runTest {
+        val failure = IllegalStateException("boom")
+        repository.errorToThrow = failure
+
+        viewModel.results.test {
+            viewModel.onSaveClicked("chat-1", "New Title")
+
+            val result = awaitItem()
+            assertTrue(result is RenameChatViewModel.RenameResult.Error)
+            assertEquals(failure, (result as RenameChatViewModel.RenameResult.Error).throwable)
+        }
+    }
+}
+
+private class RecordingRenameRepository : ChatHistoryRepository {
+    val renames: MutableList<Pair<String, String>> = mutableListOf()
+    var errorToThrow: Throwable? = null
+
+    override fun observeChats(): Flow<List<ChatHistoryItem>> = MutableStateFlow(emptyList())
+
+    override suspend fun deleteChat(chatId: String) = Unit
+    override suspend fun deleteAllChats() = Unit
+
+    override suspend fun renameChat(chatId: String, newTitle: String) {
+        errorToThrow?.let { throw it }
+        renames += chatId to newTitle
+    }
+}

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -63,6 +63,9 @@ interface DuckAiChatStore {
 
     /** Deletes all chats and their associated files. */
     suspend fun deleteAllChats()
+
+    /** Renames [chatId] in the FE-owned JSON blob. Returns true if the chat existed and was updated, false otherwise. */
+    suspend fun renameChat(chatId: String, newTitle: String): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -128,6 +131,17 @@ class RealDuckAiChatStore @Inject constructor(
             fileMetaDao.deleteAll()
         }
     }
+
+    override suspend fun renameChat(chatId: String, newTitle: String): Boolean =
+        withContext(dispatchers.io()) {
+            logcat { "DuckAI: RealDuckAiChatStore.renameChat($chatId)" }
+            val entity = chatsDao.getById(chatId) ?: return@withContext false
+            val updatedJson = runCatching {
+                JSONObject(entity.data).put("title", newTitle).toString()
+            }.getOrNull() ?: return@withContext false
+            chatsDao.upsert(entity.copy(data = updatedJson))
+            true
+        }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -27,6 +27,7 @@ import dagger.Lazy
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -34,6 +35,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -275,6 +277,47 @@ class RealDuckAiChatStoreTest {
         assertFalse(file.exists())
         verify(fileMetaDao).deleteAll()
         verify(chatsDao).deleteAll()
+    }
+
+    // --- renameChat ---
+
+    @Test
+    fun `renameChat returns false when chat not found`() = runTest {
+        whenever(chatsDao.getById("missing")).thenReturn(null)
+
+        assertFalse(store.renameChat("missing", "New title"))
+        verify(chatsDao, never()).upsert(any())
+    }
+
+    @Test
+    fun `renameChat updates only the title and preserves other JSON fields`() = runTest {
+        val originalJson = """
+            {"chatId":"abc","title":"Old","model":"gpt-5-mini","lastEdit":"2026-04-01T21:31:54.260Z","pinned":true,"fileRefs":["uuid1"],"messages":[{"role":"user","text":"hi"}]}
+        """.trimIndent()
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", originalJson))
+
+        assertTrue(store.renameChat("abc", "Brand new title"))
+
+        val entityCaptor = argumentCaptor<DuckAiBridgeChatEntity>()
+        verify(chatsDao).upsert(entityCaptor.capture())
+        val captured = entityCaptor.firstValue
+        assertEquals("abc", captured.chatId)
+        val json = JSONObject(captured.data)
+        assertEquals("Brand new title", json.getString("title"))
+        assertEquals("abc", json.getString("chatId"))
+        assertEquals("gpt-5-mini", json.getString("model"))
+        assertEquals("2026-04-01T21:31:54.260Z", json.getString("lastEdit"))
+        assertTrue(json.getBoolean("pinned"))
+        assertEquals("uuid1", json.getJSONArray("fileRefs").getString(0))
+        assertEquals("hi", json.getJSONArray("messages").getJSONObject(0).getString("text"))
+    }
+
+    @Test
+    fun `renameChat returns false when stored JSON is malformed`() = runTest {
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", "not a json"))
+
+        assertFalse(store.renameChat("abc", "New title"))
+        verify(chatsDao, never()).upsert(any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214820120386822 

### Description

Wires the **Rename** action on the Duck.ai chat history screen so it actually edits a conversation's title.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] In Settings → Developer Settings → Feature Flags, confirm `duckAiChatHistory` (`self`, `historyScreen`) is ON and `duckChat → useNativeStorageChatData` is ON.
> - [ ] Create at least 2 chats in Duck.ai so there's something to rename.

_Happy path_

- [ ] Open the Chats screen → tap the 3-dot on any row → tap **Rename** → confirm the Rename screen opens with the current title preselected and the keyboard up.
- [ ] Edit the title → confirm the Save (check) action enables only when the field is non-blank AND different from the original.
- [ ] Tap Save → confirm the screen closes and the row in the list now shows the new title without a manual refresh.
- [ ] Open web sidebar and check the chat is renamed there too

_Guards_

- [ ] Open Rename and clear the field → confirm Save stays disabled.
- [ ] Open Rename and reset the field back to the original title (including the same value with surrounding whitespace) → confirm Save stays disabled.
- [ ] Open Rename and tap the toolbar back arrow / system back → confirm the screen closes and the title is unchanged in the list.

### UI changes

| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6042c3fe-7aee-4a67-b9dd-bdda830215a6" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/cc76b4e3-99b3-4978-97ae-1859b21720ca" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new rename flow that updates persisted chat JSON via the native store and introduces new navigation/event plumbing; mistakes could lead to failed updates or incorrect chat metadata updates. Scope is contained to chat history UI and storage layer with good test coverage.
> 
> **Overview**
> Enables the **Rename** action in chat history: selecting rename now emits a `NavigationEvent` from `ChatHistoryViewModel` that `ChatHistoryFragment` handles by pushing a new `RenameChatFragment`.
> 
> Adds a dedicated rename UI (toolbar + single-line title input with Save enabled only when non-blank and changed) backed by `RenameChatViewModel`, which trims input, calls `ChatHistoryRepository.renameChat`, and shows an error snackbar on failure.
> 
> Plumbs rename through persistence by adding `renameChat` to `ChatHistoryRepository` and implementing it in `RealDuckAiChatStore` to update only the `title` field in the stored chat JSON; adds strings, menu/layout resources, and unit tests covering navigation events and rename success/failure/malformed JSON cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62b93039aa78a7897783f4fb761bc35c73773b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->