### PR TITLE
Add AnnotatedString overload to DaxText composable

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
@@ -20,8 +20,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
@@ -42,6 +48,34 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBoxInverted
 @Composable
 fun DaxText(
     text: String,
+    modifier: Modifier = Modifier,
+    style: DuckDuckGoTextStyle = DuckDuckGoTheme.typography.body1,
+    color: Color = DuckDuckGoTheme.textColors.primary,
+    textAlign: TextAlign? = null,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        color = color,
+        style = style.asTextStyle,
+        textAlign = textAlign,
+        overflow = overflow,
+        maxLines = maxLines,
+        modifier = modifier,
+    )
+}
+
+/**
+ * [AnnotatedString] variant of [DaxText]. Use this when the text needs inline
+ * styling (bold spans, color spans, links, etc.). Build the [AnnotatedString]
+ * with [buildAnnotatedString] or compose it from string resources.
+ *
+ * @param color The default text color applied to spans that do not override it via [SpanStyle].
+ */
+@Composable
+fun DaxText(
+    text: AnnotatedString,
     modifier: Modifier = Modifier,
     style: DuckDuckGoTextStyle = DuckDuckGoTheme.typography.body1,
     color: Color = DuckDuckGoTheme.textColors.primary,
@@ -226,6 +260,24 @@ private fun DaxTextColorDisabledPreview() {
         DaxText(
             text = "Disabled Color",
             color = DuckDuckGoTheme.textColors.disabled,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxTextAnnotatedStringPreview() {
+    PreviewBox {
+        DaxText(
+            text = buildAnnotatedString {
+                append("Normal, ")
+                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("bold") }
+                append(", ")
+                withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) { append("underlined") }
+                append(", and ")
+                withStyle(SpanStyle(color = DuckDuckGoTheme.textColors.secondary)) { append("colored") }
+                append(" spans.")
+            },
         )
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/text/DaxText.kt
@@ -72,7 +72,10 @@ fun DaxText(
  * with [buildAnnotatedString] or compose it from string resources.
  *
  * @param color The default text color applied to spans that do not override it via [SpanStyle].
- */
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1211634956773768
+ * Figma reference: https://www.figma.com/design/jHLwh4erLbNc2YeobQpGFt/Design-System-Guidelines?node-id=1313-19967
+ * */
 @Composable
 fun DaxText(
     text: AnnotatedString,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1214603537846227?focus=true

### Description

Adds an `AnnotatedString` overload of the `DaxText` composable in the design system. Same parameter list as the existing `String` variant (style, color, alignment, overflow, max lines) so the call site is identical apart from the text type. This lets callers apply inline styling — bold/underline/color spans, links, etc. — using `buildAnnotatedString { … }` while keeping DuckDuckGo typography and color defaults.

### Steps to test this PR
CI passes

### UI changes
No UI changes (new component overload — no existing call sites affected). New `DaxTextAnnotatedStringPreview` available in the design-system module showing bold / underline / color spans. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive overload and preview-only demo with no behavioral changes to existing `String` call sites.
> 
> **Overview**
> Adds a new `DaxText(text: AnnotatedString, ...)` overload so callers can render inline-styled Compose text (e.g., bold/underline/color spans) while keeping the same parameter surface and DuckDuckGo design-system defaults as the existing `String` variant.
> 
> Includes a new `DaxTextAnnotatedStringPreview` demonstrating styled spans via `buildAnnotatedString`/`withStyle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202101b4fc335841800235bad43faedaa9d8056e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->