### PR TITLE
Update content scope scripts to version 14.10.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -5196,17 +5196,48 @@
       }
     }
     /**
+     * Defines a no-op `getCapabilities` shim on the given target (either an InputDeviceInfo
+     * instance or a synthetic intermediate prototype). The shim is `wrapToString`-masked so
+     * `Function.prototype.toString` looks native, and the descriptor matches native methods.
+     * No-ops when `getCapabilities` is not exposed on InputDeviceInfo.prototype in this browser.
+     * @param {object} target
+     */
+    defineSyntheticGetCapabilities(target) {
+      if (typeof /** @type {any} */
+      target.getCapabilities !== "function") return;
+      const getCapabilities = function getCapabilities2() {
+        return {};
+      };
+      this.defineProperty(target, "getCapabilities", {
+        value: wrapToString(getCapabilities, getCapabilities, "function getCapabilities() { [native code] }"),
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
+    }
+    /**
      * Creates a valid MediaDeviceInfo or InputDeviceInfo object that passes instanceof checks
      * @param {'videoinput' | 'audioinput' | 'audiooutput'} kind - The device kind
+     * @param {'syntheticPrototype' | 'instanceOwn'} [shimMode] - Where the synthetic shim
+     *   for brand-checked InputDeviceInfo methods lives:
+     *   - 'syntheticPrototype' (default): intermediate prototype between the instance and
+     *     `InputDeviceInfo.prototype`. Hides shims from `hasOwnProperty` on the instance, at
+     *     the cost of a one-level prototype-chain depth difference.
+     *   - 'instanceOwn': preserve `InputDeviceInfo.prototype` as the direct prototype; place
+     *     own masked shims on the instance.
      * @returns {MediaDeviceInfo | InputDeviceInfo}
      */
-    createMediaDeviceInfo(kind) {
+    createMediaDeviceInfo(kind, shimMode = "syntheticPrototype") {
+      const isInputDevice = kind === "videoinput" || kind === "audioinput";
       let deviceInfo;
-      if (kind === "videoinput" || kind === "audioinput") {
-        if (typeof InputDeviceInfo !== "undefined" && InputDeviceInfo.prototype) {
+      if (isInputDevice && typeof InputDeviceInfo !== "undefined" && InputDeviceInfo.prototype) {
+        if (shimMode === "instanceOwn") {
           deviceInfo = Object.create(InputDeviceInfo.prototype);
+          this.defineSyntheticGetCapabilities(deviceInfo);
         } else {
-          deviceInfo = Object.create(MediaDeviceInfo.prototype);
+          const syntheticInputDeviceInfoPrototype = Object.create(InputDeviceInfo.prototype);
+          this.defineSyntheticGetCapabilities(syntheticInputDeviceInfoPrototype);
+          deviceInfo = Object.create(syntheticInputDeviceInfoPrototype);
         }
       } else {
         deviceInfo = Object.create(MediaDeviceInfo.prototype);
@@ -5280,19 +5311,20 @@
           const settings = this.getFeatureSetting("enumerateDevices") || {};
           const timeoutEnabled = settings.timeoutEnabled !== false;
           const timeoutMs = settings.timeoutMs ?? 2e3;
+          const shimMode = settings.shimMode === "instanceOwn" ? "instanceOwn" : "syntheticPrototype";
           try {
             const messagingPromise = this.messaging.request(MSG_DEVICE_ENUMERATION, {});
             const response = timeoutEnabled ? await this.withTimeout(messagingPromise, timeoutMs) : await messagingPromise;
             if (response.willPrompt) {
               const devices = [];
               if (response.videoInput) {
-                devices.push(this.createMediaDeviceInfo("videoinput"));
+                devices.push(this.createMediaDeviceInfo("videoinput", shimMode));
               }
               if (response.audioInput) {
-                devices.push(this.createMediaDeviceInfo("audioinput"));
+                devices.push(this.createMediaDeviceInfo("audioinput", shimMode));
               }
               if (response.audioOutput) {
-                devices.push(this.createMediaDeviceInfo("audiooutput"));
+                devices.push(this.createMediaDeviceInfo("audiooutput", shimMode));
               }
               return Promise.resolve(devices);
             } else {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8024,17 +8024,48 @@
       }
     }
     /**
+     * Defines a no-op `getCapabilities` shim on the given target (either an InputDeviceInfo
+     * instance or a synthetic intermediate prototype). The shim is `wrapToString`-masked so
+     * `Function.prototype.toString` looks native, and the descriptor matches native methods.
+     * No-ops when `getCapabilities` is not exposed on InputDeviceInfo.prototype in this browser.
+     * @param {object} target
+     */
+    defineSyntheticGetCapabilities(target) {
+      if (typeof /** @type {any} */
+      target.getCapabilities !== "function") return;
+      const getCapabilities = function getCapabilities2() {
+        return {};
+      };
+      this.defineProperty(target, "getCapabilities", {
+        value: wrapToString(getCapabilities, getCapabilities, "function getCapabilities() { [native code] }"),
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
+    }
+    /**
      * Creates a valid MediaDeviceInfo or InputDeviceInfo object that passes instanceof checks
      * @param {'videoinput' | 'audioinput' | 'audiooutput'} kind - The device kind
+     * @param {'syntheticPrototype' | 'instanceOwn'} [shimMode] - Where the synthetic shim
+     *   for brand-checked InputDeviceInfo methods lives:
+     *   - 'syntheticPrototype' (default): intermediate prototype between the instance and
+     *     `InputDeviceInfo.prototype`. Hides shims from `hasOwnProperty` on the instance, at
+     *     the cost of a one-level prototype-chain depth difference.
+     *   - 'instanceOwn': preserve `InputDeviceInfo.prototype` as the direct prototype; place
+     *     own masked shims on the instance.
      * @returns {MediaDeviceInfo | InputDeviceInfo}
      */
-    createMediaDeviceInfo(kind) {
+    createMediaDeviceInfo(kind, shimMode = "syntheticPrototype") {
+      const isInputDevice = kind === "videoinput" || kind === "audioinput";
       let deviceInfo;
-      if (kind === "videoinput" || kind === "audioinput") {
-        if (typeof InputDeviceInfo !== "undefined" && InputDeviceInfo.prototype) {
+      if (isInputDevice && typeof InputDeviceInfo !== "undefined" && InputDeviceInfo.prototype) {
+        if (shimMode === "instanceOwn") {
           deviceInfo = Object.create(InputDeviceInfo.prototype);
+          this.defineSyntheticGetCapabilities(deviceInfo);
         } else {
-          deviceInfo = Object.create(MediaDeviceInfo.prototype);
+          const syntheticInputDeviceInfoPrototype = Object.create(InputDeviceInfo.prototype);
+          this.defineSyntheticGetCapabilities(syntheticInputDeviceInfoPrototype);
+          deviceInfo = Object.create(syntheticInputDeviceInfoPrototype);
         }
       } else {
         deviceInfo = Object.create(MediaDeviceInfo.prototype);
@@ -8108,19 +8139,20 @@
           const settings = this.getFeatureSetting("enumerateDevices") || {};
           const timeoutEnabled = settings.timeoutEnabled !== false;
           const timeoutMs = settings.timeoutMs ?? 2e3;
+          const shimMode = settings.shimMode === "instanceOwn" ? "instanceOwn" : "syntheticPrototype";
           try {
             const messagingPromise = this.messaging.request(MSG_DEVICE_ENUMERATION, {});
             const response = timeoutEnabled ? await this.withTimeout(messagingPromise, timeoutMs) : await messagingPromise;
             if (response.willPrompt) {
               const devices = [];
               if (response.videoInput) {
-                devices.push(this.createMediaDeviceInfo("videoinput"));
+                devices.push(this.createMediaDeviceInfo("videoinput", shimMode));
               }
               if (response.audioInput) {
-                devices.push(this.createMediaDeviceInfo("audioinput"));
+                devices.push(this.createMediaDeviceInfo("audioinput", shimMode));
               }
               if (response.audioOutput) {
-                devices.push(this.createMediaDeviceInfo("audiooutput"));
+                devices.push(this.createMediaDeviceInfo("audiooutput", shimMode));
               }
               return Promise.resolve(devices);
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.9.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.10.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.82.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.82.0.tgz",
-      "integrity": "sha512-Q0WkYlQSQxWQq7I3I+nq+Kk+/NkQuMzJ2DUm87pdLHk8sLpJMmuM61+9F35zcMS48bfy690Pi7RGzPJBDGRx6A==",
+      "version": "14.84.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.84.0.tgz",
+      "integrity": "sha512-bXTYDIyDytvK8f+9BRTU9QF5KmJuj7Qg7aE9GckPYmRAQvDBbm+I1OaoAWsw9nyzq6aCs2q6PeAa3YNXHApEEA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c3d43a3f971d8c21ba3624e0e1c2ee2598ddfd1c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#89ab4a1fa2292e40e8745e14f96706ddc7751fd1",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.1.tgz",
-      "integrity": "sha512-IGVFdLcBhOGcvbumQPIJYPYYoV+8NlpIbehBWMoDEV/vl1OXAuDwXnj0PEFc4ogQTt7JwFUOHcyiDLn8VfaEsA==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.3.tgz",
+      "integrity": "sha512-E2jcCtlkdJFm0gUH1GL+99CgAGudlOpMfpWJqKUL9lfPFbEuw//xypbyLUdTJcz31eBJaHq1ql163dIJ00/m1A==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.17.1",
-        "@ghostery/adblocker-extended-selectors": "^2.17.1",
+        "@ghostery/adblocker-content": "^2.17.3",
+        "@ghostery/adblocker-extended-selectors": "^2.17.3",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.1.tgz",
-      "integrity": "sha512-8ljkGaO3nIDXYw5lgiu6ZH1TQyaTmUUx8z/IMpoFFuhZPPOmioMX8hUahEobcI5JzW2KQln7c1V9b60FZaFPlQ==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.3.tgz",
+      "integrity": "sha512-Fm+hj0zhCkBzn3C3Ha/99dV0IRRW5gCP83ivya2JUgqb8styEBC62EGv6pPWOBEHqSvlLr4EygcWMlSZH4zISg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.17.1"
+        "@ghostery/adblocker-extended-selectors": "^2.17.3"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.1.tgz",
-      "integrity": "sha512-724Q/OBX8n78ga72ZPh6jUvDKNqp+IOBy9ujsqPNV9NCIgeC29+s9Axru3i1BRG6co+qGaCQxg3EUsvXH2prCw==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.3.tgz",
+      "integrity": "sha512-LlKTpvD8mscNb6NXPJ0yqLv4qvMP9ZRf33HNuQvQxY+nf4nU+ipYjhoNjvPrKAIrvHtIT4DhE+FeD4pAtp5GXQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.9.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.10.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214925089945603?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates third-party injected `content-scope-scripts` and changes the `enumerateDevices` compatibility shim behavior, which could affect media-device detection on some sites. Dependency bumps in `package-lock.json` may also introduce subtle runtime behavior changes via upstream packages.
> 
> **Overview**
> **Updates dependency:** Bumps `@duckduckgo/content-scope-scripts` from `14.9.0` to `14.10.0` (plus associated lockfile updates, including `@duckduckgo/autoconsent` and `@ghostery/adblocker*`).
> 
> **Web-compat change:** Adjusts the injected Android `enumerateDevices` fix to optionally add a masked no-op `InputDeviceInfo.getCapabilities` shim, configurable via `enumerateDevices.shimMode` (`syntheticPrototype` default vs `instanceOwn`), and threads this mode through `createMediaDeviceInfo` when returning synthetic device entries during permission prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a442f0866bb3c68175659fc76ef8a8ec930d3f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->