### PR TITLE
Update attachment picker (native input)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -227,6 +227,8 @@ class AttachmentView(
         val supportedFileTypes = state?.supportedFileTypes.orEmpty()
         val supportsImages = state?.supportsImageUpload == true
 
+        if (!supportsImages && supportedFileTypes.isEmpty()) return
+
         val container = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
             setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.popup_menu_bg)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -20,16 +20,20 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Typeface
 import android.net.Uri
+import android.view.Gravity
+import android.view.LayoutInflater
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.PopupWindow
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
-import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
+import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.duckchat.impl.R
@@ -52,6 +56,7 @@ class AttachmentView(
     var onFilePickerRequested: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
 
     private var viewModel: AttachmentViewModel? = null
+    private var popupWindow: PopupWindow? = null
     private var thumbnailsLayout: LinearLayout? = null
     private var imageAttachmentsContainer: ImageAttachmentsContainerView? = null
     private var fileAttachmentsContainer: FileAttachmentsContainerView? = null
@@ -59,7 +64,7 @@ class AttachmentView(
 
     init {
         addView(buildAttachButton())
-        setOnClickListener { showChooserDialog() }
+        setOnClickListener { showPopupMenu() }
     }
 
     fun bind(scope: CoroutineScope, factory: ViewViewModelFactory) {
@@ -212,63 +217,95 @@ class AttachmentView(
         )
     }
 
-    private fun showChooserDialog() {
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        dismissPopup()
+    }
+
+    private fun showPopupMenu() {
         val state = viewModel?.attachmentState?.value
         val supportedFileTypes = state?.supportedFileTypes.orEmpty()
         val supportsImages = state?.supportsImageUpload == true
-        val mimeTypes = state?.acceptedMimeTypes ?: listOf("image/*")
 
-        host?.showAttachmentChooser(true)
-        val title = if (supportsImages) {
-            context.getString(R.string.imageCaptureCameraGalleryDisambiguationTitle)
-        } else {
-            context.getString(R.string.fileCaptureBrowseDisambiguationTitle)
+        val container = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.popup_menu_bg)
         }
-        ActionBottomSheetDialog.Builder(context)
-            .setTitle(title)
-            .setPrimaryItem(
-                context.getString(R.string.imageCaptureCameraGalleryDisambiguationGalleryOption),
-                com.duckduckgo.mobile.android.R.drawable.ic_image_24,
-            )
-            .apply {
-                if (supportsImages) {
-                    setSecondaryItem(
-                        context.getString(R.string.imageCaptureCameraGalleryDisambiguationCameraOption),
-                        com.duckduckgo.mobile.android.R.drawable.ic_camera_24,
-                    )
-                }
+        val popup = PopupWindow(
+            ScrollView(context).apply {
+                addView(container)
+                isVerticalScrollBarEnabled = false
+            },
+            resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.popupMenuWidth),
+            LayoutParams.WRAP_CONTENT,
+            false,
+        ).apply {
+            elevation = resources.getDimension(R.dimen.modelPickerMenuElevation)
+            isOutsideTouchable = true
+            setOnDismissListener { popupWindow = null }
+        }
+
+        if (supportsImages) {
+            addMenuItem(
+                container = container,
+                iconRes = com.duckduckgo.mobile.android.R.drawable.ic_camera_24,
+                titleRes = R.string.attachmentTakePhoto,
+            ) {
+                popup.dismiss()
+                host?.showAttachmentChooser(true)
+                onCameraCaptureRequested?.invoke(buildImagePickerCallback())
             }
-            .addEventListener(buildDialogListener(supportsImages, supportedFileTypes, mimeTypes))
-            .show()
+
+            addMenuItem(
+                container = container,
+                iconRes = com.duckduckgo.mobile.android.R.drawable.ic_image_24,
+                titleRes = R.string.attachmentAttachPhoto,
+            ) {
+                popup.dismiss()
+                host?.showAttachmentChooser(true)
+                onFilePickerRequested?.invoke(buildImagePickerCallback(), listOf("image/*"))
+            }
+        }
+
+        if (supportedFileTypes.isNotEmpty()) {
+            addMenuItem(
+                container = container,
+                iconRes = R.drawable.ic_folder_24,
+                titleRes = R.string.attachmentAttachFile,
+            ) {
+                popup.dismiss()
+                host?.showAttachmentChooser(true)
+                onFilePickerRequested?.invoke(buildFilePickerCallback(), supportedFileTypes)
+            }
+        }
+
+        popupWindow = popup
+        showAtPosition(popup)
     }
 
-    private fun buildDialogListener(
-        supportsImages: Boolean,
-        supportedFileTypes: List<String>,
-        mimeTypes: List<String>,
-    ) = object : ActionBottomSheetDialog.EventListener() {
-        private var pickerLaunched = false
+    private fun addMenuItem(container: LinearLayout, iconRes: Int, titleRes: Int, onClick: () -> Unit) {
+        val row = LayoutInflater.from(context).inflate(R.layout.view_options_menu_item, container, false)
+        row.minimumHeight = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.popupMenuItemHeight)
+        row.findViewById<ImageView>(R.id.optionsMenuItemIcon).setImageResource(iconRes)
+        row.findViewById<DaxTextView>(R.id.optionsMenuItemTitle).setText(titleRes)
+        row.findViewById<DaxTextView>(R.id.optionsMenuItemSubtitle).visibility = GONE
+        row.findViewById<ImageView>(R.id.optionsMenuItemTrailingIcon).visibility = GONE
+        row.setOnClickListener { onClick() }
+        container.addView(row)
+    }
 
-        override fun onPrimaryItemClicked() {
-            pickerLaunched = true
-            val callback = if (supportsImages && supportedFileTypes.isNotEmpty()) {
-                buildCombinedPickerCallback()
-            } else if (supportedFileTypes.isNotEmpty()) {
-                buildFilePickerCallback()
-            } else {
-                buildImagePickerCallback()
-            }
-            onFilePickerRequested?.invoke(callback, mimeTypes)
-        }
+    private fun showAtPosition(popup: PopupWindow) {
+        val button = getChildAt(0) ?: this
+        val loc = IntArray(2).also { button.getLocationOnScreen(it) }
+        popup.showAtLocation(rootView, Gravity.TOP or Gravity.START, loc[0], loc[1])
+    }
 
-        override fun onSecondaryItemClicked() {
-            pickerLaunched = true
-            onCameraCaptureRequested?.invoke(buildImagePickerCallback())
+    private fun dismissPopup() {
+        popupWindow?.let {
+            it.setOnDismissListener(null)
+            if (it.isShowing) it.dismiss()
         }
-
-        override fun onBottomSheetDismissed() {
-            if (!pickerLaunched) host?.showAttachmentChooser(false)
-        }
+        popupWindow = null
     }
 
     private fun buildImagePickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->
@@ -279,10 +316,5 @@ class AttachmentView(
     private fun buildFilePickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->
         val list = uris?.toList()
         if (!list.isNullOrEmpty()) viewModel?.onFilesPicked(list)
-    }
-
-    private fun buildCombinedPickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->
-        val list = uris?.toList() ?: return@ValueCallback
-        if (list.isNotEmpty()) viewModel?.onMixedAttachmentsPicked(list)
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_folder_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_folder_24.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7,3C4.239,3 2,5.239 2,8V16C2,18.761 4.239,21 7,21H17C19.761,21 22,18.761 22,16V10.588C22,7.827 19.761,5.588 17,5.588H14.541C13.775,5.588 13.057,5.222 12.607,4.603C11.875,3.596 10.705,3 9.459,3H7ZM3.5,8C3.5,6.067 5.067,4.5 7,4.5H9.459C10.225,4.5 10.943,4.866 11.393,5.485C12.125,6.492 13.295,7.088 14.541,7.088H17C18.361,7.088 19.541,7.865 20.12,9H3.5V8ZM3.5,10.5V16C3.5,17.933 5.067,19.5 7,19.5H17C18.933,19.5 20.5,17.933 20.5,16V10.588C20.5,10.559 20.5,10.529 20.499,10.5H3.5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -57,6 +57,12 @@
     <string name="duckAiEndCtaTitle">You\'ve got this!</string>
     <string name="duckAiEndCtaDescription"><![CDATA[Use the address bar to search and visit sites or toggle to Duck.ai for private AI chat.<br/><br/>You can use Duck.ai from anywhere you see the chat icon]]></string>
     <string name="duckAiEndCtaButton">High five!</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="attachmentTakePhoto">Take Photo</string>
+    <string name="attachmentAttachPhoto">Attach Photo</string>
+    <string name="attachmentAttachFile">Attach File</string>
+
     <!-- File attachment -->
     <string name="duckChatFileAttachmentRemoveContentDescription">Remove file</string>
     <string name="duckChatFileAttachmentLimitPerConversation" instruction="%1$d is the maximum number of files allowed in a single conversation.">You can only attach %1$d files per conversation.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214907772007655?focus=true

### Description

- Updates the attachment chooser to show a similar dialog to the options and reasoning dialogs
- Adds an additional option if files are supported

### Steps to test this PR

_With the native input enabled_
- [x] Select GPT-5
- [x] Verify that take photo, attach photo and attach file are available
- [x] Select 4o-mini
- [x] Verify that only take photo and attach photo are available
- [x] Verify that the options work as expected

### UI changes
<img width="1080" height="822" alt="Screenshot_20260518_182532" src="https://github.com/user-attachments/assets/af87fd47-915c-42f4-b25f-50aeb755b9fe" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor limited to the attachment picker surface; main risk is regressions in picker launch/dismiss behavior and supported type gating.
> 
> **Overview**
> Switches the attachment button in `AttachmentView` from an `ActionBottomSheetDialog` chooser to a `PopupWindow` menu styled like other native-input menus, including proper dismissal handling on detach.
> 
> The menu now conditionally shows **Take Photo**, **Attach Photo**, and a new **Attach File** option based on `supportsImageUpload` and `supportedFileTypes`, and adds new strings plus a new `ic_folder_24` icon for the file option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a94133e5f2b11695a93bfdebfa3ba5e0379ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->