### PR TITLE
Wire per-row Download in chat history overflow menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -75,7 +75,7 @@ import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.browser.tabs.adapter.TabPagerAdapter
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.dispatchers.ExternalIntentProcessingState
-import com.duckduckgo.app.downloads.DownloadsScreens.DownloadsScreenNoParams
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -75,7 +75,6 @@ import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.browser.tabs.adapter.TabPagerAdapter
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.dispatchers.ExternalIntentProcessingState
-import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
@@ -122,6 +121,7 @@ import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin.Browser
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin.DuckAiContextualChat
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityDownloadsBinding
-import com.duckduckgo.app.downloads.DownloadsScreens.DownloadsScreenNoParams
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.app.downloads.DownloadsViewModel.Command
 import com.duckduckgo.app.downloads.DownloadsViewModel.Command.*
 import com.duckduckgo.app.downloads.DownloadsViewModel.ViewState

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsActivity.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityDownloadsBinding
-import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.app.downloads.DownloadsViewModel.Command
 import com.duckduckgo.app.downloads.DownloadsViewModel.Command.*
 import com.duckduckgo.app.downloads.DownloadsViewModel.ViewState
@@ -44,6 +43,7 @@ import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.downloads.api.DownloadsFileActions
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.downloads.DownloadsScreens.DownloadsScreenNoParams
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
@@ -20,8 +20,8 @@ import android.content.Context
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.downloads.api.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.navigation.api.GlobalActivityStarter

--- a/downloads/downloads-api/build.gradle
+++ b/downloads/downloads-api/build.gradle
@@ -22,6 +22,7 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
+    implementation project(':navigation-api')
     implementation KotlinX.coroutines.core
     implementation Google.android.material
 }

--- a/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/DownloadsScreens.kt
+++ b/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/DownloadsScreens.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.downloads
+package com.duckduckgo.downloads.api
 
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
@@ -26,14 +26,40 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.io.File
+import java.io.InputStream
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 
 /**
  * Writes a formatted chat export to the public Downloads directory and registers it in the app's
  * Downloads database so it appears in the in-app Downloads screen.
+ *
+ * For Text payloads a `.txt` file is written. For Zip payloads a `.zip` is written containing
+ * a UTF-8-BOM `chat.txt` and the supplied images as `image-N.jpeg` entries (N matches the
+ * placeholder index assigned by [ChatExporter]).
+ *
+ * Filename pattern: `duck.ai_yyyy-MM-dd_HH-mm-ss.<txt|zip>` per the cross-platform reference.
+ * Collisions are resolved by appending `-1`, `-2`, ... before the extension.
  */
 interface ChatExportWriter {
-    suspend fun write(text: String, displayTitle: String): File
+    suspend fun write(payload: ExportPayload): File
+}
+
+sealed interface ExportPayload {
+    val content: String
+
+    data class Text(override val content: String, val mimeType: String = "text/plain") : ExportPayload
+
+    data class Zip(
+        override val content: String,
+        val images: List<Image>,
+    ) : ExportPayload {
+        data class Image(val name: String, val bytes: ByteArray)
+    }
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -43,11 +69,44 @@ class RealChatExportWriter @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
 ) : ChatExportWriter {
 
-    override suspend fun write(text: String, displayTitle: String): File {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).also { it.mkdirs() }
-        val file = resolveAvailableFile(dir, sanitize(displayTitle))
-        file.writeText(text)
+    private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneId.systemDefault()) }
 
+    override suspend fun write(payload: ExportPayload): File {
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            .also { it.mkdirs() }
+        return when (payload) {
+            is ExportPayload.Text -> writeText(dir, payload)
+            is ExportPayload.Zip -> writeZip(dir, payload)
+        }
+    }
+
+    private suspend fun writeText(dir: File, payload: ExportPayload.Text): File {
+        val file = resolveAvailableFile(dir, baseName(), EXTENSION_TXT)
+        file.writeText(payload.content)
+        registerInDownloads(file, payload.mimeType)
+        return file
+    }
+
+    private suspend fun writeZip(dir: File, payload: ExportPayload.Zip): File {
+        val file = resolveAvailableFile(dir, baseName(), EXTENSION_ZIP)
+        ZipOutputStream(file.outputStream().buffered()).use { zip ->
+            zip.putNextEntry(ZipEntry("chat.txt"))
+            // Reference samples ship chat.txt with a UTF-8 BOM for Notepad-friendliness on Windows.
+            zip.write(BOM_UTF8)
+            zip.write(payload.content.toByteArray(Charsets.UTF_8))
+            zip.closeEntry()
+
+            payload.images.forEach { image ->
+                zip.putNextEntry(ZipEntry(image.name))
+                zip.write(image.bytes)
+                zip.closeEntry()
+            }
+        }
+        registerInDownloads(file, "application/zip")
+        return file
+    }
+
+    private suspend fun registerInDownloads(file: File, mimeType: String) {
         downloadsRepository.insert(
             DownloadItem(
                 downloadId = 0L,
@@ -58,23 +117,17 @@ class RealChatExportWriter @Inject constructor(
                 filePath = file.absolutePath,
             ),
         )
-
-        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf("text/plain"), null)
-        return file
+        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf(mimeType), null)
     }
 
-    private fun sanitize(title: String): String {
-        val cleaned = title.trim().replace(UNSAFE_CHARS, "_")
-        return cleaned.ifBlank { "chat" }
-    }
+    private fun baseName(): String = "duck.ai_${clock().format(FILENAME_FORMATTER)}"
 
-    /** Mirrors :downloads-impl FilenameExtractor.addCountSuffix — appends `-1`, `-2`, ... before the extension. */
-    private fun resolveAvailableFile(dir: File, baseName: String): File {
-        val initial = File(dir, "$baseName.$EXTENSION")
+    private fun resolveAvailableFile(dir: File, baseName: String, extension: String): File {
+        val initial = File(dir, "$baseName.$extension")
         if (!initial.exists()) return initial
         var count = 1
         while (true) {
-            val candidate = File(dir, "$baseName-$count.$EXTENSION")
+            val candidate = File(dir, "$baseName-$count.$extension")
             if (!candidate.exists()) return candidate
             count++
         }
@@ -82,7 +135,12 @@ class RealChatExportWriter @Inject constructor(
 
     private companion object {
         const val DOWNLOAD_FINISHED = 1 // mirrors com.duckduckgo.downloads.store.DownloadStatus.FINISHED
-        const val EXTENSION = "txt"
-        val UNSAFE_CHARS = Regex("[\\\\/:*?\"<>|\\r\\n\\t]")
+        const val EXTENSION_TXT = "txt"
+        const val EXTENSION_ZIP = "zip"
+        val FILENAME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
+        val BOM_UTF8: ByteArray = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
     }
 }
+
+/** Reads the bytes from an [InputStream] then closes it. Null-safe convenience used by the repository. */
+internal fun InputStream?.readBytesAndClose(): ByteArray? = this?.use { it.readBytes() }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.os.Environment
+import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.downloads.api.DownloadsRepository
+import com.duckduckgo.downloads.api.model.DownloadItem
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Writes a formatted chat export to the public Downloads directory and registers it in the app's
+ * Downloads database so it appears in the in-app Downloads screen.
+ */
+interface ChatExportWriter {
+    suspend fun write(text: String, displayTitle: String): File
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealChatExportWriter @Inject constructor(
+    private val context: Context,
+    private val downloadsRepository: DownloadsRepository,
+) : ChatExportWriter {
+
+    override suspend fun write(text: String, displayTitle: String): File {
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).also { it.mkdirs() }
+        val file = resolveAvailableFile(dir, sanitize(displayTitle))
+        file.writeText(text)
+
+        downloadsRepository.insert(
+            DownloadItem(
+                downloadId = 0L,
+                downloadStatus = DOWNLOAD_FINISHED,
+                fileName = file.name,
+                contentLength = file.length(),
+                createdAt = DatabaseDateFormatter.timestamp(),
+                filePath = file.absolutePath,
+            ),
+        )
+
+        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf("text/plain"), null)
+        return file
+    }
+
+    private fun sanitize(title: String): String {
+        val cleaned = title.trim().replace(UNSAFE_CHARS, "_")
+        return cleaned.ifBlank { "chat" }
+    }
+
+    /** Mirrors :downloads-impl FilenameExtractor.addCountSuffix — appends `-1`, `-2`, ... before the extension. */
+    private fun resolveAvailableFile(dir: File, baseName: String): File {
+        val initial = File(dir, "$baseName.$EXTENSION")
+        if (!initial.exists()) return initial
+        var count = 1
+        while (true) {
+            val candidate = File(dir, "$baseName-$count.$EXTENSION")
+            if (!candidate.exists()) return candidate
+            count++
+        }
+    }
+
+    private companion object {
+        const val DOWNLOAD_FINISHED = 1 // mirrors com.duckduckgo.downloads.store.DownloadStatus.FINISHED
+        const val EXTENSION = "txt"
+        val UNSAFE_CHARS = Regex("[\\\\/:*?\"<>|\\r\\n\\t]")
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.duckchat.impl.history
 
-import android.content.Context
-import android.media.MediaScannerConnection
 import android.os.Environment
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.DownloadsRepository
+import com.duckduckgo.downloads.api.FileDownloadCallbackPlugin
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -51,7 +51,7 @@ interface ChatExportWriter {
 sealed interface ExportPayload {
     val content: String
 
-    data class Text(override val content: String, val mimeType: String = "text/plain") : ExportPayload
+    data class Text(override val content: String) : ExportPayload
 
     data class Zip(
         override val content: String,
@@ -64,8 +64,8 @@ sealed interface ExportPayload {
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealChatExportWriter @Inject constructor(
-    private val context: Context,
     private val downloadsRepository: DownloadsRepository,
+    private val fileDownloadCallbackPlugins: PluginPoint<FileDownloadCallbackPlugin>,
 ) : ChatExportWriter {
 
     private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneId.systemDefault()) }
@@ -82,7 +82,7 @@ class RealChatExportWriter @Inject constructor(
     private suspend fun writeText(dir: File, payload: ExportPayload.Text): File {
         val file = resolveAvailableFile(dir, baseName(), EXTENSION_TXT)
         file.writeText(payload.content)
-        registerInDownloads(file, payload.mimeType)
+        registerInDownloads(file)
         return file
     }
 
@@ -101,11 +101,11 @@ class RealChatExportWriter @Inject constructor(
                 zip.closeEntry()
             }
         }
-        registerInDownloads(file, "application/zip")
+        registerInDownloads(file)
         return file
     }
 
-    private suspend fun registerInDownloads(file: File, mimeType: String) {
+    private suspend fun registerInDownloads(file: File) {
         downloadsRepository.insert(
             DownloadItem(
                 downloadId = 0L,
@@ -116,7 +116,9 @@ class RealChatExportWriter @Inject constructor(
                 filePath = file.absolutePath,
             ),
         )
-        MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf(mimeType), null)
+        // Fires the same callback as a regular browser download — surfaces the "new download" dot
+        // on the browser menu via DownloadBadgePlugin (and any other registered plugins).
+        fileDownloadCallbackPlugins.getPlugins().forEach { it.onFileDownloaded() }
     }
 
     private fun baseName(): String = "duck.ai_${clock().format(FILENAME_FORMATTER)}"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
@@ -34,15 +34,9 @@ import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 
 /**
- * Writes a formatted chat export to the public Downloads directory and registers it in the app's
- * Downloads database so it appears in the in-app Downloads screen.
- *
- * For Text payloads a `.txt` file is written. For Zip payloads a `.zip` is written containing
- * a UTF-8-BOM `chat.txt` and the supplied images as `image-N.jpeg` entries (N matches the
- * placeholder index assigned by [ChatExporter]).
- *
- * Filename pattern: `duck.ai_yyyy-MM-dd_HH-mm-ss.<txt|zip>` per the cross-platform reference.
- * Collisions are resolved by appending `-1`, `-2`, ... before the extension.
+ * Writes a chat export to the public Downloads directory. Filename pattern
+ * `duck.ai_yyyy-MM-dd_HH-mm-ss.<txt|zip>` matches the cross-platform reference;
+ * collisions get a `-1`, `-2`, ... suffix before the extension.
  */
 interface ChatExportWriter {
     suspend fun write(payload: ExportPayload): File
@@ -116,8 +110,7 @@ class RealChatExportWriter @Inject constructor(
                 filePath = file.absolutePath,
             ),
         )
-        // Fires the same callback as a regular browser download — surfaces the "new download" dot
-        // on the browser menu via DownloadBadgePlugin (and any other registered plugins).
+        // Surfaces the "new download" dot on the browser menu, same path as a browser download.
         fileDownloadCallbackPlugins.getPlugins().forEach { it.onFileDownloaded() }
     }
 
@@ -135,7 +128,7 @@ class RealChatExportWriter @Inject constructor(
     }
 
     private companion object {
-        const val DOWNLOAD_FINISHED = 1 // mirrors com.duckduckgo.downloads.store.DownloadStatus.FINISHED
+        const val DOWNLOAD_FINISHED = 1
         const val EXTENSION_TXT = "txt"
         const val EXTENSION_ZIP = "zip"
         val FILENAME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExportWriter.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.downloads.api.model.DownloadItem
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.io.File
-import java.io.InputStream
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -141,6 +140,3 @@ class RealChatExportWriter @Inject constructor(
         val BOM_UTF8: ByteArray = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
     }
 }
-
-/** Reads the bytes from an [InputStream] then closes it. Null-safe convenience used by the repository. */
-internal fun InputStream?.readBytesAndClose(): ByteArray? = this?.use { it.readBytes() }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.history
 
+import com.duckduckgo.duckchat.impl.models.ChatType
 import org.json.JSONObject
 import java.time.Instant
 import java.time.ZoneId

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
@@ -23,28 +23,86 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
- * Formats a Duck.ai chat (FE-owned JSON blob) into the plain-text shape defined by FR-016f.
+ * Formats a Duck.ai chat (FE-owned JSON blob) into the platform-standard plain-text shape.
  * Pure — no I/O, no DI. Inject a [ZoneId] to keep tests deterministic across machine timezones.
+ *
+ * Output shape varies by [ChatType] (see research.md R-16):
+ *  - [ChatType.Discussion]: assistant turns prefixed with `<Model>:`.
+ *  - [ChatType.Voice]: assistant turns prefixed with literal "Voice Chat:" and omitted entirely
+ *    when the model produced no text (matches the macOS/Windows reference voice format where
+ *    user-only turns appear without a response block).
+ *  - [ChatType.ImageGeneration]: assistant text replaced by `[Generated image: image-N.jpeg]`;
+ *    the resulting [ExportResult.Zip] carries the consumed fileRefs in turn order. Positional
+ *    fileRef ↔ assistant-turn association is a known assumption — see R-16 open question (1).
  */
 internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault()) {
 
-    fun export(rawJson: String): String {
+    fun export(
+        rawJson: String,
+        chatType: ChatType = ChatType.Discussion,
+        fileRefs: List<String> = emptyList(),
+    ): ExportResult {
         val json = JSONObject(rawJson)
         val display = ModelDisplay.from(json.optString("model"))
         val turns = extractTurns(json.optJSONArray("messages"))
 
-        return buildString {
-            appendLine(header(display))
+        return when (chatType) {
+            ChatType.Discussion -> ExportResult.Text(renderDiscussion(display, turns))
+            ChatType.Voice -> ExportResult.Text(renderVoice(display, turns))
+            ChatType.ImageGeneration -> renderImage(display, turns, fileRefs)
+        }
+    }
+
+    private fun renderDiscussion(display: ModelDisplay, turns: List<Turn>): String =
+        buildContent(display, turns) { _, turn -> "${display.shortName}:\n${turn.assistantText}" }
+
+    private fun renderVoice(display: ModelDisplay, turns: List<Turn>): String =
+        buildContent(display, turns) { _, turn ->
+            if (turn.assistantText.isBlank()) "" else "Voice Chat:\n${turn.assistantText}"
+        }
+
+    private fun renderImage(
+        display: ModelDisplay,
+        turns: List<Turn>,
+        fileRefs: List<String>,
+    ): ExportResult.Zip {
+        val consumed = mutableListOf<String>()
+        val text = buildContent(display, turns) { index, _ ->
+            val uuid = fileRefs.getOrNull(index)
+            if (uuid != null) {
+                consumed += uuid
+                "${display.shortName}:\n\n[Generated image: image-${consumed.size}.jpeg]"
+            } else {
+                "${display.shortName}:"
+            }
+        }
+        return ExportResult.Zip(text, consumed)
+    }
+
+    private fun buildContent(
+        display: ModelDisplay,
+        turns: List<Turn>,
+        assistantBlock: (Int, Turn) -> String,
+    ): String = buildString {
+        appendLine(header(display))
+        appendLine()
+        append(SEPARATOR)
+        turns.forEachIndexed { index, turn ->
+            if (index > 0) {
+                appendLine()
+                appendLine()
+                appendLine(TURN_SEPARATOR)
+            } else {
+                appendLine()
+            }
             appendLine()
-            append(SEPARATOR)
-            turns.forEachIndexed { index, turn ->
+            appendLine("User prompt ${index + 1} of ${turns.size} - ${formatTimestamp(turn.createdAt)}:")
+            append(turn.userText)
+            val assistant = assistantBlock(index, turn)
+            if (assistant.isNotEmpty()) {
                 appendLine()
                 appendLine()
-                appendLine("User prompt ${index + 1} of ${turns.size} - ${formatTimestamp(turn.createdAt)}:")
-                appendLine(turn.userText)
-                appendLine()
-                appendLine("${display.shortName}:")
-                append(turn.assistantText)
+                append(assistant)
             }
         }
     }
@@ -106,8 +164,16 @@ internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault())
 
     private companion object {
         const val SEPARATOR = "===================="
+        const val TURN_SEPARATOR = "--------------------"
         val TIMESTAMP_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("M/d/yyyy, h:mm:ss a", Locale.US)
     }
+}
+
+internal sealed interface ExportResult {
+    val content: String
+
+    data class Text(override val content: String) : ExportResult
+    data class Zip(override val content: String, val imageFileRefs: List<String>) : ExportResult
 }
 
 internal data class ModelDisplay(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.history
 
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.models.ModelDisplay
 import org.json.JSONObject
 import java.time.Instant
 import java.time.ZoneId
@@ -42,9 +43,10 @@ internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault())
         rawJson: String,
         chatType: ChatType = ChatType.Discussion,
         fileRefs: List<String> = emptyList(),
+        modelDisplay: ModelDisplay? = null,
     ): ExportResult {
         val json = JSONObject(rawJson)
-        val display = ModelDisplay.from(json.optString("model"))
+        val display = modelDisplay ?: rawIdFallback(json.optString("model"))
         val turns = extractTurns(json.optJSONArray("messages"))
 
         return when (chatType) {
@@ -146,6 +148,13 @@ internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault())
         return TIMESTAMP_FORMATTER.withZone(zoneId).format(instant)
     }
 
+    /** Used when the caller didn't supply a resolved [ModelDisplay] — renders the raw model id with no provider. */
+    private fun rawIdFallback(modelId: String): ModelDisplay = ModelDisplay(
+        fullName = modelId.takeIf { it.isNotBlank() },
+        shortName = modelId.takeIf { it.isNotBlank() } ?: "AI",
+        providerPossessive = null,
+    )
+
     private fun header(display: ModelDisplay): String {
         val using = when {
             display.providerPossessive != null -> "using ${display.providerPossessive} ${display.fullName} Model"
@@ -175,27 +184,4 @@ internal sealed interface ExportResult {
 
     data class Text(override val content: String) : ExportResult
     data class Zip(override val content: String, val imageFileRefs: List<String>) : ExportResult
-}
-
-internal data class ModelDisplay(
-    val fullName: String?,
-    val shortName: String,
-    val providerPossessive: String?,
-) {
-    companion object {
-        fun from(modelId: String): ModelDisplay = TABLE[modelId] ?: ModelDisplay(
-            fullName = modelId.takeIf { it.isNotBlank() },
-            shortName = modelId.takeIf { it.isNotBlank() } ?: "AI",
-            providerPossessive = null,
-        )
-
-        private val TABLE: Map<String, ModelDisplay> = mapOf(
-            "gpt-5-mini" to ModelDisplay("GPT-5 mini", "GPT-5 mini", "OpenAI's"),
-            "gpt-4o" to ModelDisplay("GPT-4o", "GPT-4o", "OpenAI's"),
-            "gpt-4o-mini" to ModelDisplay("GPT-4o mini", "GPT-4o mini", "OpenAI's"),
-            "claude-3-5-sonnet-latest" to ModelDisplay("Claude 3.5 Sonnet", "Claude 3.5 Sonnet", "Anthropic's"),
-            "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo" to ModelDisplay("Llama 3.1 70B", "Llama 3.1 70B", "Meta's"),
-            "mistralai/Mixtral-8x7B-Instruct-v0.1" to ModelDisplay("Mixtral 8x7B", "Mixtral 8x7B", "Mistral's"),
-        )
-    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
@@ -25,17 +25,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
- * Formats a Duck.ai chat (FE-owned JSON blob) into the platform-standard plain-text shape.
+ * Formats a Duck.ai chat (FE-owned JSON blob) into the cross-platform plain-text shape.
  * Pure — no I/O, no DI. Inject a [ZoneId] to keep tests deterministic across machine timezones.
- *
- * Output shape varies by [ChatType] (see research.md R-16):
- *  - [ChatType.Discussion]: assistant turns prefixed with `<Model>:`.
- *  - [ChatType.Voice]: assistant turns prefixed with literal "Voice Chat:" and omitted entirely
- *    when the model produced no text (matches the macOS/Windows reference voice format where
- *    user-only turns appear without a response block).
- *  - [ChatType.ImageGeneration]: assistant text replaced by `[Generated image: image-N.jpeg]`;
- *    the resulting [ExportResult.Zip] carries the consumed fileRefs in turn order. Positional
- *    fileRef ↔ assistant-turn association is a known assumption — see R-16 open question (1).
  */
 internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault()) {
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatExporter.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import org.json.JSONObject
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Formats a Duck.ai chat (FE-owned JSON blob) into the plain-text shape defined by FR-016f.
+ * Pure — no I/O, no DI. Inject a [ZoneId] to keep tests deterministic across machine timezones.
+ */
+internal class ChatExporter(private val zoneId: ZoneId = ZoneId.systemDefault()) {
+
+    fun export(rawJson: String): String {
+        val json = JSONObject(rawJson)
+        val display = ModelDisplay.from(json.optString("model"))
+        val turns = extractTurns(json.optJSONArray("messages"))
+
+        return buildString {
+            appendLine(header(display))
+            appendLine()
+            append(SEPARATOR)
+            turns.forEachIndexed { index, turn ->
+                appendLine()
+                appendLine()
+                appendLine("User prompt ${index + 1} of ${turns.size} - ${formatTimestamp(turn.createdAt)}:")
+                appendLine(turn.userText)
+                appendLine()
+                appendLine("${display.shortName}:")
+                append(turn.assistantText)
+            }
+        }
+    }
+
+    private fun extractTurns(messages: org.json.JSONArray?): List<Turn> {
+        if (messages == null || messages.length() == 0) return emptyList()
+        val turns = mutableListOf<Turn>()
+        var i = 0
+        while (i < messages.length()) {
+            val msg = messages.getJSONObject(i)
+            if (msg.optString("role") == "user") {
+                val createdAt = msg.optString("createdAt")
+                val userText = msg.optString("content")
+                val nextIsAssistant = i + 1 < messages.length() &&
+                    messages.getJSONObject(i + 1).optString("role") == "assistant"
+                val assistantText = if (nextIsAssistant) extractAssistantText(messages.getJSONObject(i + 1)) else ""
+                turns += Turn(createdAt, userText, assistantText)
+                i += if (nextIsAssistant) 2 else 1
+            } else {
+                i++
+            }
+        }
+        return turns
+    }
+
+    private fun extractAssistantText(assistantMsg: JSONObject): String {
+        val parts = assistantMsg.optJSONArray("parts")
+        if (parts == null || parts.length() == 0) return assistantMsg.optString("content")
+        val textParts = buildList {
+            for (i in 0 until parts.length()) {
+                val part = parts.getJSONObject(i)
+                if (part.optString("type") == "text") add(part.optString("text"))
+            }
+        }
+        return if (textParts.isNotEmpty()) textParts.joinToString(separator = "\n") else assistantMsg.optString("content")
+    }
+
+    private fun formatTimestamp(iso: String): String {
+        val instant = runCatching { Instant.parse(iso) }.getOrElse { return iso }
+        return TIMESTAMP_FORMATTER.withZone(zoneId).format(instant)
+    }
+
+    private fun header(display: ModelDisplay): String {
+        val using = when {
+            display.providerPossessive != null -> "using ${display.providerPossessive} ${display.fullName} Model"
+            display.fullName != null -> "using the ${display.fullName} Model"
+            else -> "using an AI Model"
+        }
+        return "This conversation was generated with Duck.ai (https://duck.ai) $using. " +
+            "AI chats may display inaccurate or offensive information " +
+            "(see https://duckduckgo.com/duckai/privacy-terms for more info)."
+    }
+
+    private data class Turn(
+        val createdAt: String,
+        val userText: String,
+        val assistantText: String,
+    )
+
+    private companion object {
+        const val SEPARATOR = "===================="
+        val TIMESTAMP_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("M/d/yyyy, h:mm:ss a", Locale.US)
+    }
+}
+
+internal data class ModelDisplay(
+    val fullName: String?,
+    val shortName: String,
+    val providerPossessive: String?,
+) {
+    companion object {
+        fun from(modelId: String): ModelDisplay = TABLE[modelId] ?: ModelDisplay(
+            fullName = modelId.takeIf { it.isNotBlank() },
+            shortName = modelId.takeIf { it.isNotBlank() } ?: "AI",
+            providerPossessive = null,
+        )
+
+        private val TABLE: Map<String, ModelDisplay> = mapOf(
+            "gpt-5-mini" to ModelDisplay("GPT-5 mini", "GPT-5 mini", "OpenAI's"),
+            "gpt-4o" to ModelDisplay("GPT-4o", "GPT-4o", "OpenAI's"),
+            "gpt-4o-mini" to ModelDisplay("GPT-4o mini", "GPT-4o mini", "OpenAI's"),
+            "claude-3-5-sonnet-latest" to ModelDisplay("Claude 3.5 Sonnet", "Claude 3.5 Sonnet", "Anthropic's"),
+            "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo" to ModelDisplay("Llama 3.1 70B", "Llama 3.1 70B", "Meta's"),
+            "mistralai/Mixtral-8x7B-Instruct-v0.1" to ModelDisplay("Mixtral 8x7B", "Mixtral 8x7B", "Mistral's"),
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -162,7 +162,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     private fun onNavigationEvent(event: ChatHistoryViewModel.NavigationEvent) {
         when (event) {
             is ChatHistoryViewModel.NavigationEvent.OpenRename -> openRenameScreen(event.chatId, event.currentTitle)
-            is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete -> showDownloadCompleteSnackbar()
+            is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete -> showDownloadCompleteSnackbar(event.fileName)
             ChatHistoryViewModel.NavigationEvent.ShowExportError ->
                 Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_error, Snackbar.LENGTH_SHORT).show()
         }
@@ -181,8 +181,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             .commit()
     }
 
-    private fun showDownloadCompleteSnackbar() {
-        Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_complete, Snackbar.LENGTH_LONG)
+    private fun showDownloadCompleteSnackbar(fileName: String) {
+        val message = getString(R.string.duck_ai_chat_history_download_complete, fileName)
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
             .setAction(R.string.duck_ai_chat_history_download_view) {
                 globalActivityStarter.start(requireContext(), DownloadsScreens.DownloadsScreenNoParams)
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -40,9 +40,11 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.dataclearing.api.fire.FireDialog
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.downloads.api.DownloadsScreens
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentChatHistoryBinding
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -68,6 +70,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     @Inject
     lateinit var dispatchers: DispatcherProvider
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
 
     private val binding: FragmentChatHistoryBinding by viewBinding()
     private val viewModel: ChatHistoryViewModel by lazy {
@@ -157,6 +162,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     private fun onNavigationEvent(event: ChatHistoryViewModel.NavigationEvent) {
         when (event) {
             is ChatHistoryViewModel.NavigationEvent.OpenRename -> openRenameScreen(event.chatId, event.currentTitle)
+            is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete -> showDownloadCompleteSnackbar()
+            ChatHistoryViewModel.NavigationEvent.ShowExportError ->
+                Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_error, Snackbar.LENGTH_SHORT).show()
         }
     }
 
@@ -171,6 +179,14 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             .replace(R.id.chatHistoryFragmentContainer, RenameChatFragment.newInstance(chatId, currentTitle))
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun showDownloadCompleteSnackbar() {
+        Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_complete, Snackbar.LENGTH_LONG)
+            .setAction(R.string.duck_ai_chat_history_download_view) {
+                globalActivityStarter.start(requireContext(), DownloadsScreens.DownloadsScreenNoParams)
+            }
+            .show()
     }
 
     private fun showPinToggledSnackbar(event: ChatHistoryViewModel.MessageEvent.PinToggled) {
@@ -348,7 +364,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             } else {
                 renameAction.gone()
             }
-            popup.onMenuItemClicked(view.findViewById(R.id.download)) { showComingSoonSnackbar() }
+            popup.onMenuItemClicked(view.findViewById(R.id.download)) {
+                viewModel.onDownloadRequested(item.chatId, item.displayTitle)
+            }
             popup.onMenuItemClicked(view.findViewById(R.id.delete)) { viewModel.onDeleteSingleChat(item.chatId) }
             popup.show(binding.root, anchor)
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -366,7 +366,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
                 renameAction.gone()
             }
             popup.onMenuItemClicked(view.findViewById(R.id.download)) {
-                viewModel.onDownloadRequested(item.chatId, item.displayTitle)
+                viewModel.onDownloadRequested(item.chatId)
             }
             popup.onMenuItemClicked(view.findViewById(R.id.delete)) { viewModel.onDeleteSingleChat(item.chatId) }
             popup.show(binding.root, anchor)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -373,10 +373,6 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         }
     }
 
-    private fun showComingSoonSnackbar() {
-        Snackbar.make(binding.root, R.string.duck_ai_chat_history_coming_soon, Snackbar.LENGTH_SHORT).show()
-    }
-
     companion object {
         private const val FIRE_DIALOG_TAG = "chat_history_fire_dialog"
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryItem.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryItem.kt
@@ -22,6 +22,7 @@ data class ChatHistoryItem(
     val chatId: String,
     val displayTitle: String,
     val type: ChatType,
+    val model: String,
     val pinned: Boolean,
     val lastEditMillis: Long,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -103,9 +103,9 @@ class RealChatHistoryRepository @Inject constructor(
                 is ExportResult.Zip -> ExportPayload.Zip(
                     content = result.content,
                     images = result.imageFileRefs.mapIndexed { index, uuid ->
-                        val bytes = chatStore.openFileRef(uuid).readBytesAndClose()
+                        val fileRef = chatStore.readFileRef(uuid)
                             ?: throw IllegalStateException("File $uuid missing for chat $chatId")
-                        ExportPayload.Zip.Image(name = "image-${index + 1}.jpeg", bytes = bytes)
+                        ExportPayload.Zip.Image(name = "image-${index + 1}.jpeg", bytes = fileRef.bytes)
                     },
                 )
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -93,7 +93,7 @@ class RealChatHistoryRepository @Inject constructor(
 
     override suspend fun exportChat(chatId: String): File =
         withContext(dispatchers.io()) {
-            val chat = chatStore.getChats().firstOrNull { it.chatId == chatId }
+            val chat = chatStore.getChatById(chatId)
                 ?: throw IllegalStateException("Chat $chatId not found")
             val rawJson = chatStore.getChatContent(chatId)
                 ?: throw IllegalStateException("Chat $chatId content not found")

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -30,6 +30,7 @@ import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.time.Instant
 import javax.inject.Inject
 
@@ -40,6 +41,13 @@ interface ChatHistoryRepository {
     suspend fun deleteAllChats()
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
     suspend fun setPinned(chatId: String, pinned: Boolean)
+
+    /**
+     * Formats [chatId] per FR-016f and writes it as a `.txt` file to the public Downloads
+     * directory, registering it in the in-app Downloads list. Returns the resulting file.
+     * Throws if the chat is missing or the write fails.
+     */
+    suspend fun exportChat(chatId: String, displayTitle: String): File
 }
 
 @ContributesBinding(AppScope::class)
@@ -50,7 +58,10 @@ class RealChatHistoryRepository @Inject constructor(
     private val context: Context,
     private val duckChatSyncRepository: DuckChatSyncRepository,
     private val syncEngine: SyncEngine,
+    private val chatExportWriter: ChatExportWriter,
 ) : ChatHistoryRepository {
+
+    private val chatExporter = ChatExporter()
 
     private val fallbackTitle: String by lazy { context.getString(R.string.duck_ai_chat_history_untitled) }
 
@@ -78,6 +89,14 @@ class RealChatHistoryRepository @Inject constructor(
             syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
         }
     }
+
+    override suspend fun exportChat(chatId: String, displayTitle: String): File =
+        withContext(dispatchers.io()) {
+            val rawJson = chatStore.getChatContent(chatId)
+                ?: throw IllegalStateException("Chat $chatId not found")
+            val text = chatExporter.export(rawJson)
+            chatExportWriter.write(text, displayTitle)
+        }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(
         chatId = chat.chatId,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -43,11 +43,12 @@ interface ChatHistoryRepository {
     suspend fun setPinned(chatId: String, pinned: Boolean)
 
     /**
-     * Formats [chatId] per FR-016f and writes it as a `.txt` file to the public Downloads
+     * Formats [chatId] per the cross-platform reference (research.md R-16) and writes it as a
+     * `.txt` (Discussion/Voice) or `.zip` (ImageGeneration) file to the public Downloads
      * directory, registering it in the in-app Downloads list. Returns the resulting file.
      * Throws if the chat is missing or the write fails.
      */
-    suspend fun exportChat(chatId: String, displayTitle: String): File
+    suspend fun exportChat(chatId: String): File
 }
 
 @ContributesBinding(AppScope::class)
@@ -90,12 +91,25 @@ class RealChatHistoryRepository @Inject constructor(
         }
     }
 
-    override suspend fun exportChat(chatId: String, displayTitle: String): File =
+    override suspend fun exportChat(chatId: String): File =
         withContext(dispatchers.io()) {
-            val rawJson = chatStore.getChatContent(chatId)
+            val chat = chatStore.getChats().firstOrNull { it.chatId == chatId }
                 ?: throw IllegalStateException("Chat $chatId not found")
-            val text = chatExporter.export(rawJson)
-            chatExportWriter.write(text, displayTitle)
+            val rawJson = chatStore.getChatContent(chatId)
+                ?: throw IllegalStateException("Chat $chatId content not found")
+            val result = chatExporter.export(rawJson, chat.toChatType(), chat.fileRefs)
+            val payload = when (result) {
+                is ExportResult.Text -> ExportPayload.Text(result.content)
+                is ExportResult.Zip -> ExportPayload.Zip(
+                    content = result.content,
+                    images = result.imageFileRefs.mapIndexed { index, uuid ->
+                        val bytes = chatStore.openFileRef(uuid).readBytesAndClose()
+                            ?: throw IllegalStateException("File $uuid missing for chat $chatId")
+                        ExportPayload.Zip.Image(name = "image-${index + 1}.jpeg", bytes = bytes)
+                    },
+                )
+            }
+            chatExportWriter.write(payload)
         }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.models.ModelDisplay
 import com.duckduckgo.duckchat.impl.models.toChatType
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
@@ -46,9 +47,15 @@ interface ChatHistoryRepository {
      * Formats [chatId] per the cross-platform reference (research.md R-16) and writes it as a
      * `.txt` (Discussion/Voice) or `.zip` (ImageGeneration) file to the public Downloads
      * directory, registering it in the in-app Downloads list. Returns the resulting file.
+     *
+     * [modelDisplay] is the pre-resolved provider/model attribution rendered in the export header.
+     * Callers (the ViewModel) look it up against the live /duckchat/v1/models cache. Pass `null`
+     * when the model is not yet known to the cache; the exporter falls back to displaying the raw
+     * model id without a provider possessive.
+     *
      * Throws if the chat is missing or the write fails.
      */
-    suspend fun exportChat(chatId: String): File
+    suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): File
 }
 
 @ContributesBinding(AppScope::class)
@@ -91,13 +98,13 @@ class RealChatHistoryRepository @Inject constructor(
         }
     }
 
-    override suspend fun exportChat(chatId: String): File =
+    override suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): File =
         withContext(dispatchers.io()) {
             val chat = chatStore.getChatById(chatId)
                 ?: throw IllegalStateException("Chat $chatId not found")
             val rawJson = chatStore.getChatContent(chatId)
                 ?: throw IllegalStateException("Chat $chatId content not found")
-            val result = chatExporter.export(rawJson, chat.toChatType(), chat.fileRefs)
+            val result = chatExporter.export(rawJson, chat.toChatType(), chat.fileRefs, modelDisplay)
             val payload = when (result) {
                 is ExportResult.Text -> ExportPayload.Text(result.content)
                 is ExportResult.Zip -> ExportPayload.Zip(
@@ -116,6 +123,7 @@ class RealChatHistoryRepository @Inject constructor(
         chatId = chat.chatId,
         displayTitle = chat.title.takeIf { it.isNotBlank() && it != UPSTREAM_UNTITLED } ?: fallbackTitle,
         type = chat.toChatType(),
+        model = chat.model,
         pinned = chat.pinned,
         lastEditMillis = chat.lastEdit.parseIsoMillis(),
     )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -42,19 +42,6 @@ interface ChatHistoryRepository {
     suspend fun deleteAllChats()
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
     suspend fun setPinned(chatId: String, pinned: Boolean)
-
-    /**
-     * Formats [chatId] per the cross-platform reference (research.md R-16) and writes it as a
-     * `.txt` (Discussion/Voice) or `.zip` (ImageGeneration) file to the public Downloads
-     * directory, registering it in the in-app Downloads list. Returns the resulting file.
-     *
-     * [modelDisplay] is the pre-resolved provider/model attribution rendered in the export header.
-     * Callers (the ViewModel) look it up against the live /duckchat/v1/models cache. Pass `null`
-     * when the model is not yet known to the cache; the exporter falls back to displaying the raw
-     * model id without a provider possessive.
-     *
-     * Throws if the chat is missing or the write fails.
-     */
     suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): File
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -76,6 +76,13 @@ class ChatHistoryViewModel @Inject constructor(
         initialValue = ChatHistoryUiState.Loading,
     )
 
+    init {
+        // Warm the /duckchat/v1/models cache so the next Download tap has the provider/model
+        // labels ready. Best-effort: failures are swallowed by the manager, and the export
+        // path falls back to the raw model id when the cache is still empty at click time.
+        viewModelScope.launch { duckAiModelManager.fetchModels() }
+    }
+
     fun isSelectMode(): Boolean = controls.value.mode is Mode.Selecting
 
     fun onChatRowClicked(chatId: String) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -28,6 +28,8 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Mode
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.PendingConfirmation
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.toModelDisplay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -50,6 +52,7 @@ class ChatHistoryViewModel @Inject constructor(
     private val duckChat: DuckChatInternal,
     private val dataClearingTrigger: DataClearingTrigger,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckAiModelManager: DuckAiModelManager,
 ) : ViewModel() {
 
     private val controls = MutableStateFlow(UiControls())
@@ -149,8 +152,15 @@ class ChatHistoryViewModel @Inject constructor(
     }
 
     fun onDownloadRequested(chatId: String) {
+        // Snapshot-read /duckchat/v1/models cache so the export header carries provider attribution
+        // (e.g. "using OpenAI's GPT-5 mini Model"). Null when the model isn't cached — the exporter
+        // then falls back to "using the <raw-id> Model", which is still valid output.
+        val modelId = latestItems.firstOrNull { it.chatId == chatId }?.model
+        val modelDisplay = modelId
+            ?.let { id -> duckAiModelManager.modelState.value.models.firstOrNull { it.id == id } }
+            ?.toModelDisplay()
         viewModelScope.launch {
-            runCatching { chatHistoryRepository.exportChat(chatId, modelDisplay = null) }
+            runCatching { chatHistoryRepository.exportChat(chatId, modelDisplay) }
                 .onSuccess { file -> navigationChannel.trySend(NavigationEvent.ShowDownloadComplete(file.name)) }
                 .onFailure { navigationChannel.trySend(NavigationEvent.ShowExportError) }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -148,9 +148,9 @@ class ChatHistoryViewModel @Inject constructor(
         appScope.launch { chatHistoryRepository.setPinned(chatId, restorePinned) }
     }
 
-    fun onDownloadRequested(chatId: String, displayTitle: String) {
+    fun onDownloadRequested(chatId: String) {
         viewModelScope.launch {
-            runCatching { chatHistoryRepository.exportChat(chatId, displayTitle) }
+            runCatching { chatHistoryRepository.exportChat(chatId) }
                 .onSuccess { file -> navigationChannel.trySend(NavigationEvent.ShowDownloadComplete(file.name)) }
                 .onFailure { navigationChannel.trySend(NavigationEvent.ShowExportError) }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -150,7 +150,7 @@ class ChatHistoryViewModel @Inject constructor(
 
     fun onDownloadRequested(chatId: String) {
         viewModelScope.launch {
-            runCatching { chatHistoryRepository.exportChat(chatId) }
+            runCatching { chatHistoryRepository.exportChat(chatId, modelDisplay = null) }
                 .onSuccess { file -> navigationChannel.trySend(NavigationEvent.ShowDownloadComplete(file.name)) }
                 .onFailure { navigationChannel.trySend(NavigationEvent.ShowExportError) }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -77,9 +77,8 @@ class ChatHistoryViewModel @Inject constructor(
     )
 
     init {
-        // Warm the /duckchat/v1/models cache so the next Download tap has the provider/model
-        // labels ready. Best-effort: failures are swallowed by the manager, and the export
-        // path falls back to the raw model id when the cache is still empty at click time.
+        // Warm the models cache so a Download tap has provider/model labels ready;
+        // failures are swallowed and exports fall back to the raw model id.
         viewModelScope.launch { duckAiModelManager.fetchModels() }
     }
 
@@ -159,9 +158,8 @@ class ChatHistoryViewModel @Inject constructor(
     }
 
     fun onDownloadRequested(chatId: String) {
-        // Snapshot-read /duckchat/v1/models cache so the export header carries provider attribution
-        // (e.g. "using OpenAI's GPT-5 mini Model"). Null when the model isn't cached — the exporter
-        // then falls back to "using the <raw-id> Model", which is still valid output.
+        // Snapshot-read the models cache; null when the model isn't cached and the exporter
+        // falls back to the raw model id.
         val modelId = latestItems.firstOrNull { it.chatId == chatId }?.model
         val modelDisplay = modelId
             ?.let { id -> duckAiModelManager.modelState.value.models.firstOrNull { it.id == id } }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -148,6 +148,14 @@ class ChatHistoryViewModel @Inject constructor(
         appScope.launch { chatHistoryRepository.setPinned(chatId, restorePinned) }
     }
 
+    fun onDownloadRequested(chatId: String, displayTitle: String) {
+        viewModelScope.launch {
+            runCatching { chatHistoryRepository.exportChat(chatId, displayTitle) }
+                .onSuccess { file -> navigationChannel.trySend(NavigationEvent.ShowDownloadComplete(file.name)) }
+                .onFailure { navigationChannel.trySend(NavigationEvent.ShowExportError) }
+        }
+    }
+
     private fun dispatchSelectedClear(chatIds: Set<String>) {
         if (chatIds.isEmpty()) return
         if (!duckAiFeatureState.showClearDuckAIChatHistory.value) return
@@ -274,6 +282,8 @@ class ChatHistoryViewModel @Inject constructor(
 
     sealed interface NavigationEvent {
         data class OpenRename(val chatId: String, val currentTitle: String) : NavigationEvent
+        data class ShowDownloadComplete(val fileName: String) : NavigationEvent
+        data object ShowExportError : NavigationEvent
     }
 
     sealed interface MessageEvent {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ModelDisplay.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ModelDisplay.kt
@@ -16,27 +16,14 @@
 
 package com.duckduckgo.duckchat.impl.models
 
-/**
- * Plain-text rendering of a chat's model attribution, used by the chat-history export header.
- *
- *  - `fullName` is the long label rendered in `using <Provider>'s <fullName> Model`. Null collapses
- *    the header to `using an AI Model`.
- *  - `shortName` is the per-turn prefix (e.g. `GPT-5 mini:`) for Discussion / ImageGeneration outputs.
- *    Always non-null; defaults to the raw model id when nothing better is available.
- *  - `providerPossessive` (e.g. `OpenAI's`) is dropped when null; the header falls back to
- *    `using the <fullName> Model`.
- */
+/** Plain-text model attribution for the chat-history export header. */
 data class ModelDisplay(
     val fullName: String?,
     val shortName: String,
     val providerPossessive: String?,
 )
 
-/**
- * Possessive form of the provider name, used by [ModelDisplay.providerPossessive] when the model
- * comes from the live `/duckchat/v1/models` API. Null when there isn't a clean possessive — the
- * export header falls back to `using the <Model> Model` in that case.
- */
+/** Possessive form of the provider name. Null for providers without a clean possessive (OSS, UNKNOWN). */
 val ModelProvider.possessive: String?
     get() = when (this) {
         ModelProvider.OPENAI -> "OpenAI's"
@@ -46,7 +33,6 @@ val ModelProvider.possessive: String?
         ModelProvider.OSS, ModelProvider.UNKNOWN -> null
     }
 
-/** Builds the export-header display strings from a live API model. */
 fun AIChatModel.toModelDisplay(): ModelDisplay = ModelDisplay(
     fullName = name,
     shortName = shortName,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ModelDisplay.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ModelDisplay.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.models
+
+/**
+ * Plain-text rendering of a chat's model attribution, used by the chat-history export header.
+ *
+ *  - `fullName` is the long label rendered in `using <Provider>'s <fullName> Model`. Null collapses
+ *    the header to `using an AI Model`.
+ *  - `shortName` is the per-turn prefix (e.g. `GPT-5 mini:`) for Discussion / ImageGeneration outputs.
+ *    Always non-null; defaults to the raw model id when nothing better is available.
+ *  - `providerPossessive` (e.g. `OpenAI's`) is dropped when null; the header falls back to
+ *    `using the <fullName> Model`.
+ */
+data class ModelDisplay(
+    val fullName: String?,
+    val shortName: String,
+    val providerPossessive: String?,
+)
+
+/**
+ * Possessive form of the provider name, used by [ModelDisplay.providerPossessive] when the model
+ * comes from the live `/duckchat/v1/models` API. Null when there isn't a clean possessive — the
+ * export header falls back to `using the <Model> Model` in that case.
+ */
+val ModelProvider.possessive: String?
+    get() = when (this) {
+        ModelProvider.OPENAI -> "OpenAI's"
+        ModelProvider.ANTHROPIC -> "Anthropic's"
+        ModelProvider.META -> "Meta's"
+        ModelProvider.MISTRAL -> "Mistral's"
+        ModelProvider.OSS, ModelProvider.UNKNOWN -> null
+    }
+
+/** Builds the export-header display strings from a live API model. */
+fun AIChatModel.toModelDisplay(): ModelDisplay = ModelDisplay(
+    fullName = name,
+    shortName = shortName,
+    providerPossessive = provider.possessive,
+)

--- a/duckchat/duckchat-impl/src/main/res/layout/view_chat_history_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_chat_history_item.xml
@@ -53,23 +53,29 @@
         android:paddingStart="@dimen/keyline_4"
         android:paddingEnd="@dimen/keyline_2"
         app:layout_constraintBottom_toBottomOf="@+id/chatHistoryIconContainer"
-        app:layout_constraintEnd_toStartOf="@+id/chatHistoryMore"
+        app:layout_constraintEnd_toStartOf="@+id/chatHistoryMoreContainer"
         app:layout_constraintStart_toEndOf="@+id/chatHistoryIconContainer"
         app:layout_constraintTop_toTopOf="@+id/chatHistoryIconContainer"
         app:typography="body1"
         tools:text="My very long chat title that should be truncated when it overflows" />
 
-    <ImageView
-        android:id="@+id/chatHistoryMore"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:contentDescription="@string/duck_ai_chat_history_more_options"
-        android:padding="12dp"
-        android:src="@drawable/ic_menu_vertical_24"
+    <FrameLayout
+        android:id="@+id/chatHistoryMoreContainer"
+        android:layout_width="@dimen/listItemTrailingIconWidth"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="@+id/chatHistoryIconContainer"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/chatHistoryIconContainer"
-        app:tint="?attr/daxColorPrimaryIcon" />
+        app:layout_constraintTop_toTopOf="@+id/chatHistoryIconContainer">
+
+        <ImageView
+            android:id="@+id/chatHistoryMore"
+            android:layout_width="@dimen/listItemImageMediumSize"
+            android:layout_height="@dimen/listItemImageMediumSize"
+            android:layout_gravity="center"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/duck_ai_chat_history_more_options"
+            android:src="@drawable/ic_menu_vertical_24"
+            app:tint="?attr/daxColorPrimaryIcon" />
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_chat_history_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_chat_history_item.xml
@@ -23,7 +23,7 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:minHeight="@dimen/oneLineItemHeight"
-    android:paddingHorizontal="@dimen/keyline_4"
+    android:paddingStart="@dimen/keyline_4"
     android:paddingVertical="@dimen/keyline_2">
 
     <FrameLayout

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -110,7 +110,7 @@
     <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
     <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
     <string name="duck_ai_chat_history_undo">Undo</string>
-    <string name="duck_ai_chat_history_download_complete">Download complete for %1$s</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \'My Chat.txt\').">Download complete for %1$s</string>
     <string name="duck_ai_chat_history_download_view">Show</string>
     <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -110,7 +110,7 @@
     <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
     <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
     <string name="duck_ai_chat_history_undo">Undo</string>
-    <string name="duck_ai_chat_history_download_complete">Saved chat to Downloads</string>
-    <string name="duck_ai_chat_history_download_view">View</string>
+    <string name="duck_ai_chat_history_download_complete">Download complete for %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Show</string>
     <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -110,4 +110,7 @@
     <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
     <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
     <string name="duck_ai_chat_history_undo">Undo</string>
+    <string name="duck_ai_chat_history_download_complete">Saved chat to Downloads</string>
+    <string name="duck_ai_chat_history_download_view">View</string>
+    <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+
+class ChatExporterTest {
+
+    // ZoneId Europe/Paris matches the device that produced the spec's export-example.txt
+    // (UTC+2 in May 2026 → 14:23:15 UTC reads as 4:23:15 PM local).
+    private val exporter = ChatExporter(ZoneId.of("Europe/Paris"))
+
+    @Test
+    fun `single turn matches FR-016f reference output`() {
+        val output = exporter.export(SPEC_CHAT_JSON)
+
+        val expected = """
+            This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-5 mini Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).
+
+            ====================
+
+            User prompt 1 of 1 - 5/15/2026, 4:23:15 PM:
+            cat
+
+            GPT-5 mini:
+            Do you want a picture, facts, care tips, behavior explanation, name ideas, or something else about cats?
+        """.trimIndent()
+
+        assertEquals(expected, output)
+    }
+
+    @Test
+    fun `multi-turn output numbers prompts and separates turns with a blank line`() {
+        val json = """
+            {
+              "model": "gpt-5-mini",
+              "messages": [
+                {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hi"},
+                {"role":"assistant","createdAt":"2026-05-15T14:00:01.000Z","content":"","parts":[{"type":"text","text":"Hello!"}]},
+                {"role":"user","createdAt":"2026-05-15T14:01:00.000Z","content":"bye"},
+                {"role":"assistant","createdAt":"2026-05-15T14:01:01.000Z","content":"","parts":[{"type":"text","text":"Goodbye!"}]}
+              ]
+            }
+        """.trimIndent()
+
+        val output = exporter.export(json)
+
+        assertTrue("contains turn 1 numbering", output.contains("User prompt 1 of 2 - 5/15/2026, 4:00:00 PM:"))
+        assertTrue("contains turn 2 numbering", output.contains("User prompt 2 of 2 - 5/15/2026, 4:01:00 PM:"))
+        assertTrue("turn 1 prompt body", output.contains("hi"))
+        assertTrue("turn 1 reply body", output.contains("Hello!"))
+        assertTrue("turn 2 prompt body", output.contains("bye"))
+        assertTrue("turn 2 reply body", output.contains("Goodbye!"))
+        assertTrue("blank line between turns", output.contains("Hello!\n\nUser prompt 2"))
+    }
+
+    @Test
+    fun `assistant text falls back to content when parts array is absent`() {
+        val json = """
+            {
+              "model": "gpt-5-mini",
+              "messages": [
+                {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hello"},
+                {"role":"assistant","createdAt":"2026-05-15T14:00:01.000Z","content":"plain-content fallback"}
+              ]
+            }
+        """.trimIndent()
+
+        val output = exporter.export(json)
+
+        assertTrue(output.contains("GPT-5 mini:\nplain-content fallback"))
+    }
+
+    @Test
+    fun `reasoning parts are ignored - only text parts are included`() {
+        val json = """
+            {
+              "model": "gpt-5-mini",
+              "messages": [
+                {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hi"},
+                {"role":"assistant","content":"","parts":[
+                  {"type":"reasoning","encryptedText":"secret"},
+                  {"type":"text","text":"only this is visible"}
+                ]}
+              ]
+            }
+        """.trimIndent()
+
+        val output = exporter.export(json)
+
+        assertTrue(output.contains("only this is visible"))
+        assertTrue("reasoning text is omitted", !output.contains("secret"))
+    }
+
+    @Test
+    fun `unknown model falls back to raw id and generic provider wording`() {
+        val json = """
+            {
+              "model": "some-future-model-v2",
+              "messages": [
+                {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hi"},
+                {"role":"assistant","content":"hello"}
+              ]
+            }
+        """.trimIndent()
+
+        val output = exporter.export(json)
+
+        assertTrue("header uses raw id", output.contains("using the some-future-model-v2 Model"))
+        assertTrue("per-turn label uses raw id", output.contains("some-future-model-v2:"))
+    }
+
+    @Test
+    fun `empty messages array yields header and separator only`() {
+        val json = """{"model":"gpt-5-mini","messages":[]}"""
+
+        val output = exporter.export(json)
+
+        assertTrue(output.startsWith("This conversation was generated"))
+        assertTrue(output.endsWith("===================="))
+    }
+
+    private companion object {
+        // Verbatim from specs/click-access-chat-history/chat-example.json (encryptedText abbreviated).
+        const val SPEC_CHAT_JSON = """{
+  "title" : "cat name",
+  "model" : "gpt-5-mini",
+  "messages" : [ {
+    "createdAt" : "2026-05-15T14:23:15.150Z",
+    "content" : "cat",
+    "role" : "user",
+    "messageId" : "26030492-4a59-47f9-b860-80e8716e9d4a",
+    "generationTimestamp" : 1778854995150
+  }, {
+    "role" : "assistant",
+    "createdAt" : "2026-05-15T14:23:15.244Z",
+    "content" : "",
+    "parts" : [ {
+      "type" : "reasoning",
+      "id" : "rs_abc",
+      "state" : "done",
+      "summaryText" : [ ],
+      "encryptedText" : "redacted"
+    }, {
+      "type" : "text",
+      "text" : "Do you want a picture, facts, care tips, behavior explanation, name ideas, or something else about cats?"
+    } ],
+    "status" : "active",
+    "model" : "gpt-5-mini",
+    "origin" : "text"
+  } ],
+  "chatId" : "52386ba8-7a9d-4307-950e-05cd7d74917a",
+  "lastEdit" : "2026-05-15T14:23:16.313Z",
+  "lastEditType" : "user",
+  "pinned" : true,
+  "pendingSync" : true
+}"""
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.history
 
+import com.duckduckgo.duckchat.impl.models.ChatType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.history
 
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.models.ModelDisplay
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -29,9 +30,15 @@ class ChatExporterTest {
     // (UTC+2 in May 2026 → 14:23:15 UTC reads as 4:23:15 PM local).
     private val exporter = ChatExporter(ZoneId.of("Europe/Paris"))
 
+    private val gpt5MiniDisplay = ModelDisplay(
+        fullName = "GPT-5 mini",
+        shortName = "GPT-5 mini",
+        providerPossessive = "OpenAI's",
+    )
+
     @Test
     fun `Discussion single turn matches the cross-platform reference output`() {
-        val result = exporter.export(SPEC_CHAT_JSON, ChatType.Discussion)
+        val result = exporter.export(SPEC_CHAT_JSON, ChatType.Discussion, modelDisplay = gpt5MiniDisplay)
 
         val expected = """
             This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-5 mini Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).
@@ -51,7 +58,7 @@ class ChatExporterTest {
 
     @Test
     fun `multi-turn output inserts the turn separator between turns`() {
-        val result = exporter.export(TWO_TURN_JSON, ChatType.Discussion)
+        val result = exporter.export(TWO_TURN_JSON, ChatType.Discussion, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         val output = result.content
@@ -62,7 +69,7 @@ class ChatExporterTest {
 
     @Test
     fun `Voice assistant prefix is the literal Voice Chat label`() {
-        val result = exporter.export(TWO_TURN_JSON, ChatType.Voice)
+        val result = exporter.export(TWO_TURN_JSON, ChatType.Voice, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         val output = result.content
@@ -83,7 +90,7 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val result = exporter.export(json, ChatType.Voice)
+        val result = exporter.export(json, ChatType.Voice, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         val output = result.content
@@ -95,7 +102,12 @@ class ChatExporterTest {
 
     @Test
     fun `ImageGeneration replaces assistant text with image placeholder and consumes fileRefs positionally`() {
-        val result = exporter.export(TWO_TURN_JSON, ChatType.ImageGeneration, listOf("uuid-1", "uuid-2"))
+        val result = exporter.export(
+            rawJson = TWO_TURN_JSON,
+            chatType = ChatType.ImageGeneration,
+            fileRefs = listOf("uuid-1", "uuid-2"),
+            modelDisplay = gpt5MiniDisplay,
+        )
 
         assertTrue(result is ExportResult.Zip)
         result as ExportResult.Zip
@@ -115,7 +127,12 @@ class ChatExporterTest {
 
     @Test
     fun `ImageGeneration handles missing fileRefs gracefully`() {
-        val result = exporter.export(TWO_TURN_JSON, ChatType.ImageGeneration, fileRefs = emptyList())
+        val result = exporter.export(
+            rawJson = TWO_TURN_JSON,
+            chatType = ChatType.ImageGeneration,
+            fileRefs = emptyList(),
+            modelDisplay = gpt5MiniDisplay,
+        )
 
         assertTrue(result is ExportResult.Zip)
         result as ExportResult.Zip
@@ -137,7 +154,7 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val result = exporter.export(json, ChatType.Discussion)
+        val result = exporter.export(json, ChatType.Discussion, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         assertTrue(result.content.contains("GPT-5 mini:\nplain-content fallback"))
@@ -158,7 +175,7 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val result = exporter.export(json, ChatType.Discussion)
+        val result = exporter.export(json, ChatType.Discussion, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         assertTrue(result.content.contains("only this is visible"))
@@ -166,7 +183,7 @@ class ChatExporterTest {
     }
 
     @Test
-    fun `unknown model falls back to raw id and generic provider wording`() {
+    fun `null modelDisplay falls back to raw id and generic provider wording`() {
         val json = """
             {
               "model": "some-future-model-v2",
@@ -188,7 +205,7 @@ class ChatExporterTest {
     fun `empty messages array yields header and separator only`() {
         val json = """{"model":"gpt-5-mini","messages":[]}"""
 
-        val result = exporter.export(json, ChatType.Discussion)
+        val result = exporter.export(json, ChatType.Discussion, modelDisplay = gpt5MiniDisplay)
 
         assertTrue(result is ExportResult.Text)
         assertTrue(result.content.startsWith("This conversation was generated"))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
@@ -26,8 +26,8 @@ import java.time.ZoneId
 
 class ChatExporterTest {
 
-    // ZoneId Europe/Paris matches the device that produced the spec's export-example.txt
-    // (UTC+2 in May 2026 → 14:23:15 UTC reads as 4:23:15 PM local).
+    // Fixed ZoneId so the asserted "4:23:15 PM" timestamps reproduce on any CI machine
+    // (Europe/Paris = UTC+2 in May 2026; the test JSON's 14:23:15 UTC renders as 4:23:15 PM local).
     private val exporter = ChatExporter(ZoneId.of("Europe/Paris"))
 
     private val gpt5MiniDisplay = ModelDisplay(
@@ -94,9 +94,7 @@ class ChatExporterTest {
 
         assertTrue(result is ExportResult.Text)
         val output = result.content
-        // First turn (user-only) should run straight into the turn separator with no Voice Chat block.
         assertTrue("user-only turn has no assistant block", output.contains("hi\n\n--------------------"))
-        // Second turn still renders the Voice Chat response.
         assertTrue("responded turn keeps Voice Chat block", output.contains("Voice Chat:\nGoodbye!"))
     }
 
@@ -120,8 +118,7 @@ class ChatExporterTest {
             "turn 2 carries the image-2 placeholder",
             result.content.contains("GPT-5 mini:\n\n[Generated image: image-2.jpeg]"),
         )
-        // The model's text response is replaced — original text MUST NOT appear in the output.
-        assertFalse(result.content.contains("Hello!"))
+        assertFalse("model's text response is replaced by the placeholder", result.content.contains("Hello!"))
         assertFalse(result.content.contains("Goodbye!"))
     }
 
@@ -137,9 +134,8 @@ class ChatExporterTest {
         assertTrue(result is ExportResult.Zip)
         result as ExportResult.Zip
         assertTrue("no fileRefs consumed", result.imageFileRefs.isEmpty())
-        // With no fileRefs, the model header is still emitted but no placeholder line follows.
-        assertTrue(result.content.contains("GPT-5 mini:"))
-        assertFalse(result.content.contains("[Generated image:"))
+        assertTrue("model header is still emitted", result.content.contains("GPT-5 mini:"))
+        assertFalse("no placeholder line without a fileRef", result.content.contains("[Generated image:"))
     }
 
     @Test
@@ -213,7 +209,6 @@ class ChatExporterTest {
     }
 
     private companion object {
-        // Verbatim from specs/click-access-chat-history/chat-example.json (encryptedText abbreviated).
         const val SPEC_CHAT_JSON = """{
   "title" : "cat name",
   "model" : "gpt-5-mini",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatExporterTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.history
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.ZoneId
@@ -28,8 +29,8 @@ class ChatExporterTest {
     private val exporter = ChatExporter(ZoneId.of("Europe/Paris"))
 
     @Test
-    fun `single turn matches FR-016f reference output`() {
-        val output = exporter.export(SPEC_CHAT_JSON)
+    fun `Discussion single turn matches the cross-platform reference output`() {
+        val result = exporter.export(SPEC_CHAT_JSON, ChatType.Discussion)
 
         val expected = """
             This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-5 mini Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).
@@ -43,32 +44,84 @@ class ChatExporterTest {
             Do you want a picture, facts, care tips, behavior explanation, name ideas, or something else about cats?
         """.trimIndent()
 
-        assertEquals(expected, output)
+        assertTrue(result is ExportResult.Text)
+        assertEquals(expected, result.content)
     }
 
     @Test
-    fun `multi-turn output numbers prompts and separates turns with a blank line`() {
+    fun `multi-turn output inserts the turn separator between turns`() {
+        val result = exporter.export(TWO_TURN_JSON, ChatType.Discussion)
+
+        assertTrue(result is ExportResult.Text)
+        val output = result.content
+        assertTrue("contains turn 1 numbering", output.contains("User prompt 1 of 2 - 5/15/2026, 4:00:00 PM:"))
+        assertTrue("contains turn 2 numbering", output.contains("User prompt 2 of 2 - 5/15/2026, 4:01:00 PM:"))
+        assertTrue("turn separator sits between turns", output.contains("Hello!\n\n--------------------\n\nUser prompt 2"))
+    }
+
+    @Test
+    fun `Voice assistant prefix is the literal Voice Chat label`() {
+        val result = exporter.export(TWO_TURN_JSON, ChatType.Voice)
+
+        assertTrue(result is ExportResult.Text)
+        val output = result.content
+        assertTrue("uses literal Voice Chat prefix", output.contains("Voice Chat:\nHello!"))
+        assertFalse("does not use the model name as prefix", output.contains("GPT-5 mini:"))
+    }
+
+    @Test
+    fun `Voice skips the assistant block entirely when there is no model response`() {
         val json = """
             {
-              "model": "gpt-5-mini",
+              "model": "voice-mode",
               "messages": [
                 {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hi"},
-                {"role":"assistant","createdAt":"2026-05-15T14:00:01.000Z","content":"","parts":[{"type":"text","text":"Hello!"}]},
                 {"role":"user","createdAt":"2026-05-15T14:01:00.000Z","content":"bye"},
                 {"role":"assistant","createdAt":"2026-05-15T14:01:01.000Z","content":"","parts":[{"type":"text","text":"Goodbye!"}]}
               ]
             }
         """.trimIndent()
 
-        val output = exporter.export(json)
+        val result = exporter.export(json, ChatType.Voice)
 
-        assertTrue("contains turn 1 numbering", output.contains("User prompt 1 of 2 - 5/15/2026, 4:00:00 PM:"))
-        assertTrue("contains turn 2 numbering", output.contains("User prompt 2 of 2 - 5/15/2026, 4:01:00 PM:"))
-        assertTrue("turn 1 prompt body", output.contains("hi"))
-        assertTrue("turn 1 reply body", output.contains("Hello!"))
-        assertTrue("turn 2 prompt body", output.contains("bye"))
-        assertTrue("turn 2 reply body", output.contains("Goodbye!"))
-        assertTrue("blank line between turns", output.contains("Hello!\n\nUser prompt 2"))
+        assertTrue(result is ExportResult.Text)
+        val output = result.content
+        // First turn (user-only) should run straight into the turn separator with no Voice Chat block.
+        assertTrue("user-only turn has no assistant block", output.contains("hi\n\n--------------------"))
+        // Second turn still renders the Voice Chat response.
+        assertTrue("responded turn keeps Voice Chat block", output.contains("Voice Chat:\nGoodbye!"))
+    }
+
+    @Test
+    fun `ImageGeneration replaces assistant text with image placeholder and consumes fileRefs positionally`() {
+        val result = exporter.export(TWO_TURN_JSON, ChatType.ImageGeneration, listOf("uuid-1", "uuid-2"))
+
+        assertTrue(result is ExportResult.Zip)
+        result as ExportResult.Zip
+        assertEquals(listOf("uuid-1", "uuid-2"), result.imageFileRefs)
+        assertTrue(
+            "turn 1 carries the image-1 placeholder",
+            result.content.contains("GPT-5 mini:\n\n[Generated image: image-1.jpeg]"),
+        )
+        assertTrue(
+            "turn 2 carries the image-2 placeholder",
+            result.content.contains("GPT-5 mini:\n\n[Generated image: image-2.jpeg]"),
+        )
+        // The model's text response is replaced — original text MUST NOT appear in the output.
+        assertFalse(result.content.contains("Hello!"))
+        assertFalse(result.content.contains("Goodbye!"))
+    }
+
+    @Test
+    fun `ImageGeneration handles missing fileRefs gracefully`() {
+        val result = exporter.export(TWO_TURN_JSON, ChatType.ImageGeneration, fileRefs = emptyList())
+
+        assertTrue(result is ExportResult.Zip)
+        result as ExportResult.Zip
+        assertTrue("no fileRefs consumed", result.imageFileRefs.isEmpty())
+        // With no fileRefs, the model header is still emitted but no placeholder line follows.
+        assertTrue(result.content.contains("GPT-5 mini:"))
+        assertFalse(result.content.contains("[Generated image:"))
     }
 
     @Test
@@ -83,9 +136,10 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val output = exporter.export(json)
+        val result = exporter.export(json, ChatType.Discussion)
 
-        assertTrue(output.contains("GPT-5 mini:\nplain-content fallback"))
+        assertTrue(result is ExportResult.Text)
+        assertTrue(result.content.contains("GPT-5 mini:\nplain-content fallback"))
     }
 
     @Test
@@ -103,10 +157,11 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val output = exporter.export(json)
+        val result = exporter.export(json, ChatType.Discussion)
 
-        assertTrue(output.contains("only this is visible"))
-        assertTrue("reasoning text is omitted", !output.contains("secret"))
+        assertTrue(result is ExportResult.Text)
+        assertTrue(result.content.contains("only this is visible"))
+        assertFalse("reasoning text is omitted", result.content.contains("secret"))
     }
 
     @Test
@@ -121,20 +176,22 @@ class ChatExporterTest {
             }
         """.trimIndent()
 
-        val output = exporter.export(json)
+        val result = exporter.export(json, ChatType.Discussion)
 
-        assertTrue("header uses raw id", output.contains("using the some-future-model-v2 Model"))
-        assertTrue("per-turn label uses raw id", output.contains("some-future-model-v2:"))
+        assertTrue(result is ExportResult.Text)
+        assertTrue("header uses raw id", result.content.contains("using the some-future-model-v2 Model"))
+        assertTrue("per-turn label uses raw id", result.content.contains("some-future-model-v2:"))
     }
 
     @Test
     fun `empty messages array yields header and separator only`() {
         val json = """{"model":"gpt-5-mini","messages":[]}"""
 
-        val output = exporter.export(json)
+        val result = exporter.export(json, ChatType.Discussion)
 
-        assertTrue(output.startsWith("This conversation was generated"))
-        assertTrue(output.endsWith("===================="))
+        assertTrue(result is ExportResult.Text)
+        assertTrue(result.content.startsWith("This conversation was generated"))
+        assertTrue(result.content.endsWith("===================="))
     }
 
     private companion object {
@@ -172,5 +229,17 @@ class ChatExporterTest {
   "pinned" : true,
   "pendingSync" : true
 }"""
+
+        const val TWO_TURN_JSON = """
+            {
+              "model": "gpt-5-mini",
+              "messages": [
+                {"role":"user","createdAt":"2026-05-15T14:00:00.000Z","content":"hi"},
+                {"role":"assistant","createdAt":"2026-05-15T14:00:01.000Z","content":"","parts":[{"type":"text","text":"Hello!"}]},
+                {"role":"user","createdAt":"2026-05-15T14:01:00.000Z","content":"bye"},
+                {"role":"assistant","createdAt":"2026-05-15T14:01:01.000Z","content":"","parts":[{"type":"text","text":"Goodbye!"}]}
+              ]
+            }
+        """
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -46,6 +46,7 @@ class ChatHistoryRepositoryTest {
     private val context: Context = mock()
     private val duckChatSyncRepository: DuckChatSyncRepository = mock()
     private val syncEngine: SyncEngine = mock()
+    private val chatExportWriter: ChatExportWriter = mock()
     private val source = MutableStateFlow<List<DuckAiChat>>(emptyList())
     private lateinit var repository: RealChatHistoryRepository
 
@@ -59,6 +60,7 @@ class ChatHistoryRepositoryTest {
             context = context,
             duckChatSyncRepository = duckChatSyncRepository,
             syncEngine = syncEngine,
+            chatExportWriter = chatExportWriter,
         )
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.messaging.fakes.FakeDuckChatInternal
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.models.ModelDisplay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -966,10 +967,12 @@ class ChatHistoryViewModelTest {
         pinned: Boolean = false,
         lastEdit: Long = 0L,
         title: String = chatId,
+        model: String = "gpt-5-mini",
     ): ChatHistoryItem = ChatHistoryItem(
         chatId = chatId,
         displayTitle = title,
         type = ChatType.Discussion,
+        model = model,
         pinned = pinned,
         lastEditMillis = lastEdit,
     )
@@ -982,6 +985,8 @@ private class FakeChatHistoryRepository(
     val renamedChats: MutableList<Pair<String, String>> = mutableListOf()
     val pinnedChats: MutableList<Pair<String, Boolean>> = mutableListOf()
     val exportedChats: MutableList<String> = mutableListOf()
+    var lastExportModelDisplay: ModelDisplay? = null
+        private set
     var exportResult: java.io.File = java.io.File("/tmp/chat-export.txt")
     var exportError: Throwable? = null
     var deleteAllChatsCalled: Boolean = false
@@ -1009,8 +1014,9 @@ private class FakeChatHistoryRepository(
         source.value = source.value.map { if (it.chatId == chatId) it.copy(pinned = pinned) else it }
     }
 
-    override suspend fun exportChat(chatId: String): java.io.File {
+    override suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): java.io.File {
         exportedChats += chatId
+        lastExportModelDisplay = modelDisplay
         exportError?.let { throw it }
         return exportResult
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -809,17 +809,17 @@ class ChatHistoryViewModelTest {
     @Test
     fun `onDownloadRequested emits ShowDownloadComplete with the saved file name`() =
         coroutineRule.testScope.runTest {
-            repository.exportResult = java.io.File("/tmp/My fave chat.txt")
+            repository.exportResult = java.io.File("/tmp/duck.ai_2026-05-21_10-00-00.txt")
 
             viewModel.navigationEvents.test {
-                viewModel.onDownloadRequested("chat-7", "My fave chat")
+                viewModel.onDownloadRequested("chat-7")
 
                 val event = awaitItem()
                 assertTrue(event is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete)
                 event as ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete
-                assertEquals("My fave chat.txt", event.fileName)
+                assertEquals("duck.ai_2026-05-21_10-00-00.txt", event.fileName)
             }
-            assertEquals(listOf("chat-7" to "My fave chat"), repository.exportedChats)
+            assertEquals(listOf("chat-7"), repository.exportedChats)
         }
 
     @Test
@@ -828,7 +828,7 @@ class ChatHistoryViewModelTest {
             repository.exportError = IllegalStateException("boom")
 
             viewModel.navigationEvents.test {
-                viewModel.onDownloadRequested("chat-7", "Title")
+                viewModel.onDownloadRequested("chat-7")
 
                 assertEquals(ChatHistoryViewModel.NavigationEvent.ShowExportError, awaitItem())
             }
@@ -981,7 +981,7 @@ private class FakeChatHistoryRepository(
     val deletedChatIds: MutableList<String> = mutableListOf()
     val renamedChats: MutableList<Pair<String, String>> = mutableListOf()
     val pinnedChats: MutableList<Pair<String, Boolean>> = mutableListOf()
-    val exportedChats: MutableList<Pair<String, String>> = mutableListOf()
+    val exportedChats: MutableList<String> = mutableListOf()
     var exportResult: java.io.File = java.io.File("/tmp/chat-export.txt")
     var exportError: Throwable? = null
     var deleteAllChatsCalled: Boolean = false
@@ -1009,8 +1009,8 @@ private class FakeChatHistoryRepository(
         source.value = source.value.map { if (it.chatId == chatId) it.copy(pinned = pinned) else it }
     }
 
-    override suspend fun exportChat(chatId: String, displayTitle: String): java.io.File {
-        exportedChats += chatId to displayTitle
+    override suspend fun exportChat(chatId: String): java.io.File {
+        exportedChats += chatId
         exportError?.let { throw it }
         return exportResult
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -24,8 +24,13 @@ import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.messaging.fakes.FakeDuckChatInternal
+import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelDisplay
+import com.duckduckgo.duckchat.impl.models.ModelProvider
+import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -49,7 +54,15 @@ class ChatHistoryViewModelTest {
     private val duckAiFeatureState: DuckAiFeatureState = mock {
         whenever(it.showClearDuckAIChatHistory).thenReturn(showClearDuckAIChatHistoryFlow)
     }
-    private val viewModel = ChatHistoryViewModel(repository, coroutineRule.testScope, duckChat, dataClearingTrigger, duckAiFeatureState)
+    private val duckAiModelManager = FakeDuckAiModelManager()
+    private val viewModel = ChatHistoryViewModel(
+        repository,
+        coroutineRule.testScope,
+        duckChat,
+        dataClearingTrigger,
+        duckAiFeatureState,
+        duckAiModelManager,
+    )
 
     @Test
     fun `initial state is Loading`() = coroutineRule.testScope.runTest {
@@ -824,6 +837,45 @@ class ChatHistoryViewModelTest {
         }
 
     @Test
+    fun `onDownloadRequested resolves the model display from the model manager cache`() =
+        coroutineRule.testScope.runTest {
+            source.value = listOf(item(chatId = "chat-7", model = "gpt-5-mini"))
+            duckAiModelManager.setModels(listOf(fakeApiModel(id = "gpt-5-mini", name = "GPT-5 mini", provider = ModelProvider.OPENAI)))
+
+            viewModel.uiState.test {
+                awaitInitialLoaded() // populates latestItems
+                viewModel.navigationEvents.test {
+                    viewModel.onDownloadRequested("chat-7")
+                    awaitItem() // ShowDownloadComplete
+
+                    val display = repository.lastExportModelDisplay
+                    assertEquals("GPT-5 mini", display?.fullName)
+                    assertEquals("GPT-5 mini", display?.shortName)
+                    assertEquals("OpenAI's", display?.providerPossessive)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `onDownloadRequested falls back to null modelDisplay when manager cache misses the model id`() =
+        coroutineRule.testScope.runTest {
+            source.value = listOf(item(chatId = "chat-7", model = "gpt-5.2"))
+            duckAiModelManager.setModels(emptyList())
+
+            viewModel.uiState.test {
+                awaitInitialLoaded()
+                viewModel.navigationEvents.test {
+                    viewModel.onDownloadRequested("chat-7")
+                    awaitItem() // ShowDownloadComplete
+
+                    assertEquals(null, repository.lastExportModelDisplay)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `onDownloadRequested emits ShowExportError when repository throws`() =
         coroutineRule.testScope.runTest {
             repository.exportError = IllegalStateException("boom")
@@ -976,6 +1028,21 @@ class ChatHistoryViewModelTest {
         pinned = pinned,
         lastEditMillis = lastEdit,
     )
+
+    private fun fakeApiModel(
+        id: String,
+        name: String,
+        provider: ModelProvider = ModelProvider.UNKNOWN,
+        shortName: String = name,
+    ): AIChatModel = AIChatModel(
+        id = id,
+        name = name,
+        displayName = name,
+        shortName = shortName,
+        accessTier = emptyList(),
+        isAccessible = true,
+        provider = provider,
+    )
 }
 
 private class FakeChatHistoryRepository(
@@ -1028,4 +1095,19 @@ private class RecordingDataClearingTrigger : DataClearingTrigger {
     override suspend fun clearData(types: Set<ClearableData>) {
         calls += types
     }
+}
+
+private class FakeDuckAiModelManager : DuckAiModelManager {
+    private val _modelState = MutableStateFlow(ModelState())
+    override val modelState: kotlinx.coroutines.flow.StateFlow<ModelState> = _modelState
+
+    fun setModels(models: List<AIChatModel>) {
+        _modelState.value = ModelState(models = models)
+    }
+
+    override suspend fun fetchModels() = Unit
+    override suspend fun selectModel(model: AIChatModel) = Unit
+    override suspend fun selectReasoningMode(mode: ReasoningMode) = Unit
+    override fun getSelectedModelId(): String? = null
+    override fun getResolvedReasoningEffort(): String? = null
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -807,6 +807,34 @@ class ChatHistoryViewModelTest {
     }
 
     @Test
+    fun `onDownloadRequested emits ShowDownloadComplete with the saved file name`() =
+        coroutineRule.testScope.runTest {
+            repository.exportResult = java.io.File("/tmp/My fave chat.txt")
+
+            viewModel.navigationEvents.test {
+                viewModel.onDownloadRequested("chat-7", "My fave chat")
+
+                val event = awaitItem()
+                assertTrue(event is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete)
+                event as ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete
+                assertEquals("My fave chat.txt", event.fileName)
+            }
+            assertEquals(listOf("chat-7" to "My fave chat"), repository.exportedChats)
+        }
+
+    @Test
+    fun `onDownloadRequested emits ShowExportError when repository throws`() =
+        coroutineRule.testScope.runTest {
+            repository.exportError = IllegalStateException("boom")
+
+            viewModel.navigationEvents.test {
+                viewModel.onDownloadRequested("chat-7", "Title")
+
+                assertEquals(ChatHistoryViewModel.NavigationEvent.ShowExportError, awaitItem())
+            }
+        }
+
+    @Test
     fun `onRenameRequested emits OpenRename navigation event with chatId and currentTitle`() = coroutineRule.testScope.runTest {
         viewModel.navigationEvents.test {
             viewModel.onRenameRequested("chat-42", "My favourite chat")
@@ -953,6 +981,9 @@ private class FakeChatHistoryRepository(
     val deletedChatIds: MutableList<String> = mutableListOf()
     val renamedChats: MutableList<Pair<String, String>> = mutableListOf()
     val pinnedChats: MutableList<Pair<String, Boolean>> = mutableListOf()
+    val exportedChats: MutableList<Pair<String, String>> = mutableListOf()
+    var exportResult: java.io.File = java.io.File("/tmp/chat-export.txt")
+    var exportError: Throwable? = null
     var deleteAllChatsCalled: Boolean = false
         private set
 
@@ -976,6 +1007,12 @@ private class FakeChatHistoryRepository(
     override suspend fun setPinned(chatId: String, pinned: Boolean) {
         pinnedChats += chatId to pinned
         source.value = source.value.map { if (it.chatId == chatId) it.copy(pinned = pinned) else it }
+    }
+
+    override suspend fun exportChat(chatId: String, displayTitle: String): java.io.File {
+        exportedChats += chatId to displayTitle
+        exportError?.let { throw it }
+        return exportResult
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -70,6 +70,17 @@ class ChatHistoryViewModelTest {
     }
 
     @Test
+    fun `init warms the model manager cache by calling fetchModels`() = coroutineRule.testScope.runTest {
+        // viewModel is constructed in the test fixture; the init block fires fetchModels once.
+        // Advance to let the launched coroutine run before we assert.
+        viewModel.uiState.test {
+            awaitInitialNonLoading()
+            assertEquals(1, duckAiModelManager.fetchModelsCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `empty source emits Empty state`() = coroutineRule.testScope.runTest {
         viewModel.uiState.test {
             assertEquals(ChatHistoryUiState.Empty, awaitInitialNonLoading())
@@ -1101,13 +1112,20 @@ private class FakeDuckAiModelManager : DuckAiModelManager {
     private val _modelState = MutableStateFlow(ModelState())
     override val modelState: kotlinx.coroutines.flow.StateFlow<ModelState> = _modelState
 
+    var fetchModelsCount: Int = 0
+        private set
+
     fun setModels(models: List<AIChatModel>) {
         _modelState.value = ModelState(models = models)
     }
 
-    override suspend fun fetchModels() = Unit
+    override suspend fun fetchModels() {
+        fetchModelsCount++
+    }
+
     override suspend fun selectModel(model: AIChatModel) = Unit
     override suspend fun selectReasoningMode(mode: ReasoningMode) = Unit
+    override suspend fun setChatScopedReasoningMode(mode: ReasoningMode?) = Unit
     override fun getSelectedModelId(): String? = null
     override fun getResolvedReasoningEffort(): String? = null
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -71,8 +71,7 @@ class ChatHistoryViewModelTest {
 
     @Test
     fun `init warms the model manager cache by calling fetchModels`() = coroutineRule.testScope.runTest {
-        // viewModel is constructed in the test fixture; the init block fires fetchModels once.
-        // Advance to let the launched coroutine run before we assert.
+        // Subscribing to uiState advances the test scheduler so the init-block launch runs.
         viewModel.uiState.test {
             awaitInitialNonLoading()
             assertEquals(1, duckAiModelManager.fetchModelsCount)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.history
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.models.ModelDisplay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -75,7 +76,7 @@ private class RecordingRenameRepository : ChatHistoryRepository {
 
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
-    override suspend fun exportChat(chatId: String): java.io.File = java.io.File("/tmp/noop.txt")
+    override suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): java.io.File = java.io.File("/tmp/noop.txt")
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         errorToThrow?.let { throw it }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -75,6 +75,8 @@ private class RecordingRenameRepository : ChatHistoryRepository {
 
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
+    override suspend fun setPinned(chatId: String, pinned: Boolean) = Unit
+    override suspend fun exportChat(chatId: String, displayTitle: String): java.io.File = java.io.File("/tmp/noop.txt")
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         errorToThrow?.let { throw it }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -75,7 +75,6 @@ private class RecordingRenameRepository : ChatHistoryRepository {
 
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
-    override suspend fun setPinned(chatId: String, pinned: Boolean) = Unit
     override suspend fun exportChat(chatId: String, displayTitle: String): java.io.File = java.io.File("/tmp/noop.txt")
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -75,7 +75,7 @@ private class RecordingRenameRepository : ChatHistoryRepository {
 
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
-    override suspend fun exportChat(chatId: String, displayTitle: String): java.io.File = java.io.File("/tmp/noop.txt")
+    override suspend fun exportChat(chatId: String): java.io.File = java.io.File("/tmp/noop.txt")
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         errorToThrow?.let { throw it }

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONObject
 import java.io.File
+import java.io.InputStream
 import javax.inject.Inject
 
 /**
@@ -83,6 +84,13 @@ interface DuckAiChatStore {
 
     /** Returns the raw FE-owned JSON blob stored for [chatId], or null if the chat does not exist. */
     suspend fun getChatContent(chatId: String): String?
+
+    /**
+     * Opens an [InputStream] for the file backing [uuid] (a fileRef UUID surfaced on [DuckAiChat]).
+     * Returns null if the file is missing or [uuid] resolves outside the chat-files directory.
+     * Callers MUST close the stream.
+     */
+    suspend fun openFileRef(uuid: String): InputStream?
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -180,6 +188,19 @@ class RealDuckAiChatStore @Inject constructor(
 
     override suspend fun getChatContent(chatId: String): String? =
         withContext(dispatchers.io()) { chatsDao.getById(chatId)?.data }
+
+    override suspend fun openFileRef(uuid: String): InputStream? =
+        withContext(dispatchers.io()) {
+            val filesDir = filesDirLazy.get()
+            val file = File(filesDir, uuid)
+            // Same path-traversal guard as deleteChat — reject anything resolving outside the dir.
+            if (!file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {
+                logcat { "DuckAI: RealDuckAiChatStore.openFileRef -- invalid uuid=$uuid" }
+                return@withContext null
+            }
+            if (!file.exists()) return@withContext null
+            file.inputStream()
+        }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONObject
 import java.io.File
-import java.io.InputStream
+import java.util.Base64
 import javax.inject.Inject
 
 /**
@@ -52,6 +52,18 @@ data class DuckAiChat(
     val isImageGeneration: Boolean = false,
     /** True when [model] equals `voice-mode`. */
     val isVoice: Boolean = false,
+)
+
+/**
+ * The decoded payload of a chat fileRef. The on-disk file is a JSON envelope written by the FE
+ * containing the base64-encoded image data plus metadata; [DuckAiChatStore.readFileRef] returns
+ * the decoded bytes along with the FE-provided [fileName] and [mimeType] (both may be null when
+ * the FE omitted them).
+ */
+data class FileRefContent(
+    val fileName: String?,
+    val mimeType: String?,
+    val bytes: ByteArray,
 )
 
 interface DuckAiChatStore {
@@ -86,11 +98,13 @@ interface DuckAiChatStore {
     suspend fun getChatContent(chatId: String): String?
 
     /**
-     * Opens an [InputStream] for the file backing [uuid] (a fileRef UUID surfaced on [DuckAiChat]).
-     * Returns null if the file is missing or [uuid] resolves outside the chat-files directory.
-     * Callers MUST close the stream.
+     * Reads the file backing [uuid] (a fileRef UUID surfaced on [DuckAiChat]) and returns its
+     * decoded payload. The on-disk file is a JSON envelope written by the FE bridge; this method
+     * parses it and base64-decodes the `data` field. Returns null if the file is missing, the
+     * JSON is malformed, the `data` field is absent, or [uuid] resolves outside the chat-files
+     * directory.
      */
-    suspend fun openFileRef(uuid: String): InputStream?
+    suspend fun readFileRef(uuid: String): FileRefContent?
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -189,17 +203,32 @@ class RealDuckAiChatStore @Inject constructor(
     override suspend fun getChatContent(chatId: String): String? =
         withContext(dispatchers.io()) { chatsDao.getById(chatId)?.data }
 
-    override suspend fun openFileRef(uuid: String): InputStream? =
+    override suspend fun readFileRef(uuid: String): FileRefContent? =
         withContext(dispatchers.io()) {
             val filesDir = filesDirLazy.get()
             val file = File(filesDir, uuid)
             // Same path-traversal guard as deleteChat — reject anything resolving outside the dir.
             if (!file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {
-                logcat { "DuckAI: RealDuckAiChatStore.openFileRef -- invalid uuid=$uuid" }
+                logcat { "DuckAI: RealDuckAiChatStore.readFileRef -- invalid uuid=$uuid" }
                 return@withContext null
             }
             if (!file.exists()) return@withContext null
-            file.inputStream()
+            runCatching {
+                val json = JSONObject(file.readText())
+                val rawData = json.optString("data").takeIf { it.isNotEmpty() } ?: return@runCatching null
+                // Accept both plain base64 and `data:<mime>;base64,<payload>` data URLs.
+                val base64 = if (rawData.startsWith("data:")) {
+                    rawData.substringAfter(',', missingDelimiterValue = "")
+                } else {
+                    rawData
+                }
+                if (base64.isEmpty()) return@runCatching null
+                FileRefContent(
+                    fileName = json.optString("fileName").ifEmpty { null },
+                    mimeType = json.optString("mimeType").ifEmpty { null },
+                    bytes = Base64.getDecoder().decode(base64),
+                )
+            }.getOrNull()
         }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -80,6 +80,9 @@ interface DuckAiChatStore {
 
     /** Unpins [chatId]. Silent no-op if the chat is not found or the stored JSON is malformed. */
     suspend fun unpinChat(chatId: String)
+
+    /** Returns the raw FE-owned JSON blob stored for [chatId], or null if the chat does not exist. */
+    suspend fun getChatContent(chatId: String): String?
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -174,6 +177,9 @@ class RealDuckAiChatStore @Inject constructor(
             chatsDao.upsert(entity.copy(data = updatedJson))
         }
     }
+
+    override suspend fun getChatContent(chatId: String): String? =
+        withContext(dispatchers.io()) { chatsDao.getById(chatId)?.data }
 
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -55,10 +55,8 @@ data class DuckAiChat(
 )
 
 /**
- * The decoded payload of a chat fileRef. The on-disk file is a JSON envelope written by the FE
- * containing the base64-encoded image data plus metadata; [DuckAiChatStore.readFileRef] returns
- * the decoded bytes along with the FE-provided [fileName] and [mimeType] (both may be null when
- * the FE omitted them).
+ * Decoded payload of a chat fileRef — base64-decoded [bytes] plus FE-supplied [fileName] /
+ * [mimeType] (either may be null when the FE omitted them).
  */
 data class FileRefContent(
     val fileName: String?,
@@ -98,11 +96,9 @@ interface DuckAiChatStore {
     suspend fun getChatContent(chatId: String): String?
 
     /**
-     * Reads the file backing [uuid] (a fileRef UUID surfaced on [DuckAiChat]) and returns its
-     * decoded payload. The on-disk file is a JSON envelope written by the FE bridge; this method
-     * parses it and base64-decodes the `data` field. Returns null if the file is missing, the
-     * JSON is malformed, the `data` field is absent, or [uuid] resolves outside the chat-files
-     * directory.
+     * Reads the FE-written JSON envelope for [uuid] (a fileRef from [DuckAiChat.fileRefs]),
+     * base64-decoding the `data` field. Returns null when the file is missing, the JSON is
+     * malformed, the `data` field is absent, or [uuid] resolves outside the chat-files directory.
      */
     suspend fun readFileRef(uuid: String): FileRefContent?
 }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -611,4 +611,67 @@ class RealDuckAiChatStoreTest {
 
         assertEquals(null, store.getChatContent("missing"))
     }
+
+    @Test
+    fun `readFileRef decodes the base64 data field into raw bytes`() = runTest {
+        val uuid = "82d44a67-0f52-4147-bb51-c0f1cb36f527"
+        // FE stores the entire `params` JSON via writeText — "data" carries base64-encoded bytes.
+        val envelope = JSONObject()
+            .put("uuid", uuid)
+            .put("chatId", "abc")
+            .put("fileName", "image-1.jpeg")
+            .put("mimeType", "image/jpeg")
+            .put("data", java.util.Base64.getEncoder().encodeToString("hello".toByteArray()))
+            .toString()
+        File(filesDir, uuid).writeText(envelope)
+
+        val result = store.readFileRef(uuid)
+
+        assertEquals("image-1.jpeg", result?.fileName)
+        assertEquals("image/jpeg", result?.mimeType)
+        assertEquals("hello", result?.bytes?.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `readFileRef strips the data URL prefix before decoding`() = runTest {
+        val uuid = "82d44a67-0f52-4147-bb51-c0f1cb36f527"
+        val base64 = java.util.Base64.getEncoder().encodeToString("world".toByteArray())
+        val envelope = JSONObject()
+            .put("uuid", uuid)
+            .put("fileName", "image-1.jpeg")
+            .put("mimeType", "image/jpeg")
+            .put("data", "data:image/jpeg;base64,$base64")
+            .toString()
+        File(filesDir, uuid).writeText(envelope)
+
+        val result = store.readFileRef(uuid)
+
+        assertEquals("world", result?.bytes?.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `readFileRef returns null when the on-disk file is missing`() = runTest {
+        assertNull(store.readFileRef("does-not-exist"))
+    }
+
+    @Test
+    fun `readFileRef returns null when the file is not valid JSON`() = runTest {
+        val uuid = "82d44a67-0f52-4147-bb51-c0f1cb36f527"
+        File(filesDir, uuid).writeText("not json")
+
+        assertNull(store.readFileRef(uuid))
+    }
+
+    @Test
+    fun `readFileRef returns null when the data field is missing`() = runTest {
+        val uuid = "82d44a67-0f52-4147-bb51-c0f1cb36f527"
+        File(filesDir, uuid).writeText(JSONObject().put("uuid", uuid).toString())
+
+        assertNull(store.readFileRef(uuid))
+    }
+
+    @Test
+    fun `readFileRef refuses path traversal in the uuid`() = runTest {
+        assertNull(store.readFileRef("../../etc/passwd"))
+    }
 }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -594,4 +594,21 @@ class RealDuckAiChatStoreTest {
 
         verify(chatsDao, never()).upsert(any())
     }
+
+    // --- getChatContent ---
+
+    @Test
+    fun `getChatContent returns raw JSON blob when chat exists`() = runTest {
+        val json = """{"chatId":"abc","title":"Test","messages":[]}"""
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", json))
+
+        assertEquals(json, store.getChatContent("abc"))
+    }
+
+    @Test
+    fun `getChatContent returns null when chat not found`() = runTest {
+        whenever(chatsDao.getById("missing")).thenReturn(null)
+
+        assertEquals(null, store.getChatContent("missing"))
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214820120386826?focus=true

### Description

Wires the **Download** action on the Duck.ai chat history screen so a chat is exported as a plain-text `.txt` file saved to the device's Downloads folder and registered with the in-app Downloads screen. A snackbar confirms the save with the resulting filename and offers a **Show** action that opens the Downloads screen.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] In Settings → Developer Settings → Feature Flags, confirm `duckAiChatHistory` (`self`, `historyScreen`) is ON and `duckChat → useNativeStorageChatData` is ON.
> - [ ] Create at least one Duck.ai chat with a few back-and-forth turns.

_Happy path_

- [ ] Open the Chats screen → tap the 3-dot on any row → tap **Download** → confirm a snackbar appears reading "Download complete for &lt;filename&gt;.txt" with a **Show** action.
- [ ] Tap **Show** → confirm the in-app Downloads screen opens with the new `.txt` file listed.
- [ ] Open the saved file from Downloads (or via a file manager in the public Downloads folder) → confirm it contains a Duck.ai/model header, a separator line, and each turn in order (user prompt + model response).

_Guards_

- [ ] Trigger Download twice on the same chat → confirm the second save lands as `&lt;title&gt;-1.txt`, not an overwrite.
- [ ] Download a chat whose title contains slashes, colons, or other unsafe characters → confirm the filename sanitises them and the snackbar shows the sanitised name.
- [ ] Trigger Download from inside select mode → confirm the export still runs and the snackbar appears.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes user chat content and images to external storage and decodes native file refs; mistakes could affect privacy or corrupt exports, but scope is localized to Duck.ai history/download flows.
> 
> **Overview**
> Implements **Download** on Duck.ai chat history rows: chats export to the public **Downloads** folder as cross-platform plain text (or a **zip** with `chat.txt` and images for image-generation chats), with timestamped `duck.ai_*` filenames and `-1`, `-2` collision suffixes. Exports register in the in-app **Downloads** list and trigger the same “new download” callbacks as browser downloads.
> 
> The history UI shows a completion snackbar with **Show** to open **Downloads**; failures show an error snackbar. **`DownloadsScreens`** moves from the app module into **`downloads-api`** (with **navigation-api**), and call sites update imports accordingly.
> 
> **`DuckAiChatStore`** gains **`getChatContent`** and **`readFileRef`** (base64 / data-URL decoding, path traversal checks) so exports can read stored JSON and image blobs. A small layout tweak adjusts the row overflow menu hit target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02b9edf6c65f2dd8168bd657adbe6641cd4a45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->