### PR TITLE
Add core ad blocking capabilities

### DIFF
--- a/ad-blocking/ad-blocking-impl/build.gradle
+++ b/ad-blocking/ad-blocking-impl/build.gradle
@@ -36,6 +36,7 @@ android {
 }
 
 dependencies {
+    implementation AndroidX.core.ktx
     implementation  AndroidX.work.runtimeKtx
     implementation AndroidX.room.runtime
     ksp AndroidX.room.compiler

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -47,7 +47,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
 
     private val payload: StateFlow<String?> = repository
         .scriptletsFlow()
-        .map { data -> data?.let(::buildScript) }
+        .map(::buildScript)
         .stateIn(appScope, SharingStarted.Eagerly, initialValue = null)
 
     @UiThread
@@ -81,8 +81,8 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
 
     override fun onPageFinished(webView: WebView, url: String?, site: Site?) = Unit
 
-    private fun buildScript(data: AdBlockingScriptletData): String? =
-        data.scriptlets
+    private fun buildScript(scriptlets: List<Scriptlet>): String? =
+        scriptlets
             .takeUnless { it.isEmpty() }
             ?.sortedBy { it.name }
             ?.joinToString(separator = "\n") { it.content }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.webkit.WebView
+import androidx.annotation.UiThread
+import androidx.core.net.toUri
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.app.browser.Domain
+import com.duckduckgo.app.browser.UriString
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.browser.api.JsInjectorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import logcat.logcat
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesMultibinding(AppScope::class)
+class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
+    private val feature: AdBlockingExtensionFeature,
+    repository: AdBlockingExtensionRepository,
+    @AppCoroutineScope appScope: CoroutineScope,
+) : JsInjectorPlugin {
+
+    private val payload: StateFlow<String?> = repository
+        .scriptletsFlow()
+        .map { data -> data?.let(::buildScript) }
+        .stateIn(appScope, SharingStarted.Eagerly, initialValue = null)
+
+    @UiThread
+    override fun onPageStarted(
+        webView: WebView,
+        url: String?,
+        isDesktopMode: Boolean?,
+        activeExperiments: List<Toggle>,
+    ) {
+        if (!feature.isDiscoverable().isEnabled()) {
+            logcat { "Feature not discoverable, skipping" }
+            return
+        }
+        if (!feature.self().isEnabled()) {
+            logcat { "Feature not operational, skipping" }
+            return
+        }
+        val uri = url?.toUri() ?: return
+        if (domains.none { UriString.sameOrSubdomain(uri, it) }) {
+            logcat { "No domains matching, skipping" }
+            return
+        }
+        val script = payload.value ?: run {
+            logcat { "Empty payload, skipping" }
+            return
+        }
+
+        logcat { "Injecting script" }
+        webView.evaluateJavascript("javascript:$script", null)
+    }
+
+    override fun onPageFinished(webView: WebView, url: String?, site: Site?) = Unit
+
+    private fun buildScript(data: AdBlockingScriptletData): String? =
+        data.scriptlets
+            .takeUnless { it.isEmpty() }
+            ?.sortedBy { it.name }
+            ?.joinToString(separator = "\n") { it.content }
+
+    private val domains = listOf(
+        Domain("youtube.com"),
+        Domain("youtube-nocookie.com"),
+    )
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.adblocking.impl
 import android.webkit.WebView
 import androidx.annotation.UiThread
 import androidx.core.net.toUri
-import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.app.browser.Domain
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -40,7 +40,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 @ContributesMultibinding(AppScope::class)
 class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
-    private val feature: AdBlockingExtensionFeature,
+    private val statusChecker: AdBlockingStatusChecker,
     repository: AdBlockingExtensionRepository,
     @AppCoroutineScope appScope: CoroutineScope,
 ) : JsInjectorPlugin {
@@ -57,12 +57,8 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
     ) {
-        if (!feature.isDiscoverable().isEnabled()) {
-            logcat { "Feature not discoverable, skipping" }
-            return
-        }
-        if (!feature.self().isEnabled()) {
-            logcat { "Feature not operational, skipping" }
+        if (!statusChecker.canInject()) {
+            logcat { "Status checker rejected injection, skipping" }
             return
         }
         val uri = url?.toUri() ?: return

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 interface AdBlockingExtensionRepository {
     suspend fun getStoredVersion(): String?
     suspend fun storeScriptlets(version: String, scriptlets: Map<String, ByteArray>)
-    fun scriptletsFlow(): Flow<AdBlockingScriptletData?>
+    fun scriptletsFlow(): Flow<List<Scriptlet>>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -48,16 +48,8 @@ class RealAdBlockingExtensionRepository @Inject constructor(
         )
     }
 
-    override fun scriptletsFlow(): Flow<AdBlockingScriptletData?> =
+    override fun scriptletsFlow(): Flow<List<Scriptlet>> =
         dao.scriptletsFlow().map { rows ->
-            if (rows.isEmpty()) {
-                null
-            } else {
-                AdBlockingScriptletData(
-                    scriptlets = rows.map { row ->
-                        AdBlockingScriptletData.Scriptlet(name = row.name, content = String(row.content))
-                    },
-                )
-            }
+            rows.map { row -> Scriptlet(name = row.name, content = String(row.content)) }
         }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
@@ -21,11 +21,14 @@ import com.duckduckgo.adblocking.impl.store.ScriptletEntity
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 interface AdBlockingExtensionRepository {
     suspend fun getStoredVersion(): String?
     suspend fun storeScriptlets(version: String, scriptlets: Map<String, ByteArray>)
+    fun scriptletsFlow(): Flow<AdBlockingScriptletData?>
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -44,4 +47,17 @@ class RealAdBlockingExtensionRepository @Inject constructor(
             },
         )
     }
+
+    override fun scriptletsFlow(): Flow<AdBlockingScriptletData?> =
+        dao.scriptletsFlow().map { rows ->
+            if (rows.isEmpty()) {
+                null
+            } else {
+                AdBlockingScriptletData(
+                    scriptlets = rows.map { row ->
+                        AdBlockingScriptletData.Scriptlet(name = row.name, content = String(row.content))
+                    },
+                )
+            }
+        }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionRepository.kt
@@ -50,6 +50,6 @@ class RealAdBlockingExtensionRepository @Inject constructor(
 
     override fun scriptletsFlow(): Flow<List<Scriptlet>> =
         dao.scriptletsFlow().map { rows ->
-            rows.map { row -> Scriptlet(name = row.name, content = String(row.content)) }
+            rows.map { row -> Scriptlet(name = row.name, content = String(row.content, Charsets.UTF_8)) }
         }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingScriptletData.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingScriptletData.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+data class AdBlockingScriptletData(
+    val scriptlets: List<Scriptlet>,
+) {
+    data class Scriptlet(
+        val name: String,
+        val content: String,
+    )
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/Scriptlet.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/Scriptlet.kt
@@ -16,11 +16,7 @@
 
 package com.duckduckgo.adblocking.impl
 
-data class AdBlockingScriptletData(
-    val scriptlets: List<Scriptlet>,
-) {
-    data class Scriptlet(
-        val name: String,
-        val content: String,
-    )
-}
+data class Scriptlet(
+    val name: String,
+    val content: String,
+)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -34,12 +34,12 @@ class RealAdBlockingStatusChecker @Inject constructor(
 ) : AdBlockingStatusChecker {
 
     override fun canInject(): Boolean {
-        if (!feature.isDiscoverable().isEnabled()) {
-            logcat { "Feature not discoverable" }
+        if (!feature.self().isEnabled()) {
+            logcat { "Kill-switch is off" }
             return false
         }
-        if (!feature.self().isEnabled()) {
-            logcat { "Feature not operational" }
+        if (feature.enableContingencyMode().isEnabled()) {
+            logcat { "Contingency mode is on" }
             return false
         }
         return true

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import logcat.logcat
+import javax.inject.Inject
+
+interface AdBlockingStatusChecker {
+    fun canInject(): Boolean
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAdBlockingStatusChecker @Inject constructor(
+    private val feature: AdBlockingExtensionFeature,
+) : AdBlockingStatusChecker {
+
+    override fun canInject(): Boolean {
+        if (!feature.isDiscoverable().isEnabled()) {
+            logcat { "Feature not discoverable" }
+            return false
+        }
+        if (!feature.self().isEnabled()) {
+            logcat { "Feature not operational" }
+            return false
+        }
+        return true
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -43,7 +43,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
 
     private var discoverableEnabled = true
     private var operationalEnabled = true
-    private val scriptletsFlow = MutableStateFlow<AdBlockingScriptletData?>(null)
+    private val scriptletsFlow = MutableStateFlow<List<Scriptlet>>(emptyList())
 
     private val isDiscoverableToggle: Toggle = mock {
         on { isEnabled() } doAnswer { discoverableEnabled }
@@ -61,14 +61,10 @@ class AdBlockingExtensionJsInjectorPluginTest {
     private val webView: WebView = mock()
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
-    private val singleScriptlet = AdBlockingScriptletData(
-        scriptlets = listOf(AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('a')")),
-    )
-    private val twoScriptlets = AdBlockingScriptletData(
-        scriptlets = listOf(
-            AdBlockingScriptletData.Scriptlet(name = "b.js", content = "console.log('b')"),
-            AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('a')"),
-        ),
+    private val singleScriptlet = listOf(Scriptlet(name = "a.js", content = "console.log('a')"))
+    private val twoScriptlets = listOf(
+        Scriptlet(name = "b.js", content = "console.log('b')"),
+        Scriptlet(name = "a.js", content = "console.log('a')"),
     )
 
     private val plugin by lazy {
@@ -174,15 +170,8 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
-    fun whenScriptletDataIsNullThenScriptIsNotInjected() {
-        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
-
-        verify(webView, never()).evaluateJavascript(any(), isNull())
-    }
-
-    @Test
     fun whenScriptletsListIsEmptyThenScriptIsNotInjected() {
-        scriptletsFlow.value = AdBlockingScriptletData(scriptlets = emptyList())
+        scriptletsFlow.value = emptyList()
 
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
@@ -203,9 +192,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
         scriptletsFlow.value = singleScriptlet
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
-        scriptletsFlow.value = AdBlockingScriptletData(
-            scriptlets = listOf(AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('updated')")),
-        )
+        scriptletsFlow.value = listOf(Scriptlet(name = "a.js", content = "console.log('updated')"))
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
         verify(webView).evaluateJavascript(

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -18,8 +18,7 @@ package com.duckduckgo.adblocking.impl
 
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
-import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -41,19 +40,11 @@ import org.mockito.kotlin.verify
 @RunWith(AndroidJUnit4::class)
 class AdBlockingExtensionJsInjectorPluginTest {
 
-    private var discoverableEnabled = true
-    private var operationalEnabled = true
+    private var canInject = true
     private val scriptletsFlow = MutableStateFlow<List<Scriptlet>>(emptyList())
 
-    private val isDiscoverableToggle: Toggle = mock {
-        on { isEnabled() } doAnswer { discoverableEnabled }
-    }
-    private val selfToggle: Toggle = mock {
-        on { isEnabled() } doAnswer { operationalEnabled }
-    }
-    private val feature: AdBlockingExtensionFeature = mock {
-        on { isDiscoverable() } doReturn isDiscoverableToggle
-        on { self() } doReturn selfToggle
+    private val statusChecker: AdBlockingStatusChecker = mock {
+        on { canInject() } doAnswer { canInject }
     }
     private val repository: AdBlockingExtensionRepository = mock {
         on { scriptletsFlow() } doReturn scriptletsFlow
@@ -69,7 +60,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
 
     private val plugin by lazy {
         AdBlockingExtensionJsInjectorPlugin(
-            feature = feature,
+            statusChecker = statusChecker,
             repository = repository,
             appScope = testScope,
         )
@@ -141,18 +132,8 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
-    fun whenKillSwitchIsOffThenScriptIsNotInjected() {
-        discoverableEnabled = false
-        scriptletsFlow.value = singleScriptlet
-
-        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
-
-        verify(webView, never()).evaluateJavascript(any(), isNull())
-    }
-
-    @Test
-    fun whenOperationalIsOffThenScriptIsNotInjected() {
-        operationalEnabled = false
+    fun whenStatusCheckerRejectsThenScriptIsNotInjected() {
+        canInject = false
         scriptletsFlow.value = singleScriptlet
 
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
@@ -202,22 +183,11 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
-    fun whenKillSwitchFlipsOffMidSessionThenNextInjectionNoOps() {
+    fun whenStatusCheckerStartsRejectingMidSessionThenNextInjectionNoOps() {
         scriptletsFlow.value = singleScriptlet
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
-        discoverableEnabled = false
-        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
-
-        verify(webView).evaluateJavascript(any(), isNull())
-    }
-
-    @Test
-    fun whenOperationalFlipsOffMidSessionThenNextInjectionNoOps() {
-        scriptletsFlow.value = singleScriptlet
-        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
-
-        operationalEnabled = false
+        canInject = false
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
         verify(webView).evaluateJavascript(any(), isNull())

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class AdBlockingExtensionJsInjectorPluginTest {
+
+    private var discoverableEnabled = true
+    private var operationalEnabled = true
+    private val scriptletsFlow = MutableStateFlow<AdBlockingScriptletData?>(null)
+
+    private val isDiscoverableToggle: Toggle = mock {
+        on { isEnabled() } doAnswer { discoverableEnabled }
+    }
+    private val selfToggle: Toggle = mock {
+        on { isEnabled() } doAnswer { operationalEnabled }
+    }
+    private val feature: AdBlockingExtensionFeature = mock {
+        on { isDiscoverable() } doReturn isDiscoverableToggle
+        on { self() } doReturn selfToggle
+    }
+    private val repository: AdBlockingExtensionRepository = mock {
+        on { scriptletsFlow() } doReturn scriptletsFlow
+    }
+    private val webView: WebView = mock()
+    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
+
+    private val singleScriptlet = AdBlockingScriptletData(
+        scriptlets = listOf(AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('a')")),
+    )
+    private val twoScriptlets = AdBlockingScriptletData(
+        scriptlets = listOf(
+            AdBlockingScriptletData.Scriptlet(name = "b.js", content = "console.log('b')"),
+            AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('a')"),
+        ),
+    )
+
+    private val plugin by lazy {
+        AdBlockingExtensionJsInjectorPlugin(
+            feature = feature,
+            repository = repository,
+            appScope = testScope,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        testScope.cancel()
+    }
+
+    @Test
+    fun whenAllGatesAreOpenThenScriptIsInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(
+            eq("javascript:console.log('a')"),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenMultipleScriptletsThenAllAreInjectedInSortedOrder() {
+        scriptletsFlow.value = twoScriptlets
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(
+            eq("javascript:console.log('a')\nconsole.log('b')"),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenUrlIsSubdomainOfConfiguredDomainThenScriptIsInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://m.youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenUrlHasWwwPrefixThenScriptIsInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://www.youtube.com", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenUrlMatchesSecondConfiguredDomainThenScriptIsInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://youtube-nocookie.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenUrlHostNotInConfiguredDomainsThenScriptIsNotInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://example.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenKillSwitchIsOffThenScriptIsNotInjected() {
+        discoverableEnabled = false
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenOperationalIsOffThenScriptIsNotInjected() {
+        operationalEnabled = false
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenUrlIsNullThenScriptIsNotInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = null, isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenScriptletDataIsNullThenScriptIsNotInjected() {
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenScriptletsListIsEmptyThenScriptIsNotInjected() {
+        scriptletsFlow.value = AdBlockingScriptletData(scriptlets = emptyList())
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenUrlHasNoHostThenScriptIsNotInjected() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageStarted(webView, url = "data:text/html,<p>hi</p>", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenScriptletDataIsUpdatedThenNextInjectionUsesNewPayload() {
+        scriptletsFlow.value = singleScriptlet
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        scriptletsFlow.value = AdBlockingScriptletData(
+            scriptlets = listOf(AdBlockingScriptletData.Scriptlet(name = "a.js", content = "console.log('updated')")),
+        )
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(
+            eq("javascript:console.log('updated')"),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenKillSwitchFlipsOffMidSessionThenNextInjectionNoOps() {
+        scriptletsFlow.value = singleScriptlet
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        discoverableEnabled = false
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenOperationalFlipsOffMidSessionThenNextInjectionNoOps() {
+        scriptletsFlow.value = singleScriptlet
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        operationalEnabled = false
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenOnPageFinishedCalledThenNoInjection() {
+        scriptletsFlow.value = singleScriptlet
+
+        plugin.onPageFinished(webView, url = "https://youtube.com/page", site = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.domain
+
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class RealAdBlockingStatusCheckerTest {
+
+    private var discoverableEnabled = true
+    private var operationalEnabled = true
+
+    private val isDiscoverableToggle: Toggle = mock {
+        on { isEnabled() } doAnswer { discoverableEnabled }
+    }
+    private val selfToggle: Toggle = mock {
+        on { isEnabled() } doAnswer { operationalEnabled }
+    }
+    private val feature: AdBlockingExtensionFeature = mock {
+        on { isDiscoverable() } doReturn isDiscoverableToggle
+        on { self() } doReturn selfToggle
+    }
+
+    private val checker = RealAdBlockingStatusChecker(feature)
+
+    @Test
+    fun whenBothRemoteFlagsEnabledThenCanInject() {
+        assertTrue(checker.canInject())
+    }
+
+    @Test
+    fun whenDiscoverableFlagDisabledThenCannotInject() {
+        discoverableEnabled = false
+
+        assertFalse(checker.canInject())
+    }
+
+    @Test
+    fun whenOperationalFlagDisabledThenCannotInject() {
+        operationalEnabled = false
+
+        assertFalse(checker.canInject())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -27,37 +27,37 @@ import org.mockito.kotlin.mock
 
 class RealAdBlockingStatusCheckerTest {
 
-    private var discoverableEnabled = true
-    private var operationalEnabled = true
+    private var killSwitchEnabled = true
+    private var contingencyModeEnabled = false
 
-    private val isDiscoverableToggle: Toggle = mock {
-        on { isEnabled() } doAnswer { discoverableEnabled }
-    }
     private val selfToggle: Toggle = mock {
-        on { isEnabled() } doAnswer { operationalEnabled }
+        on { isEnabled() } doAnswer { killSwitchEnabled }
+    }
+    private val contingencyModeToggle: Toggle = mock {
+        on { isEnabled() } doAnswer { contingencyModeEnabled }
     }
     private val feature: AdBlockingExtensionFeature = mock {
-        on { isDiscoverable() } doReturn isDiscoverableToggle
         on { self() } doReturn selfToggle
+        on { enableContingencyMode() } doReturn contingencyModeToggle
     }
 
     private val checker = RealAdBlockingStatusChecker(feature)
 
     @Test
-    fun whenBothRemoteFlagsEnabledThenCanInject() {
+    fun whenKillSwitchIsOnAndContingencyModeIsOffThenCanInject() {
         assertTrue(checker.canInject())
     }
 
     @Test
-    fun whenDiscoverableFlagDisabledThenCannotInject() {
-        discoverableEnabled = false
+    fun whenKillSwitchIsOffThenCannotInject() {
+        killSwitchEnabled = false
 
         assertFalse(checker.canInject())
     }
 
     @Test
-    fun whenOperationalFlagDisabledThenCannotInject() {
-        operationalEnabled = false
+    fun whenContingencyModeIsOnThenCannotInject() {
+        contingencyModeEnabled = true
 
         assertFalse(checker.canInject())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1213078401808051?focus=true

### Description
Add core ad blocking capabilities

### Steps to test this PR

_Feature 1_
- [x] Fresh install the app
- [x] Open YouTube.com
- [x] Check logs for `Kill-switch is off` and `Status checker rejected injection, skipping`
- [x] Go to feature flag inventory and enable `adBlockingExtension.enableContingencyMode`. Then enable `adBlockingExtension` (order is important here)
- [x] Kill and reopen the app
- [x] Check logs for `Contingency mode is on` and `Status checker rejected injection, skipping`
- [x] Go to feature flag inventory and disable `adBlockingExtension.enableContingencyMode`
- [x] Kill and reopen the app
- [x] Check logs for `Empty payload, skipping`
- [x] Browse through a few videos and check ads are shown

_Feature 2_
- [x] Apply _Patch 1: Update RC URL_
- [x] Fresh install the app
- [x] Open YouTube.com
- [x] Check logs for `Kill-switch is off` and `Status checker rejected injection, skipping`
- [x] Go to feature flag inventory and enable `adBlockingExtension`
- [x] Kill and reopen the app
- [x] Check logs for `Injecting script`
- [x] Browse through a few videos and check ads are not shown


### Patches

_Patch 1: Update RC URL_
```
Subject: [PATCH] Update privacy-config URL
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision ca28c5a412606fefb8bcee8532f901d9fe30b55c)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1779203719053)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-5175/v4/android-config.json"
```

### UI changes
n/a




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser page-load JS injection and ad-blocking behavior on high-traffic sites; mitigated by feature kill-switch, contingency mode, and domain allowlist.
> 
> **Overview**
> Adds **runtime injection** of stored ad-blocking scriptlets into the browser via a new `JsInjectorPlugin` that runs on **page start** for YouTube-related hosts only.
> 
> Injection is gated by **`AdBlockingStatusChecker`**: the `adBlockingExtension` kill-switch must be on and **contingency mode** must be off. The plugin builds a combined JS payload from **`scriptletsFlow()`** on the extension repository (sorted scriptlet names, joined content) and calls **`evaluateJavascript`** when the URL matches configured domains and payload is non-empty.
> 
> The repository gains a reactive **`scriptletsFlow()`** mapping Room entities to a new **`Scriptlet`** model. Unit tests cover injector behavior (domains, toggles, empty payload, updates) and status checker flag combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8ffe3b8499700ec31e1b8f4c88990f6ebe8eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->