### PR TITLE
In-memory entity lookup cache

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupPerfAndroidTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupPerfAndroidTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.util.Log
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.app.trackerdetection.api.ActionJsonAdapter
+import com.duckduckgo.app.trackerdetection.api.TdsJson
+import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
+import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
+import com.squareup.moshi.Moshi
+import okio.buffer
+import okio.source
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * On-device microbenchmark comparing [TdsEntityLookup] (DB-walking) against
+ * [CachedTdsEntityLookup] (map-walking) on a real Room database seeded with the
+ * production tracker dataset bundled in the app at app/src/main/res/raw/tds.json
+ * (R.raw.tds).
+ *
+ * The two impls share the same `EntityLookup` surface — they differ only in how
+ * `entityForUrl` resolves a host:
+ *   - legacy: recursive DAO walk (2 queries per subdomain level)
+ *   - cached: in-memory HashMap label walk (1 hash lookup per level)
+ *
+ * Three URL workloads exercise the dominant real-world cases:
+ *   1. EXACT — host equals a known tracker domain (one lookup either way).
+ *   2. DEEP — host is a deep subdomain of a known tracker domain (label walk).
+ *   3. MISS — host has no entry anywhere in the data (worst case; eTLD-bounded
+ *      walk until no match).
+ *
+ * NOTE: this class is annotated @Ignore so CI does not run it. To execute manually:
+ *   1. From Android Studio: right-click the test method or class and choose "Run".
+ *      The IDE bypasses @Ignore for explicit invocations.
+ *   2. From the CLI: temporarily comment out the @Ignore annotation, run the gradle
+ *      command below, then revert. JUnit honors @Ignore even when --tests targets
+ *      the class directly.
+ *
+ *     ./gradlew :app:connectedPlayDebugAndroidTest \
+ *         -Pandroid.testInstrumentationRunnerArguments.class=com.duckduckgo.app.trackerdetection.CachedTdsEntityLookupPerfAndroidTest
+ *
+ * Output is emitted to logcat under tag "EntityLookupPerf"; capture with:
+ *     adb logcat -s EntityLookupPerf:I *:S
+ *
+ * Numbers are observation-only — no pass/fail assertion.
+ */
+// @Ignore("Performance benchmark — run manually, not in CI. See class kdoc for instructions.")
+@RunWith(AndroidJUnit4::class)
+class CachedTdsEntityLookupPerfAndroidTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var entityDao: TdsEntityDao
+    private lateinit var domainEntityDao: TdsDomainEntityDao
+    private lateinit var legacy: TdsEntityLookup
+    private lateinit var cached: CachedTdsEntityLookup
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        entityDao = db.tdsEntityDao()
+        domainEntityDao = db.tdsDomainEntityDao()
+
+        val tdsJson = loadTdsJson()
+        entityDao.insertAll(tdsJson.jsonToEntities())
+        domainEntityDao.insertAll(tdsJson.jsonToDomainEntities())
+
+        legacy = TdsEntityLookup(entityDao, domainEntityDao)
+        cached = CachedTdsEntityLookup(entityDao, domainEntityDao).also { it.refresh() }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun benchmarkLegacyVsCachedAcrossWorkloads() {
+        logRuntimeContext()
+
+        val knownDomains: List<String> = domainEntityDao.getAll().map { it.domain }
+        val entityCount = entityDao.getAll().size
+        val urls = buildUrlSample(knownDomains)
+
+        log("--- Dataset ---")
+        log("Entities loaded: $entityCount")
+        log("Domain-entity rows: ${knownDomains.size}")
+        log("URL sample: ${urls.exact.size} EXACT + ${urls.deep.size} DEEP + ${urls.miss.size} MISS = ${urls.total} URLs")
+        log("Measured iterations per workload: $MEASURED_ITERATIONS")
+        log("---------------")
+
+        // JIT / ART warmup — both impls, all three workloads.
+        repeat(WARMUP_ROUNDS) {
+            runWorkload(legacy, urls)
+            runWorkload(cached, urls)
+        }
+
+        val legacyResults = measureAllWorkloads(legacy)
+        val cachedResults = measureAllWorkloads(cached)
+
+        log("")
+        log("=== EntityLookup benchmark (on-device) ===")
+        logWorkloadComparison("EXACT (host equals known tracker domain)", legacyResults.exact, cachedResults.exact, urls.exact.size)
+        logWorkloadComparison("DEEP  (deep subdomain of known tracker)", legacyResults.deep, cachedResults.deep, urls.deep.size)
+        logWorkloadComparison("MISS  (host with no entry — worst case)", legacyResults.miss, cachedResults.miss, urls.miss.size)
+
+        val legacyTotalNs = legacyResults.exact + legacyResults.deep + legacyResults.miss
+        val cachedTotalNs = cachedResults.exact + cachedResults.deep + cachedResults.miss
+        val totalCalls = urls.total.toLong() * MEASURED_ITERATIONS
+        val legacyPerCall = legacyTotalNs / totalCalls
+        val cachedPerCall = cachedTotalNs / totalCalls
+        val speedup = legacyTotalNs.toDouble() / cachedTotalNs.toDouble()
+
+        log("")
+        log("--- Overall ($totalCalls calls per impl) ---")
+        log("Legacy : total ${legacyTotalNs / 1_000_000} ms | per-call $legacyPerCall ns")
+        log("Cached : total ${cachedTotalNs / 1_000_000} ms | per-call $cachedPerCall ns")
+        log("Speedup: ${"%.2f".format(speedup)}x")
+    }
+
+    private data class WorkloadResults(val exact: Long, val deep: Long, val miss: Long)
+
+    private fun measureAllWorkloads(lookup: EntityLookup): WorkloadResults {
+        val urls = buildUrlSample(domainEntityDao.getAll().map { it.domain })
+        val exactNs = measureNs(lookup, urls.exact)
+        val deepNs = measureNs(lookup, urls.deep)
+        val missNs = measureNs(lookup, urls.miss)
+        return WorkloadResults(exactNs, deepNs, missNs)
+    }
+
+    private fun measureNs(lookup: EntityLookup, hosts: List<String>): Long {
+        val start = System.nanoTime()
+        repeat(MEASURED_ITERATIONS) {
+            hosts.forEach { lookup.entityForUrl(it) }
+        }
+        return System.nanoTime() - start
+    }
+
+    private fun runWorkload(lookup: EntityLookup, urls: UrlSample) {
+        urls.exact.forEach { lookup.entityForUrl(it) }
+        urls.deep.forEach { lookup.entityForUrl(it) }
+        urls.miss.forEach { lookup.entityForUrl(it) }
+    }
+
+    private data class UrlSample(val exact: List<String>, val deep: List<String>, val miss: List<String>) {
+        val total: Int get() = exact.size + deep.size + miss.size
+    }
+
+    /**
+     * Build a representative URL sample across three workloads.
+     *
+     * Hosts are taken deterministically from the loaded data so the sample is reproducible
+     * across runs. The DEEP workload prepends three labels to amplify the per-level cost
+     * the cached impl optimises away.
+     */
+    private fun buildUrlSample(knownDomains: List<String>): UrlSample {
+        val exactBase = knownDomains.take(SAMPLE_PER_WORKLOAD)
+        val exact = exactBase.map { "http://$it/index" }
+        val deep = exactBase.map { "http://a.b.c.$it/index" }
+        val miss = (0 until SAMPLE_PER_WORKLOAD).map { i -> "http://unrelated$i.example-not-tracking.com/index" }
+        return UrlSample(exact = exact, deep = deep, miss = miss)
+    }
+
+    private fun loadTdsJson(): TdsJson {
+        val moshi = Moshi.Builder().add(ActionJsonAdapter()).build()
+        val adapter = moshi.adapter(TdsJson::class.java)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.resources.openRawResource(R.raw.tds).source().buffer().use { adapter.fromJson(it) }
+            ?: error("Failed to parse R.raw.tds")
+    }
+
+    private fun logWorkloadComparison(label: String, legacyNs: Long, cachedNs: Long, urlsInWorkload: Int) {
+        val calls = urlsInWorkload.toLong() * MEASURED_ITERATIONS
+        val legacyPerCall = legacyNs / calls
+        val cachedPerCall = cachedNs / calls
+        val speedup = legacyNs.toDouble() / cachedNs.toDouble()
+        log(label)
+        log("  Legacy : total ${legacyNs / 1_000_000} ms | per-call $legacyPerCall ns")
+        log("  Cached : total ${cachedNs / 1_000_000} ms | per-call $cachedPerCall ns")
+        log("  Speedup: ${"%.2f".format(speedup)}x")
+    }
+
+    /**
+     * Prints proof-of-environment up front so anyone reading the output knows this is genuinely
+     * running on the device's ART runtime and not on a JVM. Same shape as TdsClientPerfAndroidTest
+     * so the output is grep-friendly across benchmarks.
+     */
+    private fun logRuntimeContext() {
+        val rt = Runtime.getRuntime()
+        val vmName = System.getProperty("java.vm.name") ?: "?"
+        val vmVersion = System.getProperty("java.vm.version") ?: "?"
+        val mb = 1024L * 1024L
+        log("--- Runtime context ---")
+        log("PID: ${android.os.Process.myPid()} (this is the on-device app_process running ART)")
+        log("VM: $vmName $vmVersion (\"Dalvik\" = ART; not HotSpot)")
+        log("Cores available: ${rt.availableProcessors()}")
+        log("Heap: max=${rt.maxMemory() / mb} MB, total=${rt.totalMemory() / mb} MB, free=${rt.freeMemory() / mb} MB")
+        log("Build fingerprint: ${Build.FINGERPRINT}")
+        logSocDetails()
+        log("-----------------------")
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun logSocDetails() {
+        val soc = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            "${Build.SOC_MANUFACTURER} / ${Build.SOC_MODEL}"
+        } else {
+            "n/a (requires API 31+, this device is API ${Build.VERSION.SDK_INT})"
+        }
+        log("SoC: $soc")
+        log("Hardware: ${Build.HARDWARE} | Board: ${Build.BOARD} | Device: ${Build.DEVICE}")
+        runCatching {
+            val cpuinfo = File("/proc/cpuinfo").readText()
+            val processorCount = cpuinfo.lineSequence().count { it.startsWith("processor") }
+            val hardwareLine = cpuinfo.lineSequence()
+                .firstOrNull { it.startsWith("Hardware") }
+                ?.substringAfter(":")?.trim()
+            val cpuParts = cpuinfo.lineSequence()
+                .filter { it.startsWith("CPU part") }
+                .map { it.substringAfter(":").trim() }
+                .toSet()
+            log("/proc/cpuinfo: kernel-visible cores=$processorCount, hardware=\"${hardwareLine ?: "(unset)"}\", distinct CPU parts=$cpuParts")
+        }.onFailure {
+            log("/proc/cpuinfo: not readable (${it.message})")
+        }
+    }
+
+    private fun log(message: String) {
+        Log.i(LOG_TAG, message)
+    }
+
+    companion object {
+        private const val LOG_TAG = "EntityLookupPerf"
+        private const val WARMUP_ROUNDS = 5
+        private const val MEASURED_ITERATIONS = 200
+        private const val SAMPLE_PER_WORKLOAD = 100
+    }
+}

--- a/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupPerfAndroidTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupPerfAndroidTest.kt
@@ -70,7 +70,7 @@ import java.io.File
  *
  * Numbers are observation-only — no pass/fail assertion.
  */
-// @Ignore("Performance benchmark — run manually, not in CI. See class kdoc for instructions.")
+@Ignore("Performance benchmark — run manually, not in CI. See class kdoc for instructions.")
 @RunWith(AndroidJUnit4::class)
 class CachedTdsEntityLookupPerfAndroidTest {
 

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -41,11 +41,7 @@ import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.location.data.LocationPermissionsRepositoryImpl
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.app.trackerdetection.EntityLookup
-import com.duckduckgo.app.trackerdetection.TdsEntityLookup
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
-import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
-import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
@@ -65,14 +61,6 @@ import dagger.multibindings.IntoSet
 @Module
 @ContributesTo(AppScope::class)
 object PrivacyModule {
-
-    @Provides
-    @SingleInstanceIn(AppScope::class)
-    fun entityLookup(
-        entityDao: TdsEntityDao,
-        domainEntityDao: TdsDomainEntityDao,
-    ): EntityLookup =
-        TdsEntityLookup(entityDao, domainEntityDao)
 
     @Provides
     fun clearDataAction(

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -71,6 +71,14 @@ interface AndroidBrowserConfigFeature {
     fun precompileTdsRegex(): Toggle
 
     /**
+     * Routes entity lookups through the in-memory cached path
+     * (CachedTdsEntityLookup). When disabled, the legacy DB-walking
+     * TdsEntityLookup is used. Default INTERNAL during rollout.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun cachedEntityLookup(): Toggle
+
+    /**
      * @return `true` when the remote config has the global "errorPagePixel" androidBrowserConfig
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `true`

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/CachedEntityLookupRCWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/CachedEntityLookupRCWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels.remoteconfig
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface CachedEntityLookupRCWrapper {
+    val enabled: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealCachedEntityLookupRCWrapper @Inject constructor(
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : CachedEntityLookupRCWrapper {
+    override val enabled by lazy { androidBrowserConfigFeature.cachedEntityLookup().isEnabled() }
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -59,11 +60,13 @@ class CachedTdsEntityLookup @Inject constructor(
 
     private fun labelWalk(host: String): Entity? {
         val snap = activeSnapshot()
+        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate = host
         while (true) {
             snap.domainToEntityName[candidate]?.let { entityName ->
                 return snap.entityByName[entityName]
             }
+            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import android.net.Uri
+import androidx.annotation.WorkerThread
+import androidx.core.net.toUri
+import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
+import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
+import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+class CachedTdsEntityLookup @Inject constructor(
+    private val entityDao: TdsEntityDao,
+    private val domainEntityDao: TdsDomainEntityDao,
+) : EntityLookupWithRefresh {
+
+    private data class Snapshot(
+        val domainToEntityName: Map<String, String>,
+        val entityByName: Map<String, Entity>,
+    )
+
+    @Volatile
+    private var snapshot: Snapshot? = null
+
+    override fun refresh() {
+        snapshot = loadSnapshot()
+    }
+
+    override fun entityForUrl(url: String): Entity? {
+        val host = url.toUri().baseHost ?: return null
+        return labelWalk(host)
+    }
+
+    override fun entityForUrl(url: Uri): Entity? {
+        val host = url.host ?: return null
+        return labelWalk(host)
+    }
+
+    override fun entityForName(name: String): Entity? = activeSnapshot().entityByName[name]
+
+    private fun labelWalk(host: String): Entity? {
+        val snap = activeSnapshot()
+        var candidate = host
+        while (true) {
+            snap.domainToEntityName[candidate]?.let { entityName ->
+                return snap.entityByName[entityName]
+            }
+            val dot = candidate.indexOf('.')
+            if (dot < 0) return null
+            candidate = candidate.substring(dot + 1)
+        }
+    }
+
+    private fun activeSnapshot(): Snapshot {
+        snapshot?.let { return it }
+        return synchronized(this) {
+            snapshot?.let { return it }
+            loadSnapshot().also { snapshot = it }
+        }
+    }
+
+    @WorkerThread
+    private fun loadSnapshot(): Snapshot {
+        val entityByName: Map<String, Entity> = entityDao.getAll().associateBy { it.name }
+        val domainToEntityName: Map<String, String> =
+            domainEntityDao.getAll().associate { it.domain to it.entityName }
+        return Snapshot(
+            domainToEntityName = domainToEntityName,
+            entityByName = entityByName,
+        )
+    }
+}
+
+internal interface EntityLookupWithRefresh : EntityLookup, EntityLookupRefresher

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegate.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegate.kt
@@ -20,10 +20,13 @@ import android.net.Uri
 import com.duckduckgo.app.pixels.remoteconfig.CachedEntityLookupRCWrapper
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 import javax.inject.Provider
 
+@ContributesBinding(AppScope::class, boundType = EntityLookup::class)
+@ContributesBinding(AppScope::class, boundType = EntityLookupRefresher::class)
 @SingleInstanceIn(AppScope::class)
 class EntityLookupDelegate @Inject constructor(
     private val legacy: Provider<TdsEntityLookup>,

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegate.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegate.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import android.net.Uri
+import com.duckduckgo.app.pixels.remoteconfig.CachedEntityLookupRCWrapper
+import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import javax.inject.Provider
+
+@SingleInstanceIn(AppScope::class)
+class EntityLookupDelegate @Inject constructor(
+    private val legacy: Provider<TdsEntityLookup>,
+    private val cached: Provider<CachedTdsEntityLookup>,
+    private val flag: CachedEntityLookupRCWrapper,
+) : EntityLookup, EntityLookupRefresher {
+
+    private val active: EntityLookupWithRefresh by lazy {
+        if (flag.enabled) cached.get() else legacy.get()
+    }
+
+    override fun entityForUrl(url: String): Entity? = active.entityForUrl(url)
+
+    override fun entityForUrl(url: Uri): Entity? = active.entityForUrl(url)
+
+    override fun entityForName(name: String): Entity? = active.entityForName(name)
+
+    override fun refresh() = active.refresh()
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupRefresher.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/EntityLookupRefresher.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import androidx.annotation.WorkerThread
+
+interface EntityLookupRefresher {
+    @WorkerThread
+    fun refresh()
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
@@ -26,14 +26,16 @@ import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 
+@ContributesBinding(AppScope::class, boundType = EntityLookupRefresher::class)
 @SingleInstanceIn(AppScope::class)
 class TdsEntityLookup @Inject constructor(
     private val entityDao: TdsEntityDao,
     private val domainEntityDao: TdsDomainEntityDao,
-) : EntityLookup {
+) : EntityLookup, EntityLookupRefresher {
 
     var entities: List<TdsEntity> = emptyList()
 
@@ -67,6 +69,11 @@ class TdsEntityLookup @Inject constructor(
     @WorkerThread
     override fun entityForName(name: String): Entity? {
         return entityDao.get(name)
+    }
+
+    override fun refresh() {
+        // No-op. Legacy DB-walking lookup has no in-memory cache to rebuild;
+        // every request hits the DAOs directly.
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
@@ -26,11 +26,9 @@ import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TdsEntity
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.di.scopes.AppScope
-import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 
-@ContributesBinding(AppScope::class, boundType = EntityLookupRefresher::class)
 @SingleInstanceIn(AppScope::class)
 class TdsEntityLookup @Inject constructor(
     private val entityDao: TdsEntityDao,

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
 class TdsEntityLookup @Inject constructor(
     private val entityDao: TdsEntityDao,
     private val domainEntityDao: TdsDomainEntityDao,
-) : EntityLookup, EntityLookupRefresher {
+) : EntityLookupWithRefresh {
 
     var entities: List<TdsEntity> = emptyList()
 

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDataLoader.kt
@@ -65,6 +65,7 @@ class TrackerDataLoader @Inject constructor(
     private val appDatabase: AppDatabase,
     private val moshi: Moshi,
     private val urlToTypeMapper: UrlToTypeMapper,
+    private val entityLookupRefresher: EntityLookupRefresher,
     private val dispatcherProvider: DispatcherProvider,
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
     private val precompileTdsRegexRCWrapper: PrecompileTdsRegexRCWrapper,
@@ -127,6 +128,7 @@ class TrackerDataLoader @Inject constructor(
             precompileRegex = precompileTdsRegexRCWrapper.enabled,
         )
         trackerDetectorClientProvider.addClient(client)
+        entityLookupRefresher.refresh()
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupParityTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupParityTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
+import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
+import com.duckduckgo.app.trackerdetection.model.TdsDomainEntity
+import com.duckduckgo.app.trackerdetection.model.TdsEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class CachedTdsEntityLookupParityTest {
+
+    private val entities = listOf(
+        TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5),
+        TdsEntity(name = "Beta", displayName = "Beta", prevalence = 0.1),
+    )
+
+    private val domainEntities = listOf(
+        TdsDomainEntity(domain = "tracker.com", entityName = "Acme"),
+        TdsDomainEntity(domain = "deep.beta.com", entityName = "Beta"),
+    )
+
+    private val entitiesByName: Map<String, TdsEntity> = entities.associateBy { it.name }
+    private val domainsByName: Map<String, TdsDomainEntity> = domainEntities.associateBy { it.domain }
+
+    private val entityDao: TdsEntityDao = mock<TdsEntityDao>().also { dao ->
+        whenever(dao.getAll()).thenReturn(entities)
+        whenever(dao.get(any())).thenAnswer { invocation -> entitiesByName[invocation.getArgument<String>(0)] }
+    }
+
+    private val domainEntityDao: TdsDomainEntityDao = mock<TdsDomainEntityDao>().also { dao ->
+        whenever(dao.getAll()).thenReturn(domainEntities)
+        whenever(dao.get(any())).thenAnswer { invocation -> domainsByName[invocation.getArgument<String>(0)] }
+    }
+
+    private val legacy = TdsEntityLookup(entityDao, domainEntityDao)
+    private val cached = CachedTdsEntityLookup(entityDao, domainEntityDao).also { it.refresh() }
+
+    private val goldenHosts = listOf(
+        "http://tracker.com",
+        "http://www.tracker.com",
+        "http://api.tracker.com",
+        "http://a.b.c.tracker.com",
+        "http://deep.beta.com",
+        "http://x.deep.beta.com",
+        "http://unknown.com",
+        "http://nested.unknown.com",
+        "http://localhost",
+    )
+
+    @Test
+    fun stringOverloadParity() {
+        for (url in goldenHosts) {
+            val expected = legacy.entityForUrl(url)
+            val actual = cached.entityForUrl(url)
+            assertEquals("string parity for $url", expected?.name, actual?.name)
+        }
+    }
+
+    @Test
+    fun uriOverloadParity() {
+        for (url in goldenHosts) {
+            val expected = legacy.entityForUrl(url.toUri())
+            val actual = cached.entityForUrl(url.toUri())
+            assertEquals("uri parity for $url", expected?.name, actual?.name)
+        }
+    }
+
+    @Test
+    fun entityForNameParity() {
+        for (name in listOf("Acme", "Beta", "Unknown")) {
+            val expected = legacy.entityForName(name)
+            val actual = cached.entityForName(name)
+            assertEquals("name parity for $name", expected?.name, actual?.name)
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookupTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
+import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
+import com.duckduckgo.app.trackerdetection.model.TdsDomainEntity
+import com.duckduckgo.app.trackerdetection.model.TdsEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class CachedTdsEntityLookupTest {
+
+    private val mockEntityDao: TdsEntityDao = mock()
+    private val mockDomainEntityDao: TdsDomainEntityDao = mock()
+
+    private val testee = CachedTdsEntityLookup(mockEntityDao, mockDomainEntityDao)
+
+    @Test
+    fun whenExactDomainHitThenReturnsMatchingEntity() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Acme")),
+        )
+
+        val entity = testee.entityForUrl("http://tracker.com")
+
+        assertEquals("Acme", entity?.name)
+    }
+
+    @Test
+    fun whenSubdomainHostThenLabelWalkFindsParentEntity() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Acme")),
+        )
+
+        val entity = testee.entityForUrl("http://a.b.c.tracker.com")
+
+        assertEquals("Acme", entity?.name)
+    }
+
+    @Test
+    fun whenStringOverloadWithWwwPrefixThenWwwStripped() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Acme")),
+        )
+
+        val entity = testee.entityForUrl("http://www.tracker.com")
+
+        assertEquals("Acme", entity?.name)
+    }
+
+    @Test
+    fun whenUriOverloadThenUsesRawHostWithoutWwwStrip() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Acme")),
+        )
+
+        val entity = testee.entityForUrl("http://tracker.com".toUri())
+
+        assertEquals("Acme", entity?.name)
+    }
+
+    @Test
+    fun whenEntityForNameThenReturnsDirectHit() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(
+                TdsEntity(name = "Acme", displayName = "Acme", prevalence = 0.5),
+                TdsEntity(name = "Beta", displayName = "Beta", prevalence = 0.1),
+            ),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(emptyList())
+
+        val entity = testee.entityForName("Beta")
+
+        assertEquals("Beta", entity?.name)
+    }
+
+    @Test
+    fun whenNoMatchThenReturnsNull() {
+        whenever(mockEntityDao.getAll()).thenReturn(emptyList())
+        whenever(mockDomainEntityDao.getAll()).thenReturn(emptyList())
+
+        assertNull(testee.entityForUrl("http://unknown.com"))
+        assertNull(testee.entityForUrl("http://unknown.com".toUri()))
+        assertNull(testee.entityForName("Unknown"))
+    }
+
+    @Test
+    fun whenRefreshThenSnapshotReplaced() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "First", displayName = "First", prevalence = 0.1)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "First")),
+        )
+
+        assertEquals("First", testee.entityForUrl("http://tracker.com")?.name)
+
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Second", displayName = "Second", prevalence = 0.2)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Second")),
+        )
+        testee.refresh()
+
+        assertEquals("Second", testee.entityForUrl("http://tracker.com")?.name)
+    }
+
+    @Test
+    fun whenFirstCallBeforeRefreshThenLazyLoadsFromDao() {
+        whenever(mockEntityDao.getAll()).thenReturn(
+            listOf(TdsEntity(name = "Lazy", displayName = "Lazy", prevalence = 0.5)),
+        )
+        whenever(mockDomainEntityDao.getAll()).thenReturn(
+            listOf(TdsDomainEntity(domain = "tracker.com", entityName = "Lazy")),
+        )
+
+        val entity = testee.entityForUrl("http://tracker.com")
+
+        assertEquals("Lazy", entity?.name)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/EntityLookupDelegateTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection
+
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.pixels.remoteconfig.CachedEntityLookupRCWrapper
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import javax.inject.Provider
+
+@RunWith(AndroidJUnit4::class)
+class EntityLookupDelegateTest {
+
+    private val mockLegacy: TdsEntityLookup = mock()
+    private val mockCached: CachedTdsEntityLookup = mock()
+
+    private fun delegateWithFlag(enabled: Boolean) = EntityLookupDelegate(
+        legacy = Provider { mockLegacy },
+        cached = Provider { mockCached },
+        flag = object : CachedEntityLookupRCWrapper {
+            override val enabled: Boolean = enabled
+        },
+    )
+
+    @Test
+    fun whenFlagOnRefreshForwardsToCached() {
+        val testee = delegateWithFlag(enabled = true)
+
+        testee.refresh()
+
+        verify(mockCached).refresh()
+        verify(mockLegacy, never()).refresh()
+    }
+
+    @Test
+    fun whenFlagOffRefreshForwardsToLegacy() {
+        val testee = delegateWithFlag(enabled = false)
+
+        testee.refresh()
+
+        verify(mockLegacy).refresh()
+        verify(mockCached, never()).refresh()
+    }
+
+    @Test
+    fun whenFlagChangesMidSessionDelegateKeepsFirstImpl() {
+        var enabled = true
+        val flag = object : CachedEntityLookupRCWrapper {
+            override val enabled: Boolean get() = enabled
+        }
+        val testee = EntityLookupDelegate(
+            legacy = Provider { mockLegacy },
+            cached = Provider { mockCached },
+            flag = flag,
+        )
+
+        testee.refresh()
+        enabled = false
+        testee.refresh()
+
+        verify(mockCached, times(2)).refresh()
+        verify(mockLegacy, never()).refresh()
+    }
+
+    @Test
+    fun whenEntityForUrlStringWithFlagOnForwardsToCached() {
+        val testee = delegateWithFlag(enabled = true)
+
+        testee.entityForUrl("http://tracker.com")
+
+        verify(mockCached).entityForUrl("http://tracker.com")
+        verify(mockLegacy, never()).entityForUrl(any<String>())
+    }
+
+    @Test
+    fun whenEntityForUrlUriWithFlagOffForwardsToLegacy() {
+        val testee = delegateWithFlag(enabled = false)
+        val uri = "http://tracker.com".toUri()
+
+        testee.entityForUrl(uri)
+
+        verify(mockLegacy).entityForUrl(uri)
+        verify(mockCached, never()).entityForUrl(any<Uri>())
+    }
+
+    @Test
+    fun whenEntityForNameWithFlagOnForwardsToCached() {
+        val testee = delegateWithFlag(enabled = true)
+
+        testee.entityForName("Acme")
+
+        verify(mockCached).entityForName("Acme")
+        verify(mockLegacy, never()).entityForName(any())
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
@@ -84,12 +84,12 @@ class TrackerDataLoaderTest {
             moshi = Moshi.Builder().build(),
             urlToTypeMapper = mockUrlToTypeMapper,
             entityLookupRefresher = mockEntityLookupRefresher,
-            coroutineRule.testDispatcherProvider,
-            object : OptimizeTrackerEvaluationRCWrapper {
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            optimizeTrackerEvaluationRCWrapper = object : OptimizeTrackerEvaluationRCWrapper {
                 override val enabled: Boolean
                     get() = false
             },
-            object : PrecompileTdsRegexRCWrapper {
+            precompileTdsRegexRCWrapper = object : PrecompileTdsRegexRCWrapper {
                 override val enabled: Boolean
                     get() = false
             },

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDataLoaderTest.kt
@@ -64,6 +64,7 @@ class TrackerDataLoaderTest {
     private val mockContext: Context = mock()
     private val mockAppDatabase: AppDatabase = mock()
     private val mockUrlToTypeMapper: UrlToTypeMapper = mock()
+    private val mockEntityLookupRefresher: EntityLookupRefresher = mock()
 
     private val runnableCaptor = argumentCaptor<Runnable>()
     private val tdsMetaDataCaptor = argumentCaptor<TdsMetadata>()
@@ -82,6 +83,7 @@ class TrackerDataLoaderTest {
             appDatabase = mockAppDatabase,
             moshi = Moshi.Builder().build(),
             urlToTypeMapper = mockUrlToTypeMapper,
+            entityLookupRefresher = mockEntityLookupRefresher,
             coroutineRule.testDispatcherProvider,
             object : OptimizeTrackerEvaluationRCWrapper {
                 override val enabled: Boolean


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1213808460359639?focus=true

### Description  


Introduces an opt-in in-memory cached path for entity lookups used during tracker detection, behind a remote-config flag.

The legacy TdsEntityLookup resolves the entity for a URL by walking labels and hitting TdsDomainEntityDao / TdsEntityDao once per label. The new CachedTdsEntityLookup builds a single in-memory snapshot (domain → entityName, entityName → Entity) and resolves via a HashMap walk bounded at eTLD+1,
eliminating per-label DB round-trips.

Key pieces:

- CachedTdsEntityLookup — snapshot-backed lookup, lazy first load, label walk capped at eTLD+1.
- EntityLookupRefresher — narrow refresh() interface so callers don't need the full EntityLookup surface. Legacy impl is a no-op; cached impl rebuilds the snapshot.
- TrackerDataLoader — calls entityLookupRefresher.refresh() after a TDS reload so the cache tracks dataset updates.
- EntityLookupDelegate — @ContributesBinding proxy for both EntityLookup and EntityLookupRefresher. Samples the cachedEntityLookup toggle once (lazy) and routes to either the cached or legacy impl for the rest of the process.
- cachedEntityLookup toggle added to AndroidBrowserConfigFeature (default INTERNAL) plus CachedEntityLookupRCWrapper.
- Manual Dagger @Provides for EntityLookup removed from PrivacyModule (replaced by the delegate's @ContributesBinding).

Tests:

- CachedTdsEntityLookupTest — unit coverage for cached lookup behavior.
- CachedTdsEntityLookupParityTest — verifies cached and legacy return the same entity for the same input.
- EntityLookupDelegateTest — flag routing + delegation.
- CachedTdsEntityLookupPerfAndroidTest — @Ignored on-device microbenchmark vs. the legacy impl, seeded from the bundled tds.json. Manual run only; instructions in the class kdoc.

No behavior change with the flag off — EntityLookupDelegate defaults to the legacy TdsEntityLookup.

### Steps to test this PR

1. Install from this branch
2. Flag-off path (legacy) — with cachedEntityLookup disabled, browse a few sites that load trackers (e.g. a news site) and confirm the Privacy Dashboard still attributes trackers to the correct owning entity. Behavior should be identical to develop.
3. Flag-on path (cached) — enable cachedEntityLookup via the internal feature-flag screen, force-stop and relaunch the app, repeat step 2. Tracker entity attribution should be unchanged (exact domain, deep subdomain, and unknown-host cases).
4. Refresh-on-TDS-update — trigger a TDS reload (e.g. via the internal "Force update" affordance) with the flag on, then revisit a tracker-heavy site and confirm entity attribution still works (i.e. the cache rebuilt rather than going stale).

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tracker-detection entity attribution and introduces a new cached lookup path; although gated by remote config and covered by tests, mistakes could mis-attribute or miss tracker entities when enabled.
> 
> **Overview**
> Adds an opt-in, in-memory cached implementation for tracker *entity* lookups (`CachedTdsEntityLookup`) and a DI-routed delegate (`EntityLookupDelegate`) that selects cached vs legacy behavior via the new `androidBrowserConfig.cachedEntityLookup` remote-config toggle.
> 
> Introduces `EntityLookupRefresher` and updates `TrackerDataLoader` to call `refresh()` after TDS loads so the cache stays in sync; the legacy `TdsEntityLookup` now implements the refresh contract as a no-op. Removes the manual `EntityLookup` provider from `PrivacyModule`, adds unit/parity/delegation tests, and includes an `@Ignore`d on-device microbenchmark for manual perf comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56bcf30c6a7c69029d284e6b6aeaad0ae60223a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->