### PR TITLE
manually collapsing keyboard should unfocus the widget 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -260,9 +260,7 @@ class RealNativeInputManager @Inject constructor(
         val widget = widgetFrom(rootView) ?: return
         val widgetRoot = widgetRoot
 
-        if (omnibarController.isDuckAiMode()) {
-            widget.setToggleVisible(isVisible)
-        }
+        widget.setToggleVisible(isVisible)
 
         if (isVisible) {
             isPickingImage = false
@@ -283,6 +281,8 @@ class RealNativeInputManager @Inject constructor(
         if (isPickingImage) return
         if (omnibarController.isDuckAiMode()) {
             updateWidgetFocus(widget)
+        } else {
+            hideNativeInput()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1214157224317277/task/1214932000935441?focus=true

### Steps to test this PR
- open widget in browser.
- collapse keyboard manually.
- widget should also collapse.

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/3d6438c3-9c79-4865-8978-22c607b750f9" />|<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/8c299bcb-4a03-428c-9413-91d31b3a0d61" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior on keyboard hide to close the native input widget in non-DuckAI mode, which could affect focus/visibility flows across browsing and needs UI regression testing.
> 
> **Overview**
> When the keyboard is dismissed, `RealNativeInputManager` now consistently updates the widget toggle visibility and, in non-DuckAI mode, collapses the native input widget by calling `hideNativeInput()`.
> 
> In DuckAI mode, keyboard dismissal continues to adjust focus via `updateWidgetFocus` instead of collapsing the widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9775ec46f3941f81476768b8d8f102269d376e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->