### PR TITLE
Fix NativeInputModeWidget UninitializedPropertyAccessException

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -82,16 +82,20 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     override fun onWebViewMode() {
-        if (isNativeInputEnabled) card?.show() else card?.gone()
-        // WEBVIEW mode means a chat is in progress.
-        // Hide the picker so the user can't change models mid-chat.
-        widget?.setModelPickerEnabled(false)
+        if (isNativeInputEnabled) {
+            card?.show()
+            // WEBVIEW mode means a chat is in progress.
+            // Hide the picker so the user can't change models mid-chat.
+            widget?.setModelPickerEnabled(false)
+        } else {
+            card?.gone()
+        }
     }
 
     override fun onInputMode() {
         card?.gone()
         // INPUT mode is a new chat: restore the picker
-        widget?.setModelPickerEnabled(true)
+        if (isNativeInputEnabled) widget?.setModelPickerEnabled(true)
     }
 
     private fun applyCardShape(card: MaterialCardView) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214930970110537?focus=true

### Description

- Fixes the manager trying to set the model picker on an uninitialized view

### Steps to test this PR

_With native input disabled_
- [ ] Smoke test contextual sheet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e5fa969260660d0f1f2010df3bd16e325fbd7d55. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->