### PR TITLE
Detect image-generation chats from ui-component message parts

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -235,6 +235,14 @@ interface DuckChatFeature {
     fun deleteFromAutocomplete(): Toggle
 
     /**
+     * @return `true` when chat-suggestion rows in the omnibar autocomplete render a per-type leading icon
+     * (Discussion / ImageGeneration / Voice) instead of the default Discussion icon.
+     * If the remote feature is not present defaults to `true`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun chatSuggestionTypeIcon(): Toggle
+
+    /**
      * Kill switch for opening Duck.ai voice chat when the digital assistant intent is received.
      * @return `true` when the remote config has the "digitalAssistantDuckAi"
      * sub-feature flag enabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -78,17 +78,15 @@ class RealChatHistoryRepository @Inject constructor(
         lastEditMillis = chat.lastEdit.parseIsoMillis(),
     )
 
-    private fun DuckAiChat.toChatType(): ChatType = model.toChatType()
+    private fun DuckAiChat.toChatType(): ChatType = when {
+        isImageGeneration -> ChatType.ImageGeneration
+        isVoice -> ChatType.Voice
+        else -> ChatType.Discussion
+    }
 
     private fun String.parseIsoMillis(): Long = runCatching { Instant.parse(this).toEpochMilli() }.getOrDefault(0L)
 
     private companion object {
         const val UPSTREAM_UNTITLED = "Untitled Chat"
     }
-}
-
-internal fun String.toChatType(): ChatType = when (this) {
-    "image-generation" -> ChatType.ImageGeneration
-    "voice-mode" -> ChatType.Voice
-    else -> ChatType.Discussion
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.models.toChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.squareup.anvil.annotations.ContributesBinding
@@ -77,12 +78,6 @@ class RealChatHistoryRepository @Inject constructor(
         pinned = chat.pinned,
         lastEditMillis = chat.lastEdit.parseIsoMillis(),
     )
-
-    private fun DuckAiChat.toChatType(): ChatType = when {
-        isImageGeneration -> ChatType.ImageGeneration
-        isVoice -> ChatType.Voice
-        else -> ChatType.Discussion
-    }
 
     private fun String.parseIsoMillis(): Long = runCatching { Instant.parse(this).toEpochMilli() }.getOrDefault(0L)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewHolder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewHolder.kt
@@ -26,6 +26,7 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.models.iconRes
 
 class ChatHistoryViewHolder(
     itemView: View,
@@ -78,16 +79,10 @@ class ChatHistoryViewHolder(
             iconContainer.contentDescription = itemView.context.getString(R.string.duck_ai_chat_history_row_selected_content_description)
         } else {
             iconContainer.setBackgroundResource(R.drawable.bg_chat_history_circle_solid)
-            typeIcon.setImageResource(iconFor(item.type, item.pinned))
+            typeIcon.setImageResource(item.type.iconRes(item.pinned))
             typeIcon.colorFilter = null
             iconContainer.contentDescription = null
         }
-    }
-
-    private fun iconFor(type: ChatType, pinned: Boolean): Int = when (type) {
-        ChatType.Discussion -> if (pinned) R.drawable.ic_chat_pin_24 else R.drawable.ic_chat_24
-        ChatType.ImageGeneration -> if (pinned) R.drawable.ic_images_pin_24 else R.drawable.ic_images_24
-        ChatType.Voice -> if (pinned) R.drawable.ic_voice_pin_24 else R.drawable.ic_voice_24
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestion.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestion.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
 
+import com.duckduckgo.duckchat.impl.models.ChatType
 import java.time.LocalDateTime
 
 /**
@@ -26,4 +27,5 @@ data class ChatSuggestion(
     val title: String,
     val lastEdit: LocalDateTime,
     val pinned: Boolean,
+    val type: ChatType = ChatType.Discussion,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestionsAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatSuggestionsAdapter.kt
@@ -21,8 +21,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.ItemChatSuggestionBinding
+import com.duckduckgo.duckchat.impl.models.iconRes
 
 class ChatSuggestionsAdapter(
     private val onChatClicked: (ChatSuggestion) -> Unit,
@@ -47,13 +47,7 @@ class ChatSuggestionsAdapter(
 
         fun bind(suggestion: ChatSuggestion, onChatClicked: (ChatSuggestion) -> Unit) {
             binding.chatSuggestionTitle.text = suggestion.title
-
-            val iconRes = if (suggestion.pinned) {
-                R.drawable.ic_chat_pin_24
-            } else {
-                R.drawable.ic_chat_24
-            }
-            binding.chatSuggestionIcon.setImageResource(iconRes)
+            binding.chatSuggestionIcon.setImageResource(suggestion.type.iconRes(suggestion.pinned))
 
             binding.root.setOnClickListener {
                 onChatClicked(suggestion)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.feature.maxHistoryCount
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.models.toChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import java.time.Instant
@@ -52,6 +53,7 @@ class ChatSuggestionsNativeReader @Inject constructor(
                     title = chat.title,
                     lastEdit = parseLastEdit(chat.lastEdit),
                     pinned = chat.pinned,
+                    type = chat.toChatType(),
                 )
             }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/reader/ChatSuggestionsNativeReader.kt
@@ -17,8 +17,10 @@
 package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader
 
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.feature.maxHistoryCount
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.impl.models.toChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -31,11 +33,13 @@ import javax.inject.Inject
 class ChatSuggestionsNativeReader @Inject constructor(
     private val store: DuckAiChatStore,
     private val feature: DuckAiChatHistoryFeature,
+    private val duckChatFeature: DuckChatFeature,
 ) : ChatSuggestionsReader {
 
     override suspend fun fetchSuggestions(query: String): List<ChatSuggestion> {
         val maxSuggestions = feature.maxHistoryCount()
         val recentCutoff = LocalDateTime.now().minusDays(RECENT_DAYS_CUTOFF).toLocalDate().atStartOfDay()
+        val typeIconEnabled = duckChatFeature.chatSuggestionTypeIcon().isEnabled()
 
         return store.getChats()
             .filter { chat ->
@@ -53,7 +57,7 @@ class ChatSuggestionsNativeReader @Inject constructor(
                     title = chat.title,
                     lastEdit = parseLastEdit(chat.lastEdit),
                     pinned = chat.pinned,
-                    type = chat.toChatType(),
+                    type = if (typeIconEnabled) chat.toChatType() else ChatType.Discussion,
                 )
             }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ChatType.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ChatType.kt
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.history
+package com.duckduckgo.duckchat.impl.models
+
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
 
 enum class ChatType {
     Discussion,
     ImageGeneration,
     Voice,
+}
+
+internal fun DuckAiChat.toChatType(): ChatType = when {
+    isImageGeneration -> ChatType.ImageGeneration
+    isVoice -> ChatType.Voice
+    else -> ChatType.Discussion
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ChatTypeIcon.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/ChatTypeIcon.kt
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.history
+package com.duckduckgo.duckchat.impl.models
 
-import com.duckduckgo.duckchat.impl.models.ChatType
+import androidx.annotation.DrawableRes
+import com.duckduckgo.duckchat.impl.R
 
-data class ChatHistoryItem(
-    val chatId: String,
-    val displayTitle: String,
-    val type: ChatType,
-    val pinned: Boolean,
-    val lastEditMillis: Long,
-)
+@DrawableRes
+internal fun ChatType.iconRes(pinned: Boolean): Int = when (this) {
+    ChatType.Discussion -> if (pinned) R.drawable.ic_chat_pin_24 else R.drawable.ic_chat_24
+    ChatType.ImageGeneration -> if (pinned) R.drawable.ic_images_pin_24 else R.drawable.ic_images_24
+    ChatType.Voice -> if (pinned) R.drawable.ic_voice_pin_24 else R.drawable.ic_voice_24
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -89,8 +89,8 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `observeChats derives ImageGeneration when model is image-generation`() = runTest {
-        source.value = listOf(chat(chatId = "abc", title = "Image", model = "image-generation"))
+    fun `observeChats derives ImageGeneration when isImageGeneration flag is true`() = runTest {
+        source.value = listOf(chat(chatId = "abc", title = "Image", isImageGeneration = true))
 
         repository.observeChats().test {
             assertEquals(ChatType.ImageGeneration, awaitItem().single().type)
@@ -98,8 +98,8 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `observeChats derives Voice when model is voice-mode`() = runTest {
-        source.value = listOf(chat(chatId = "abc", title = "Voice", model = "voice-mode"))
+    fun `observeChats derives Voice when isVoice flag is true`() = runTest {
+        source.value = listOf(chat(chatId = "abc", title = "Voice", isVoice = true))
 
         repository.observeChats().test {
             assertEquals(ChatType.Voice, awaitItem().single().type)
@@ -107,7 +107,16 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `observeChats derives Discussion fallback when model is unknown`() = runTest {
+    fun `observeChats prefers ImageGeneration over Voice when both flags are true`() = runTest {
+        source.value = listOf(chat(chatId = "abc", title = "Mixed", isImageGeneration = true, isVoice = true))
+
+        repository.observeChats().test {
+            assertEquals(ChatType.ImageGeneration, awaitItem().single().type)
+        }
+    }
+
+    @Test
+    fun `observeChats derives Discussion fallback when no classification flag is set`() = runTest {
         source.value = listOf(chat(chatId = "abc", title = "Just text", model = "gpt-5-mini"))
 
         repository.observeChats().test {
@@ -116,7 +125,7 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `observeChats derives Discussion fallback when model is empty`() = runTest {
+    fun `observeChats derives Discussion fallback when model is empty and no flags set`() = runTest {
         source.value = listOf(chat(chatId = "abc", title = "Just text", model = ""))
 
         repository.observeChats().test {
@@ -192,6 +201,8 @@ class ChatHistoryRepositoryTest {
         lastEdit: String = "2026-04-01T00:00:00.000Z",
         pinned: Boolean = false,
         fileRefs: List<String> = emptyList(),
+        isImageGeneration: Boolean = false,
+        isVoice: Boolean = false,
     ): DuckAiChat = DuckAiChat(
         chatId = chatId,
         title = title,
@@ -199,6 +210,8 @@ class ChatHistoryRepositoryTest {
         lastEdit = lastEdit,
         pinned = pinned,
         fileRefs = fileRefs,
+        isImageGeneration = isImageGeneration,
+        isVoice = isVoice,
     )
 
     private companion object {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.history.ChatHistoryUiState.Loaded
 import com.duckduckgo.duckchat.impl.messaging.fakes.FakeDuckChatInternal
+import com.duckduckgo.duckchat.impl.models.ChatType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsNativeReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsNativeReaderTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.ui.inputscreen.suggestions.reader
 
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsNativeReader
 import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
@@ -41,14 +42,18 @@ class ChatSuggestionsNativeReaderTest {
 
     private val store: DuckAiChatStore = mock()
     private val feature: DuckAiChatHistoryFeature = mock()
+    private val duckChatFeature: DuckChatFeature = mock()
     private val toggle: Toggle = mock()
+    private val typeIconToggle: Toggle = mock()
     private lateinit var reader: ChatSuggestionsNativeReader
 
     @Before
     fun setup() {
         whenever(feature.self()).thenReturn(toggle)
         whenever(toggle.getSettings()).thenReturn("""{"maxHistoryCount":5}""")
-        reader = ChatSuggestionsNativeReader(store, feature)
+        whenever(duckChatFeature.chatSuggestionTypeIcon()).thenReturn(typeIconToggle)
+        whenever(typeIconToggle.isEnabled()).thenReturn(true)
+        reader = ChatSuggestionsNativeReader(store, feature, duckChatFeature)
     }
 
     @Test
@@ -143,6 +148,15 @@ class ChatSuggestionsNativeReaderTest {
     @Test
     fun `fetchSuggestions defaults to ChatType_Discussion when no flag is set`() = runTest {
         val chat = chatWithLastEdit(Instant.now().minus(1, ChronoUnit.DAYS).toString())
+        whenever(store.getChats()).thenReturn(listOf(chat))
+
+        assertEquals(ChatType.Discussion, reader.fetchSuggestions(query = "").single().type)
+    }
+
+    @Test
+    fun `fetchSuggestions forces Discussion when chatSuggestionTypeIcon toggle is disabled`() = runTest {
+        whenever(typeIconToggle.isEnabled()).thenReturn(false)
+        val chat = chatWithLastEdit(Instant.now().minus(1, ChronoUnit.DAYS).toString(), isImageGeneration = true)
         whenever(store.getChats()).thenReturn(listOf(chat))
 
         assertEquals(ChatType.Discussion, reader.fetchSuggestions(query = "").single().type)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsNativeReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/reader/ChatSuggestionsNativeReaderTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.ui.inputscreen.suggestions.reader
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsNativeReader
+import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -123,16 +124,44 @@ class ChatSuggestionsNativeReaderTest {
         reader.tearDown() // should not throw
     }
 
+    @Test
+    fun `fetchSuggestions maps isImageGeneration flag to ChatType_ImageGeneration`() = runTest {
+        val chat = chatWithLastEdit(Instant.now().minus(1, ChronoUnit.DAYS).toString(), isImageGeneration = true)
+        whenever(store.getChats()).thenReturn(listOf(chat))
+
+        assertEquals(ChatType.ImageGeneration, reader.fetchSuggestions(query = "").single().type)
+    }
+
+    @Test
+    fun `fetchSuggestions maps isVoice flag to ChatType_Voice`() = runTest {
+        val chat = chatWithLastEdit(Instant.now().minus(1, ChronoUnit.DAYS).toString(), isVoice = true)
+        whenever(store.getChats()).thenReturn(listOf(chat))
+
+        assertEquals(ChatType.Voice, reader.fetchSuggestions(query = "").single().type)
+    }
+
+    @Test
+    fun `fetchSuggestions defaults to ChatType_Discussion when no flag is set`() = runTest {
+        val chat = chatWithLastEdit(Instant.now().minus(1, ChronoUnit.DAYS).toString())
+        whenever(store.getChats()).thenReturn(listOf(chat))
+
+        assertEquals(ChatType.Discussion, reader.fetchSuggestions(query = "").single().type)
+    }
+
     private fun chatWithLastEdit(
         lastEdit: String,
         chatId: String = "chat-1",
         title: String = "Test",
         pinned: Boolean = false,
+        isImageGeneration: Boolean = false,
+        isVoice: Boolean = false,
     ) = DuckAiChat(
         chatId = chatId,
         title = title,
         model = "gpt-5-mini",
         lastEdit = lastEdit,
         pinned = pinned,
+        isImageGeneration = isImageGeneration,
+        isVoice = isVoice,
     )
 }

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -34,8 +34,7 @@ import javax.inject.Inject
 
 /**
  * Stable metadata extracted from FE-owned chat JSON.
- * Only top-level fields that are unlikely to change are parsed here.
- * Message content is intentionally excluded — it is complex and FE-owned.
+ * The raw message tree is not exposed — consumers get precomputed classification flags instead.
  */
 data class DuckAiChat(
     val chatId: String,
@@ -48,6 +47,10 @@ data class DuckAiChat(
     val fileRefs: List<String> = emptyList(),
     /** Reasoning mode chosen for this chat, or `null` if the FE didn't record one. */
     val reasoningMode: String? = null,
+    /** True when any assistant message contains a `ui-component` part named `generate-image` (FE-owned rule). */
+    val isImageGeneration: Boolean = false,
+    /** True when [model] equals `voice-mode`. */
+    val isVoice: Boolean = false,
 )
 
 interface DuckAiChatStore {
@@ -175,10 +178,11 @@ class RealDuckAiChatStore @Inject constructor(
     private fun DuckAiBridgeChatEntity.toDuckAiChat(): DuckAiChat? = runCatching {
         val json = JSONObject(data)
         val chatId = json.optString("chatId").takeIf { it.isNotEmpty() } ?: return@runCatching null
+        val model = json.optString("model")
         DuckAiChat(
             chatId = chatId,
             title = json.optString("title").ifEmpty { "Untitled Chat" },
-            model = json.optString("model"),
+            model = model,
             lastEdit = json.optString("lastEdit"),
             pinned = json.optBoolean("pinned", false),
             fileRefs = json.optJSONArray("fileRefs")?.let { arr ->
@@ -189,6 +193,31 @@ class RealDuckAiChatStore @Inject constructor(
             } else {
                 json.optString("reasoningMode").takeIf { it.isNotEmpty() }
             },
+            isImageGeneration = json.hasGenerateImageUiComponent(),
+            isVoice = model == VOICE_MODEL,
         )
     }.getOrNull()
+
+    private fun JSONObject.hasGenerateImageUiComponent(): Boolean {
+        val messages = optJSONArray("messages") ?: return false
+        for (i in 0 until messages.length()) {
+            val message = messages.optJSONObject(i) ?: continue
+            if (message.optString("role") != ASSISTANT_ROLE) continue
+            val parts = message.optJSONArray("parts") ?: continue
+            for (j in 0 until parts.length()) {
+                val part = parts.optJSONObject(j) ?: continue
+                if (part.optString("type") == UI_COMPONENT_TYPE && part.optString("name") == GENERATE_IMAGE_NAME) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private companion object {
+        const val VOICE_MODEL = "voice-mode"
+        const val ASSISTANT_ROLE = "assistant"
+        const val UI_COMPONENT_TYPE = "ui-component"
+        const val GENERATE_IMAGE_NAME = "generate-image"
+    }
 }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -199,6 +199,150 @@ class RealDuckAiChatStoreTest {
         assertTrue(store.getChats().isEmpty())
     }
 
+    // --- derived classification flags ---
+
+    @Test
+    fun `getChats sets isImageGeneration when assistant message has generate-image ui-component part`() = runTest {
+        val json = """
+            {
+              "chatId": "abc",
+              "title": "Image",
+              "model": "gpt-5-mini",
+              "lastEdit": "2026-05-15T14:23:16.313Z",
+              "pinned": false,
+              "messages": [
+                { "role": "user", "content": "draw a cat" },
+                {
+                  "role": "assistant",
+                  "parts": [
+                    { "type": "ui-component", "name": "generate-image" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertTrue(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats does not set isImageGeneration when generate-image part is on a non-assistant message`() = runTest {
+        val json = """
+            {
+              "chatId": "abc",
+              "title": "x",
+              "model": "gpt-5-mini",
+              "lastEdit": "2026-05-15T14:23:16.313Z",
+              "pinned": false,
+              "messages": [
+                {
+                  "role": "user",
+                  "parts": [
+                    { "type": "ui-component", "name": "generate-image" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats does not set isImageGeneration for other ui-component names`() = runTest {
+        val json = """
+            {
+              "chatId": "abc",
+              "title": "x",
+              "model": "gpt-5-mini",
+              "lastEdit": "2026-05-15T14:23:16.313Z",
+              "pinned": false,
+              "messages": [
+                {
+                  "role": "assistant",
+                  "parts": [
+                    { "type": "ui-component", "name": "something-else" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats does not set isImageGeneration when part type is not ui-component`() = runTest {
+        val json = """
+            {
+              "chatId": "abc",
+              "title": "x",
+              "model": "gpt-5-mini",
+              "lastEdit": "2026-05-15T14:23:16.313Z",
+              "pinned": false,
+              "messages": [
+                {
+                  "role": "assistant",
+                  "parts": [
+                    { "type": "text", "name": "generate-image" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats defaults isImageGeneration to false when messages is missing`() = runTest {
+        val json = """{"chatId":"abc","title":"x","model":"gpt-5-mini","lastEdit":"2026-05-15T14:23:16.313Z","pinned":false}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats defaults isImageGeneration to false when parts is missing on assistant message`() = runTest {
+        val json = """
+            {
+              "chatId": "abc",
+              "title": "x",
+              "model": "gpt-5-mini",
+              "lastEdit": "2026-05-15T14:23:16.313Z",
+              "pinned": false,
+              "messages": [
+                { "role": "assistant", "content": "hi" }
+              ]
+            }
+        """.trimIndent()
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isImageGeneration)
+    }
+
+    @Test
+    fun `getChats sets isVoice when model is voice-mode`() = runTest {
+        val json = """{"chatId":"abc","title":"v","model":"voice-mode","lastEdit":"2026-05-15T14:23:16.313Z","pinned":false}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        val chat = store.getChats()[0]
+        assertTrue(chat.isVoice)
+        assertFalse(chat.isImageGeneration)
+    }
+
+    @Test
+    fun `getChats does not set isVoice for other models`() = runTest {
+        val json = """{"chatId":"abc","title":"x","model":"gpt-5-mini","lastEdit":"2026-05-15T14:23:16.313Z","pinned":false}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertFalse(store.getChats()[0].isVoice)
+    }
+
     @Test
     fun `getChatsFlow emits mapped business model on each DAO emission`() = runTest {
         val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"2026-04-01T21:31:54.260Z","pinned":true}"""


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212015278241917/task/1214918311210465?focus=true 

### Description

ImageGeneration chat detection moves from `DuckAiChat.model` to a structural rule on the chat message tree (assistant message whose `parts[]` carries a `ui-component` / `generate-image` entry). The resulting per-type leading icon (Discussion / ImageGeneration / Voice) now drives both the chat history screen and the omnibar chat-history suggestions; on suggestions it sits behind the new `chatSuggestionTypeIcon` toggle (default TRUE) so the propagation can be rolled back independently.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] `duckChat`: confirm `useNativeStorageChatData` is ON and `chatSuggestionTypeIcon` is ON.
> - [ ] In Duck.ai, create three chats: (a) a normal text discussion, (b) an image-generation chat (ask Duck.ai to draw something so the FE produces the `ui-component` / `generate-image` part), (c) a voice chat.

_Happy path — icons by chat type on both surfaces_

- [ ] Open the chat history screen from the browser menu → confirm each row's leading icon matches its chat type (chat bubble for text, picture for image-gen, mic for voice).
- [ ] Focus the omnibar so chat-history suggestions appear → confirm each suggestion row's leading icon matches the same chat type as the corresponding row on the chat history screen.

_Guards — pinned variants_

- [ ] Pin the image-generation chat from Duck.ai → re-open both surfaces → confirm both show the pinned ImageGeneration icon variant.

_Flag rollback (suggestions only)_

- [ ] In Developer Settings, flip `duckChat.chatSuggestionTypeIcon` to OFF.
- [ ] Trigger chat-history suggestions in the omnibar → confirm every row renders the Discussion icon (chat bubble), regardless of chat type.
- [ ] Open the chat history screen → confirm it still renders per-type icons (the flag does not affect the history screen).

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/02d1a0dc-efb0-4e27-988a-c0cc5f7954e0" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/8fd20b90-dc2e-4675-8c96-0a197b6baebb" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how chat type is derived by parsing FE-owned chat JSON (including iterating message parts) and uses that classification to drive UI rendering behind a new toggle for suggestions.
> 
> **Overview**
> **Chat type classification is refactored and surfaced in UI.** `DuckAiChat` now includes derived flags (`isImageGeneration`, `isVoice`), with image-generation detected by scanning assistant `messages[].parts[]` for a `ui-component` named `generate-image`, and `ChatType` mapping moved into `impl.models`.
> 
> **Per-type leading icons are now used consistently.** Chat history rows and omnibar chat-history suggestions render icons via a shared `ChatType.iconRes(pinned)` helper; suggestions additionally carry a `type` field and are gated by a new `duckChat.chatSuggestionTypeIcon` toggle (default `true`) that can force the legacy Discussion icon.
> 
> Tests are updated/added to validate the new classification rules and toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdde78cbfb4bf779681c5d6126f72e90bfe6970a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->