### PR TITLE
Fix autocomplete fill button

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2798,8 +2798,12 @@ class BrowserTabFragment :
             is Command.CancelIncomingAutofillRequest -> injectAutofillCredentials(it.url, null)
             is Command.LaunchAutofillSettings -> launchAutofillManagementScreen(it.privacyProtectionEnabled)
             is Command.EditWithSelectedQuery -> {
-                omnibar.setText(it.query)
-                omnibar.setTextSelection(it.query.length)
+                if (nativeInputManager.isNativeInputEnabled()) {
+                    nativeInputManager.setText(it.query)
+                } else {
+                    omnibar.setText(it.query)
+                    omnibar.setTextSelection(it.query.length)
+                }
             }
 
             is ShowBackNavigationHistory -> showBackNavigationHistory(it)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -100,6 +100,7 @@ interface NativeInputManager {
     fun handleDuckAiVoiceResult(query: String)
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
     fun setPickingImage(picking: Boolean)
+    fun setText(text: String)
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -151,6 +152,12 @@ class RealNativeInputManager @Inject constructor(
 
     override fun setPickingImage(picking: Boolean) {
         isPickingImage = picking
+    }
+
+    override fun setText(text: String) {
+        if (!::rootView.isInitialized) return
+        val widget = widgetFrom(rootView) ?: return
+        widget.text = text
     }
 
     override fun handleDuckAiVoiceResult(query: String) {


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214750702332632?focus=true

### Description
- Fix autocomplete fill button
### Steps to test this PR
- enable native input widget
- type something and observe autocomplete
- tap the fill button on the right side of an autocomplete entry
- input text is filled.

### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/964673d7-13f5-48d5-876f-05ff1612b15a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit aa561e995988b648f023b248e2f5da6a8e248394. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->