### PR TITLE
Upsell ai models subscriptions

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -475,7 +475,7 @@ class RealNativeInputManager @Inject constructor(
             )
             onPaidTierChanged = { isPaid ->
                 val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
-                omnibarController.updateTierTitle(tier) { launchUpgrade() }
+                omnibarController.updateTierTitle(tier) { launchPurchase() }
             }
             if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())
@@ -707,7 +707,7 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun launchUpgrade() {
+    private fun launchPurchase() {
         globalActivityStarter.start(rootView.context, SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE))
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatConstants.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatConstants.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl
 object DuckChatConstants {
     const val JS_MESSAGING_FEATURE_NAME = "aiChat"
     const val CHAT_ID_PARAM = "chatID"
+    const val DUCK_AI_FEATURE_PAGE = "duckai"
 
     object JsResponseKeys {
         const val OK = "ok"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -110,6 +110,16 @@ data class AIChatModel(
 
     fun supportsTool(tool: Tool): Boolean = supportedTools.contains(tool)
 
+    /** The lowest [UserTier] required to access this model, or `null` if no public tier applies. */
+    val requiredTier: UserTier?
+        get() = when {
+            accessTier.isEmpty() -> UserTier.FREE
+            accessTier.contains(UserTier.FREE.rawValue) -> UserTier.FREE
+            accessTier.contains(UserTier.PLUS.rawValue) -> UserTier.PLUS
+            accessTier.contains(UserTier.PRO.rawValue) -> UserTier.PRO
+            else -> null
+        }
+
     companion object {
         val NATIVE_SUPPORTED_IMAGE_FORMATS = listOf("png", "jpeg", "webp")
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -149,7 +149,7 @@ enum class ModelProvider {
         fun from(id: String, providerString: String?): ModelProvider {
             return when {
                 id.startsWith("meta-llama/") || id.startsWith("meta-llama_") || providerString == "azure" -> META
-                id.startsWith("mistralai/") || id.startsWith("mistralai_") -> MISTRAL
+                id.startsWith("mistralai/") || id.startsWith("mistralai_") || providerString == "mistral" -> MISTRAL
                 id.contains("gpt-oss") -> OSS
                 providerString == "anthropic" -> ANTHROPIC
                 providerString == "openai" -> OPENAI

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -125,7 +125,9 @@ class RealDuckAiModelManager @Inject constructor(
             try {
                 val userTier = resolveUserTier()
                 val response = fetchModelsResponse()
-                val models = response.models.map { resolveModel(it, userTier) }
+                val models = response.models
+                    .map { resolveModel(it, userTier) }
+                    .filterNot { it.accessTier.isEmpty() && !it.isAccessible }
                 val attachmentLimits = resolveAttachmentLimits(response.attachmentLimits, userTier)
                 stateMutex.withLock {
                     val selectedModelId = validateAndPersistSelection(models)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -44,6 +44,7 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override fun createView(context: Context, host: NativeInputHost): View {
         return ModelPickerView(context).also { picker ->
             modelPicker = WeakReference(picker)
+            picker.setHost(host)
             picker.setPickerEnabled(true)
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -54,7 +54,6 @@ import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import logcat.logcat
 import javax.inject.Inject
 
 interface ModelPicker {
@@ -87,7 +86,7 @@ class ModelPickerView @JvmOverloads constructor(
     private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastObservedModelId: String? = null
-    private var host: NativeInputHost? = null
+    private lateinit var host: NativeInputHost
     override var onMenuShown: (() -> Unit)? = null
     override var onMenuDismissed: (() -> Unit)? = null
     override var onModelSelected: (() -> Unit)? = null
@@ -165,16 +164,11 @@ class ModelPickerView @JvmOverloads constructor(
         }
     }
 
-    private fun currentSurface(): PickerSurface {
-        val inputContext = host?.getInputState()?.inputContext
-        if (inputContext == null) {
-            logcat { "Duck.ai picker: host not set, defaulting upsell surface to ADDRESS_BAR. Funnel attribution may be wrong." }
-        }
-        return when (inputContext) {
+    private fun currentSurface(): PickerSurface =
+        when (host.getInputState().inputContext) {
             InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.DUCK_AI_TAB
-            InputContext.BROWSER, null -> PickerSurface.ADDRESS_BAR
+            InputContext.BROWSER -> PickerSurface.ADDRESS_BAR
         }
-    }
 
     private fun showMenu() {
         val state = viewModel.state.value

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -40,14 +40,21 @@ import com.duckduckgo.common.ui.view.divider.HorizontalDivider
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
 import com.google.android.material.chip.Chip
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import logcat.logcat
 import javax.inject.Inject
 
 interface ModelPicker {
@@ -58,6 +65,7 @@ interface ModelPicker {
     fun isImageGenerationSupported(): Boolean
     fun isWebSearchSupported(): Boolean
     fun setPickerEnabled(enabled: Boolean)
+    fun setHost(host: NativeInputHost)
 }
 
 @InjectWith(ViewScope::class)
@@ -69,13 +77,17 @@ class ModelPickerView @JvmOverloads constructor(
 
     @Inject lateinit var viewModelFactory: ViewViewModelFactory
 
+    @Inject lateinit var globalActivityStarter: GlobalActivityStarter
+
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[ModelPickerViewModel::class.java]
     }
     private val chip: Chip by lazy { findViewById(R.id.modelPickerChip) }
     private var stateJob: Job? = null
+    private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastObservedModelId: String? = null
+    private var host: NativeInputHost? = null
     override var onMenuShown: (() -> Unit)? = null
     override var onMenuDismissed: (() -> Unit)? = null
     override var onModelSelected: (() -> Unit)? = null
@@ -101,6 +113,10 @@ class ModelPickerView @JvmOverloads constructor(
     override fun setPickerEnabled(enabled: Boolean) {
         this.pickerEnabled = enabled
         if (isAttachedToWindow) updateVisibility()
+    }
+
+    override fun setHost(host: NativeInputHost) {
+        this.host = host
     }
 
     private fun updateVisibility() {
@@ -133,6 +149,31 @@ class ModelPickerView @JvmOverloads constructor(
                 }
             }
             .launchIn(scope)
+
+        commandJob?.cancel()
+        commandJob = viewModel.commands
+            .onEach { processCommand(it) }
+            .launchIn(scope)
+    }
+
+    private fun processCommand(command: ModelPickerViewModel.Command) {
+        when (command) {
+            is ModelPickerViewModel.Command.LaunchPurchase ->
+                globalActivityStarter.start(context, SubscriptionPurchase(origin = command.origin, featurePage = DUCK_AI_FEATURE_PAGE))
+            is ModelPickerViewModel.Command.LaunchUpgrade ->
+                globalActivityStarter.start(context, SubscriptionUpgrade(origin = command.origin))
+        }
+    }
+
+    private fun currentSurface(): PickerSurface {
+        val inputContext = host?.getInputState()?.inputContext
+        if (inputContext == null) {
+            logcat { "Duck.ai picker: host not set, defaulting upsell surface to ADDRESS_BAR. Funnel attribution may be wrong." }
+        }
+        return when (inputContext) {
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.DUCK_AI_TAB
+            InputContext.BROWSER, null -> PickerSurface.ADDRESS_BAR
+        }
     }
 
     private fun showMenu() {
@@ -195,6 +236,8 @@ class ModelPickerView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         stateJob?.cancel()
         stateJob = null
+        commandJob?.cancel()
+        commandJob = null
         dismissPopup()
     }
 
@@ -223,13 +266,9 @@ class ModelPickerView @JvmOverloads constructor(
             setLeadingIcon(viewModel.getIconResForModel(model))
             if (selected) setTrailingIconResource(com.duckduckgo.mobile.android.R.drawable.ic_check_24)
             configureTrailingIcon()
-            if (model.isAccessible) {
-                setOnClickListener {
-                    viewModel.selectModel(model)
-                    popup.dismiss()
-                }
-            } else {
-                setDisabled()
+            setOnClickListener {
+                viewModel.onModelTapped(model, currentSurface())
+                popup.dismiss()
             }
             layoutParams = LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -164,10 +164,10 @@ class ModelPickerView @JvmOverloads constructor(
         }
     }
 
-    private fun currentSurface(): PickerSurface =
+    private fun currentSurface(): ModelPickerViewModel.PickerSurface =
         when (host.getInputState().inputContext) {
-            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.DUCK_AI_TAB
-            InputContext.BROWSER -> PickerSurface.ADDRESS_BAR
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ModelPickerViewModel.PickerSurface.DUCK_AI_TAB
+            InputContext.BROWSER -> ModelPickerViewModel.PickerSurface.ADDRESS_BAR
         }
 
     private fun showMenu() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -114,11 +114,11 @@ class ModelPickerViewModel @Inject constructor(
         data class LaunchUpgrade(val origin: String) : Command()
     }
 
+    enum class PickerSurface(val origin: String) {
+        ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
+        DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
+    }
+
     private fun List<AIChatModel>.toSectionOrNull(@StringRes headerRes: Int?): ModelSection? =
         takeIf { it.isNotEmpty() }?.let { ModelSection(headerRes, it) }
-}
-
-enum class PickerSurface(val origin: String) {
-    ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
-    DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -29,8 +29,13 @@ import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 
 data class ModelSection(@StringRes val headerRes: Int?, val models: List<AIChatModel>)
@@ -58,35 +63,47 @@ class ModelPickerViewModel @Inject constructor(
         }
     }
 
-    fun selectModel(model: AIChatModel) {
-        viewModelScope.launch {
-            modelManager.selectModel(model)
+    private val command = Channel<Command>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val commands: Flow<Command> = command.receiveAsFlow()
+
+    fun onModelTapped(model: AIChatModel, surface: PickerSurface) {
+        if (model.isAccessible) {
+            viewModelScope.launch { modelManager.selectModel(model) }
+            return
+        }
+        val userTier = modelManager.modelState.value.userTier
+        val requiredTier = model.requiredTier ?: run {
+            logcat { "Duck.ai picker: tapped model has no public required tier (id=${model.id}, accessTier=${model.accessTier}), ignoring." }
+            return
+        }
+        when {
+            requiredTier == UserTier.FREE -> {
+                logcat { "Duck.ai picker: inaccessible model with FREE required tier (id=${model.id}), no upsell route." }
+            }
+            userTier == UserTier.FREE -> command.trySend(Command.LaunchPurchase(surface.origin))
+            userTier == UserTier.PLUS && requiredTier == UserTier.PRO -> command.trySend(Command.LaunchUpgrade(surface.origin))
+            else -> {
+                logcat { "Duck.ai picker: no native subscription flow for tap (userTier=$userTier, requiredTier=$requiredTier, id=${model.id})." }
+            }
         }
     }
 
-    fun buildSections(state: ModelState): List<ModelSection> =
-        if (state.userTier != UserTier.FREE) getSubscriberModels(state.models) else getFreeModels(state.models)
+    fun buildSections(state: ModelState): List<ModelSection> {
+        // Models with a null requiredTier (non-public access tiers only, e.g. "internal") have no
+        // section to land in and are intentionally hidden from the picker.
+        state.models.filter { it.requiredTier == null }.forEach {
+            logcat { "Duck.ai picker: hiding model with no public required tier (id=${it.id}, accessTier=${it.accessTier})." }
+        }
+        val freeModels = state.models.filter { it.requiredTier == UserTier.FREE }
+        val plusModels = state.models.filter { it.requiredTier == UserTier.PLUS }
+        val proModels = state.models.filter { it.requiredTier == UserTier.PRO }
 
-    private fun getSubscriberModels(models: List<AIChatModel>): List<ModelSection> {
-        val advanced = models.filter { !it.accessTier.contains(FREE_TIER) }
-        val basic = models.filter { it.accessTier.contains(FREE_TIER) }
         return listOfNotNull(
-            advanced.toSectionOrNull(R.string.duckAiModelPickerAdvancedModels),
-            basic.toSectionOrNull(R.string.duckAiModelPickerBasicModels),
+            freeModels.toSectionOrNull(headerRes = null),
+            plusModels.toSectionOrNull(R.string.duckAiModelPickerPlusModels),
+            proModels.toSectionOrNull(R.string.duckAiModelPickerProModels),
         )
     }
-
-    private fun getFreeModels(models: List<AIChatModel>): List<ModelSection> {
-        val accessible = models.filter { it.isAccessible }
-        val premium = models.filter { !it.isAccessible }
-        return listOfNotNull(
-            accessible.toSectionOrNull(headerRes = null),
-            premium.toSectionOrNull(headerRes = null),
-        )
-    }
-
-    private fun List<AIChatModel>.toSectionOrNull(@StringRes headerRes: Int?): ModelSection? =
-        takeIf { it.isNotEmpty() }?.let { ModelSection(headerRes, it) }
 
     @DrawableRes
     fun getIconResForModel(model: AIChatModel): Int? = when (model.provider) {
@@ -98,7 +115,16 @@ class ModelPickerViewModel @Inject constructor(
         ModelProvider.UNKNOWN -> null
     }
 
-    companion object {
-        private const val FREE_TIER = "free"
+    sealed class Command {
+        data class LaunchPurchase(val origin: String) : Command()
+        data class LaunchUpgrade(val origin: String) : Command()
     }
+
+    private fun List<AIChatModel>.toSectionOrNull(@StringRes headerRes: Int?): ModelSection? =
+        takeIf { it.isNotEmpty() }?.let { ModelSection(headerRes, it) }
+}
+
+enum class PickerSurface(val origin: String) {
+    ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
+    DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -89,19 +89,13 @@ class ModelPickerViewModel @Inject constructor(
     }
 
     fun buildSections(state: ModelState): List<ModelSection> {
+        val byTier = state.models.groupBy { it.requiredTier }
         // Models with a null requiredTier (non-public access tiers only, e.g. "internal") have no
         // section to land in and are intentionally hidden from the picker.
-        state.models.filter { it.requiredTier == null }.forEach {
-            logcat { "Duck.ai picker: hiding model with no public required tier (id=${it.id}, accessTier=${it.accessTier})." }
-        }
-        val freeModels = state.models.filter { it.requiredTier == UserTier.FREE }
-        val plusModels = state.models.filter { it.requiredTier == UserTier.PLUS }
-        val proModels = state.models.filter { it.requiredTier == UserTier.PRO }
-
         return listOfNotNull(
-            freeModels.toSectionOrNull(headerRes = null),
-            plusModels.toSectionOrNull(R.string.duckAiModelPickerPlusModels),
-            proModels.toSectionOrNull(R.string.duckAiModelPickerProModels),
+            byTier[UserTier.FREE].orEmpty().toSectionOrNull(headerRes = null),
+            byTier[UserTier.PLUS].orEmpty().toSectionOrNull(R.string.duckAiModelPickerPlusModels),
+            byTier[UserTier.PRO].orEmpty().toSectionOrNull(R.string.duckAiModelPickerProModels),
         )
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/view_model_picker_section_header.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_model_picker_section_header.xml
@@ -15,11 +15,12 @@
   -->
 
 <com.duckduckgo.common.ui.view.text.DaxTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sectionHeaderText"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingStart="@dimen/keyline_4"
     android:paddingTop="@dimen/keyline_2"
     android:paddingEnd="@dimen/keyline_4"
-    android:textAppearance="@style/Typography.DuckDuckGo.Caption"
-    android:textColor="?attr/daxColorSecondaryText" />
+    android:textColor="?attr/daxColorTertiaryText"
+    app:typography="caption" />

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -23,9 +23,8 @@
     <string name="native_input_chat_hint">Ask anything privately…</string>
 
     <!-- Model Picker -->
-    <string name="duckAiModelPickerAdvancedModels" translatable="false">Advanced Models</string>
-    <string name="duckAiModelPickerBasicModels" translatable="false">Basic Models</string>
-    <string name="duckAiModelPickerPremiumModels" translatable="false">Advanced Models \u2014 DuckDuckGo subscription</string>
+    <string name="duckAiModelPickerPlusModels" translatable="false">Plus</string>
+    <string name="duckAiModelPickerProModels" translatable="false">Pro</string>
 
     <!-- Reasoning Mode Picker -->
     <string name="duckChatReasoningModeContentDescription" translatable="false">Reasoning mode</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AIChatModelTest {
+
+    @Test
+    fun whenAccessTierIsEmptyThenRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, model(accessTier = emptyList()).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsOnlyFreeThenRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, model(accessTier = listOf("free")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsOnlyPlusThenRequiredTierIsPlus() {
+        assertEquals(UserTier.PLUS, model(accessTier = listOf("plus")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsOnlyProThenRequiredTierIsPro() {
+        assertEquals(UserTier.PRO, model(accessTier = listOf("pro")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsFreeAndPlusThenRequiredTierIsFree() {
+        // FREE has priority over PLUS in the lookup.
+        assertEquals(UserTier.FREE, model(accessTier = listOf("plus", "free")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsPlusAndProThenRequiredTierIsPlus() {
+        // PLUS has priority over PRO in the lookup.
+        assertEquals(UserTier.PLUS, model(accessTier = listOf("pro", "plus")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsFreePlusProThenRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, model(accessTier = listOf("pro", "plus", "free")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsOnlyNonPublicTierThenRequiredTierIsNull() {
+        assertNull(model(accessTier = listOf("internal")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierContainsMultipleNonPublicTiersThenRequiredTierIsNull() {
+        assertNull(model(accessTier = listOf("internal", "enterprise")).requiredTier)
+    }
+
+    @Test
+    fun whenAccessTierMixesPublicAndNonPublicTiersThenRequiredTierIsTheLowestPublic() {
+        assertEquals(UserTier.PLUS, model(accessTier = listOf("internal", "plus")).requiredTier)
+        assertEquals(UserTier.PRO, model(accessTier = listOf("internal", "pro")).requiredTier)
+        assertEquals(UserTier.FREE, model(accessTier = listOf("internal", "free")).requiredTier)
+    }
+
+    private fun model(accessTier: List<String>) = AIChatModel(
+        id = "id",
+        name = "name",
+        displayName = "name",
+        shortName = "name",
+        accessTier = accessTier,
+        isAccessible = false,
+    )
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -133,22 +133,6 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
-    fun whenEmptyAccessTierAndNoEntityAccessThenModelNotAccessible() = runTest {
-        whenever(dataStore.getSelectedModel()).thenReturn(null)
-        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
-        whenever(modelsService.getModels(any())).thenReturn(
-            AIChatModelsResponse(
-                listOf(remoteModel("id", accessTier = emptyList(), entityHasAccess = false)),
-            ),
-        )
-
-        testee = createManager()
-        testee.fetchModels()
-
-        assertFalse(testee.modelState.value.models[0].isAccessible)
-    }
-
-    @Test
     fun whenNonEmptyAccessTierAndTierMatchesThenAccessible() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
@@ -369,6 +353,26 @@ class RealDuckAiModelManagerTest {
         testee.fetchModels()
 
         assertEquals(UserTier.PRO, testee.modelState.value.userTier)
+    }
+
+    @Test
+    fun whenModelHasEmptyAccessTierAndEntityHasNoAccessThenModelIsFilteredOut() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("visible", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("ghost", accessTier = emptyList(), entityHasAccess = false),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val ids = testee.modelState.value.models.map { it.id }
+        assertEquals(listOf("visible"), ids)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel.PickerSurface
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.ui
 
+import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
@@ -25,7 +26,10 @@ import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,6 +42,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ModelPickerViewModelTest {
 
     @get:Rule
@@ -77,52 +82,108 @@ class ModelPickerViewModelTest {
     }
 
     @Test
-    fun whenSelectModelThenDelegatesToModelManager() = runTest {
-        val model = freeModel("id", "model")
-
-        testee.selectModel(model)
-
-        verify(modelManager).selectModel(model)
-    }
-
-    @Test
     fun whenMenuShowingDefaultThenFalse() {
         assertFalse(testee.menuShowing)
     }
 
     @Test
-    fun whenFreeUserThenFreeSectionHasNoHeader() {
+    fun whenFreeUserThenSectionsAreFreePlusPro() = runTest {
         val state = ModelState(
-            models = listOf(freeModel("id1", "model1"), premiumModel("id2", "model2")),
+            models = listOf(freeModel("f"), plusModel("p"), proModel("pr")),
             userTier = UserTier.FREE,
         )
 
         val sections = testee.buildSections(state)
 
+        assertEquals(3, sections.size)
         assertNull(sections[0].headerRes)
-        assertEquals(listOf("id1"), sections[0].models.map { it.id })
+        assertEquals(R.string.duckAiModelPickerPlusModels, sections[1].headerRes)
+        assertEquals(R.string.duckAiModelPickerProModels, sections[2].headerRes)
     }
 
     @Test
-    fun whenFreeUserThenPremiumSectionHasHeader() {
+    fun whenPlusUserThenSectionsAreFreePlusPro() = runTest {
         val state = ModelState(
-            models = listOf(freeModel("id1", "model1"), premiumModel("id2", "model2")),
+            models = listOf(freeModel("f"), plusModel("p", accessible = true), proModel("pr")),
+            userTier = UserTier.PLUS,
+        )
+
+        val sections = testee.buildSections(state)
+
+        assertEquals(3, sections.size)
+        assertNull(sections[0].headerRes)
+        assertEquals(R.string.duckAiModelPickerPlusModels, sections[1].headerRes)
+        assertEquals(R.string.duckAiModelPickerProModels, sections[2].headerRes)
+    }
+
+    @Test
+    fun whenProUserThenSectionsAreFreePlusPro() = runTest {
+        val state = ModelState(
+            models = listOf(freeModel("f"), plusModel("p", accessible = true), proModel("pr", accessible = true)),
+            userTier = UserTier.PRO,
+        )
+
+        val sections = testee.buildSections(state)
+
+        assertEquals(3, sections.size)
+        assertNull(sections[0].headerRes)
+        assertEquals(R.string.duckAiModelPickerPlusModels, sections[1].headerRes)
+        assertEquals(R.string.duckAiModelPickerProModels, sections[2].headerRes)
+    }
+
+    @Test
+    fun whenModelIsFreeTierThenPlacedInFreeSection() = runTest {
+        val state = ModelState(
+            models = listOf(freeModel("f1"), freeModel("f2")),
             userTier = UserTier.FREE,
         )
 
         val sections = testee.buildSections(state)
 
-        assertEquals(2, sections.size)
-        assertNull(sections[1].headerRes)
-        assertEquals(listOf("id2"), sections[1].models.map { it.id })
+        assertEquals(1, sections.size)
+        assertNull(sections[0].headerRes)
+        assertEquals(listOf("f1", "f2"), sections[0].models.map { it.id })
     }
 
     @Test
-    fun whenFreeUserWithOnlyFreeModelsThenOnlyFreeSectionWithNoHeader() {
+    fun whenModelAccessTierContainsBothPlusAndProThenPlacedInPlusSection() = runTest {
         val state = ModelState(
-            models = listOf(freeModel("id1", "model1"), freeModel("id2", "model2")),
+            models = listOf(plusModel("p1")),
             userTier = UserTier.FREE,
         )
+
+        val sections = testee.buildSections(state)
+
+        assertEquals(1, sections.size)
+        assertEquals(R.string.duckAiModelPickerPlusModels, sections[0].headerRes)
+        assertEquals(listOf("p1"), sections[0].models.map { it.id })
+    }
+
+    @Test
+    fun whenModelAccessTierIsProOnlyThenPlacedInProSection() = runTest {
+        val state = ModelState(
+            models = listOf(proModel("pr1")),
+            userTier = UserTier.FREE,
+        )
+
+        val sections = testee.buildSections(state)
+
+        assertEquals(1, sections.size)
+        assertEquals(R.string.duckAiModelPickerProModels, sections[0].headerRes)
+        assertEquals(listOf("pr1"), sections[0].models.map { it.id })
+    }
+
+    @Test
+    fun whenModelAccessTierIsEmptyAndAccessibleThenPlacedInFreeSection() = runTest {
+        val ubiquitous = AIChatModel(
+            id = "u",
+            name = "u",
+            displayName = "u",
+            shortName = "u",
+            accessTier = emptyList(),
+            isAccessible = true,
+        )
+        val state = ModelState(models = listOf(ubiquitous), userTier = UserTier.FREE)
 
         val sections = testee.buildSections(state)
 
@@ -131,20 +192,7 @@ class ModelPickerViewModelTest {
     }
 
     @Test
-    fun whenFreeUserWithOnlyPremiumModelsThenOnlyPremiumSectionWithHeader() {
-        val state = ModelState(
-            models = listOf(premiumModel("id1", "model1")),
-            userTier = UserTier.FREE,
-        )
-
-        val sections = testee.buildSections(state)
-
-        assertEquals(1, sections.size)
-        assertNull(sections[0].headerRes)
-    }
-
-    @Test
-    fun whenFreeUserWithNoModelsThenNoSections() {
+    fun whenNoModelsThenNoSections() = runTest {
         val state = ModelState(models = emptyList(), userTier = UserTier.FREE)
 
         val sections = testee.buildSections(state)
@@ -153,65 +201,162 @@ class ModelPickerViewModelTest {
     }
 
     @Test
-    fun whenSubscriberThenAdvancedSectionFirst() {
-        val state = ModelState(
-            models = listOf(advancedModel("id1", "model1"), basicModel("id2", "model2")),
-            userTier = UserTier.PLUS,
-        )
+    fun whenAccessibleModelTappedThenSelectModelInvokedAndNoCommandEmitted() = runTest {
+        val model = freeModel("f")
 
-        val sections = testee.buildSections(state)
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
+            runCurrent()
 
-        assertEquals(2, sections.size)
-        assertEquals(R.string.duckAiModelPickerAdvancedModels, sections[0].headerRes)
-        assertEquals(listOf("id1"), sections[0].models.map { it.id })
+            verify(modelManager).selectModel(model)
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
     }
 
     @Test
-    fun whenSubscriberThenBasicSectionSecond() {
-        val state = ModelState(
-            models = listOf(advancedModel("id1", "model1"), basicModel("id2", "model2")),
-            userTier = UserTier.PLUS,
-        )
+    fun whenFreeUserTapsPlusModelFromAddressBarThenLaunchPurchaseCommandEmittedWithAddressBarOrigin() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        val model = plusModel("p")
 
-        val sections = testee.buildSections(state)
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
 
-        assertEquals(R.string.duckAiModelPickerBasicModels, sections[1].headerRes)
-        assertEquals(listOf("id2"), sections[1].models.map { it.id })
+            assertEquals(
+                ModelPickerViewModel.Command.LaunchPurchase("funnel_nativeinput_androidapp__modelpicker"),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
     }
 
     @Test
-    fun whenSubscriberWithOnlyAdvancedModelsThenOnlyAdvancedSection() {
+    fun whenFreeUserTapsProModelFromDuckAiTabThenLaunchPurchaseCommandEmittedWithDuckAiOrigin() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        val model = proModel("pr")
+
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
+
+            assertEquals(
+                ModelPickerViewModel.Command.LaunchPurchase("funnel_duckai_androidapp__modelpicker"),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPlusUserTapsProModelFromAddressBarThenLaunchUpgradeCommandEmittedWithAddressBarOrigin() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.PLUS)
+        val model = proModel("pr")
+
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
+
+            assertEquals(
+                ModelPickerViewModel.Command.LaunchUpgrade("funnel_nativeinput_androidapp__modelpicker"),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPlusUserTapsProModelFromDuckAiTabThenLaunchUpgradeCommandEmittedWithDuckAiOrigin() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.PLUS)
+        val model = proModel("pr")
+
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
+
+            assertEquals(
+                ModelPickerViewModel.Command.LaunchUpgrade("funnel_duckai_androidapp__modelpicker"),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInaccessibleModelHasNoPublicTierThenNoCommandEmitted() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        val ghost = AIChatModel(
+            id = "ghost",
+            name = "ghost",
+            displayName = "ghost",
+            shortName = "ghost",
+            accessTier = emptyList(),
+            isAccessible = false,
+        )
+
+        testee.commands.test {
+            testee.onModelTapped(ghost, PickerSurface.ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreeUserTapsModelWithNonPublicAccessTierThenNoCommandEmitted() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        val internalModel = AIChatModel(
+            id = "internal-1",
+            name = "internal-1",
+            displayName = "internal-1",
+            shortName = "internal-1",
+            accessTier = listOf("internal"),
+            isAccessible = false,
+        )
+
+        testee.commands.test {
+            testee.onModelTapped(internalModel, PickerSurface.ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPlusUserTapsModelWithNonPublicAccessTierThenNoCommandEmitted() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.PLUS)
+        val internalModel = AIChatModel(
+            id = "internal-1",
+            name = "internal-1",
+            displayName = "internal-1",
+            shortName = "internal-1",
+            accessTier = listOf("internal"),
+            isAccessible = false,
+        )
+
+        testee.commands.test {
+            testee.onModelTapped(internalModel, PickerSurface.DUCK_AI_TAB)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenModelAccessTierIsNonPublicOnlyThenNotPlacedInAnySection() = runTest {
+        val internalModel = AIChatModel(
+            id = "internal-1",
+            name = "internal-1",
+            displayName = "internal-1",
+            shortName = "internal-1",
+            accessTier = listOf("internal"),
+            isAccessible = false,
+        )
         val state = ModelState(
-            models = listOf(advancedModel("id1", "model1")),
-            userTier = UserTier.PLUS,
+            models = listOf(freeModel("f1"), internalModel),
+            userTier = UserTier.FREE,
         )
 
         val sections = testee.buildSections(state)
 
         assertEquals(1, sections.size)
-        assertEquals(R.string.duckAiModelPickerAdvancedModels, sections[0].headerRes)
-    }
-
-    @Test
-    fun whenSubscriberWithOnlyBasicModelsThenOnlyBasicSection() {
-        val state = ModelState(
-            models = listOf(basicModel("id1", "model1")),
-            userTier = UserTier.PLUS,
-        )
-
-        val sections = testee.buildSections(state)
-
-        assertEquals(1, sections.size)
-        assertEquals(R.string.duckAiModelPickerBasicModels, sections[0].headerRes)
-    }
-
-    @Test
-    fun whenSubscriberWithNoModelsThenNoSections() {
-        val state = ModelState(models = emptyList(), userTier = UserTier.PLUS)
-
-        val sections = testee.buildSections(state)
-
-        assertTrue(sections.isEmpty())
+        assertEquals(listOf("f1"), sections[0].models.map { it.id })
     }
 
     @Test
@@ -327,7 +472,7 @@ class ModelPickerViewModelTest {
 
     private fun freeModel(
         id: String,
-        shortName: String,
+        shortName: String = id,
         provider: ModelProvider = ModelProvider.UNKNOWN,
         supportedTools: List<Tool> = emptyList(),
     ) = AIChatModel(
@@ -341,30 +486,21 @@ class ModelPickerViewModelTest {
         supportedTools = supportedTools,
     )
 
-    private fun premiumModel(id: String, shortName: String) = AIChatModel(
+    private fun plusModel(id: String, shortName: String = id, accessible: Boolean = false) = AIChatModel(
         id = id,
         name = id,
         displayName = id,
         shortName = shortName,
-        accessTier = listOf("plus"),
-        isAccessible = false,
+        accessTier = listOf("plus", "pro"),
+        isAccessible = accessible,
     )
 
-    private fun advancedModel(id: String, shortName: String) = AIChatModel(
+    private fun proModel(id: String, shortName: String = id, accessible: Boolean = false) = AIChatModel(
         id = id,
         name = id,
         displayName = id,
         shortName = shortName,
-        accessTier = listOf("plus"),
-        isAccessible = true,
-    )
-
-    private fun basicModel(id: String, shortName: String) = AIChatModel(
-        id = id,
-        name = id,
-        displayName = id,
-        shortName = shortName,
-        accessTier = listOf("free"),
-        isAccessible = true,
+        accessTier = listOf("pro"),
+        isAccessible = accessible,
     )
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -223,7 +223,7 @@ class ModelPickerViewModelTest {
             testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchPurchase("funnel_nativeinput_androidapp__modelpicker"),
+                ModelPickerViewModel.Command.LaunchPurchase(PickerSurface.ADDRESS_BAR.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -239,7 +239,7 @@ class ModelPickerViewModelTest {
             testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchPurchase("funnel_duckai_androidapp__modelpicker"),
+                ModelPickerViewModel.Command.LaunchPurchase(PickerSurface.DUCK_AI_TAB.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -255,7 +255,7 @@ class ModelPickerViewModelTest {
             testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchUpgrade("funnel_nativeinput_androidapp__modelpicker"),
+                ModelPickerViewModel.Command.LaunchUpgrade(PickerSurface.ADDRESS_BAR.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -271,7 +271,7 @@ class ModelPickerViewModelTest {
             testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchUpgrade("funnel_duckai_androidapp__modelpicker"),
+                ModelPickerViewModel.Command.LaunchUpgrade(PickerSurface.DUCK_AI_TAB.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214681379562041?focus=true 

### Description

Adds subscription upsell flows to the Duck.ai native model picker. Tapping a gated model now routes the user into the native subscription Purchase flow (Free → Plus/Pro) or Upgrade flow (Plus → Pro), instead of being disabled/silent. Models are grouped into Free / Plus / Pro sections regardless of the viewer's tier.

### High-level changes

**Model + tier knowledge:**
- New `AIChatModel.requiredTier: UserTier?` derived from `accessTier`. Returns the lowest public tier that grants access, or `null` if the model has only non-public access tier strings (e.g. `"internal"`) that the app can't route an upsell to.
- New `PickerSurface` enum (top-level in `ModelPickerViewModel.kt`) carrying the per-surface analytics funnel origin (`funnel_nativeinput_androidapp__modelpicker` / `funnel_duckai_androidapp__modelpicker`).
- `RealDuckAiModelManager.fetchModels()` filters out "ghost" models (empty `accessTier` with `entityHasAccess = false`)

**Picker UI (`ModelPickerView` / `ModelPickerViewModel`):**
- `buildSections()` rewritten to always produce Free / Plus / Pro sections for every viewer tier. Models with `requiredTier == null` are intentionally hidden.
- Section headers visually updated (See screenshot below)
- The `setDisabled()` styling for inaccessible items is gone; every item is fully tappable.
- `ModelPickerViewModel` runs the decision: accessible → `selectModel`; gated → emits `Command.LaunchPurchase` / `Command.LaunchUpgrade`
- `NativeInputHost` plumbed into the view so `currentSurface()` can read `inputContext` at tap time.
- Existing `NativeInputManager.launchUpgrade()` renamed to `launchPurchase()` to properly reflect the behavior it launches

### Steps to test this PR

_Free user_
- [ ] Sign out / confirm Free tier.
- [ ] Open the Duck.ai native input model picker.
- [ ] Verify three sections render: free models (no header), then **plus** header + Plus models, then **pro** header + Pro models.
- [ ] Tap a Plus model → native Purchase flow opens.
- [ ] Tap a Pro model → native Purchase flow opens.
- [ ] Tap a Free model → model selects.

_Plus user_ (I tested this by temporary hardcoding a pro user to be PLUS in `RealDuckAiModelManager.resolveUserTier`)
- [ ] Sign in with a Plus account.
- [ ] Open the model picker.
- [ ] Tap a Plus model → model selects normally.
- [ ] Tap a Pro model → native **Upgrade** flow opens (not Purchase).

_Pro user_
- [ ] Sign in with a Pro account
- [ ] Open the picker.
- [ ] Tap any tier of model → model selects normally. No subscription flow opens.


_Sign out_
- [ ] Sign out while picker is open → picker refreshes; Free model selected. Pro/Plus models trigger purchase flow

### UI changes

**Purchase Flow**

https://github.com/user-attachments/assets/a0d70af7-4fe8-4ed6-9027-f032e68396a8 

**Upgrade Flow**

https://github.com/user-attachments/assets/21ada09c-00fe-4168-a0d7-73da378699c4

**Screenshot**
<img width="222" height="675" alt="Screenshot 2026-05-18 at 7 16 55 PM" src="https://github.com/user-attachments/assets/6549223c-483d-487b-a795-1f2b97f32622" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new subscription purchase/upgrade routing from the model picker and changes how models are filtered/sectioned by tier, which could affect who can see/select models and trigger billing UI flows.
> 
> **Overview**
> Tapping an inaccessible Duck.ai model in the native model picker now triggers a **native subscription upsell** (Free → `SubscriptionPurchase`, Plus → `SubscriptionUpgrade`) instead of showing a disabled item; the picker emits commands from `ModelPickerViewModel` and `ModelPickerView` executes the navigation with per-surface `origin` values.
> 
> Model tier handling is updated by deriving `AIChatModel.requiredTier` from `accessTier`, grouping the picker into **Free/Plus/Pro** sections (hiding models with only non-public tiers), and filtering out “ghost” models in `RealDuckAiModelManager.fetchModels()` where `accessTier` is empty and the user has no access. Minor tweaks include expanding Mistral provider detection, adding `DUCK_AI_FEATURE_PAGE` constant, and updating section header styling/strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d09668237541106392123e8d6cd09c19696deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->