### PR TITLE
Fire Mode: Toggle switch

### DIFF
--- a/android-design-system/design-system/src/main/res/drawable/ic_fire_tabs_24.xml
+++ b/android-design-system/design-system/src/main/res/drawable/ic_fire_tabs_24.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14.906,12C16.615,12 18,13.385 18,15.094V18.906C18,20.615 16.615,22 14.906,22H9.094C7.385,22 6,20.615 6,18.906V15.094C6,13.385 7.385,12 9.094,12H14.906ZM9.094,13.5C8.214,13.5 7.5,14.214 7.5,15.094V18.906C7.5,19.786 8.214,20.5 9.094,20.5H14.906C15.786,20.5 16.5,19.786 16.5,18.906V15.094C16.5,14.214 15.786,13.5 14.906,13.5H9.094ZM9.896,2.036C10.097,1.971 10.318,1.994 10.502,2.1C11.632,2.751 12.225,3.674 12.6,4.625C12.942,5.495 13.107,6.419 13.383,7.31C13.427,7.453 13.775,8.271 14.934,8.271C15.498,8.271 15.833,8.108 16.037,7.949C16.252,7.782 16.369,7.581 16.429,7.452C16.51,7.25 16.546,7.029 16.591,6.816C16.638,6.593 16.675,6.352 16.794,6.153C16.819,6.111 16.913,5.957 17.105,5.855C17.219,5.796 17.37,5.752 17.543,5.771C17.687,5.786 17.817,5.843 17.933,5.928V5.929C18.055,6.024 22.031,9.12 22.031,14.509C22.031,15.943 21.506,17.243 20.625,18.341C20.227,18.837 19.5,18.513 19.5,17.877V17.763C19.5,17.486 19.596,17.221 19.747,16.989C20.231,16.249 20.518,15.403 20.531,14.509C20.531,11.318 18.898,9.042 17.856,7.915C17.685,8.394 17.358,8.822 16.958,9.133C16.482,9.503 15.82,9.771 14.934,9.771C12.829,9.771 12.088,8.197 11.95,7.754C11.546,6.45 11.415,4.902 10.403,3.895C9.135,6.301 7.424,7.893 6.082,9.319C4.578,10.918 3.531,12.303 3.531,14.509C3.544,15.372 3.811,16.19 4.266,16.912C4.409,17.14 4.5,17.399 4.5,17.668V17.805C4.5,18.444 3.768,18.765 3.375,18.261C2.532,17.18 2.031,15.909 2.031,14.509C2.031,11.698 3.434,9.946 4.99,8.292C6.559,6.624 8.282,5.044 9.442,2.444C9.534,2.253 9.691,2.102 9.896,2.036Z"
+      android:fillColor="?attr/daxColorPrimaryIcon" />
+</vector>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -283,9 +283,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
     // we don't store isExternal in the tab model, as it's only meant for the first time the tab is loaded.
     private val externalLaunchTabIds = mutableSetOf<String>()
 
-    // prevents new Browser mode's ViewPager showing old webviews when the mode changes
-    private var skipTabPagerStateSaveOnRecreate = false
-
     private lateinit var renderer: BrowserStateRenderer
 
     private val binding: ActivityBrowserBinding by viewBinding()
@@ -370,6 +367,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.daggerInject()
+
+        val savedMode = savedInstanceState?.getString(KEY_SAVED_BROWSER_MODE)
+        val modeChangedSinceSave = savedMode != null && savedMode != currentBrowserMode.name
+        if (modeChangedSinceSave) {
+            savedInstanceState?.remove(KEY_TAB_PAGER_STATE)
+        }
+
         intent?.sanitize()
         logcat(INFO) { "onCreate called. freshAppLaunch: ${dataClearer.isFreshAppLaunch}, savedInstanceState: $savedInstanceState" }
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
@@ -381,6 +385,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
 
         super.onCreate(savedInstanceState = newInstanceState, daggerInject = false)
+
+        if (modeChangedSinceSave) {
+            // remove restored VM and fragments
+            viewModelStore.clear()
+            removeStaleTabFragments()
+        }
 
         bindMockupToolbars()
 
@@ -424,7 +434,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        if (swipingTabsFeature.isEnabled && !skipTabPagerStateSaveOnRecreate) {
+        outState.putString(KEY_SAVED_BROWSER_MODE, currentBrowserMode.name)
+        if (swipingTabsFeature.isEnabled) {
             outState.putParcelable(KEY_TAB_PAGER_STATE, tabPagerAdapter.saveState())
         }
         pendingFireToRegularIntent?.let { outState.putParcelable(KEY_PENDING_FIRE_TO_REGULAR_INTENT, it) }
@@ -1222,19 +1233,25 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     /**
      * Recreates the activity whenever the user switches browser mode. The activity is built for
-     * one mode at a time (single adapter, single currentTab, single lastActiveTabs).
-     *
-     * The previous mode's BrowserTabFragments must NOT be restored, otherwise the new mode's
-     * ViewPager renders the old mode's webviews on top. We flag this so onSaveInstanceState
-     * skips the tab pager bundle.
+     * one mode at a time. The previous mode's tab state is stripped from the saved bundle, and any
+     * stale tab fragments are removed after restoration.
      */
     private fun observeBrowserModeChanges() {
         lifecycleScope.launch {
             viewModel.currentMode.drop(1).collect {
-                skipTabPagerStateSaveOnRecreate = true
                 recreate()
             }
         }
+    }
+
+    private fun removeStaleTabFragments() {
+        val staleFragments = supportFragmentManager.fragments.filterIsInstance<BrowserTabFragment>()
+        if (staleFragments.isEmpty()) return
+        val transaction = supportFragmentManager.beginTransaction()
+        staleFragments.forEach { transaction.remove(it) }
+        // The activity is still in pre-onResume territory here; commitNowAllowingStateLoss is
+        // the right tool — synchronous and tolerant of an in-progress save/restore.
+        transaction.commitNowAllowingStateLoss()
     }
 
     override fun onAttachFragment(fragment: androidx.fragment.app.Fragment) {
@@ -1341,6 +1358,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         private const val MAX_ACTIVE_TABS = 40
         private const val KEY_TAB_PAGER_STATE = "tabPagerState"
         private const val KEY_PENDING_FIRE_TO_REGULAR_INTENT = "pendingFireToRegularIntent"
+        private const val KEY_SAVED_BROWSER_MODE = "savedBrowserMode"
 
         private const val DISABLE_SWIPING_DELAY = 1000L
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1951,7 +1951,7 @@ class BrowserTabFragment :
 
     private fun launchTabSwitcher() {
         val activity = activity ?: return
-        val intent = TabSwitcherActivity.intent(activity, tabId)
+        val intent = TabSwitcherActivity.intent(activity)
         tabSwitcherActivityResult.launch(intent)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -121,7 +121,7 @@ class BrowserViewModel @Inject constructor(
 
     val currentMode: StateFlow<BrowserMode> = browserModeStateHolder.currentMode
 
-    suspend fun switchToMode(mode: BrowserMode): Boolean {
+    fun switchToMode(mode: BrowserMode): Boolean {
         if (mode != BrowserMode.REGULAR && !fireModeAvailability.isAvailable()) return false
         browserModeStateHolder.switchTo(mode)
         return true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -36,6 +36,8 @@ import androidx.annotation.StringRes
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.core.net.toUri
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.browser.SSLErrorType.EXPIRED
@@ -617,7 +619,7 @@ class BrowserWebViewClient @Inject constructor(
             webViewClientListener?.run {
                 pageFinished(webView, WebViewNavigationState(navigationList), url)
             }
-            flushCookies()
+            flushCookies(webView)
             printInjector.injectPrint(webView)
 
             if (url != null && url != ABOUT_BLANK) {
@@ -660,8 +662,15 @@ class BrowserWebViewClient @Inject constructor(
         }
     }
 
-    private fun flushCookies() {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
+    /**
+     * Flush cookies on the WebView's view-tree lifecycleScope (the fragment's
+     * viewLifecycleOwner) instead of appCoroutineScope. When the fragment's view is
+     * destroyed, the scope auto-cancels — preventing a post-destroy flush from SEGV'ing
+     * on the freed native cookie store of this WebView's profile.
+     */
+    private fun flushCookies(webView: WebView) {
+        val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        scope.launch(dispatcherProvider.io()) {
             cookieManagerProvider.get()?.flush()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.tabs.ui
 
 import android.content.Context
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.ViewConfiguration
@@ -80,7 +81,19 @@ class BrowserModeToggleView @JvmOverloads constructor(
     }
 
     fun setRegularTabCount(count: Int) {
-        binding.regularTabCount.text = count.toString()
+        val isInfinite = count >= INFINITE_TAB_COUNT_THRESHOLD
+        binding.regularTabCount.apply {
+            text = if (isInfinite) {
+                context.getString(R.string.browserModeToggleTabCountInfinite)
+            } else {
+                count.toString()
+            }
+            setTextSize(
+                TypedValue.COMPLEX_UNIT_SP,
+                if (isInfinite) INFINITE_TEXT_SIZE_SP else DIGIT_TEXT_SIZE_SP,
+            )
+            translationY = if (isInfinite) -INFINITE_VERTICAL_SHIFT_DP.toPx(context).toFloat() else 0f
+        }
     }
 
     fun setOnModeChangedListener(listener: (BrowserMode) -> Unit) {
@@ -156,5 +169,9 @@ class BrowserModeToggleView @JvmOverloads constructor(
     private companion object {
         const val OUTER_ELEVATION_DP = 4
         const val SLIDE_DURATION_MS = 220L
+        const val INFINITE_TAB_COUNT_THRESHOLD = 100
+        const val DIGIT_TEXT_SIZE_SP = 12f
+        const val INFINITE_TEXT_SIZE_SP = 13f
+        const val INFINITE_VERTICAL_SHIFT_DP = 1
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
@@ -69,8 +69,8 @@ class BrowserModeToggleView @JvmOverloads constructor(
         clipToPadding = false
         elevation = OUTER_ELEVATION_DP.toPx(context).toFloat()
 
-        binding.fireSegment.setOnClickListener { dispatchUserSelection(BrowserMode.FIRE) }
-        binding.regularSegment.setOnClickListener { dispatchUserSelection(BrowserMode.REGULAR) }
+        binding.fireSegment.setOnClickListener { dispatchToggle() }
+        binding.regularSegment.setOnClickListener { dispatchToggle() }
     }
 
     fun setMode(mode: BrowserMode) {
@@ -169,9 +169,12 @@ class BrowserModeToggleView @JvmOverloads constructor(
         }
     }
 
-    private fun dispatchUserSelection(mode: BrowserMode) {
-        if (mode == currentMode) return
-        listener?.invoke(mode)
+    private fun dispatchToggle() {
+        val target = when (currentMode) {
+            BrowserMode.FIRE -> BrowserMode.REGULAR
+            BrowserMode.REGULAR, null -> BrowserMode.FIRE
+        }
+        listener?.invoke(target)
     }
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
@@ -127,7 +127,7 @@ class BrowserModeToggleView @JvmOverloads constructor(
                     candidate.coerceIn(0f, segmentWidthPx.toFloat())
                 return true
             }
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+            MotionEvent.ACTION_UP -> {
                 val finalX = binding.selectionIndicator.translationX
                 val snappedMode =
                     if (finalX < segmentWidthPx / 2f) BrowserMode.FIRE else BrowserMode.REGULAR
@@ -142,6 +142,14 @@ class BrowserModeToggleView @JvmOverloads constructor(
                     // No mode change — snap the indicator back to the current segment.
                     animateIndicatorTo(snappedMode, animated = true)
                 }
+                return true
+            }
+            MotionEvent.ACTION_CANCEL -> {
+                // Gesture was interrupted (focus loss, multi-touch, parent intercept) —
+                // not a user-completed selection. Revert to the current mode without
+                // firing the listener.
+                dragging = false
+                currentMode?.let { animateIndicatorTo(it, animated = true) }
                 return true
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ViewBrowserModeToggleBinding
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.common.ui.view.toPx
+import kotlin.math.abs
+
+/**
+ * Segmented pill toggle that lets the user switch between [BrowserMode.FIRE] (left)
+ * and [BrowserMode.REGULAR] (right). The white "raised" selection indicator slides
+ * between segments — either on tap, or by direct horizontal drag (snaps to nearest
+ * side on release).
+ *
+ * Programmatic state updates via [setMode] / [setRegularTabCount] never fire the
+ * change listener — only user interactions do.
+ */
+class BrowserModeToggleView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding: ViewBrowserModeToggleBinding =
+        ViewBrowserModeToggleBinding.inflate(LayoutInflater.from(context), this)
+
+    private val segmentWidthPx: Int =
+        resources.getDimensionPixelSize(R.dimen.browserModeToggleSegmentWidth)
+
+    private val touchSlop: Int = ViewConfiguration.get(context).scaledTouchSlop
+
+    private var listener: ((BrowserMode) -> Unit)? = null
+    private var currentMode: BrowserMode? = null
+
+    private var dragging = false
+    private var initialTouchX = 0f
+    private var initialIndicatorX = 0f
+
+    init {
+        setBackgroundResource(R.drawable.background_browser_mode_toggle)
+
+        val pad = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_0)
+        setPadding(pad, pad, pad, pad)
+        clipChildren = false
+        clipToPadding = false
+        elevation = OUTER_ELEVATION_DP.toPx(context).toFloat()
+
+        binding.fireSegment.setOnClickListener { dispatchUserSelection(BrowserMode.FIRE) }
+        binding.regularSegment.setOnClickListener { dispatchUserSelection(BrowserMode.REGULAR) }
+    }
+
+    fun setMode(mode: BrowserMode) {
+        if (mode == currentMode) return
+        val previous = currentMode
+        currentMode = mode
+        animateIndicatorTo(mode, animated = previous != null)
+    }
+
+    fun setRegularTabCount(count: Int) {
+        binding.regularTabCount.text = count.toString()
+    }
+
+    fun setOnModeChangedListener(listener: (BrowserMode) -> Unit) {
+        this.listener = listener
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                initialTouchX = ev.x
+                initialIndicatorX = binding.selectionIndicator.translationX
+                dragging = false
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (!dragging && abs(ev.x - initialTouchX) > touchSlop) {
+                    dragging = true
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                    return true
+                }
+            }
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        if (!dragging) return super.onTouchEvent(ev)
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_MOVE -> {
+                val candidate = initialIndicatorX + (ev.x - initialTouchX)
+                binding.selectionIndicator.translationX =
+                    candidate.coerceIn(0f, segmentWidthPx.toFloat())
+                return true
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                val finalX = binding.selectionIndicator.translationX
+                val snappedMode =
+                    if (finalX < segmentWidthPx / 2f) BrowserMode.FIRE else BrowserMode.REGULAR
+                dragging = false
+
+                if (snappedMode != currentMode) {
+                    // Let the ViewModel publish the change; setMode arrives via the flow
+                    // and finishes the animation. Don't pre-animate here — keeps a single
+                    // source of truth and avoids a snap-and-jump if the switch is vetoed.
+                    listener?.invoke(snappedMode)
+                } else {
+                    // No mode change — snap the indicator back to the current segment.
+                    animateIndicatorTo(snappedMode, animated = true)
+                }
+                return true
+            }
+        }
+        return super.onTouchEvent(ev)
+    }
+
+    private fun animateIndicatorTo(mode: BrowserMode, animated: Boolean) {
+        val targetX = if (mode == BrowserMode.REGULAR) segmentWidthPx.toFloat() else 0f
+        if (animated) {
+            binding.selectionIndicator.animate()
+                .translationX(targetX)
+                .setDuration(SLIDE_DURATION_MS)
+                .setInterpolator(FastOutSlowInInterpolator())
+                .start()
+        } else {
+            binding.selectionIndicator.translationX = targetX
+        }
+    }
+
+    private fun dispatchUserSelection(mode: BrowserMode) {
+        if (mode == currentMode) return
+        listener?.invoke(mode)
+    }
+
+    private companion object {
+        const val OUTER_ELEVATION_DP = 4
+        const val SLIDE_DURATION_MS = 220L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/DefaultSnackbar.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/DefaultSnackbar.kt
@@ -74,4 +74,8 @@ class DefaultSnackbar(
     fun show() {
         snackbar.show()
     }
+
+    fun dismiss() {
+        snackbar.dismiss()
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -190,6 +190,7 @@ class TabSwitcherActivity :
     // tab so the user doesn't land in an arbitrary scroll position.
     private var lastObservedBrowserMode: com.duckduckgo.browsermode.api.BrowserMode? = null
     private var scrollToActiveTabOnNextUpdate = false
+    private var lastSnackbar: DefaultSnackbar? = null
 
     private val binding: ActivityTabSwitcherBinding by viewBinding()
     private val popupMenu by lazy {
@@ -600,12 +601,13 @@ class TabSwitcherActivity :
             ShowAnimatedTileDismissalDialog -> showAnimatedTileDismissalDialog()
             DismissAnimatedTileDismissalDialog -> tabSwitcherAnimationTileRemovalDialog!!.dismiss()
             Command.ShowFireBottomSheet -> onFireButtonClicked()
+            Command.DismissSnackbar -> lastSnackbar?.dismiss()
         }
     }
 
     private fun showBookmarkSnackbarWithUndo(numBookmarks: Int) {
         val message = resources.getQuantityString(R.plurals.tabSwitcherBookmarkToast, numBookmarks, numBookmarks)
-        DefaultSnackbar(
+        lastSnackbar = DefaultSnackbar(
             parentView = binding.root,
             message = message,
             anchor = snackbarAnchorView,
@@ -613,7 +615,8 @@ class TabSwitcherActivity :
             showAction = numBookmarks > 0,
             onAction = viewModel::undoBookmarkAction,
             onDismiss = viewModel::finishBookmarkAction,
-        ).show()
+        )
+        lastSnackbar?.show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -754,7 +757,7 @@ class TabSwitcherActivity :
     }
 
     private fun showTabsDeletedSnackbar(tabIds: List<String>) {
-        DefaultSnackbar(
+        lastSnackbar = DefaultSnackbar(
             parentView = binding.root,
             message = resources.getQuantityString(R.plurals.tabSwitcherCloseTabsSnackbar, tabIds.size, tabIds.size),
             anchor = snackbarAnchorView,
@@ -762,7 +765,8 @@ class TabSwitcherActivity :
             showAction = true,
             onAction = { launch { viewModel.onUndoDeleteTabs(tabIds) } },
             onDismiss = { launch { viewModel.onUndoDeleteSnackbarDismissed(tabIds) } },
-        ).show()
+        )
+        lastSnackbar?.show()
     }
 
     private fun launchShareLinkChooser(

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -26,12 +26,15 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.drawToBitmap
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -73,6 +76,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowUndoDeleteTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
 import com.duckduckgo.browser.api.ui.BrowserScreens.TabSwitcherScreenNoParams
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.button.ButtonType
@@ -185,11 +189,19 @@ class TabSwitcherActivity :
     private var isTrackerAnimationPanelVisible = false
     private var browserModeToggle: BrowserModeToggleView? = null
 
-    // Tracks the mode we last rendered for. When the toggle flips, the next viewState emission
-    // will arrive with a different mode's tab list — we want to scroll to that mode's active
-    // tab so the user doesn't land in an arbitrary scroll position.
-    private var lastObservedBrowserMode: com.duckduckgo.browsermode.api.BrowserMode? = null
-    private var scrollToActiveTabOnNextUpdate = false
+    // Non-null while a mode switch is in flight
+    private var modeSwitch: ModeSwitch? = null
+
+    /**
+     * Holds the bitmap overlay covering the recycler
+     * and a reference to the items list visible at fade-out time; the observer compares against
+     * [staleItems] to detect when the new mode's tabs have arrived.
+     */
+    private data class ModeSwitch(
+        val overlay: ImageView?,
+        val staleItems: List<TabSwitcherItem>,
+    )
+
     private var lastSnackbar: DefaultSnackbar? = null
 
     private val binding: ActivityTabSwitcherBinding by viewBinding()
@@ -363,18 +375,65 @@ class TabSwitcherActivity :
             ),
         )
         toggle.setOnModeChangedListener { mode ->
-            viewModel.onBrowserModeToggled(mode)
+            fadeOutAndSwitchMode(mode)
         }
 
-        // Seed from the current viewState so the first frame matches the final state — otherwise
-        // the toolbar flashes its default title and the indicator sits on FIRE for one frame.
         applyViewState(viewModel.viewState.value)
     }
 
     private fun applyViewState(state: TabSwitcherViewModel.ViewState) {
         browserModeToggle?.setMode(state.browserMode)
-        browserModeToggle?.setRegularTabCount(state.regularTabCount)
+        state.regularTabCount?.let { browserModeToggle?.setRegularTabCount(it) }
         updateToolbarTitle(state.mode, state.tabs.size)
+    }
+
+    // Snapshot the recycler and overlay it; the recycler updates underneath (mode switch, diff
+    // dispatch, scroll, Glide loads — none of it visible behind the static bitmap). When the
+    // observer sees a fresh tabSwitcherItems reference it calls revealNewMode, which crossfades
+    // the overlay out and the live recycler in.
+    private fun fadeOutAndSwitchMode(newMode: BrowserMode) {
+        if (modeSwitch != null) return
+
+        val overlay = runCatching { tabsRecycler.drawToBitmap() }.getOrNull()?.let { bitmap ->
+            ImageView(this).apply {
+                setImageBitmap(bitmap)
+                scaleType = ImageView.ScaleType.FIT_XY
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                )
+            }.also(tabsContainer::addView)
+        }
+        if (overlay != null) {
+            tabsRecycler.alpha = 0f
+        }
+
+        modeSwitch = ModeSwitch(overlay, viewModel.viewState.value.tabSwitcherItems)
+
+        // Suppress diff animations across the swap so items don't keep shuffling
+        tabsRecycler.itemAnimator = null
+
+        browserModeToggle?.setMode(newMode)
+        viewModel.onBrowserModeToggled(newMode)
+
+        // Fallback for the degenerate case where both modes have an empty list
+        tabsRecycler.postDelayed(::revealNewMode, FADE_IN_FALLBACK_MS)
+    }
+
+    private fun revealNewMode() {
+        val state = modeSwitch ?: return
+        modeSwitch = null
+        tabsRecycler.itemAnimator = DefaultItemAnimator()
+
+        tabsRecycler.animate()
+            .alpha(1f)
+            .setDuration(FADE_DURATION_MS)
+            .start()
+        state.overlay?.animate()
+            ?.alpha(0f)
+            ?.setDuration(FADE_DURATION_MS)
+            ?.withEndAction { tabsContainer.removeView(state.overlay) }
+            ?.start()
     }
 
     private fun updateToolbarTitle(
@@ -432,18 +491,17 @@ class TabSwitcherActivity :
             viewModel.viewState.flowWithLifecycle(lifecycle).collectLatest {
                 tabsRecycler.invalidateItemDecorations()
 
-                if (lastObservedBrowserMode != null && lastObservedBrowserMode != it.browserMode) {
-                    scrollToActiveTabOnNextUpdate = true
-                }
-                lastObservedBrowserMode = it.browserMode
-
-                val shouldScroll = (firstTimeLoadingTabsList || scrollToActiveTabOnNextUpdate) && it.tabs.isNotEmpty()
+                val staleItems = modeSwitch?.staleItems
+                val freshAfterModeSwitch = staleItems != null && it.tabSwitcherItems !== staleItems
+                val shouldScroll = it.tabs.isNotEmpty() && (firstTimeLoadingTabsList || freshAfterModeSwitch)
 
                 tabsAdapter.updateData(it.tabSwitcherItems) {
                     if (shouldScroll) {
                         firstTimeLoadingTabsList = false
-                        scrollToActiveTabOnNextUpdate = false
                         scrollToActiveTab(it.tabSwitcherItems)
+                    }
+                    if (freshAfterModeSwitch) {
+                        tabsRecycler.post(::revealNewMode)
                     }
                 }
 
@@ -961,5 +1019,7 @@ class TabSwitcherActivity :
         private const val TAB_GRID_COLUMN_WIDTH_DP = 180
         private const val TAB_GRID_MAX_COLUMN_COUNT = 4
         private const val KEY_FIRST_TIME_LOADING = "FIRST_TIME_LOADING"
+        private const val FADE_DURATION_MS = 180L
+        private const val FADE_IN_FALLBACK_MS = 1200L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -181,6 +181,8 @@ class TabSwitcherActivity :
 
     private var currentLayoutType: LayoutType? = null
 
+    private var isOnScrolledListenerAttached = false
+
     private var skipTabPurge: Boolean = false
 
     private lateinit var tabTouchHelper: TabTouchHelper
@@ -539,11 +541,12 @@ class TabSwitcherActivity :
 
     private fun updateLayoutType(layoutType: LayoutType) {
         if (layoutType == currentLayoutType) {
+            attachOnScrolledListener()
             tabsRecycler.show()
             return
         }
         tabsRecycler.hide()
-        tabsRecycler.removeOnScrollListener(onScrolledListener)
+        detachOnScrolledListener()
 
         val centerOffsetPercent = getCurrentCenterOffset()
 
@@ -553,15 +556,29 @@ class TabSwitcherActivity :
             scrollToPreviousCenterOffset(
                 centerOffsetPercent = centerOffsetPercent,
                 onScrollCompleted = {
-                    tabsRecycler.addOnScrollListener(onScrolledListener)
+                    attachOnScrolledListener()
                 },
             )
         } else {
             scrollToActiveTab(viewModel.viewState.value.tabSwitcherItems)
-            tabsRecycler.addOnScrollListener(onScrolledListener)
+            attachOnScrolledListener()
         }
 
         tabsRecycler.show()
+    }
+
+    private fun attachOnScrolledListener() {
+        if (isOnScrolledListenerAttached) return
+
+        tabsRecycler.addOnScrollListener(onScrolledListener)
+        isOnScrolledListenerAttached = true
+    }
+
+    private fun detachOnScrolledListener() {
+        if (!isOnScrolledListenerAttached) return
+
+        tabsRecycler.removeOnScrollListener(onScrolledListener)
+        isOnScrolledListenerAttached = false
     }
 
     private fun applyLayoutType(layoutType: LayoutType) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -31,6 +31,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.children
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.drawToBitmap
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -178,6 +179,8 @@ class TabSwitcherActivity :
     // we need to scroll to show selected tab, but only if it is the first time loading the tabs.
     private var firstTimeLoadingTabsList = true
 
+    private var currentLayoutType: LayoutType? = null
+
     private var skipTabPurge: Boolean = false
 
     private lateinit var tabTouchHelper: TabTouchHelper
@@ -233,8 +236,6 @@ class TabSwitcherActivity :
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        firstTimeLoadingTabsList = savedInstanceState?.getBoolean(KEY_FIRST_TIME_LOADING) ?: true
-
         tabsAdapter.setAnimationTileCloseClickListener {
             viewModel.onTrackerAnimationInfoPanelClicked()
         }
@@ -272,12 +273,6 @@ class TabSwitcherActivity :
         } else {
             binding.navigationBar.gone()
         }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-
-        outState.putBoolean(KEY_FIRST_TIME_LOADING, firstTimeLoadingTabsList)
     }
 
     private fun configureViewReferences() {
@@ -325,6 +320,14 @@ class TabSwitcherActivity :
         tabsRecycler.setHasFixedSize(true)
 
         handleSelectionModeCancellation()
+
+        // Seed the LayoutManager from the cached layoutType before observers start. Without
+        // this, the layoutType collector's first emission on rotation would swap the LM and
+        // discard the viewState collector's pending scrollToActiveTab.
+        viewModel.layoutType.value?.let {
+            applyLayoutType(it)
+            tabsRecycler.show()
+        }
     }
 
     private fun handleSelectionModeCancellation() {
@@ -535,34 +538,45 @@ class TabSwitcherActivity :
     }
 
     private fun updateLayoutType(layoutType: LayoutType) {
+        if (layoutType == currentLayoutType) {
+            tabsRecycler.show()
+            return
+        }
         tabsRecycler.hide()
         tabsRecycler.removeOnScrollListener(onScrolledListener)
 
         val centerOffsetPercent = getCurrentCenterOffset()
 
+        applyLayoutType(layoutType)
+
+        if (centerOffsetPercent.isFinite()) {
+            scrollToPreviousCenterOffset(
+                centerOffsetPercent = centerOffsetPercent,
+                onScrollCompleted = {
+                    tabsRecycler.addOnScrollListener(onScrolledListener)
+                },
+            )
+        } else {
+            scrollToActiveTab(viewModel.viewState.value.tabSwitcherItems)
+            tabsRecycler.addOnScrollListener(onScrolledListener)
+        }
+
+        tabsRecycler.show()
+    }
+
+    private fun applyLayoutType(layoutType: LayoutType) {
         when (layoutType) {
             LayoutType.GRID -> {
                 val columnCount = gridViewColumnCalculator.calculateNumberOfColumns(TAB_GRID_COLUMN_WIDTH_DP, TAB_GRID_MAX_COLUMN_COUNT)
-
-                val gridLayoutManager = getGridLayoutManager(columnCount)
-                tabsRecycler.layoutManager = gridLayoutManager
+                tabsRecycler.layoutManager = getGridLayoutManager(columnCount)
             }
             LayoutType.LIST -> {
                 tabsRecycler.layoutManager = LinearLayoutManager(this@TabSwitcherActivity)
             }
         }
-
         tabsAdapter.onLayoutTypeChanged(layoutType)
         tabTouchHelper.onLayoutTypeChanged(layoutType)
-
-        scrollToPreviousCenterOffset(
-            centerOffsetPercent = centerOffsetPercent,
-            onScrollCompleted = {
-                tabsRecycler.addOnScrollListener(onScrolledListener)
-            },
-        )
-
-        tabsRecycler.show()
+        currentLayoutType = layoutType
     }
 
     private fun getGridLayoutManager(columnCount: Int): GridLayoutManager =
@@ -633,7 +647,7 @@ class TabSwitcherActivity :
         val layoutManager = tabsRecycler.layoutManager as? LinearLayoutManager ?: return
         val innerHeight = tabsRecycler.height - tabsRecycler.paddingTop - tabsRecycler.paddingBottom
         if (innerHeight <= 0) {
-            layoutManager.scrollToPosition(index)
+            tabsRecycler.doOnPreDraw { scrollToPosition(index) }
             return
         }
         val rowHeight = tabsRecycler.children.firstOrNull {
@@ -1037,7 +1051,6 @@ class TabSwitcherActivity :
 
         private const val TAB_GRID_COLUMN_WIDTH_DP = 180
         private const val TAB_GRID_MAX_COLUMN_COUNT = 4
-        private const val KEY_FIRST_TIME_LOADING = "FIRST_TIME_LOADING"
         private const val FADE_DURATION_MS = 180L
         private const val FADE_IN_FALLBACK_MS = 1200L
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -189,7 +189,6 @@ class TabSwitcherActivity :
     private var isTrackerAnimationPanelVisible = false
     private var browserModeToggle: BrowserModeToggleView? = null
 
-    // Non-null while a mode switch is in flight
     private var modeSwitch: ModeSwitch? = null
 
     /**
@@ -387,10 +386,8 @@ class TabSwitcherActivity :
         updateToolbarTitle(state.mode, state.tabs.size)
     }
 
-    // Snapshot the recycler and overlay it; the recycler updates underneath (mode switch, diff
-    // dispatch, scroll, Glide loads — none of it visible behind the static bitmap). When the
-    // observer sees a fresh tabSwitcherItems reference it calls revealNewMode, which crossfades
-    // the overlay out and the live recycler in.
+    // Snapshot the recycler and overlay it; the recycler updates underneath, hidden by the
+    // bitmap. The observer reveals once fresh items arrive.
     private fun fadeOutAndSwitchMode(newMode: BrowserMode) {
         if (modeSwitch != null) return
 
@@ -408,7 +405,8 @@ class TabSwitcherActivity :
             tabsRecycler.alpha = 0f
         }
 
-        modeSwitch = ModeSwitch(overlay, viewModel.viewState.value.tabSwitcherItems)
+        val thisSwitch = ModeSwitch(overlay, viewModel.viewState.value.tabSwitcherItems)
+        modeSwitch = thisSwitch
 
         // Suppress diff animations across the swap so items don't keep shuffling
         tabsRecycler.itemAnimator = null
@@ -416,8 +414,11 @@ class TabSwitcherActivity :
         browserModeToggle?.setMode(newMode)
         viewModel.onBrowserModeToggled(newMode)
 
-        // Fallback for the degenerate case where both modes have an empty list
-        tabsRecycler.postDelayed(::revealNewMode, FADE_IN_FALLBACK_MS)
+        // Fallback for when fresh items never arrive (e.g. both modes empty). Identity-checked so
+        // a stale timer from a previous switch can't reveal the current one.
+        tabsRecycler.postDelayed({
+            if (modeSwitch === thisSwitch) revealNewMode()
+        }, FADE_IN_FALLBACK_MS)
     }
 
     private fun revealNewMode() {
@@ -493,14 +494,14 @@ class TabSwitcherActivity :
 
                 val staleItems = modeSwitch?.staleItems
                 val freshAfterModeSwitch = staleItems != null && it.tabSwitcherItems !== staleItems
-                val shouldScroll = it.tabs.isNotEmpty() && (firstTimeLoadingTabsList || freshAfterModeSwitch)
+                val shouldTryScroll = it.tabs.isNotEmpty() && (firstTimeLoadingTabsList || freshAfterModeSwitch)
 
                 tabsAdapter.updateData(it.tabSwitcherItems) {
-                    if (shouldScroll) {
-                        firstTimeLoadingTabsList = false
-                        scrollToActiveTab(it.tabSwitcherItems)
-                    }
-                    if (freshAfterModeSwitch) {
+                    // Scroll inside the commit callback so the new items are committed first.
+                    // If no active tab yet (race with flowSelectedTab), retry on next emission.
+                    val scrolled = shouldTryScroll && scrollToActiveTab(it.tabSwitcherItems)
+                    if (scrolled) firstTimeLoadingTabsList = false
+                    if (freshAfterModeSwitch && scrolled) {
                         tabsRecycler.post(::revealNewMode)
                     }
                 }
@@ -617,21 +618,21 @@ class TabSwitcherActivity :
         }
     }
 
-    private fun scrollToActiveTab(items: List<TabSwitcherItem>) {
+    private fun scrollToActiveTab(items: List<TabSwitcherItem>): Boolean {
         val index = items.indexOfFirst {
             (it is NormalTab && it.isActive) || (it is DuckAiTab && it.isActive)
         }
-        if (index != -1) {
-            scrollToPosition(index)
-        }
+        if (index == -1) return false
+        scrollToPosition(index)
+        return true
     }
 
     private fun scrollToPosition(index: Int) {
-        tabsRecycler.post {
-            val height = tabsRecycler.height
-            val offset = height / 2 - (tabsRecycler.getChildAt(0)?.height ?: 0) / 2
-            (tabsRecycler.layoutManager as? LinearLayoutManager)?.scrollToPositionWithOffset(index, offset)
-        }
+        val layoutManager = tabsRecycler.layoutManager as? LinearLayoutManager ?: return
+        val height = tabsRecycler.height
+        val firstChildHeight = tabsRecycler.getChildAt(0)?.height ?: 0
+        val offset = (height / 2 - firstChildHeight / 2).coerceAtLeast(0)
+        layoutManager.scrollToPositionWithOffset(index, offset)
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -20,6 +20,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
@@ -183,6 +184,7 @@ class TabSwitcherActivity :
     private var layoutTypeMenuItem: MenuItem? = null
     private var tabSwitcherAnimationTileRemovalDialog: DaxAlertDialog? = null
     private var isTrackerAnimationPanelVisible = false
+    private var browserModeToggle: BrowserModeToggleView? = null
 
     private val binding: ActivityTabSwitcherBinding by viewBinding()
     private val popupMenu by lazy {
@@ -221,6 +223,7 @@ class TabSwitcherActivity :
         extractIntentExtras()
         configureViewReferences()
         setupToolbar(toolbar)
+        configureBrowserModeToggle()
         configureRecycler()
         configureNavigationBar()
 
@@ -346,19 +349,42 @@ class TabSwitcherActivity :
         )
     }
 
+    private fun configureBrowserModeToggle() {
+        if (!viewModel.isBrowserModeToggleVisible) return
+
+        val toggle = BrowserModeToggleView(this).also { browserModeToggle = it }
+        toolbar.addView(
+            toggle,
+            Toolbar.LayoutParams(
+                Toolbar.LayoutParams.WRAP_CONTENT,
+                Toolbar.LayoutParams.WRAP_CONTENT,
+                Gravity.START or Gravity.CENTER_VERTICAL,
+            ),
+        )
+        toggle.setOnModeChangedListener { mode ->
+            viewModel.onBrowserModeToggled(mode)
+        }
+    }
+
     private fun updateToolbarTitle(
         mode: Mode,
         tabCount: Int,
     ) {
+        val toggle = browserModeToggle
+        val showToggle = toggle != null && mode !is Selection
+
+        toggle?.visibility = if (showToggle) View.VISIBLE else View.GONE
+
         toolbar.title =
-            if (mode is Selection) {
-                if (mode.selectedTabs.isEmpty()) {
-                    getString(R.string.selectTabsMenuItem)
-                } else {
-                    getString(R.string.tabSelectionTitle, mode.selectedTabs.size)
-                }
-            } else {
-                resources.getQuantityString(R.plurals.tabSwitcherTitle, tabCount, tabCount)
+            when {
+                mode is Selection ->
+                    if (mode.selectedTabs.isEmpty()) {
+                        getString(R.string.selectTabsMenuItem)
+                    } else {
+                        getString(R.string.tabSelectionTitle, mode.selectedTabs.size)
+                    }
+                showToggle -> ""
+                else -> resources.getQuantityString(R.plurals.tabSwitcherTitle, tabCount, tabCount)
             }
     }
 
@@ -422,6 +448,19 @@ class TabSwitcherActivity :
         lifecycleScope.launch {
             urlDisplayRepository.isFullUrlEnabled.flowWithLifecycle(lifecycle).collect {
                 tabsAdapter.isFullUrlEnabled = it
+            }
+        }
+
+        if (viewModel.isBrowserModeToggleVisible) {
+            lifecycleScope.launch {
+                viewModel.browserMode.flowWithLifecycle(lifecycle).collect { mode ->
+                    browserModeToggle?.setMode(mode)
+                }
+            }
+            lifecycleScope.launch {
+                viewModel.regularTabCount.flowWithLifecycle(lifecycle).collect { count ->
+                    browserModeToggle?.setRegularTabCount(count)
+                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -30,6 +30,7 @@ import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.children
 import androidx.core.view.drawToBitmap
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -88,6 +89,7 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
@@ -629,10 +631,21 @@ class TabSwitcherActivity :
 
     private fun scrollToPosition(index: Int) {
         val layoutManager = tabsRecycler.layoutManager as? LinearLayoutManager ?: return
-        val height = tabsRecycler.height
-        val firstChildHeight = tabsRecycler.getChildAt(0)?.height ?: 0
-        val offset = (height / 2 - firstChildHeight / 2).coerceAtLeast(0)
-        layoutManager.scrollToPositionWithOffset(index, offset)
+        val innerHeight = tabsRecycler.height - tabsRecycler.paddingTop - tabsRecycler.paddingBottom
+        val rowHeight = tabsRecycler.children.firstOrNull {
+            val pos = tabsRecycler.getChildAdapterPosition(it)
+            pos != RecyclerView.NO_POSITION && tabsAdapter.getTabSwitcherItem(pos) !is TrackersAnimationInfoPanel
+        }?.height ?: 0
+        if (innerHeight <= 0 || rowHeight <= 0) {
+            layoutManager.scrollToPosition(index)
+            return
+        }
+        val columns = (layoutManager as? GridLayoutManager)?.spanCount ?: 1
+        val itemCount = tabsRecycler.adapter?.itemCount ?: 0
+        val rowsBelow = ((itemCount + columns - 1) / columns) - (index / columns) - 1
+        val centerOffset = (innerHeight - rowHeight) / 2
+        val pinToBottomOffset = innerHeight - (rowsBelow + 1) * rowHeight - 20.toPx()
+        layoutManager.scrollToPositionWithOffset(index, maxOf(centerOffset, pinToBottomOffset).coerceAtLeast(0))
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -448,7 +448,7 @@ class TabSwitcherActivity :
 
         toggle?.visibility = if (showToggle) View.VISIBLE else View.GONE
 
-        toolbar.title =
+        supportActionBar?.title =
             when {
                 mode is Selection ->
                     if (mode.selectedTabs.isEmpty()) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -632,20 +632,25 @@ class TabSwitcherActivity :
     private fun scrollToPosition(index: Int) {
         val layoutManager = tabsRecycler.layoutManager as? LinearLayoutManager ?: return
         val innerHeight = tabsRecycler.height - tabsRecycler.paddingTop - tabsRecycler.paddingBottom
+        if (innerHeight <= 0) {
+            layoutManager.scrollToPosition(index)
+            return
+        }
         val rowHeight = tabsRecycler.children.firstOrNull {
             val pos = tabsRecycler.getChildAdapterPosition(it)
             pos != RecyclerView.NO_POSITION && tabsAdapter.getTabSwitcherItem(pos) !is TrackersAnimationInfoPanel
         }?.height ?: 0
-        if (innerHeight <= 0 || rowHeight <= 0) {
-            layoutManager.scrollToPosition(index)
-            return
-        }
-        val columns = (layoutManager as? GridLayoutManager)?.spanCount ?: 1
-        val itemCount = tabsRecycler.adapter?.itemCount ?: 0
-        val rowsBelow = ((itemCount + columns - 1) / columns) - (index / columns) - 1
         val centerOffset = (innerHeight - rowHeight) / 2
-        val pinToBottomOffset = innerHeight - (rowsBelow + 1) * rowHeight - 20.toPx()
-        layoutManager.scrollToPositionWithOffset(index, maxOf(centerOffset, pinToBottomOffset).coerceAtLeast(0))
+        val offset = if (rowHeight > 0) {
+            val columns = (layoutManager as? GridLayoutManager)?.spanCount ?: 1
+            val itemCount = tabsRecycler.adapter?.itemCount ?: 0
+            val rowsBelow = ((itemCount + columns - 1) / columns) - (index / columns) - 1
+            val pinToBottomOffset = innerHeight - (rowsBelow + 1) * rowHeight - 20.toPx()
+            maxOf(centerOffset, pinToBottomOffset)
+        } else {
+            centerOffset
+        }
+        layoutManager.scrollToPositionWithOffset(index, offset.coerceAtLeast(0))
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -506,7 +506,7 @@ class TabSwitcherActivity :
                     // If no active tab yet (race with flowSelectedTab), retry on next emission.
                     val scrolled = shouldTryScroll && scrollToActiveTab(it.tabSwitcherItems)
                     if (scrolled) firstTimeLoadingTabsList = false
-                    if (freshAfterModeSwitch && scrolled) {
+                    if (freshAfterModeSwitch) {
                         tabsRecycler.post(::revealNewMode)
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -364,6 +364,16 @@ class TabSwitcherActivity :
         toggle.setOnModeChangedListener { mode ->
             viewModel.onBrowserModeToggled(mode)
         }
+
+        // Seed from the current viewState so the first frame matches the final state — otherwise
+        // the toolbar flashes its default title and the indicator sits on FIRE for one frame.
+        applyViewState(viewModel.viewState.value)
+    }
+
+    private fun applyViewState(state: TabSwitcherViewModel.ViewState) {
+        browserModeToggle?.setMode(state.browserMode)
+        browserModeToggle?.setRegularTabCount(state.regularTabCount)
+        updateToolbarTitle(state.mode, state.tabs.size)
     }
 
     private fun updateToolbarTitle(
@@ -421,6 +431,11 @@ class TabSwitcherActivity :
             viewModel.viewState.flowWithLifecycle(lifecycle).collectLatest {
                 tabsRecycler.invalidateItemDecorations()
 
+                if (lastObservedBrowserMode != null && lastObservedBrowserMode != it.browserMode) {
+                    scrollToActiveTabOnNextUpdate = true
+                }
+                lastObservedBrowserMode = it.browserMode
+
                 val shouldScroll = (firstTimeLoadingTabsList || scrollToActiveTabOnNextUpdate) && it.tabs.isNotEmpty()
 
                 tabsAdapter.updateData(it.tabSwitcherItems) {
@@ -431,7 +446,7 @@ class TabSwitcherActivity :
                     }
                 }
 
-                updateToolbarTitle(it.mode, it.tabs.size)
+                applyViewState(it)
                 updateTabGridItemDecorator()
 
                 tabTouchHelper.mode = it.mode
@@ -449,23 +464,6 @@ class TabSwitcherActivity :
         lifecycleScope.launch {
             urlDisplayRepository.isFullUrlEnabled.flowWithLifecycle(lifecycle).collect {
                 tabsAdapter.isFullUrlEnabled = it
-            }
-        }
-
-        if (viewModel.isBrowserModeToggleVisible) {
-            lifecycleScope.launch {
-                viewModel.browserMode.flowWithLifecycle(lifecycle).collect { mode ->
-                    browserModeToggle?.setMode(mode)
-                    if (lastObservedBrowserMode != null && lastObservedBrowserMode != mode) {
-                        scrollToActiveTabOnNextUpdate = true
-                    }
-                    lastObservedBrowserMode = mode
-                }
-            }
-            lifecycleScope.launch {
-                viewModel.regularTabCount.flowWithLifecycle(lifecycle).collect { count ->
-                    browserModeToggle?.setRegularTabCount(count)
-                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -656,9 +656,17 @@ class TabSwitcherActivity :
         }?.height ?: 0
         val centerOffset = (innerHeight - rowHeight) / 2
         val offset = if (rowHeight > 0) {
-            val columns = (layoutManager as? GridLayoutManager)?.spanCount ?: 1
+            val gridLayoutManager = layoutManager as? GridLayoutManager
+            val spanCount = gridLayoutManager?.spanCount ?: 1
+            val spanSizeLookup = gridLayoutManager?.spanSizeLookup
             val itemCount = tabsRecycler.adapter?.itemCount ?: 0
-            val rowsBelow = ((itemCount + columns - 1) / columns) - (index / columns) - 1
+            val targetRow = spanSizeLookup?.getSpanGroupIndex(index, spanCount) ?: index
+            val lastRow = if (itemCount > 0) {
+                spanSizeLookup?.getSpanGroupIndex(itemCount - 1, spanCount) ?: (itemCount - 1)
+            } else {
+                targetRow
+            }
+            val rowsBelow = lastRow - targetRow
             val pinToBottomOffset = innerHeight - (rowsBelow + 1) * rowHeight - 20.toPx()
             maxOf(centerOffset, pinToBottomOffset)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -27,10 +27,10 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
-import androidx.core.view.drawToBitmap
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.drawToBitmap
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -172,7 +172,6 @@ class TabSwitcherActivity :
     // we need to scroll to show selected tab, but only if it is the first time loading the tabs.
     private var firstTimeLoadingTabsList = true
 
-    private var selectedTabId: String? = null
     private var skipTabPurge: Boolean = false
 
     private lateinit var tabTouchHelper: TabTouchHelper
@@ -185,6 +184,12 @@ class TabSwitcherActivity :
     private var tabSwitcherAnimationTileRemovalDialog: DaxAlertDialog? = null
     private var isTrackerAnimationPanelVisible = false
     private var browserModeToggle: BrowserModeToggleView? = null
+
+    // Tracks the mode we last rendered for. When the toggle flips, the next viewState emission
+    // will arrive with a different mode's tab list — we want to scroll to that mode's active
+    // tab so the user doesn't land in an arbitrary scroll position.
+    private var lastObservedBrowserMode: com.duckduckgo.browsermode.api.BrowserMode? = null
+    private var scrollToActiveTabOnNextUpdate = false
 
     private val binding: ActivityTabSwitcherBinding by viewBinding()
     private val popupMenu by lazy {
@@ -220,7 +225,6 @@ class TabSwitcherActivity :
             viewModel.onTrackerAnimationInfoPanelClicked()
         }
 
-        extractIntentExtras()
         configureViewReferences()
         setupToolbar(toolbar)
         configureBrowserModeToggle()
@@ -260,10 +264,6 @@ class TabSwitcherActivity :
         super.onSaveInstanceState(outState)
 
         outState.putBoolean(KEY_FIRST_TIME_LOADING, firstTimeLoadingTabsList)
-    }
-
-    private fun extractIntentExtras() {
-        selectedTabId = intent.getStringExtra(EXTRA_KEY_SELECTED_TAB)
     }
 
     private fun configureViewReferences() {
@@ -421,12 +421,13 @@ class TabSwitcherActivity :
             viewModel.viewState.flowWithLifecycle(lifecycle).collectLatest {
                 tabsRecycler.invalidateItemDecorations()
 
-                val shouldScroll = firstTimeLoadingTabsList && it.tabs.isNotEmpty()
+                val shouldScroll = (firstTimeLoadingTabsList || scrollToActiveTabOnNextUpdate) && it.tabs.isNotEmpty()
 
                 tabsAdapter.updateData(it.tabSwitcherItems) {
                     if (shouldScroll) {
                         firstTimeLoadingTabsList = false
-                        scrollToActiveTab()
+                        scrollToActiveTabOnNextUpdate = false
+                        scrollToActiveTab(it.tabSwitcherItems)
                     }
                 }
 
@@ -455,6 +456,10 @@ class TabSwitcherActivity :
             lifecycleScope.launch {
                 viewModel.browserMode.flowWithLifecycle(lifecycle).collect { mode ->
                     browserModeToggle?.setMode(mode)
+                    if (lastObservedBrowserMode != null && lastObservedBrowserMode != mode) {
+                        scrollToActiveTabOnNextUpdate = true
+                    }
+                    lastObservedBrowserMode = mode
                 }
             }
             lifecycleScope.launch {
@@ -555,8 +560,10 @@ class TabSwitcherActivity :
         }
     }
 
-    private fun scrollToActiveTab() {
-        val index = tabsAdapter.getAdapterPositionForTab(selectedTabId)
+    private fun scrollToActiveTab(items: List<TabSwitcherItem>) {
+        val index = items.indexOfFirst {
+            (it is NormalTab && it.isActive) || (it is DuckAiTab && it.isActive)
+        }
         if (index != -1) {
             scrollToPosition(index)
         }
@@ -944,16 +951,8 @@ class TabSwitcherActivity :
     }
 
     companion object {
-        fun intent(
-            context: Context,
-            selectedTabId: String? = null,
-        ): Intent {
-            val intent = Intent(context, TabSwitcherActivity::class.java)
-            intent.putExtra(EXTRA_KEY_SELECTED_TAB, selectedTabId)
-            return intent
-        }
+        fun intent(context: Context): Intent = Intent(context, TabSwitcherActivity::class.java)
 
-        const val EXTRA_KEY_SELECTED_TAB = "selected"
         const val EXTRA_KEY_DELETED_TAB_IDS = "deletedTabIds"
         const val EXTRA_KEY_DUCK_AI_URL = "duckAIUrl"
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -213,6 +213,7 @@ class TabSwitcherViewModel @Inject constructor(
         data class ShowUndoBookmarkMessage(val numBookmarks: Int) : Command()
         data class ShowUndoDeleteTabsMessage(val tabIds: List<String>) : Command()
         data object ShowFireBottomSheet : Command()
+        data object DismissSnackbar : Command()
     }
 
     fun onNewTabRequested(fromOverflowMenu: Boolean = false) = viewModelScope.launch {
@@ -246,6 +247,7 @@ class TabSwitcherViewModel @Inject constructor(
     fun onBrowserModeToggled(mode: BrowserMode) {
         if (!isBrowserModeToggleVisible) return
         if (mode == currentMode.value) return
+        command.value = Command.DismissSnackbar
         browserModeStateHolder.switchTo(mode)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -245,9 +245,14 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onBrowserModeToggled(mode: BrowserMode) {
-        if (!isBrowserModeToggleVisible) return
-        if (mode == currentMode.value) return
+        val previousMode = currentMode.value
+        if (!isBrowserModeToggleVisible || mode == previousMode) return
+
+        val previousRepo = tabRepositoryProvider.forMode(previousMode)
+        viewModelScope.launch { previousRepo.purgeDeletableTabs() }
+
         command.value = Command.DismissSnackbar
+
         browserModeStateHolder.switchTo(mode)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -67,6 +68,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
@@ -105,6 +107,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val savedSitesRepository: SavedSitesRepository,
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
+    @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
     val isBrowserModeToggleVisible: Boolean = fireModeAvailability.isAvailable()
@@ -538,8 +541,11 @@ class TabSwitcherViewModel @Inject constructor(
         fromIndex: Int,
         toIndex: Int,
     ) {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            tabRepository.updateTabPosition(fromIndex, toIndex)
+        // Capture the repo for the current mode and run on appCoroutineScope
+        // so the DB write isn't canceled when the user immediately taps a tab to leave
+        val repo = tabRepository
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            repo.updateTabPosition(fromIndex, toIndex)
         }
     }
 
@@ -667,7 +673,7 @@ class TabSwitcherViewModel @Inject constructor(
         val isDuckAIButtonVisible: Boolean = false,
         val isSplitOmnibarEnabled: Boolean = false,
         val browserMode: BrowserMode = BrowserMode.REGULAR,
-        val regularTabCount: Int = 0,
+        val regularTabCount: Int? = null,
     ) {
         val tabs: List<Tab> = tabSwitcherItems.filterIsInstance<Tab>()
         val numSelectedTabs: Int = (mode as? Selection)?.selectedTabs?.size ?: 0

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedAppRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
@@ -90,6 +91,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class TabSwitcherViewModel @Inject constructor(
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val browserModeStateHolder: BrowserModeStateHolder,
+    private val fireModeAvailability: FireModeAvailability,
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
@@ -103,7 +105,21 @@ class TabSwitcherViewModel @Inject constructor(
     private val omnibarRepository: OmnibarRepository,
 ) : ViewModel() {
 
-    private val currentMode: StateFlow<BrowserMode> = browserModeStateHolder.currentMode
+    val isBrowserModeToggleVisible: Boolean = fireModeAvailability.isAvailable()
+
+    val browserMode: StateFlow<BrowserMode> =
+        if (isBrowserModeToggleVisible) {
+            browserModeStateHolder.currentMode
+        } else {
+            MutableStateFlow(BrowserMode.REGULAR)
+        }
+
+    private val currentMode: StateFlow<BrowserMode> get() = browserMode
+
+    val regularTabCount: StateFlow<Int> =
+        tabRepositoryProvider.forMode(BrowserMode.REGULAR).flowTabs
+            .map { it.size }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
 
     private val tabRepository: TabRepository
         get() = tabRepositoryProvider.forMode(currentMode.value)
@@ -219,6 +235,12 @@ class TabSwitcherViewModel @Inject constructor(
         pixel.fire(AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING)
         pixel.fire(AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING_DAILY, type = Daily())
         command.value = Command.ShowFireBottomSheet
+    }
+
+    fun onBrowserModeToggled(mode: BrowserMode) {
+        if (!isBrowserModeToggleVisible) return
+        if (mode == browserMode.value) return
+        browserModeStateHolder.switchTo(mode)
     }
 
     suspend fun onTabSelected(tabId: String) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -248,8 +248,8 @@ class TabSwitcherViewModel @Inject constructor(
         val previousMode = currentMode.value
         if (!isBrowserModeToggleVisible || mode == previousMode) return
 
-        val previousRepo = tabRepositoryProvider.forMode(previousMode)
-        viewModelScope.launch { previousRepo.purgeDeletableTabs() }
+        val repo = tabRepository
+        appCoroutineScope.launch { repo.purgeDeletableTabs() }
 
         command.value = Command.DismissSnackbar
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -60,6 +60,7 @@ import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
+import com.duckduckgo.common.utils.extensions.combine
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
@@ -70,6 +71,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -107,19 +109,15 @@ class TabSwitcherViewModel @Inject constructor(
 
     val isBrowserModeToggleVisible: Boolean = fireModeAvailability.isAvailable()
 
-    val browserMode: StateFlow<BrowserMode> =
+    private val currentMode: StateFlow<BrowserMode> =
         if (isBrowserModeToggleVisible) {
             browserModeStateHolder.currentMode
         } else {
             MutableStateFlow(BrowserMode.REGULAR)
         }
 
-    private val currentMode: StateFlow<BrowserMode> get() = browserMode
-
-    val regularTabCount: StateFlow<Int> =
-        tabRepositoryProvider.forMode(BrowserMode.REGULAR).flowTabs
-            .map { it.size }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
+    private val regularTabCount: Flow<Int> =
+        tabRepositoryProvider.forMode(BrowserMode.REGULAR).flowTabs.map { it.size }
 
     private val tabRepository: TabRepository
         get() = tabRepositoryProvider.forMode(currentMode.value)
@@ -154,17 +152,22 @@ class TabSwitcherViewModel @Inject constructor(
         tabSwitcherItemsFlow,
         currentMode.flatMapLatest { mode -> tabRepositoryProvider.forMode(mode).tabSwitcherData },
         duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus,
-    ) { viewState, tabSwitcherItems, tabSwitcherData, showDuckAiButton ->
+        currentMode,
+        regularTabCount,
+    ) { viewState, tabSwitcherItems, tabSwitcherData, showDuckAiButton, browserMode, regularTabCount ->
         viewState.copy(
             tabSwitcherItems = tabSwitcherItems,
             layoutType = tabSwitcherData.layoutType,
             isDuckAIButtonVisible = showDuckAiButton,
+            browserMode = browserMode,
+            regularTabCount = regularTabCount,
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
         initialValue = ViewState(
             isSplitOmnibarEnabled = omnibarRepository.omnibarType == OmnibarType.SPLIT,
+            browserMode = currentMode.value,
         ),
     )
 
@@ -239,7 +242,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onBrowserModeToggled(mode: BrowserMode) {
         if (!isBrowserModeToggleVisible) return
-        if (mode == browserMode.value) return
+        if (mode == currentMode.value) return
         browserModeStateHolder.switchTo(mode)
     }
 
@@ -663,6 +666,8 @@ class TabSwitcherViewModel @Inject constructor(
         val layoutType: LayoutType? = null,
         val isDuckAIButtonVisible: Boolean = false,
         val isSplitOmnibarEnabled: Boolean = false,
+        val browserMode: BrowserMode = BrowserMode.REGULAR,
+        val regularTabCount: Int = 0,
     ) {
         val tabs: List<Tab> = tabSwitcherItems.filterIsInstance<Tab>()
         val numSelectedTabs: Int = (mode as? Selection)?.selectedTabs?.size ?: 0

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -25,11 +25,11 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
-import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity

--- a/app/src/main/res/drawable/background_browser_mode_toggle.xml
+++ b/app/src/main/res/drawable/background_browser_mode_toggle.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/daxColorControlFillPrimary" />
+    <corners android:radius="99dp" />
+</shape>

--- a/app/src/main/res/drawable/background_browser_mode_toggle_indicator.xml
+++ b/app/src/main/res/drawable/background_browser_mode_toggle_indicator.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/daxColorControlRaisedFillPrimary" />
+    <corners android:radius="99dp" />
+</shape>

--- a/app/src/main/res/layout/view_browser_mode_toggle.xml
+++ b/app/src/main/res/layout/view_browser_mode_toggle.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <View
+        android:id="@+id/selectionIndicator"
+        android:layout_width="@dimen/browserModeToggleSegmentWidth"
+        android:layout_height="@dimen/browserModeToggleSegmentHeight"
+        android:layout_gravity="start|center_vertical"
+        android:background="@drawable/background_browser_mode_toggle_indicator"
+        android:elevation="2dp"
+        android:importantForAccessibility="no" />
+
+    <LinearLayout
+        android:id="@+id/segmentsRow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:elevation="4dp"
+        android:orientation="horizontal">
+
+        <FrameLayout
+            android:id="@+id/fireSegment"
+            android:layout_width="@dimen/browserModeToggleSegmentWidth"
+            android:layout_height="@dimen/browserModeToggleSegmentHeight"
+            android:clickable="true"
+            android:contentDescription="@string/browserModeToggleFireDescription"
+            android:focusable="true">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_fire_tabs_24" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/regularSegment"
+            android:layout_width="@dimen/browserModeToggleSegmentWidth"
+            android:layout_height="@dimen/browserModeToggleSegmentHeight"
+            android:clickable="true"
+            android:contentDescription="@string/browserModeToggleRegularDescription"
+            android:focusable="true">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_tab_24" />
+
+            <TextView
+                android:id="@+id/regularTabCount"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:fontFamily="sans-serif-condensed"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:textColor="?attr/daxColorPrimaryIcon"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                tools:ignore="DeprecatedWidgetInXml,SpUsage"
+                tools:text="9" />
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</merge>

--- a/app/src/main/res/layout/view_browser_mode_toggle.xml
+++ b/app/src/main/res/layout/view_browser_mode_toggle.xml
@@ -65,6 +65,8 @@
                 android:importantForAccessibility="no"
                 android:src="@drawable/ic_tab_24" />
 
+            <!-- textSize is set in code so we can bump it slightly when showing ∞ — see
+                 BrowserModeToggleView.setRegularTabCount. -->
             <TextView
                 android:id="@+id/regularTabCount"
                 android:layout_width="24dp"
@@ -74,9 +76,8 @@
                 android:gravity="center"
                 android:includeFontPadding="false"
                 android:textColor="?attr/daxColorPrimaryIcon"
-                android:textSize="12sp"
                 android:textStyle="bold"
-                tools:ignore="DeprecatedWidgetInXml,SpUsage"
+                tools:ignore="DeprecatedWidgetInXml"
                 tools:text="9" />
 
         </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,4 +27,6 @@
     <dimen name="onboardingBottomSheetCornerRadius">36dp</dimen>
     <dimen name="quickSetupBottomSheetHorizontalPadding">40dp</dimen>
     <dimen name="quickSetupRemoveWidgetStepNumberSize">28dp</dimen>
+    <dimen name="browserModeToggleSegmentWidth">56dp</dimen>
+    <dimen name="browserModeToggleSegmentHeight">40dp</dimen>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -126,4 +126,8 @@
         <item quantity="one" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chat?</item>
         <item quantity="other" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chats?</item>
     </plurals>
+
+    <!-- Fire mode -->
+    <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
+    <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -130,4 +130,5 @@
     <!-- Fire mode -->
     <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
     <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -734,9 +734,6 @@
     <string name="tabSelectedIndicator">Tab selected indicator</string>
     <string name="tabNotSelectedIndicator">Tab not selected indicator</string>
 
-    <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
-    <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
-
     <string name="shareMultipleLinksTitle" tools:ignore="MissingInstruction">%1$d links from DuckDuckGo</string>
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -734,6 +734,9 @@
     <string name="tabSelectedIndicator">Tab selected indicator</string>
     <string name="tabNotSelectedIndicator">Tab not selected indicator</string>
 
+    <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
+    <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
+
     <string name="shareMultipleLinksTitle" tools:ignore="MissingInstruction">%1$d links from DuckDuckGo</string>
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -33,6 +33,10 @@ import android.webkit.WebViewClient.ERROR_HOST_LOOKUP
 import android.webkit.WebViewClient.ERROR_UNKNOWN
 import android.webkit.WebViewClient.ERROR_UNSUPPORTED_SCHEME
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anrs.api.CrashLogger
@@ -180,6 +184,7 @@ class BrowserWebViewClientTest {
     fun setup() =
         runTest {
             webView = TestWebView(context)
+            webView.setViewTreeLifecycleOwner(startedLifecycleOwner())
             whenever(mockDuckPlayer.observeShouldOpenInNewTab()).thenReturn(openInNewTabFlow)
             whenever(mockContentScopeExperiments.getActiveExperiments()).thenReturn(listOf(mockToggle))
             val enabledToggle: Toggle = mock()
@@ -1719,6 +1724,12 @@ class BrowserWebViewClientTest {
         override fun getOriginalUrl(): String = EXAMPLE_URL
 
         override fun getProgress(): Int = 100
+    }
+
+    private fun startedLifecycleOwner(): LifecycleOwner = object : LifecycleOwner {
+        override val lifecycle: Lifecycle = LifecycleRegistry(this).apply {
+            currentState = Lifecycle.State.STARTED
+        }
     }
 
     private class FakePluginPoint : PluginPoint<JsInjectorPlugin> {

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -2056,9 +2056,22 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when onBrowserModeToggled to fire then switches mode on state holder`() = runTest {
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+
         testee.onBrowserModeToggled(BrowserMode.FIRE)
 
         verify(mockBrowserModeStateHolder).switchTo(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when onBrowserModeToggled then purges deletable tabs on leaving repo`() = runTest {
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+
+        testee.onBrowserModeToggled(BrowserMode.FIRE)
+        advanceUntilIdle()
+
+        verify(mockTabRepository).purgeDeletableTabs()
+        verify(mockFireTabRepository, never()).purgeDeletableTabs()
     }
 
     @Test
@@ -2067,6 +2080,14 @@ class TabSwitcherViewModelTest {
         testee.onBrowserModeToggled(BrowserMode.REGULAR)
 
         verify(mockBrowserModeStateHolder, never()).switchTo(any())
+    }
+
+    @Test
+    fun `when onBrowserModeToggled to current mode then does not purge`() = runTest {
+        testee.onBrowserModeToggled(BrowserMode.REGULAR)
+        advanceUntilIdle()
+
+        verify(mockTabRepository, never()).purgeDeletableTabs()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -222,6 +222,7 @@ class TabSwitcherViewModelTest {
             savedSitesRepository,
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
+            coroutinesTestRule.testScope,
         )
         testee.command.observeForever(mockCommandObserver)
         testee.tabSwitcherItemsLiveData.observeForever(mockTabSwitcherItemsObserver)
@@ -2005,6 +2006,7 @@ class TabSwitcherViewModelTest {
             savedSitesRepository,
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
+            coroutinesTestRule.testScope,
         )
         backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
             isolatedViewModel.viewState.collect()
@@ -2046,6 +2048,7 @@ class TabSwitcherViewModelTest {
             savedSitesRepository,
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
+            coroutinesTestRule.testScope,
         )
 
         assertFalse(isolatedViewModel.isBrowserModeToggleVisible)
@@ -2090,6 +2093,7 @@ class TabSwitcherViewModelTest {
             savedSitesRepository,
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
+            coroutinesTestRule.testScope,
         )
 
         isolatedViewModel.onBrowserModeToggled(BrowserMode.FIRE)

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -2016,6 +2016,98 @@ class TabSwitcherViewModelTest {
         verify(isolatedProvider, never()).forMode(BrowserMode.FIRE)
     }
 
+    @Test
+    fun `when fire mode available then isBrowserModeToggleVisible is true`() = runTest {
+        // @Before sets isAvailable() = true
+        assertTrue(testee.isBrowserModeToggleVisible)
+    }
+
+    @Test
+    fun `when fire mode unavailable then isBrowserModeToggleVisible is false`() = runTest {
+        val isolatedAvailability: FireModeAvailability = mock()
+        whenever(isolatedAvailability.isAvailable()).thenReturn(false)
+        val isolatedStateHolder: BrowserModeStateHolder = mock()
+        whenever(isolatedStateHolder.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+        val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()
+        whenever(isolatedProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+
+        val isolatedViewModel = TabSwitcherViewModel(
+            isolatedProvider,
+            isolatedStateHolder,
+            isolatedAvailability,
+            coroutinesTestRule.testDispatcherProvider,
+            mockPixel,
+            swipingTabsFeatureProvider,
+            duckChatMock,
+            duckAiFeatureState = duckAiFeatureStateMock,
+            mockWebTrackersBlockedAppRepository,
+            mockTabSwitcherPrefsDataStore,
+            faviconManager,
+            savedSitesRepository,
+            mockTrackersAnimationInfoPanelPixels,
+            mockOmnibarFeatureRepository,
+        )
+
+        assertFalse(isolatedViewModel.isBrowserModeToggleVisible)
+    }
+
+    @Test
+    fun `when onBrowserModeToggled to fire then switches mode on state holder`() = runTest {
+        testee.onBrowserModeToggled(BrowserMode.FIRE)
+
+        verify(mockBrowserModeStateHolder).switchTo(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when onBrowserModeToggled to current mode then does not call switchTo`() = runTest {
+        // currentModeFlow starts at REGULAR
+        testee.onBrowserModeToggled(BrowserMode.REGULAR)
+
+        verify(mockBrowserModeStateHolder, never()).switchTo(any())
+    }
+
+    @Test
+    fun `when fire mode unavailable then onBrowserModeToggled is no-op`() = runTest {
+        val isolatedAvailability: FireModeAvailability = mock()
+        whenever(isolatedAvailability.isAvailable()).thenReturn(false)
+        val isolatedStateHolder: BrowserModeStateHolder = mock()
+        whenever(isolatedStateHolder.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+        val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()
+        whenever(isolatedProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+
+        val isolatedViewModel = TabSwitcherViewModel(
+            isolatedProvider,
+            isolatedStateHolder,
+            isolatedAvailability,
+            coroutinesTestRule.testDispatcherProvider,
+            mockPixel,
+            swipingTabsFeatureProvider,
+            duckChatMock,
+            duckAiFeatureState = duckAiFeatureStateMock,
+            mockWebTrackersBlockedAppRepository,
+            mockTabSwitcherPrefsDataStore,
+            faviconManager,
+            savedSitesRepository,
+            mockTrackersAnimationInfoPanelPixels,
+            mockOmnibarFeatureRepository,
+        )
+
+        isolatedViewModel.onBrowserModeToggled(BrowserMode.FIRE)
+
+        verify(isolatedStateHolder, never()).switchTo(any())
+    }
+
+    @Test
+    fun `regularTabCount reflects regular repo tab count`() = runTest {
+        // @Before wires mockTabRepository.flowTabs to flowOf(tabList) and forMode(REGULAR) -> mockTabRepository
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        advanceUntilIdle()
+
+        assertEquals(tabList.size, testee.viewState.value.regularTabCount)
+    }
+
     private class FakeTabSwitcherDataStore : TabSwitcherDataStore {
 
         private val animationTileDismissedFlow = MutableStateFlow(false)

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.blockingObserve
 import com.duckduckgo.common.ui.DuckDuckGoTheme
@@ -130,6 +131,8 @@ class TabSwitcherViewModelTest {
 
     private val mockBrowserModeStateHolder: BrowserModeStateHolder = mock()
 
+    private val mockFireModeAvailability: FireModeAvailability = mock()
+
     private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
 
     private val mockPixel: Pixel = mock()
@@ -188,6 +191,7 @@ class TabSwitcherViewModelTest {
 
         whenever(duckAiFeatureStateMock.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(MutableStateFlow(false))
 
+        whenever(mockFireModeAvailability.isAvailable()).thenReturn(true)
         whenever(mockBrowserModeStateHolder.currentMode).thenReturn(currentModeFlow)
         whenever(mockTabRepositoryProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
 
@@ -206,6 +210,7 @@ class TabSwitcherViewModelTest {
         testee = TabSwitcherViewModel(
             mockTabRepositoryProvider,
             mockBrowserModeStateHolder,
+            mockFireModeAvailability,
             coroutinesTestRule.testDispatcherProvider,
             mockPixel,
             swipingTabsFeatureProvider,
@@ -1972,6 +1977,43 @@ class TabSwitcherViewModelTest {
 
         assertTrue(items.any { it is NormalTab && it.tabEntity.tabId == "fire-1" })
         verify(mockTabRepositoryProvider, atLeastOnce()).forMode(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when fire mode unavailable then disabled viewmodel ignores state holder and only resolves regular repo`() = runTest {
+        // Use isolated mocks so the @Before viewmodel (which subscribed to currentModeFlow) does not interfere.
+        val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()
+        val isolatedStateHolder = mock<BrowserModeStateHolder>()
+        val isolatedAvailability = mock<FireModeAvailability>()
+        val isolatedStateFlow = MutableStateFlow(BrowserMode.REGULAR)
+        whenever(isolatedAvailability.isAvailable()).thenReturn(false)
+        whenever(isolatedStateHolder.currentMode).thenReturn(isolatedStateFlow)
+        whenever(isolatedProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockTabRepository)
+
+        val isolatedViewModel = TabSwitcherViewModel(
+            isolatedProvider,
+            isolatedStateHolder,
+            isolatedAvailability,
+            coroutinesTestRule.testDispatcherProvider,
+            mockPixel,
+            swipingTabsFeatureProvider,
+            duckChatMock,
+            duckAiFeatureState = duckAiFeatureStateMock,
+            mockWebTrackersBlockedAppRepository,
+            mockTabSwitcherPrefsDataStore,
+            faviconManager,
+            savedSitesRepository,
+            mockTrackersAnimationInfoPanelPixels,
+            mockOmnibarFeatureRepository,
+        )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            isolatedViewModel.viewState.collect()
+        }
+
+        isolatedStateFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        verify(isolatedProvider, never()).forMode(BrowserMode.FIRE)
     }
 
     private class FakeTabSwitcherDataStore : TabSwitcherDataStore {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214876625000225?focus=true

### Description

Adds the Fire/Regular toggle to the tab switcher toolbar. The pill replaces the title, holds the regular tab count (∞ at 100+), slides on tap or drag, and switches `BrowserModeStateHolder` on release. `BrowserActivity` reacts by recreating itself.

### Steps to test this PR

_Toggling between modes_
- [x] Enable the `fireTabs` FF in internal dev settings
- [x] Open the tab switcher
- [x] Verify the toggle replaces the title and the right segment shows the regular tab count
- [x] Tap the fire segment
- [x] Verify the pill slides left, tab list switches to fire-mode tabs (single empty tab)
- [x] Drag the pill slowly past the midpoint
- [x] Verify it follows the finger and snaps to fire on release
- [x] Drag the pill less than halfway
- [x] Verify it snaps back to the starting side, no mode change

_Browser vs tab switcher consistency_
- [x] Open the tab switcher
- [x] Tap a fire mode tab item
- [x] Load a few websites 
- [x] Switch to the regular mode and open a few different URLs
- [x] Swipe between tabs and verify the same tabs are visible in the browser and in the tab switcher
- [x] Switch to fire mode and repeat, making sure only the fire tabs are visible in the browser and the tab switcher

_Selection_
- [x] Open the tab switcher
- [x] Note the current active tab
- [x] Switch modes
- [x] Switch modes back
- [x] Verify the current tab selection is preserved
- [x] Repeat for the other mode

_Scrolling_
- [x] If you don't have enough, add more tabs so that they fill the screen (se the internal dev-settings "Add fire tabs" generator to create 100+ regular tabs, if needed)
- [x] Select a tab that's off-screen, in either mode
- [x] Open the tab switcher and verify the active tab is scrolled-to and is visible
- [x] Switch to the other mode and back again
- [x] Verify that the active tab is still visible
- [x] Open the tab switcher while the active tab is below the fold. It scrolls to the active tab (also after flipping modes)

_Tab count_
- [x] Use the internal dev-settings "Add fire tabs" generator to create 100+ regular tabs 
- [x] Open the tab switcher
- [x] Verify the toggle shows ∞ instead of a number

_Fallback_
- [x] Disable `fireTabs` in internal settings and relaunch
- [x] Verify the toggle gone, original title back
- [x] Smoke test that no behavioural change vs. production

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser mode recreation, fragment restoration, and WebView lifecycle/cookie flushing—areas that can cause tab state glitches or crashes if edge cases are missed, though changes are guarded by Fire availability and include tests.
> 
> **Overview**
> Adds a **Fire / Regular** segmented pill (`BrowserModeToggleView`) to the tab switcher toolbar when Fire mode is available, showing the regular tab count (∞ at 100+) and switching `BrowserModeStateHolder` on tap or drag. Mode changes use a **bitmap overlay fade** in `TabSwitcherActivity`, purge deletable tabs, dismiss snackbars, and drop the intent extra for “selected tab” in favor of scrolling to the active tab from view state.
> 
> **BrowserActivity** now persists `savedBrowserMode`, strips tab pager state and clears the view model / removes stale `BrowserTabFragment`s when the saved mode differs from the current one—replacing the old “skip pager save on recreate” flag.
> 
> **Stability fixes:** cookie flush runs on the WebView’s view-tree `lifecycleScope` (avoids post-destroy native crashes); tab reorder writes use `appCoroutineScope`; `switchToMode` is synchronous.
> 
> When Fire is off, the toggle is hidden and behavior stays on regular mode only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e6cb2d90189b55578d50d11ee6fafe374d1a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->