### PR TITLE
Onboarding Brand Design Update: Enable feature on internal builds

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3009,7 +3009,10 @@ class BrowserTabFragment :
             }
         } else {
             newBrowserTab.rebrandBrowserBackground.gone()
-            newBrowserTab.browserBackground.setImageResource(backgroundRes)
+            newBrowserTab.browserBackground.apply {
+                setImageResource(backgroundRes)
+                isVisible = true
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -57,7 +57,10 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun initializePages() {
         val isBrandDesignUpdateEnabled = withContext(dispatchers.io()) {
-            onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
+            // Temporary: force legacy onboarding on CI builds so existing Maestro flows keep passing.
+            // Remove once E2E tests cover the brand-design onboarding pages.
+            !appBuildConfig.isDefaultVariantForced &&
+                onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
         }
         if (isBrandDesignUpdateEnabled) {
             pageLayoutManager.buildBrandDesignUpdatePageBlueprints()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -133,6 +133,6 @@ class OnboardingViewModel @Inject constructor(
     enum class ExtendedOnboardingFlow {
         DEFAULT,
         DUCK_AI_FOCUSED,
-        DEFAULT_WITHOUT_INTRO_CTA
+        DEFAULT_WITHOUT_INTRO_CTA,
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.OnboardingViewModel.ExtendedOnboardingFlow.*
 import com.duckduckgo.app.onboarding.ui.OnboardingViewModel.ExtendedOnboardingFlow.DEFAULT
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -48,13 +49,21 @@ class OnboardingViewModel @Inject constructor(
     private val newAddressBarOptionManager: RealNewAddressBarOptionManager,
     private val dismissedCtaDao: DismissedCtaDao,
     private val onboardingStore: OnboardingStore,
+    private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
 
-    fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+    suspend fun initializePages() {
+        val isBrandDesignUpdateEnabled = withContext(dispatchers.io()) {
+            onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
+        }
+        if (isBrandDesignUpdateEnabled) {
+            pageLayoutManager.buildBrandDesignUpdatePageBlueprints()
+        } else {
+            pageLayoutManager.buildPageBlueprints()
+        }
     }
 
     fun pageCount(): Int {
@@ -73,6 +82,7 @@ class OnboardingViewModel @Inject constructor(
                 DEFAULT -> {
                     // no-op
                 }
+
                 DUCK_AI_FOCUSED -> {
                     // Mark this as a duck.ai onboarding path so CtaViewModel shows duck.ai-specific CTAs
                     onboardingStore.setDuckAiOnboardingFlow()
@@ -86,6 +96,7 @@ class OnboardingViewModel @Inject constructor(
                         CtaId.DAX_END,
                     ).forEach { dismissedCtaDao.insert(DismissedCta(it)) }
                 }
+
                 DEFAULT_WITHOUT_INTRO_CTA -> {
                     dismissedCtaDao.insert(DismissedCta(CtaId.DAX_INTRO))
                 }
@@ -120,6 +131,8 @@ class OnboardingViewModel @Inject constructor(
     }
 
     enum class ExtendedOnboardingFlow {
-        DEFAULT, DUCK_AI_FOCUSED, DEFAULT_WITHOUT_INTRO_CTA
+        DEFAULT,
+        DUCK_AI_FOCUSED,
+        DEFAULT_WITHOUT_INTRO_CTA
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -21,34 +21,22 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
-/**
- * Feature toggles for the onboarding brand design updates.
- */
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "onboardingBrandDesignUpdate",
 )
 interface OnboardingBrandDesignUpdateToggles {
 
-    /**
-     * Main toggle for the onboarding brand design update feature.
-     * Default value: false (disabled).
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun self(): Toggle
 
-    /**
-     * Toggle for the brand design update variant.
-     * Default value: false (disabled).
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun brandDesignUpdate(): Toggle
 
     /**
-     * Kill switch for the new fire animation work (new Inferno default in
-     * Data Clearing settings + bottom-sheet Lottie swap). Default FALSE; flip
-     * ON to enable the new fire animation surfaces.
+     * Gates the new fire animation work: new Inferno default in Data Clearing
+     * settings + bottom-sheet Lottie swap.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun fireAnimationUpdate(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
@@ -28,12 +28,15 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.FullOnboardingSkipper.ViewState
 import com.duckduckgo.app.onboarding.ui.OnboardingViewModel.ExtendedOnboardingFlow.DEFAULT_WITHOUT_INTRO_CTA
 import com.duckduckgo.app.onboarding.ui.OnboardingViewModel.ExtendedOnboardingFlow.DUCK_AI_FOCUSED
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -66,6 +69,10 @@ class OnboardingViewModelTest {
 
     private val onboardingStore: OnboardingStore = mock()
 
+    private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val enabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+    private val disabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+
     private val testee: OnboardingViewModel by lazy {
         OnboardingViewModel(
             userStageStore = userStageStore,
@@ -76,6 +83,7 @@ class OnboardingViewModelTest {
             newAddressBarOptionManager = newAddressBarOptionManager,
             dismissedCtaDao = dismissedCtaDao,
             onboardingStore = onboardingStore,
+            onboardingBrandDesignUpdateToggles = onboardingBrandDesignUpdateToggles,
         )
     }
 
@@ -150,9 +158,21 @@ class OnboardingViewModelTest {
     }
 
     @Test
-    fun whenInitializePagesCalledThenBuildPageBlueprints() {
+    fun whenInitializePagesCalledAndBrandDesignUpdateDisabledThenBuildPageBlueprints() = runTest {
+        whenever(onboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(disabledToggle)
+
         testee.initializePages()
+
         verify(pageLayout).buildPageBlueprints()
+    }
+
+    @Test
+    fun whenInitializePagesCalledAndBrandDesignUpdateEnabledThenBuildBrandDesignUpdatePageBlueprints() = runTest {
+        whenever(onboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(enabledToggle)
+
+        testee.initializePages()
+
+        verify(pageLayout).buildBrandDesignUpdatePageBlueprints()
     }
 
     private fun configureSkipperFlow() = runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214898233457749?focus=true

### Description

Wires the `brandDesignUpdate` toggle into the onboarding flow and flips the `onboardingBrandDesignUpdate` toggles to default ON for the internal flavor. Internal builds now pick up the new onboarding pages by default; Play / F-Droid remain unaffected.

Also restores symmetric visibility handling in `BrowserTabFragment.setBrowserBackgroundRes` so the legacy onboarding background reappears after a brand-design CTA has previously rendered.

### Steps to test this PR

_Flag ON (default on internal builds)_
- [ ] Install a fresh internal build (`./gradlew installInternalDebug`)
- [ ] Trigger first-run onboarding
- [ ] Verify the new brand design onboarding pages are shown

_Flag OFF_

> Note: do **not** test the OFF path by toggling the flag in dev settings and then clearing app data — clearing data wipes the override and the flag resets to its `INTERNAL` default (ON). Install a Play debug build instead; on that flavor the flag's default resolves to FALSE.

- [ ] Install a fresh Play debug build (`./gradlew installPlayDebug`)
- [ ] Trigger first-run onboarding
- [ ] Verify the original (pre-brand-design-update) onboarding pages are shown

_Mid-flow flag flip — legacy background still renders_
- [ ] Install a fresh internal build (flag ON by default)
- [ ] Complete the pre-onboarding pages and progress until an in-context brand-design Dax bubble is shown
- [ ] Open internal feature flags settings → `onboardingBrandDesignUpdate` → `brandDesignUpdate`, switch it off (do not clear data)
- [ ] Advance to the next in-context CTA (e.g. tap a suggested site / pull-to-refresh / reopen the tab)
- [ ] Verify the legacy in-context Dax bubble renders with the legacy onboarding background visible behind it — not floating on a blank white surface

### UI changes
No new UI in this PR — surfaces the existing brand design pages introduced in prior PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding page initialization to branch on a remote feature toggle and updates default toggle values, which can alter first-run UX and test behavior. Also touches browser tab background visibility logic, with low but user-visible UI regression risk.
> 
> **Overview**
> **Onboarding now conditionally uses the brand-design page set.** `OnboardingViewModel.initializePages` becomes `suspend` and selects between `buildBrandDesignUpdatePageBlueprints` vs legacy `buildPageBlueprints` based on `OnboardingBrandDesignUpdateToggles.brandDesignUpdate()` (with a temporary CI/default-variant guard).
> 
> **Internal builds default the onboarding brand-design toggles to ON.** `OnboardingBrandDesignUpdateToggles` defaults (`self`, `brandDesignUpdate`, `fireAnimationUpdate`) switch from `FALSE` to `INTERNAL`, and tests are updated to cover both enabled/disabled paths.
> 
> **Fixes a UI regression when falling back to legacy onboarding styling.** `BrowserTabFragment.setBrowserBackgroundRes` now explicitly restores visibility of `browserBackground` when not using the rebrand background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4161b953001cd240bab2c1b8892217bccb615b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->