### PR TITLE
Wire per-row Pin/Unpin in chat history overflow menu

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -29,6 +29,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.common.ui.view.PopupMenuItemView
 import com.duckduckgo.common.ui.view.SearchBar
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
@@ -286,7 +287,10 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     private fun showRowPopup(item: ChatHistoryItem, anchor: View) {
         val popup = PopupMenu(layoutInflater, R.layout.popup_chat_history_row)
         val view = popup.contentView
-        popup.onMenuItemClicked(view.findViewById(R.id.pin)) { showComingSoonSnackbar() }
+        val pinAction = view.findViewById<PopupMenuItemView>(R.id.pin)
+        val pinLabel = if (item.pinned) R.string.duck_ai_chat_history_action_unpin else R.string.duck_ai_chat_history_action_pin
+        pinAction.setPrimaryText(getString(pinLabel))
+        popup.onMenuItemClicked(pinAction) { viewModel.onTogglePin(item.chatId) }
         popup.onMenuItemClicked(view.findViewById(R.id.rename)) {
             viewModel.onRenameRequested(item.chatId, item.displayTitle)
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -125,6 +125,11 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
             .onEach(::onNavigationEvent)
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        viewModel.messageEvents
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .onEach(::onMessageEvent)
+            .launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun onNavigationEvent(event: ChatHistoryViewModel.NavigationEvent) {
@@ -133,11 +138,30 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         }
     }
 
+    private fun onMessageEvent(event: ChatHistoryViewModel.MessageEvent) {
+        when (event) {
+            is ChatHistoryViewModel.MessageEvent.PinToggled -> showPinToggledSnackbar(event)
+        }
+    }
+
     private fun openRenameScreen(chatId: String, currentTitle: String) {
         parentFragmentManager.beginTransaction()
             .replace(R.id.chatHistoryFragmentContainer, RenameChatFragment.newInstance(chatId, currentTitle))
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun showPinToggledSnackbar(event: ChatHistoryViewModel.MessageEvent.PinToggled) {
+        val messageRes = if (event.wasPinned) {
+            R.string.duck_ai_chat_history_unpin_snackbar
+        } else {
+            R.string.duck_ai_chat_history_pin_snackbar
+        }
+        Snackbar.make(binding.root, messageRes, Snackbar.LENGTH_LONG)
+            .setAction(R.string.duck_ai_chat_history_undo) {
+                viewModel.onUndoTogglePin(event.chatId, restorePinned = event.wasPinned)
+            }
+            .show()
     }
 
     private fun render(state: ChatHistoryUiState) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -36,6 +36,7 @@ interface ChatHistoryRepository {
     suspend fun deleteChat(chatId: String)
     suspend fun deleteAllChats()
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
+    suspend fun setPinned(chatId: String, pinned: Boolean)
 }
 
 @ContributesBinding(AppScope::class)
@@ -62,6 +63,10 @@ class RealChatHistoryRepository @Inject constructor(
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean =
         withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
+
+    override suspend fun setPinned(chatId: String, pinned: Boolean) {
+        withContext(dispatchers.io()) { chatStore.setPinned(chatId, pinned) }
+    }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(
         chatId = chat.chatId,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -65,7 +65,9 @@ class RealChatHistoryRepository @Inject constructor(
         withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
 
     override suspend fun setPinned(chatId: String, pinned: Boolean) {
-        withContext(dispatchers.io()) { chatStore.setPinned(chatId, pinned) }
+        withContext(dispatchers.io()) {
+            if (pinned) chatStore.pinChat(chatId) else chatStore.unpinChat(chatId)
+        }
     }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -57,6 +57,9 @@ class ChatHistoryViewModel @Inject constructor(
     private val navigationChannel = Channel<NavigationEvent>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val navigationEvents: Flow<NavigationEvent> = navigationChannel.receiveAsFlow()
 
+    private val messageChannel = Channel<MessageEvent>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val messageEvents: Flow<MessageEvent> = messageChannel.receiveAsFlow()
+
     /** Cached snapshot so non-suspend action methods can read Recent without re-subscribing. */
     private var latestItems: List<ChatHistoryItem> = emptyList()
 
@@ -136,7 +139,13 @@ class ChatHistoryViewModel @Inject constructor(
 
     fun onTogglePin(chatId: String) {
         val current = latestItems.firstOrNull { it.chatId == chatId } ?: return
-        appScope.launch { chatHistoryRepository.setPinned(chatId, !current.pinned) }
+        val wasPinned = current.pinned
+        appScope.launch { chatHistoryRepository.setPinned(chatId, !wasPinned) }
+        messageChannel.trySend(MessageEvent.PinToggled(chatId = chatId, wasPinned = wasPinned))
+    }
+
+    fun onUndoTogglePin(chatId: String, restorePinned: Boolean) {
+        appScope.launch { chatHistoryRepository.setPinned(chatId, restorePinned) }
     }
 
     private fun dispatchSelectedClear(chatIds: Set<String>) {
@@ -265,6 +274,10 @@ class ChatHistoryViewModel @Inject constructor(
 
     sealed interface NavigationEvent {
         data class OpenRename(val chatId: String, val currentTitle: String) : NavigationEvent
+    }
+
+    sealed interface MessageEvent {
+        data class PinToggled(val chatId: String, val wasPinned: Boolean) : MessageEvent
     }
 
     private companion object {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -134,6 +134,11 @@ class ChatHistoryViewModel @Inject constructor(
         navigationChannel.trySend(NavigationEvent.OpenRename(chatId = chatId, currentTitle = currentTitle))
     }
 
+    fun onTogglePin(chatId: String) {
+        val current = latestItems.firstOrNull { it.chatId == chatId } ?: return
+        appScope.launch { chatHistoryRepository.setPinned(chatId, !current.pinned) }
+    }
+
     private fun dispatchSelectedClear(chatIds: Set<String>) {
         if (chatIds.isEmpty()) return
         if (!duckAiFeatureState.showClearDuckAIChatHistory.value) return

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -107,4 +107,7 @@
     <string name="duck_ai_chat_history_rename_confirm_title">Save</string>
     <string name="duck_ai_chat_history_rename_confirm_content_description">Save chat title</string>
     <string name="duck_ai_chat_history_rename_error">Couldn\'t rename chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
+    <string name="duck_ai_chat_history_undo">Undo</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -818,6 +818,46 @@ class ChatHistoryViewModelTest {
         }
     }
 
+    @Test
+    fun `onTogglePin flips pinned to true when row was unpinned`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = false))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onTogglePin("a")
+            val updated = awaitItem() as Loaded
+            assertEquals(listOf("a"), updated.pinned.map { it.chatId })
+            assertEquals(emptyList<String>(), updated.recent.map { it.chatId })
+        }
+        assertEquals(listOf("a" to true), repository.pinnedChats)
+    }
+
+    @Test
+    fun `onTogglePin flips pinned to false when row was pinned`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = true))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onTogglePin("a")
+            val updated = awaitItem() as Loaded
+            assertEquals(emptyList<String>(), updated.pinned.map { it.chatId })
+            assertEquals(listOf("a"), updated.recent.map { it.chatId })
+        }
+        assertEquals(listOf("a" to false), repository.pinnedChats)
+    }
+
+    @Test
+    fun `onTogglePin is a no-op when chatId is unknown`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = false))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onTogglePin("missing")
+            expectNoEvents()
+        }
+        assertTrue(repository.pinnedChats.isEmpty())
+    }
+
     /**
      * `stateIn(WhileSubscribed)` does not guarantee subscribers observe the `Loading` initial
      * value — the upstream may emit before the StateFlow can replay it. Tolerate both orderings.
@@ -851,6 +891,7 @@ private class FakeChatHistoryRepository(
 ) : ChatHistoryRepository {
     val deletedChatIds: MutableList<String> = mutableListOf()
     val renamedChats: MutableList<Pair<String, String>> = mutableListOf()
+    val pinnedChats: MutableList<Pair<String, Boolean>> = mutableListOf()
     var deleteAllChatsCalled: Boolean = false
         private set
 
@@ -869,6 +910,11 @@ private class FakeChatHistoryRepository(
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         renamedChats += chatId to newTitle
         return true
+    }
+
+    override suspend fun setPinned(chatId: String, pinned: Boolean) {
+        pinnedChats += chatId to pinned
+        source.value = source.value.map { if (it.chatId == chatId) it.copy(pinned = pinned) else it }
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -858,6 +858,66 @@ class ChatHistoryViewModelTest {
         assertTrue(repository.pinnedChats.isEmpty())
     }
 
+    @Test
+    fun `onTogglePin emits PinToggled message event with previous pinned state false`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = false))
+
+        viewModel.messageEvents.test {
+            // Drain the initial Loaded state so latestItems is primed.
+            viewModel.uiState.test { awaitInitialLoaded() }
+            viewModel.onTogglePin("a")
+
+            val event = awaitItem()
+            assertTrue(event is ChatHistoryViewModel.MessageEvent.PinToggled)
+            event as ChatHistoryViewModel.MessageEvent.PinToggled
+            assertEquals("a", event.chatId)
+            assertEquals(false, event.wasPinned)
+        }
+    }
+
+    @Test
+    fun `onTogglePin emits PinToggled message event with previous pinned state true`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = true))
+
+        viewModel.messageEvents.test {
+            viewModel.uiState.test { awaitInitialLoaded() }
+            viewModel.onTogglePin("a")
+
+            val event = awaitItem()
+            assertTrue(event is ChatHistoryViewModel.MessageEvent.PinToggled)
+            event as ChatHistoryViewModel.MessageEvent.PinToggled
+            assertEquals("a", event.chatId)
+            assertEquals(true, event.wasPinned)
+        }
+    }
+
+    @Test
+    fun `onTogglePin emits no message event when chatId is unknown`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = false))
+
+        viewModel.messageEvents.test {
+            viewModel.uiState.test { awaitInitialLoaded() }
+            viewModel.onTogglePin("missing")
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `onUndoTogglePin restores the requested pinned state via the repository`() = coroutineRule.testScope.runTest {
+        source.value = listOf(item("a", pinned = true))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onTogglePin("a") // a → unpinned
+            awaitItem() // Loaded after the unpin write
+            viewModel.onUndoTogglePin("a", restorePinned = true)
+            val restored = awaitItem() as Loaded
+            assertEquals(listOf("a"), restored.pinned.map { it.chatId })
+            assertEquals(emptyList<String>(), restored.recent.map { it.chatId })
+        }
+        assertEquals(listOf("a" to false, "a" to true), repository.pinnedChats)
+    }
+
     /**
      * `stateIn(WhileSubscribed)` does not guarantee subscribers observe the `Loading` initial
      * value — the upstream may emit before the StateFlow can replay it. Tolerate both orderings.

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -81,4 +81,6 @@ private class RecordingRenameRepository : ChatHistoryRepository {
         renames += chatId to newTitle
         return nextResult
     }
+
+    override suspend fun setPinned(chatId: String, pinned: Boolean) = Unit
 }

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -67,8 +67,11 @@ interface DuckAiChatStore {
     /** Renames [chatId] in the FE-owned JSON blob. Returns true if the chat existed and was updated, false otherwise. */
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
 
-    /** Sets the pinned flag on [chatId]. Returns true if the chat existed and was updated, false otherwise. */
-    suspend fun setPinned(chatId: String, pinned: Boolean): Boolean
+    /** Pins [chatId]. Silent no-op if the chat is not found or the stored JSON is malformed. */
+    suspend fun pinChat(chatId: String)
+
+    /** Unpins [chatId]. Silent no-op if the chat is not found or the stored JSON is malformed. */
+    suspend fun unpinChat(chatId: String)
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -146,16 +149,20 @@ class RealDuckAiChatStore @Inject constructor(
             true
         }
 
-    override suspend fun setPinned(chatId: String, pinned: Boolean): Boolean =
+    override suspend fun pinChat(chatId: String) = setPinned(chatId, pinned = true)
+
+    override suspend fun unpinChat(chatId: String) = setPinned(chatId, pinned = false)
+
+    private suspend fun setPinned(chatId: String, pinned: Boolean) {
         withContext(dispatchers.io()) {
             logcat { "DuckAI: RealDuckAiChatStore.setPinned($chatId, $pinned)" }
-            val entity = chatsDao.getById(chatId) ?: return@withContext false
+            val entity = chatsDao.getById(chatId) ?: return@withContext
             val updatedJson = runCatching {
                 JSONObject(entity.data).put("pinned", pinned).toString()
-            }.getOrNull() ?: return@withContext false
+            }.getOrNull() ?: return@withContext
             chatsDao.upsert(entity.copy(data = updatedJson))
-            true
         }
+    }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -66,6 +66,9 @@ interface DuckAiChatStore {
 
     /** Renames [chatId] in the FE-owned JSON blob. Returns true if the chat existed and was updated, false otherwise. */
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
+
+    /** Sets the pinned flag on [chatId]. Returns true if the chat existed and was updated, false otherwise. */
+    suspend fun setPinned(chatId: String, pinned: Boolean): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -138,6 +141,17 @@ class RealDuckAiChatStore @Inject constructor(
             val entity = chatsDao.getById(chatId) ?: return@withContext false
             val updatedJson = runCatching {
                 JSONObject(entity.data).put("title", newTitle).toString()
+            }.getOrNull() ?: return@withContext false
+            chatsDao.upsert(entity.copy(data = updatedJson))
+            true
+        }
+
+    override suspend fun setPinned(chatId: String, pinned: Boolean): Boolean =
+        withContext(dispatchers.io()) {
+            logcat { "DuckAI: RealDuckAiChatStore.setPinned($chatId, $pinned)" }
+            val entity = chatsDao.getById(chatId) ?: return@withContext false
+            val updatedJson = runCatching {
+                JSONObject(entity.data).put("pinned", pinned).toString()
             }.getOrNull() ?: return@withContext false
             chatsDao.upsert(entity.copy(data = updatedJson))
             true

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -337,24 +337,25 @@ class RealDuckAiChatStoreTest {
         verify(chatsDao).deleteAll()
     }
 
-    // --- setPinned ---
+    // --- pinChat / unpinChat ---
 
     @Test
-    fun `setPinned returns false when chat not found`() = runTest {
+    fun `pinChat is a no-op when chat not found`() = runTest {
         whenever(chatsDao.getById("missing")).thenReturn(null)
 
-        assertFalse(store.setPinned("missing", true))
+        store.pinChat("missing")
+
         verify(chatsDao, never()).upsert(any())
     }
 
     @Test
-    fun `setPinned updates only the pinned flag and preserves other JSON fields`() = runTest {
+    fun `pinChat sets pinned to true and preserves other JSON fields`() = runTest {
         val originalJson = """
             {"chatId":"abc","title":"Old","model":"gpt-5-mini","lastEdit":"2026-04-01T21:31:54.260Z","pinned":false,"fileRefs":["uuid1"],"messages":[{"role":"user","text":"hi"}]}
         """.trimIndent()
         whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", originalJson))
 
-        assertTrue(store.setPinned("abc", true))
+        store.pinChat("abc")
 
         val entityCaptor = argumentCaptor<DuckAiBridgeChatEntity>()
         verify(chatsDao).upsert(entityCaptor.capture())
@@ -369,10 +370,26 @@ class RealDuckAiChatStoreTest {
     }
 
     @Test
-    fun `setPinned returns false when stored JSON is malformed`() = runTest {
+    fun `unpinChat sets pinned to false`() = runTest {
+        val originalJson = """
+            {"chatId":"abc","title":"Old","model":"gpt-5-mini","lastEdit":"2026-04-01T21:31:54.260Z","pinned":true}
+        """.trimIndent()
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", originalJson))
+
+        store.unpinChat("abc")
+
+        val entityCaptor = argumentCaptor<DuckAiBridgeChatEntity>()
+        verify(chatsDao).upsert(entityCaptor.capture())
+        val json = JSONObject(entityCaptor.firstValue.data)
+        assertFalse(json.getBoolean("pinned"))
+    }
+
+    @Test
+    fun `pinChat is a no-op when stored JSON is malformed`() = runTest {
         whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", "not a json"))
 
-        assertFalse(store.setPinned("abc", true))
+        store.pinChat("abc")
+
         verify(chatsDao, never()).upsert(any())
     }
 }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -336,4 +336,43 @@ class RealDuckAiChatStoreTest {
         // traversal file should not be deleted — it's outside filesDir
         verify(chatsDao).deleteAll()
     }
+
+    // --- setPinned ---
+
+    @Test
+    fun `setPinned returns false when chat not found`() = runTest {
+        whenever(chatsDao.getById("missing")).thenReturn(null)
+
+        assertFalse(store.setPinned("missing", true))
+        verify(chatsDao, never()).upsert(any())
+    }
+
+    @Test
+    fun `setPinned updates only the pinned flag and preserves other JSON fields`() = runTest {
+        val originalJson = """
+            {"chatId":"abc","title":"Old","model":"gpt-5-mini","lastEdit":"2026-04-01T21:31:54.260Z","pinned":false,"fileRefs":["uuid1"],"messages":[{"role":"user","text":"hi"}]}
+        """.trimIndent()
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", originalJson))
+
+        assertTrue(store.setPinned("abc", true))
+
+        val entityCaptor = argumentCaptor<DuckAiBridgeChatEntity>()
+        verify(chatsDao).upsert(entityCaptor.capture())
+        val json = JSONObject(entityCaptor.firstValue.data)
+        assertTrue(json.getBoolean("pinned"))
+        assertEquals("Old", json.getString("title"))
+        assertEquals("abc", json.getString("chatId"))
+        assertEquals("gpt-5-mini", json.getString("model"))
+        assertEquals("2026-04-01T21:31:54.260Z", json.getString("lastEdit"))
+        assertEquals("uuid1", json.getJSONArray("fileRefs").getString(0))
+        assertEquals("hi", json.getJSONArray("messages").getJSONObject(0).getString("text"))
+    }
+
+    @Test
+    fun `setPinned returns false when stored JSON is malformed`() = runTest {
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", "not a json"))
+
+        assertFalse(store.setPinned("abc", true))
+        verify(chatsDao, never()).upsert(any())
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214820120386824?focus=true 

### Description

Wires the **Pin / Unpin** action on the Duck.ai chat history screen so a chat actually moves between the Pinned and Recent sections. The toggle fires immediately with no confirmation; a snackbar with **Undo** appears so a mistap is recoverable. State is persisted via the native chat store so the same Pinned/Recent split shows on next open and on Duck.ai itself.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] In Settings → Developer Settings → Feature Flags, confirm `duckAiChatHistory` (`self`, `historyScreen`) is ON and `duckChat → useNativeStorageChatData` is ON.
> - [ ] Create at least 2 chats in Duck.ai so there's something to pin.

_Happy path_

- [ ] Open the Chats screen → tap the 3-dot on a Recent row → tap **Pin** → confirm the row moves to a Pinned section above Recent and a "Chat pinned" snackbar appears with an **Undo** action.
- [ ] Tap the 3-dot on a Pinned row → tap **Unpin** → confirm the row moves back to Recent and a "Chat unpinned" snackbar appears with **Undo**.
- [ ] Trigger a pin → tap **Undo** before the snackbar auto-dismisses → confirm the row returns to its original section.
- [ ] Trigger an unpin → tap **Undo** → confirm the row returns to the Pinned section.

_Persistence_

- [ ] Pin a chat, close and reopen the Chats screen → confirm the chat is still in the Pinned section.
- [ ] Pin a chat on Android, then open the same chat on Duck.ai web → confirm it shows as pinned there too (and vice versa).

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/4da61325-333c-4e45-af7b-6d728a24f448" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/f6f87b66-262b-40a0-aa34-3009f77c8aa8" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/0542f8ba-1ded-4d16-b680-47fba6be5202" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6078d394-7591-4798-b9f3-7c4830cb3621" />
N/A | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/aba16786-9067-4d2f-af0d-1297924bbf25" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted pin/unpin write path into the native chat store and surfaces it via immediate UI actions with undo, which could affect chat metadata consistency across sessions. Changes are localized but touch storage JSON updates and user-facing state transitions.
> 
> **Overview**
> Enables the per-row **Pin/Unpin** action in chat history to immediately move chats between *Pinned* and *Recent*, and shows a snackbar with **Undo** after toggling.
> 
> Adds a new `ChatHistoryRepository.setPinned` flow backed by native storage (`DuckAiChatStore.pinChat`/`unpinChat`) that updates the stored chat JSON’s `pinned` field, plus ViewModel/fragment wiring (`messageEvents`) and new tests validating state changes and persistence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e7fe3338f69ab906595ca001d9444bf871bb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->