### PR TITLE
Onboarding Brand Design Update: Translations

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/settings/clear/FireAnimation.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/clear/FireAnimation.kt
@@ -30,7 +30,7 @@ sealed class FireAnimation(
     val resId: Int,
     val nameResId: Int,
 ) : Serializable {
-    data object Inferno : FireAnimation(R.raw.inferno, R.string.settingsInfernoAnimation)
+    data object Inferno : FireAnimation(R.raw.inferno, R.string.settingsHeroFireAnimation)
 
     // Displayed as "Inferno Classic" when fireAnimationUpdate toggle is on; storage key,
     // pixel value, and asset filename are intentionally preserved for blast-radius reasons.

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Анимация на огнения бутон</string>
     <string name="settingsHeroFireAnimation">Адски огън</string>
+    <string name="settingsHeroFireAnimationClassic">Стандартен огън</string>
     <string name="settingsHeroWaterAnimation">Водовъртеж</string>
     <string name="settingsHeroAbstractAnimation">Въздушна струя</string>
     <string name="settingsNoneAnimation">Няма</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Стартиране на сърфирането</string>
     <string name="preOnboardingAddressBarTitle">Къде да сложа адресната лента?</string>
     <string name="preOnboardingAddressBarOkButton">Следващ</string>
+    <string name="preOnboardingAddressBarPositionTop">Най-горе</string>
+    <string name="preOnboardingAddressBarPositionBottom">Отдолу</string>
+    <string name="preOnboardingAddressBarPositionSplit">Раздели</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Горе (по подразбиране)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">По-добре се вижда</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Отдолу</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Копиране на текста на връзката</string>
     <string name="linkTextCopied">Копиран текст на връзката</string>
     <string name="linkTextCopyFailed">Неуспешно копиране на текста на връзката</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Здравейте.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Готови ли сте за по-бърз браузър,\nкойто осигурява контрол?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d от %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва “патица“ на английски</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как се казва \"патица\" на испански</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1002,6 +1002,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Готови ли сте за по-бърз браузър,\nкойто осигурява контрол?</string>
     <string name="preOnboardingWelcomeDialogBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d от %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва “патица“ на английски</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва „патица“ на английски</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как се казва \"патица\" на испански</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1041,7 +1041,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Zdravíme tě.</string>
     <string name="preOnboardingWelcomeDialogBody1">Chceš rychlejší prohlížeč, se kterým budeš mít vše pod kontrolou?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak se anglicky řekne „kachna“</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak se španělsky řekne „kachna“</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animace tlačítka pro mazání</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Pekelná klasika</string>
     <string name="settingsHeroWaterAnimation">Vodní vír</string>
     <string name="settingsHeroAbstractAnimation">Vzdušný proud</string>
     <string name="settingsNoneAnimation">Žádný</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Spustit procházení</string>
     <string name="preOnboardingAddressBarTitle">Kam mám umístit váš adresní řádek?</string>
     <string name="preOnboardingAddressBarOkButton">Další</string>
+    <string name="preOnboardingAddressBarPositionTop">Nahoru</string>
+    <string name="preOnboardingAddressBarPositionBottom">Dole</string>
+    <string name="preOnboardingAddressBarPositionSplit">Rozdělení</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Nahoře (výchozí)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Snadno viditelné</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Dole</string>
@@ -902,7 +906,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Překvap mě!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[To je vyhledávač <b>DuckDuckGo Search</b>! Soukromý. Rychlý. S méně reklamami.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">To je vyhledávač DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">Tohle je vyhledávač DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Soukromý. Rychlý. S méně reklamami.</string>
     <string name="onboardingSerpDaxDialogButton">Mám to!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">A teď zkus přejít na nějaký web!</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopírovat text odkazu</string>
     <string name="linkTextCopied">Text odkazu zkopírován</string>
     <string name="linkTextCopyFailed">Nepodařilo se zkopírovat text odkazu</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Zdravíme tě.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Chceš rychlejší prohlížeč, se kterým budeš mít vše pod kontrolou?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak se anglicky řekne „kachna“</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak se španělsky řekne „kachna“</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Ildknap-animation</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno klassisk</string>
     <string name="settingsHeroWaterAnimation">Whirlpool</string>
     <string name="settingsHeroAbstractAnimation">Airstream</string>
     <string name="settingsNoneAnimation">Ingen</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Start søgning</string>
     <string name="preOnboardingAddressBarTitle">Hvor skal jeg placere din adresselinje?</string>
     <string name="preOnboardingAddressBarOkButton">Næste</string>
+    <string name="preOnboardingAddressBarPositionTop">Top</string>
+    <string name="preOnboardingAddressBarPositionBottom">Nederst</string>
+    <string name="preOnboardingAddressBarPositionSplit">Opdel</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Top (standard)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Let at se</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Nederst</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Kopier linktekst</string>
     <string name="linkTextCopied">Linktekst kopieret</string>
     <string name="linkTextCopyFailed">Linkteksten kunne ikke kopieres</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hej</string>
+    <string name="preOnboardingWelcomeDialogBody1">Er du klar til en hurtigere browser, der sætter dig i førersædet?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI er altid valgfrit, og beskyttelse af privatlivet er altid aktiveret.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d af %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">sådan siger man \"and\" på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">sådan siger man \"and\" på spansk</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation der Schaltfläche „Feuer“</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Klassiker</string>
     <string name="settingsHeroWaterAnimation">Whirlpool</string>
     <string name="settingsHeroAbstractAnimation">Luftstrom</string>
     <string name="settingsNoneAnimation">Gar nichts</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Mit dem Browsen beginnen</string>
     <string name="preOnboardingAddressBarTitle">Wo soll deine Adressleiste platziert werden?</string>
     <string name="preOnboardingAddressBarOkButton">Weiter</string>
+    <string name="preOnboardingAddressBarPositionTop">Nach oben</string>
+    <string name="preOnboardingAddressBarPositionBottom">Unten</string>
+    <string name="preOnboardingAddressBarPositionSplit">Teilen</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Oben (Standard)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Leicht erkennbar</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Unten</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Linktext kopieren</string>
     <string name="linkTextCopied">Linktext kopiert</string>
     <string name="linkTextCopyFailed">Linktext konnte nicht kopiert werden</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hallo.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Bereit für einen schnelleren Browser, \nder dir die Kontrolle gibt?</string>
+    <string name="preOnboardingWelcomeDialogBody2">KI ist immer optional, und \nder Datenschutz ist immer aktiviert.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d von %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Wie sagt man „Ente“ auf Englisch?</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Wie sagt man „Ente“ auf Spanisch?</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Κινούμενο κουμπί φωτιάς</string>
     <string name="settingsHeroFireAnimation">Πύρινη κόλαση</string>
+    <string name="settingsHeroFireAnimationClassic">Κλασική πύρινη κόλαση</string>
     <string name="settingsHeroWaterAnimation">Δίνη νερού</string>
     <string name="settingsHeroAbstractAnimation">Ρεύμα αέρα</string>
     <string name="settingsNoneAnimation">Κανένα</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Έναρξη περιήγησης</string>
     <string name="preOnboardingAddressBarTitle">Πού πρέπει να τοποθετήσω τη γραμμή διευθύνσεών σας;</string>
     <string name="preOnboardingAddressBarOkButton">Επόμενο</string>
+    <string name="preOnboardingAddressBarPositionTop">Κορυφή</string>
+    <string name="preOnboardingAddressBarPositionBottom">Κάτω μέρος</string>
+    <string name="preOnboardingAddressBarPositionSplit">Διαχωρισμός</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Κορυφή (Προεπιλογή)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Ευδιάκριτο</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Κάτω μέρος</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Αντιγραφή κειμένου συνδέσμου</string>
     <string name="linkTextCopied">Το κείμενο του συνδέσμου αντιγράφηκε</string>
     <string name="linkTextCopyFailed">Δεν ήταν δυνατή η αντιγραφή του κειμένου του συνδέσμου</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Γεια σας.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Είστε έτοιμοι για ένα ταχύτερο πρόγραμμα περιήγησης\nπου σας δίνει τον έλεγχο;</string>
+    <string name="preOnboardingWelcomeDialogBody2">Η τεχνητή νοημοσύνη είναι πάντα προαιρετική και η προστασία προσωπικών δεδομένων είναι πάντα ενεργοποιημένη.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d από %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">πώς να πείτε «πάπια» στα αγγλικά</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">πώς να πείτε «πάπια» στα ισπανικά</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animación del botón Fuego</string>
     <string name="settingsHeroFireAnimation">Infierno</string>
+    <string name="settingsHeroFireAnimationClassic">Infierno Clásico</string>
     <string name="settingsHeroWaterAnimation">Remolino</string>
     <string name="settingsHeroAbstractAnimation">Corriente de aire</string>
     <string name="settingsNoneAnimation">Ninguna</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Empezar a navegar</string>
     <string name="preOnboardingAddressBarTitle">¿Dónde debo poner tu barra de direcciones?</string>
     <string name="preOnboardingAddressBarOkButton">Siguiente</string>
+    <string name="preOnboardingAddressBarPositionTop">Arriba</string>
+    <string name="preOnboardingAddressBarPositionBottom">Inferior</string>
+    <string name="preOnboardingAddressBarPositionSplit">Dividir</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Arriba (predeterminado)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Fácil de ver</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Inferior</string>
@@ -866,7 +870,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">¡Sorpréndeme!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[¡Eso es <b>DuckDuckGo Search</b>! Privado. Rápido. Menos anuncios.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">¡Eso es DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">¡Así es DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Privado. Rápido. Menos anuncios.</string>
     <string name="onboardingSerpDaxDialogButton">Entendido</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">¡A continuación, intenta visitar un sitio!</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Copiar texto del enlace</string>
     <string name="linkTextCopied">Texto del enlace copiado</string>
     <string name="linkTextCopyFailed">No se pudo copiar el texto del enlace</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hola.</string>
+    <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que\nte da el control?</string>
+    <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cómo se dice «duck» en español</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1002,6 +1002,6 @@
     <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que\nte da el control?</string>
     <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «pato» en inglés</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cómo se dice «duck» en español</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tulenupu animatsioon</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
     <string name="settingsHeroWaterAnimation">Whirlpool</string>
     <string name="settingsHeroAbstractAnimation">Airstream</string>
     <string name="settingsNoneAnimation">Puudub</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Alusta sirvimist</string>
     <string name="preOnboardingAddressBarTitle">Kuhu soovid oma aadressiriba paigutada?</string>
     <string name="preOnboardingAddressBarOkButton">Järgmine</string>
+    <string name="preOnboardingAddressBarPositionTop">Tipp</string>
+    <string name="preOnboardingAddressBarPositionBottom">All</string>
+    <string name="preOnboardingAddressBarPositionSplit">Jagatud</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Üles (vaikimisi)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Kergesti märgatav</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">All</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Kopeeri lingi tekst</string>
     <string name="linkTextCopied">Lingi tekst on kopeeritud</string>
     <string name="linkTextCopyFailed">Lingi teksti ei saanud kopeerida</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Tere!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Kas oled valmis kasutama kiiremat brauserit,\nmis annab sulle kontrolli?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Tehisintellekt on alati valikuline ja\nprivaatsuskaitse on alati sisse lülitatud.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d/%2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Kuidas öelda „part“ inglise keeles</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Kuidas öelda „part“ hispaania keeles</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Liekki-painikkeen animaatio</string>
     <string name="settingsHeroFireAnimation">Tulimyrsky</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno-klassikko</string>
     <string name="settingsHeroWaterAnimation">Pyörre</string>
     <string name="settingsHeroAbstractAnimation">Ilmavirta</string>
     <string name="settingsNoneAnimation">Ei mitään</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Aloita selailu</string>
     <string name="preOnboardingAddressBarTitle">Mihin osoitepalkki pitäisi sijoittaa?</string>
     <string name="preOnboardingAddressBarOkButton">Seuraava</string>
+    <string name="preOnboardingAddressBarPositionTop">Ylös</string>
+    <string name="preOnboardingAddressBarPositionBottom">Alareuna</string>
+    <string name="preOnboardingAddressBarPositionSplit">Jaa</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Yläosa (oletus)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Helppo nähdä</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Alareuna</string>
@@ -866,7 +870,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Yllätä minut!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[Tällainen on <b>**DuckDuckGo Search**!</b> Yksityinen. Nopea. Vähemmän mainoksia.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">Tällainen on DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">Se on DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Yksityinen. Nopea. Vähemmän mainoksia.</string>
     <string name="onboardingSerpDaxDialogButton">Selvä!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Siirry seuraavaksi sivustolle!</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Kopioi linkin teksti</string>
     <string name="linkTextCopied">Linkin teksti kopioitu</string>
     <string name="linkTextCopyFailed">Linkin tekstin kopiointi epäonnistui</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hei!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Oletko valmis nopeampaan selaimeen, joka\nantaa sinulle hallinnan?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Tekoäly on aina valinnainen, ja\nyksityisyyden suoja on aina päällä.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d/%2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">miten sanotaan \"ankka\" englanniksi</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">miten sanotaan \"ankka\" espanjaksi</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation du bouton en forme de flamme</string>
     <string name="settingsHeroFireAnimation">Flammes</string>
+    <string name="settingsHeroFireAnimationClassic">Flammes Classique</string>
     <string name="settingsHeroWaterAnimation">Tourbillon</string>
     <string name="settingsHeroAbstractAnimation">Courant d\'air</string>
     <string name="settingsNoneAnimation">Aucune</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Commencer la navigation</string>
     <string name="preOnboardingAddressBarTitle">Où dois-je placer votre barre d\'adresse ?</string>
     <string name="preOnboardingAddressBarOkButton">Suivant</string>
+    <string name="preOnboardingAddressBarPositionTop">Haut de page</string>
+    <string name="preOnboardingAddressBarPositionBottom">En bas</string>
+    <string name="preOnboardingAddressBarPositionSplit">Séparée</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">En haut (par défaut)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Facile à voir</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">En bas</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Copier le texte du lien</string>
     <string name="linkTextCopied">Texte du lien copié</string>
     <string name="linkTextCopyFailed">Impossible de copier le texte du lien</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Bonjour.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Envie de profiter d\'un navigateur plus rapide qui vous donne le contrôle ?</string>
+    <string name="preOnboardingWelcomeDialogBody2">L\'IA reste une option et la protection de la confidentialité reste activée.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d sur %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">comment dire « canard » en anglais</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">comment dire « canard » en espagnol</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija gumba Vatre</string>
     <string name="settingsHeroFireAnimation">Pakao</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
     <string name="settingsHeroWaterAnimation">Vrtlog</string>
     <string name="settingsHeroAbstractAnimation">Zračna struja</string>
     <string name="settingsNoneAnimation">Nijedno</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Započni pretraživanje</string>
     <string name="preOnboardingAddressBarTitle">Gdje trebam staviti tvoju adresnu traku?</string>
     <string name="preOnboardingAddressBarOkButton">Dalje</string>
+    <string name="preOnboardingAddressBarPositionTop">Vrh</string>
+    <string name="preOnboardingAddressBarPositionBottom">Dno</string>
+    <string name="preOnboardingAddressBarPositionSplit">Podijeli</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Vrh (zadano)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Lako se vidi</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Dno</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopiraj tekst poveznice</string>
     <string name="linkTextCopied">Tekst poveznice je kopiran</string>
     <string name="linkTextCopyFailed">Nije moguće kopirati tekst poveznice</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Pozdrav!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Jesi li spreman za brži preglednik koji ti daje kontrolu?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Umjetna inteligencija uvijek je neobavezna, a zaštita privatnosti uvijek aktivna.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d od %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kako se kaže \"patka\" na engleskom</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kako se kaže \"patka\" na španjolskom</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Tűz gomb animáció</string>
     <string name="settingsHeroFireAnimation">Lángnyelvek</string>
+    <string name="settingsHeroFireAnimationClassic">Klasszikus lángnyelvek</string>
     <string name="settingsHeroWaterAnimation">Örvény</string>
     <string name="settingsHeroAbstractAnimation">Levegő</string>
     <string name="settingsNoneAnimation">Nincs</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Böngészés indítása</string>
     <string name="preOnboardingAddressBarTitle">Hol helyezzem el a címsort?</string>
     <string name="preOnboardingAddressBarOkButton">Következő</string>
+    <string name="preOnboardingAddressBarPositionTop">Fent</string>
+    <string name="preOnboardingAddressBarPositionBottom">Lent</string>
+    <string name="preOnboardingAddressBarPositionSplit">Felosztás</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Felül (alapértelmezett)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Könnyen látható</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Alul</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Link szövegének másolása</string>
     <string name="linkTextCopied">Link szövege másolva</string>
     <string name="linkTextCopyFailed">Nem sikerült másolni a link szövegét</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Szia!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Felkészültél egy gyorsabb böngészőre, amely\nsaját kezedbe adja az irányítást?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Az AI mindig opcionális, az adatvédelem\npedig állandóan be van kapcsolva.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d/%2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hogyan mondják angolul, hogy „kacsa”</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hogyan mondják spanyolul, hogy „kacsa”</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animazione Fire Button</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classico</string>
     <string name="settingsHeroWaterAnimation">Mulinello</string>
     <string name="settingsHeroAbstractAnimation">Aria</string>
     <string name="settingsNoneAnimation">Niente</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Inizia a navigare</string>
     <string name="preOnboardingAddressBarTitle">Dove devo mettere la barra degli indirizzi?</string>
     <string name="preOnboardingAddressBarOkButton">Successivo</string>
+    <string name="preOnboardingAddressBarPositionTop">Inizio</string>
+    <string name="preOnboardingAddressBarPositionBottom">Parte inferiore</string>
+    <string name="preOnboardingAddressBarPositionSplit">Dividi</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">In alto (impostazione predefinita)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Facile da vedere</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Parte inferiore</string>
@@ -866,7 +870,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Sorprendimi!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[Questo è <b>DuckDuckGo Search!</b> Privato. Veloce. Meno annunci.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">Questo è DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">È DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Privato. Veloce. Meno annunci.</string>
     <string name="onboardingSerpDaxDialogButton">Ho capito!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">In seguito, prova a visitare un sito!</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Copia il testo del link</string>
     <string name="linkTextCopied">Testo del link copiato</string>
     <string name="linkTextCopyFailed">Impossibile copiare il testo del link</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Ciao.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Vuoi un browser più veloce che ti dia il pieno controllo?</string>
+    <string name="preOnboardingWelcomeDialogBody2">L\'AI è sempre opzionale e la protezione della privacy è sempre attiva.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d di %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">come si dice \"anatra\" in inglese</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">come si dice \"anatra\" in spagnolo</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Mygtuko „Fire“ animacija</string>
     <string name="settingsHeroFireAnimation">„Inferno“</string>
+    <string name="settingsHeroFireAnimationClassic">Klasikinė pragariška ugnis</string>
     <string name="settingsHeroWaterAnimation">„Whirlpool“</string>
     <string name="settingsHeroAbstractAnimation">„Airstream“</string>
     <string name="settingsNoneAnimation">Jokie</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Pradėti naršyti</string>
     <string name="preOnboardingAddressBarTitle">Kur turėčiau nustatyti jūsų adreso juostą?</string>
     <string name="preOnboardingAddressBarOkButton">Kitas</string>
+    <string name="preOnboardingAddressBarPositionTop">Viršus</string>
+    <string name="preOnboardingAddressBarPositionBottom">Apačia</string>
+    <string name="preOnboardingAddressBarPositionSplit">Padalintas</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Viršuje (numatytasis nustatymas)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Lengva pamatyti</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Apačia</string>
@@ -902,7 +906,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Nustebink mane!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[Tai „<b>DuckDuckGo Search</b>“! Privati. Sparti. Mažiau reklamų.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">Tai „DuckDuckGo Search“!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">Čia – paieška „DuckDuckGo Search“!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Privati. Sparti. Mažiau reklamų.</string>
     <string name="onboardingSerpDaxDialogButton">Supratau!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Pabandyk apsilankyti svetainėje!</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopijuoti nuorodos tekstą</string>
     <string name="linkTextCopied">Nuorodos tekstas nukopijuotas</string>
     <string name="linkTextCopyFailed">Nepavyko nukopijuoti nuorodos teksto</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Sveiki!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ar norite spartesnės naršyklės,\nkurią patys valdote?</string>
+    <string name="preOnboardingWelcomeDialogBody2">DI neprivalomas, o privatumo apsauga\n veikia visada.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d iš %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kaip angliškai pasakyti „antis“</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kaip ispaniškai pasakyti „antis“</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1022,6 +1022,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
     <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “pīle”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -592,6 +592,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Uguns pogas animācija</string>
     <string name="settingsHeroFireAnimation">Liesmas</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
     <string name="settingsHeroWaterAnimation">Atvars</string>
     <string name="settingsHeroAbstractAnimation">Gaisa plūsma</string>
     <string name="settingsNoneAnimation">Nav</string>
@@ -862,6 +863,9 @@
     <string name="preOnboardingDaxDialog3Button">Sākt pārlūkošanu</string>
     <string name="preOnboardingAddressBarTitle">Kur novietot adreses joslu?</string>
     <string name="preOnboardingAddressBarOkButton">Nākamais</string>
+    <string name="preOnboardingAddressBarPositionTop">Populārākie</string>
+    <string name="preOnboardingAddressBarPositionBottom">Apakšā</string>
+    <string name="preOnboardingAddressBarPositionSplit">Sadalīt</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Augšpusē (pēc noklusējuma)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Viegli pamanāma</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Apakšā</string>
@@ -1013,4 +1017,11 @@
     <string name="copyLinkText">Saites teksta kopēšana</string>
     <string name="linkTextCopied">Saites teksts nokopēts</string>
     <string name="linkTextCopyFailed">Neizdevās nokopēt saites tekstu</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Sveiki!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animasjon for brannknappen</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
     <string name="settingsHeroWaterAnimation">Malstrøm</string>
     <string name="settingsHeroAbstractAnimation">Luftstrøm</string>
     <string name="settingsNoneAnimation">Ingen</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Begynn å surfe</string>
     <string name="preOnboardingAddressBarTitle">Hvor skal jeg plassere adressefeltet?</string>
     <string name="preOnboardingAddressBarOkButton">Neste</string>
+    <string name="preOnboardingAddressBarPositionTop">Topp</string>
+    <string name="preOnboardingAddressBarPositionBottom">Nederst</string>
+    <string name="preOnboardingAddressBarPositionSplit">Del</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Topp (standard)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Lett å se</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Nederst</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Kopier lenketekst</string>
     <string name="linkTextCopied">Lenketeksten er kopiert</string>
     <string name="linkTextCopyFailed">Kunne ikke kopiere lenketeksten</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Heisann.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Klar for en raskere nettleser som du har kontroll over?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si duck» på spansk</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1003,5 +1003,5 @@
     <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si duck» på spansk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «duck» på spansk</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1002,6 +1002,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Klar for en raskere nettleser som du har kontroll over?</string>
     <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «duck» på spansk</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «and» på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «and» på spansk</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animatie vuurknop</string>
     <string name="settingsHeroFireAnimation">Vuurzee</string>
+    <string name="settingsHeroFireAnimationClassic">Vuurzee Klassiek</string>
     <string name="settingsHeroWaterAnimation">Draaikolk</string>
     <string name="settingsHeroAbstractAnimation">Luchtstroom</string>
     <string name="settingsNoneAnimation">Geen</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Beginnen met browsen</string>
     <string name="preOnboardingAddressBarTitle">Waar moet ik je adresbalk plaatsen?</string>
     <string name="preOnboardingAddressBarOkButton">Volgende</string>
+    <string name="preOnboardingAddressBarPositionTop">Boven</string>
+    <string name="preOnboardingAddressBarPositionBottom">Onderkant</string>
+    <string name="preOnboardingAddressBarPositionSplit">Splitsen</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Bovenaan (standaard)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Gemakkelijk te zien</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Onderkant</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Linktekst kopiëren</string>
     <string name="linkTextCopied">Linktekst gekopieerd</string>
     <string name="linkTextCopyFailed">Linktekst kon niet worden gekopieerd.</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hoi.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ben je klaar voor een snellere browser waarmee jij de controle hebt?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d van %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hoe zeg je \'eend\' in het Engels?</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Nederlands</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1003,5 +1003,5 @@
     <string name="preOnboardingWelcomeDialogBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d van %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hoe zeg je \'eend\' in het Engels?</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Nederlands</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Spaans</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1041,7 +1041,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Cześć!</string>
     <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
     <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacja przycisku ognia</string>
     <string name="settingsHeroFireAnimation">Ogień</string>
+    <string name="settingsHeroFireAnimationClassic">Ogień klasyczny</string>
     <string name="settingsHeroWaterAnimation">Wir wodny</string>
     <string name="settingsHeroAbstractAnimation">Strumień powietrza</string>
     <string name="settingsNoneAnimation">Brak</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Rozpocznij przeglądanie</string>
     <string name="preOnboardingAddressBarTitle">Gdzie umieścić pasek adresu?</string>
     <string name="preOnboardingAddressBarOkButton">Dalej</string>
+    <string name="preOnboardingAddressBarPositionTop">Do góry</string>
+    <string name="preOnboardingAddressBarPositionBottom">Dół</string>
+    <string name="preOnboardingAddressBarPositionSplit">Podziel</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Na górze (domyślnie)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Łatwy dostęp</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Dół</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopiuj tekst linku</string>
     <string name="linkTextCopied">Skopiowano tekst linku</string>
     <string name="linkTextCopyFailed">Nie udało się skopiować tekstu linku</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Cześć!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1042,6 +1042,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
     <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „kaczka” po angielsku</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"kaczka\" po hiszpańsku</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animação do Botão de Fogo</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno clássico</string>
     <string name="settingsHeroWaterAnimation">Remoinho</string>
     <string name="settingsHeroAbstractAnimation">Corrente de ar</string>
     <string name="settingsNoneAnimation">Nenhum</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Iniciar a navegação</string>
     <string name="preOnboardingAddressBarTitle">Onde devo posicionar a barra de endereços?</string>
     <string name="preOnboardingAddressBarOkButton">Seguinte</string>
+    <string name="preOnboardingAddressBarPositionTop">Topo</string>
+    <string name="preOnboardingAddressBarPositionBottom">Parte inferior</string>
+    <string name="preOnboardingAddressBarPositionSplit">Dividir</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Topo (predefinição)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Fácil de ver</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Parte inferior</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Copiar texto do link</string>
     <string name="linkTextCopied">Texto do link copiado</string>
     <string name="linkTextCopyFailed">Não consegui copiar o texto do link</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Olá.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Pronto para um navegador mais rápido que te coloca no controlo?</string>
+    <string name="preOnboardingWelcomeDialogBody2">A IA é sempre opcional, e a\nproteção de privacidade está sempre ativa.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">como dizer \"pato\" em inglês</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">como dizer \"pato\" em espanhol</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -592,6 +592,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animație buton Foc</string>
     <string name="settingsHeroFireAnimation">Infern</string>
+    <string name="settingsHeroFireAnimationClassic">Flăcări clasice</string>
     <string name="settingsHeroWaterAnimation">Vârtej de apă</string>
     <string name="settingsHeroAbstractAnimation">Curent de aer</string>
     <string name="settingsNoneAnimation">Niciuna</string>
@@ -862,6 +863,9 @@
     <string name="preOnboardingDaxDialog3Button">Începe navigarea</string>
     <string name="preOnboardingAddressBarTitle">Unde ar trebui să îți pun bara de adrese?</string>
     <string name="preOnboardingAddressBarOkButton">Următorul</string>
+    <string name="preOnboardingAddressBarPositionTop">Sus</string>
+    <string name="preOnboardingAddressBarPositionBottom">Partea de jos</string>
+    <string name="preOnboardingAddressBarPositionSplit">Împarte</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Sus (implicit)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Ușor de văzut</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Partea de jos</string>
@@ -884,8 +888,8 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Surprinde-mă!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[Acesta este <b>DuckDuckGo Search</b>! Privat. Rapid. Mai puține reclame.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">Acesta este DuckDuckGo Search!</string>
-    <string name="onboardingSerpDaxDialogBrandDesignDescription">Privat. Rapid. Mai puține reclame.</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">Așa arată DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignDescription">Privat. Rapid. Cu mai puține reclame.</string>
     <string name="onboardingSerpDaxDialogButton">Am înțeles!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Apoi, încearcă să vizitezi un site!</string>
     <plurals name="onboardingTrackersBlockedDialogDescription">
@@ -1013,4 +1017,11 @@
     <string name="copyLinkText">Copiază textul linkului</string>
     <string name="linkTextCopied">Textul linkului a fost copiat</string>
     <string name="linkTextCopyFailed">Nu s-a putut copia textul linkului</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Salut!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ești gata pentru un browser mai rapid, care îți oferă control deplin?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Inteligența artificială este întotdeauna opțională, iar protecția confidențialității este întotdeauna activată.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d din %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cum se spune „rață” în engleză</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cum se spune „rață” în spaniolă</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Aнимация кнопки «Огонь»</string>
     <string name="settingsHeroFireAnimation">Инферно</string>
+    <string name="settingsHeroFireAnimationClassic">Классика с пламенем</string>
     <string name="settingsHeroWaterAnimation">Водоворот</string>
     <string name="settingsHeroAbstractAnimation">Воздушный поток</string>
     <string name="settingsNoneAnimation">Ничего</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Начать просмотр</string>
     <string name="preOnboardingAddressBarTitle">Где следует разместить адресную строку?</string>
     <string name="preOnboardingAddressBarOkButton">Далее</string>
+    <string name="preOnboardingAddressBarPositionTop">Вверху</string>
+    <string name="preOnboardingAddressBarPositionBottom">Внизу</string>
+    <string name="preOnboardingAddressBarPositionSplit">Разделить</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Вверху (по умолчанию)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Легко заметить</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Внизу</string>
@@ -902,7 +906,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Удиви меня!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[Это — <b>DuckDuckGo Search</b>! Надежно. Быстро. Меньше рекламы.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">Это — DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">Это — DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Надежно. Быстро. Меньше рекламы.</string>
     <string name="onboardingSerpDaxDialogButton">Понятно</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">А теперь попробуйте посетить сайт!</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Скопировать текст ссылки</string>
     <string name="linkTextCopied">Текст ссылки скопирован</string>
     <string name="linkTextCopyFailed">Не удалось скопировать текст ссылки</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Привет!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Нужен быстрый браузер,\nгде все контролируете вы?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Здесь ИИ — всегда лишь дополнительная опция, а защита конфиденциальности всегда включена.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d из %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как сказать «утка» по-английски</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как сказать «утка» по-испански</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1041,7 +1041,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Dobrý deň.</string>
     <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač,\nktorý ti dáva kontrolu?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umelá inteligencia je vždy voliteľná\na ochrana súkromia je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Ako povedať „kačica“ v angličtine</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Ako povedať „kačica“ po španielsky</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animácia tlačidla ohňa</string>
     <string name="settingsHeroFireAnimation">Peklo</string>
+    <string name="settingsHeroFireAnimationClassic">Klasické inferno</string>
     <string name="settingsHeroWaterAnimation">Vodný vír</string>
     <string name="settingsHeroAbstractAnimation">Prúd vzduchu</string>
     <string name="settingsNoneAnimation">Žiadne</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Začnite prehliadať</string>
     <string name="preOnboardingAddressBarTitle">Kam mám umiestniť váš riadok s adresou?</string>
     <string name="preOnboardingAddressBarOkButton">Ďalšie</string>
+    <string name="preOnboardingAddressBarPositionTop">Hore</string>
+    <string name="preOnboardingAddressBarPositionBottom">Spodná časť</string>
+    <string name="preOnboardingAddressBarPositionSplit">Rozdelenie</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Hore (predvolené)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Ľahko viditeľné</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Spodná časť</string>
@@ -902,7 +906,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Prekvapte ma!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[To je <b>DuckDuckGo vyhľadávanie</b>! Súkromne. Rýchlo. Menej reklám.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">To je DuckDuckGo vyhľadávanie!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">To je DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Súkromne. Rýchlo. Menej reklám.</string>
     <string name="onboardingSerpDaxDialogButton">Rozumiem!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Nabudúce skúste navštíviť webovú stránku!</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopírovať text odkazu</string>
     <string name="linkTextCopied">Skopírovaný text prepojenia</string>
     <string name="linkTextCopyFailed">Nepodarilo sa skopírovať text odkazu</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Dobrý deň.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač,\nktorý ti dáva kontrolu?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Umelá inteligencia je vždy voliteľná\na ochrana súkromia je vždy zapnutá.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Ako povedať „kačica“ v angličtine</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Ako povedať „kačica“ po španielsky</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -597,6 +597,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animacija za gumb ogenj</string>
     <string name="settingsHeroFireAnimation">Pekel</string>
+    <string name="settingsHeroFireAnimationClassic">Klasični inferno</string>
     <string name="settingsHeroWaterAnimation">Vodni mehurčki</string>
     <string name="settingsHeroAbstractAnimation">Zračni tok</string>
     <string name="settingsNoneAnimation">Brez</string>
@@ -880,6 +881,9 @@
     <string name="preOnboardingDaxDialog3Button">Začni brskanje</string>
     <string name="preOnboardingAddressBarTitle">Kam naj postavim vašo naslovno vrstico?</string>
     <string name="preOnboardingAddressBarOkButton">Naslednji</string>
+    <string name="preOnboardingAddressBarPositionTop">Vrh</string>
+    <string name="preOnboardingAddressBarPositionBottom">Spodaj</string>
+    <string name="preOnboardingAddressBarPositionSplit">Razdeli</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Zgoraj (privzeto)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Preprosto vidno</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Spodaj</string>
@@ -902,7 +906,7 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Preseneti me!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[To je iskanje <b>DuckDuckGo Search</b>! Zasebno. Hitro. Z manj oglasi.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">To je iskanje DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">To je DuckDuckGo Search!</string>
     <string name="onboardingSerpDaxDialogBrandDesignDescription">Zasebno. Hitro. Z manj oglasi.</string>
     <string name="onboardingSerpDaxDialogButton">Razumem!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Nato obiščite spletno mesto!</string>
@@ -1033,4 +1037,11 @@
     <string name="copyLinkText">Kopiraj besedilo povezave</string>
     <string name="linkTextCopied">Besedilo povezave je bilo kopirano</string>
     <string name="linkTextCopyFailed">Besedila povezave ni bilo mogoče kopirati</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Pozdravljeni.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ste pripravljeni na hitrejši brskalnik,\nki daje nadzor vam?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Umetna inteligenca je vedno neobvezna,\nzaščita zasebnosti pa je vedno vklopljena.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d od %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Kako reči »raca« v angleščini</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Kako reči »raca« v španščini</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Animation för brännarknapp</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Klassisk</string>
     <string name="settingsHeroWaterAnimation">Virvel</string>
     <string name="settingsHeroAbstractAnimation">Luftström</string>
     <string name="settingsNoneAnimation">Inga</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Börja bläddra</string>
     <string name="preOnboardingAddressBarTitle">Var ska jag placera adressfältet?</string>
     <string name="preOnboardingAddressBarOkButton">Nästa</string>
+    <string name="preOnboardingAddressBarPositionTop">Topp</string>
+    <string name="preOnboardingAddressBarPositionBottom">Botten</string>
+    <string name="preOnboardingAddressBarPositionSplit">Dela</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Överst (standard)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Lätt att se</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Botten</string>
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Kopiera länktext</string>
     <string name="linkTextCopied">Länktext kopierad</string>
     <string name="linkTextCopyFailed">Kunde inte kopiera länktext</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hej!</string>
+    <string name="preOnboardingWelcomeDialogBody1">Är du redo för en snabbare webbläsare\nsom ger dig kontroll?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI är alltid valfritt och\nintegritetsskydd är alltid på.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">vad heter ”anka” på engelska</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">vad heter ”anka” på spanska</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -587,6 +587,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Yangın Düğmesi Animasyonu</string>
     <string name="settingsHeroFireAnimation">Ateş</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Klasik</string>
     <string name="settingsHeroWaterAnimation">Girdap</string>
     <string name="settingsHeroAbstractAnimation">Hava</string>
     <string name="settingsNoneAnimation">Yok</string>
@@ -844,6 +845,9 @@
     <string name="preOnboardingDaxDialog3Button">Gezinmeye Başla</string>
     <string name="preOnboardingAddressBarTitle">Adres çubuğu nereye yerleştirilsin?</string>
     <string name="preOnboardingAddressBarOkButton">Sonraki</string>
+    <string name="preOnboardingAddressBarPositionTop">Başa dön</string>
+    <string name="preOnboardingAddressBarPositionBottom">Alt</string>
+    <string name="preOnboardingAddressBarPositionSplit">Böl</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Üst (Varsayılan)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Görmesi kolay</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Alt</string>
@@ -866,8 +870,8 @@
     <string name="onboardingSitesDaxDialogOption3">ebay.com</string>
     <string name="onboardingSitesDaxDialogOption4">Şaşırt beni!</string>
     <string name="onboardingSerpDaxDialogDescription"><![CDATA[<b>DuckDuckGo Search</b> işte bu! Özel. Hızlı. Daha az reklam.]]></string>
-    <string name="onboardingSerpDaxDialogBrandDesignTitle">DuckDuckGo Search işte bu!</string>
-    <string name="onboardingSerpDaxDialogBrandDesignDescription">Özel. Hızlı. Daha az reklam.</string>
+    <string name="onboardingSerpDaxDialogBrandDesignTitle">İşte DuckDuckGo Search!</string>
+    <string name="onboardingSerpDaxDialogBrandDesignDescription">Gizli. Hızlı. Daha az reklam.</string>
     <string name="onboardingSerpDaxDialogButton">Anladım!</string>
     <string name="onboardingSitesSuggestionsDaxDialogTitle">Sonra, bir siteyi ziyaret etmeyi deneyin!</string>
     <plurals name="onboardingTrackersBlockedDialogDescription">
@@ -993,4 +997,11 @@
     <string name="copyLinkText">Bağlantı Metnini Kopyala</string>
     <string name="linkTextCopied">Bağlantı metni kopyalandı</string>
     <string name="linkTextCopyFailed">Bağlantı metni kopyalanamadı</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Merhaba.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Kontrolü size verecek daha hızlı bir tarayıcıya hazır mısınız?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Yapay zeka her zaman isteğe bağlıdır ve gizlilik koruması her zaman etkindir.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d / %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">ingilizcede \"ördek\" nasıl denir?</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">ispanyolcada \"ördek\" nasıl denir?</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -107,10 +107,6 @@
     <string name="preOnboardingReinstallEditAction">Edit</string>
     <string name="preOnboardingReinstallStartBrowsing">Start Browsing</string>
 
-    <!-- Fire animation rollout: relabel HeroFire to "Inferno Classic" when fireAnimationUpdate is on — pending translation -->
-    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
-    <string name="settingsInfernoAnimation">Inferno</string>
-
     <plurals name="fireDialogDeleteCountTitle">
         <item quantity="one" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chat?</item>
         <item quantity="other" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chats?</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <!-- We won't have a translation for this, to be used later. -->
     <string name="trackersOverviewEmpty">No tracking requests were blocked from loading on this page. If a company\'s requests are loaded, it can allow them to profile you.</string>
@@ -54,15 +54,6 @@
     <!-- Skip Onboarding (not user-facing) -->
     <string name="skipOnboarding">Skip Onboarding</string>"
 
-    <!-- Pre-onboarding Address Bar Position -->
-    <string name="preOnboardingAddressBarPositionTop">Top</string>
-    <string name="preOnboardingAddressBarPositionBottom">Bottom</string>
-    <string name="preOnboardingAddressBarPositionSplit">Split</string>
-
-    <!-- Pre-onboarding Input Screen (AI Chat Toggle) -->
-    <string name="preOnboardingInputScreenSearchOnly">Search Only</string>
-    <string name="preOnboardingInputScreenSearchAndDuckAi">Search &amp; Duck.ai</string>
-
     <!-- Browser tab -->
     <string name="browserDuckPlayerShortUrl">Duck Player</string>
 
@@ -73,10 +64,6 @@
     <string name="duckAiHeaderFreePlan">Free Plan</string>
     <string name="duckAiHeaderUpgrade">Upgrade</string>
     <string name="duckAiHeaderPaidTitle">Duck.ai</string>
-
-    <!-- Onboarding search options (need escaped quotes for "duck") -->
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate 'duck' too.">how to say \"duck\" in english</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate 'duck' too. Don't add question mark">how to say \"duck\" in spanish</string>
 
     <!-- ADS -->
     <string name="ads_demo_activity_title" translatable="false">Android Design System Demo</string>
@@ -91,12 +78,6 @@
         }
       }]
     </string>
-
-    <!--Onboarding Rebrand Design Update-->
-    <string name="preOnboardingWelcomeDialogTitle">Hi there.</string>
-    <string name="preOnboardingWelcomeDialogBody1">Ready for a faster browser that\nputs you in control?</string>
-    <string name="preOnboardingWelcomeDialogBody2">AI is always optional, and\nprivacy protection is always on.</string>
-    <string name="onboardingStepIndicatorText" tools:ignore="MissingInstruction">%1$d of %2$d</string>
 
     <!-- Input Mode Demo Onboarding step -->
     <string name="preOnboardingInputModeDemoTitle">Ready to get started?&lt;br/&gt;Try a search or AI chat!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -843,6 +843,9 @@
     <string name="preOnboardingDaxDialog3Button">Start Browsing</string>
     <string name="preOnboardingAddressBarTitle">Where should I put your address bar?</string>
     <string name="preOnboardingAddressBarOkButton">Next</string>
+    <string name="preOnboardingAddressBarPositionTop">Top</string>
+    <string name="preOnboardingAddressBarPositionBottom">Bottom</string>
+    <string name="preOnboardingAddressBarPositionSplit">Split</string>
     <string name="highlightsPreOnboardingAddressBarOption1Title">Top (default)</string>
     <string name="highlightsPreOnboardingAddressBarOption1Description">Easy to see</string>
     <string name="highlightsPreOnboardingAddressBarOption2Title">Bottom</string>
@@ -992,4 +995,11 @@
     <string name="copyLinkText">Copy Link Text</string>
     <string name="linkTextCopied">Link text copied</string>
     <string name="linkTextCopyFailed">Couldn\'t copy link text</string>
+
+    <string name="preOnboardingWelcomeDialogTitle">Hi there.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ready for a faster browser that\nputs you in control?</string>
+    <string name="preOnboardingWelcomeDialogBody2">AI is always optional, and\nprivacy protection is always on.</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d of %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate 'duck' too.">how to say \"duck\" in english</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate 'duck' too. Don't add question mark">how to say \"duck\" in spanish</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -586,6 +586,7 @@
     <!-- Fire Animation settings -->
     <string name="settingsFireAnimation">Fire Button Animation</string>
     <string name="settingsHeroFireAnimation">Inferno</string>
+    <string name="settingsHeroFireAnimationClassic">Inferno Classic</string>
     <string name="settingsHeroWaterAnimation">Whirlpool</string>
     <string name="settingsHeroAbstractAnimation">Airstream</string>
     <string name="settingsNoneAnimation">None</string>

--- a/app/src/test/java/com/duckduckgo/app/settings/clear/FireAnimationTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/clear/FireAnimationTest.kt
@@ -118,12 +118,12 @@ class FireAnimationTest {
 
     @Test
     fun whenDisplayLabelInfernoAndIncludesInfernoThenInfernoStringResource() {
-        assertEquals(R.string.settingsInfernoAnimation, Inferno.displayLabelResId(includesInferno = true))
+        assertEquals(R.string.settingsHeroFireAnimation, Inferno.displayLabelResId(includesInferno = true))
     }
 
     @Test
     fun whenDisplayLabelInfernoAndExcludesInfernoThenInfernoStringResource() {
-        assertEquals(R.string.settingsInfernoAnimation, Inferno.displayLabelResId(includesInferno = false))
+        assertEquals(R.string.settingsHeroFireAnimation, Inferno.displayLabelResId(includesInferno = false))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214077329786543

### Description

Moves the new onboarding brand-design strings out of `donottranslate.xml` and into `strings.xml` so they get picked up by the next translation push: welcome dialog title and body, step indicator, address bar position labels (Top / Bottom / Split), and the two quoted try-a-search options. Also deletes two dead `preOnboardingInputScreen*` strings that were never wired up after the input-choice screen landed.

Alongside that, the new Inferno fire animation now reuses the existing `settingsHeroFireAnimation` resource (already localised across every locale) instead of shipping a duplicate English string. The HeroFire entry keeps its display override via `settingsHeroFireAnimationClassic`, which moves into `strings.xml` alongside the other animation names.

### Steps to test this PR

_Verify the moved strings still render correctly_
- [ ] Launch the app on a fresh install and reach the welcome screen — title and both body lines render as before
- [ ] Continue onboarding to the address bar position screen — Top / Bottom / Split labels render
- [ ] Continue onboarding and confirm the step indicator above each dialog still reads "X of Y"
- [ ] Reach the try-a-search bubble after onboarding — the first option still shows the quoted "how to say "duck" in english" copy

_Verify the fire animation picker_
- [ ] Open Settings → Fire Button → Fire Button Animation with the `fireAnimationUpdate` toggle **on** — the picker lists Inferno, Inferno Classic, Whirlpool, Airstream, None
- [ ] Toggle `fireAnimationUpdate` **off** — the picker reverts to the legacy four (Inferno, Whirlpool, Airstream, None)
- [ ] Confirm nothing in the picker reads as a raw resource name or English fallback in non-English locales

_Verify translation fixes per locale (change device language, then run through onboarding)_
- [ ] Czech, Polish, Slovak: onboarding step indicator includes the "z" connector (e.g. "1 z 4")
- [ ] Dutch: second try-a-search option mentions Spanish ("in het Spaans"), not Dutch
- [ ] Norwegian: both try-a-search options show «and» with both opening and closing guillemets
- [ ] Bulgarian: first try-a-search option uses the Bulgarian quote pair „…" around the translated word
- [ ] Spanish: first try-a-search option shows «pato» (translated); second still shows «duck» (intentional, asking how to say it in Spanish)
- [ ] Polish: both try-a-search options show "kaczka" (translated)
- [ ] Latvian: first try-a-search option shows "pīle" (translated)

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly resource-string reshuffling and new localized text; main risk is missing/incorrect string keys causing onboarding or fire-animation labels to fall back or crash at runtime.
> 
> **Overview**
> **Makes new onboarding brand-design copy translatable.** Moves several onboarding UI strings (welcome dialog, step indicator, address-bar position labels, and quoted "try a search" option text) out of `donottranslate.xml` into `values/strings.xml`, and adds corresponding translations across many locales.
> 
> **Unifies fire animation labeling.** Updates `FireAnimation.Inferno` to reuse the already-localized `settingsHeroFireAnimation` label, introduces `settingsHeroFireAnimationClassic` in `strings.xml` (and localizations) for the HeroFire override, and updates `FireAnimationTest` expectations accordingly.
> 
> Also removes unused strings and cleans up `donottranslate.xml` (drops `tools` namespace and deletes now-moved entries), plus a few minor translation wording tweaks in some locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c91bd2fdd4dccf581e1df1a1e18c9c62f0038d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
