### PR TITLE
Fix: FireDialog IllegalStateException after onSaveInstanceState

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/GranularFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/GranularFireDialog.kt
@@ -34,6 +34,7 @@ import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -97,6 +98,13 @@ class GranularFireDialog : BottomSheetDialogFragment(), FireDialog {
     }
 
     private var canFinish = false
+
+    override fun show(fragmentManager: FragmentManager, tag: String?) {
+        // FragmentManager.commit() inside DialogFragment.show() throws after onSaveInstanceState.
+        // Callers may invoke show() across a coroutine suspension; skip silently if state is saved.
+        if (fragmentManager.isStateSaved) return
+        super.show(fragmentManager, tag)
+    }
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)

--- a/app/src/main/java/com/duckduckgo/app/global/view/NonGranularFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/NonGranularFireDialog.kt
@@ -33,6 +33,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.updatePadding
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -95,6 +96,13 @@ class NonGranularFireDialog : BottomSheetDialogFragment(), FireDialog {
     }
 
     private var canRestart = false
+
+    override fun show(fragmentManager: FragmentManager, tag: String?) {
+        // FragmentManager.commit() inside DialogFragment.show() throws after onSaveInstanceState.
+        // Callers may invoke show() across a coroutine suspension; skip silently if state is saved.
+        if (fragmentManager.isStateSaved) return
+        super.show(fragmentManager, tag)
+    }
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -34,6 +34,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.updatePadding
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -109,6 +110,13 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
     private var canFinish = false
     private var pendingFragmentResultEvent: String? = null
     private var isFireAnimationUpdateEnabled = false
+
+    override fun show(fragmentManager: FragmentManager, tag: String?) {
+        // FragmentManager.commit() inside DialogFragment.show() throws after onSaveInstanceState.
+        // Callers may invoke show() across a coroutine suspension; skip silently if state is saved.
+        if (fragmentManager.isStateSaved) return
+        super.show(fragmentManager, tag)
+    }
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214931457439347?focus=true

### Description

BrowserActivity.launchFire (and the LaunchContextualChatFire handler) call dialog.show(supportFragmentManager) from a lifecycleScope.launch coroutine after createFireDialog suspends on Dispatchers.IO. If the activity moves past onSaveInstanceState during that suspension (backgrounding, config change, another activity launched on top), DialogFragment.show commits a FragmentTransaction against a state-saved FragmentManager and throws.

### Steps to test this PR

QA-optional

- [ ] Smoke test opening a fire dialog (the bug is hard to reproduce)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dialog presentation behavior to silently no-op when `FragmentManager` state is already saved, which prevents crashes but could cause the fire dialog to not appear in some lifecycle edge cases.
> 
> **Overview**
> Prevents `IllegalStateException` when presenting fire dialogs by overriding `show()` in `GranularFireDialog`, `NonGranularFireDialog`, and `SingleTabFireDialog` to *skip showing* if `FragmentManager.isStateSaved` is true.
> 
> This avoids committing a fragment transaction after `onSaveInstanceState` (e.g., when `show()` is invoked after a coroutine suspension), trading a crash for a silent no-op in that scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783d1745a9abe9f5dd2178ab6c724c8576afb86b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->