### PR TITLE
PIR: Clear emailExtractedData on step completion

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
@@ -90,6 +90,7 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                 currentBrokerStepIndex = state.currentBrokerStepIndex + 1,
                 actionRetryCount = 0,
                 generatedEmailData = null,
+                emailExtractedData = emptyMap(),
                 stageStatus = PirStageStatus(
                     currentStage = PirStage.VALIDATE,
                     stageStartMs = currentTimeProvider.currentTimeMillis(),

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
@@ -639,6 +639,7 @@ class BrokerStepCompletedEventHandlerTest {
             currentActionIndex = 1,
             actionRetryCount = 5,
             generatedEmailData = testGeneratedEmailData,
+            emailExtractedData = mapOf("verificationCode" to "123456"),
             transactionID = "txn-123",
             brokerStepStartTime = testBrokerStartTime,
             stageStatus = PirStageStatus(
@@ -656,6 +657,7 @@ class BrokerStepCompletedEventHandlerTest {
         assertEquals(1, result.nextState.currentBrokerStepIndex)
         assertEquals(0, result.nextState.actionRetryCount)
         assertNull(result.nextState.generatedEmailData)
+        assertEquals(emptyMap<String, String>(), result.nextState.emailExtractedData)
         assertEquals(PirStage.VALIDATE, result.nextState.stageStatus.currentStage)
         assertEquals(testCurrentTimeInMillis, result.nextState.stageStatus.stageStartMs)
         assertEquals("txn-123", result.nextState.transactionID)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213993026941875?focus=true

### Description
Clear `emailExtractedData` on step completion

### Steps to test this PR
Will be testable on later PRs once the whole feature is complete

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small state-reset change in the PIR runner with a focused unit test; no auth or external API changes.
> 
> **Overview**
> When a broker step finishes, the PIR actions runner now resets **`emailExtractedData`** to an empty map in the same transition that already clears **`generatedEmailData`** and advances to the next step—so values like verification codes from email polling do not carry into the next broker step’s actions.
> 
> A unit test was updated to seed non-empty **`emailExtractedData`** and assert the post-completion state is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490a00a7114867d0c87a97f8415aa41e7a0f674f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->