### PR TITLE
Add reasoning effort access to the AI chat model

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -34,6 +34,7 @@ data class RemoteAIChatModel(
     @field:Json(name = "supportsImageUpload") val supportsImageUpload: Boolean = false,
     @field:Json(name = "supportedFileTypes") val supportedFileTypes: List<String>? = null,
     @field:Json(name = "supportedReasoningEffort") val supportedReasoningEffort: List<String>? = null,
+    @field:Json(name = "reasoningEffortAccess") val reasoningEffortAccess: List<RemoteReasoningEffortAccess>? = null,
     @field:Json(name = "supportedTools") val supportedTools: List<String>? = null,
 )
 
@@ -91,6 +92,12 @@ data class AIChatAttachmentUsage(
     val fileSizeBytesUsed: Long = 0L,
 )
 
+data class RemoteReasoningEffortAccess(
+    val id: String,
+    @field:Json(name = "accessTier") val accessTier: List<String>? = null,
+    @field:Json(name = "entityHasAccess") val entityHasAccess: Boolean = false,
+)
+
 data class AIChatModel(
     val id: String,
     val name: String,
@@ -103,6 +110,7 @@ data class AIChatModel(
     val supportedImageFormats: List<String> = emptyList(),
     val supportedFileTypes: List<String> = emptyList(),
     val supportedReasoningEfforts: List<ReasoningEffort> = emptyList(),
+    val reasoningEffortAccess: List<ReasoningEffortAccess> = emptyList(),
     val supportedTools: List<Tool> = emptyList(),
 ) {
     val supportsFileUpload: Boolean
@@ -110,15 +118,8 @@ data class AIChatModel(
 
     fun supportsTool(tool: Tool): Boolean = supportedTools.contains(tool)
 
-    /** The lowest [UserTier] required to access this model, or `null` if no public tier applies. */
     val requiredTier: UserTier?
-        get() = when {
-            accessTier.isEmpty() -> UserTier.FREE
-            accessTier.contains(UserTier.FREE.rawValue) -> UserTier.FREE
-            accessTier.contains(UserTier.PLUS.rawValue) -> UserTier.PLUS
-            accessTier.contains(UserTier.PRO.rawValue) -> UserTier.PRO
-            else -> null
-        }
+        get() = lowestRequiredTier(accessTier, isAccessible)
 
     companion object {
         val NATIVE_SUPPORTED_IMAGE_FORMATS = listOf("png", "jpeg", "webp")
@@ -134,6 +135,15 @@ enum class UserTier(val rawValue: String) {
     companion object {
         fun from(raw: String?): UserTier? = entries.firstOrNull { it.rawValue == raw }
     }
+}
+
+/** Lowest public [UserTier] in [accessTier]; falls back to FREE when the list is empty and [isAccessible], else `null`. */
+internal fun lowestRequiredTier(accessTier: List<String>, isAccessible: Boolean): UserTier? = when {
+    accessTier.contains(UserTier.FREE.rawValue) -> UserTier.FREE
+    accessTier.contains(UserTier.PLUS.rawValue) -> UserTier.PLUS
+    accessTier.contains(UserTier.PRO.rawValue) -> UserTier.PRO
+    accessTier.isEmpty() && isAccessible -> UserTier.FREE
+    else -> null
 }
 
 enum class ModelProvider {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -278,6 +278,12 @@ class RealDuckAiModelManager @Inject constructor(
             supportedImageFormats = if (remote.supportsImageUpload) AIChatModel.NATIVE_SUPPORTED_IMAGE_FORMATS else emptyList(),
             supportedFileTypes = remote.supportedFileTypes.orEmpty(),
             supportedReasoningEfforts = remote.supportedReasoningEffort.orEmpty().mapNotNull(ReasoningEffort::from),
+            reasoningEffortAccess = remote.reasoningEffortAccess.orEmpty().mapNotNull { entry ->
+                val effort = ReasoningEffort.from(entry.id) ?: return@mapNotNull null
+                val tiers = entry.accessTier.orEmpty()
+                val accessible = if (tiers.isEmpty()) entry.entityHasAccess else tiers.contains(userTier.rawValue)
+                ReasoningEffortAccess(effort = effort, accessTier = tiers, isAccessible = accessible)
+            },
             supportedTools = remote.supportedTools.orEmpty().mapNotNull(Tool::from),
         )
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
@@ -48,6 +48,15 @@ data class AvailableReasoningMode(
     val effort: ReasoningEffort,
 )
 
+data class ReasoningEffortAccess(
+    val effort: ReasoningEffort,
+    val accessTier: List<String>,
+    val isAccessible: Boolean,
+) {
+    val requiredTier: UserTier?
+        get() = lowestRequiredTier(accessTier, isAccessible)
+}
+
 object ReasoningResolver {
 
     fun availableModes(supported: List<ReasoningEffort>): List<AvailableReasoningMode> =

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelDecodingTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelDecodingTest.kt
@@ -55,4 +55,92 @@ class AIChatModelDecodingTest {
         val parsed = adapter.fromJson(json)!!
         assertEquals(listOf("low", "mystery", "high"), parsed.supportedReasoningEffort)
     }
+
+    @Test
+    fun whenReasoningEffortAccessMissingThenFieldIsNull() {
+        val json = """{"id":"m","name":"n"}"""
+        val parsed = adapter.fromJson(json)!!
+        assertNull(parsed.reasoningEffortAccess)
+    }
+
+    @Test
+    fun whenReasoningEffortAccessNullThenFieldIsNull() {
+        val json = """{"id":"m","name":"n","reasoningEffortAccess":null}"""
+        val parsed = adapter.fromJson(json)!!
+        assertNull(parsed.reasoningEffortAccess)
+    }
+
+    @Test
+    fun whenReasoningEffortAccessPopulatedThenFieldDecoded() {
+        val json = """
+            {
+              "id":"m",
+              "name":"n",
+              "reasoningEffortAccess":[
+                {"id":"low","accessTier":["free","plus","pro"],"entityHasAccess":true},
+                {"id":"medium","accessTier":["pro"],"entityHasAccess":false}
+              ]
+            }
+        """.trimIndent()
+        val parsed = adapter.fromJson(json)!!
+        assertEquals(
+            listOf(
+                RemoteReasoningEffortAccess(id = "low", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                RemoteReasoningEffortAccess(id = "medium", accessTier = listOf("pro"), entityHasAccess = false),
+            ),
+            parsed.reasoningEffortAccess,
+        )
+    }
+
+    @Test
+    fun whenReasoningEffortAccessContainsUnknownIdThenStillDecodesAsRawString() {
+        val json = """
+            {
+              "id":"m",
+              "name":"n",
+              "reasoningEffortAccess":[
+                {"id":"very_high","accessTier":["pro"],"entityHasAccess":false}
+              ]
+            }
+        """.trimIndent()
+        val parsed = adapter.fromJson(json)!!
+        assertEquals(
+            listOf(RemoteReasoningEffortAccess(id = "very_high", accessTier = listOf("pro"), entityHasAccess = false)),
+            parsed.reasoningEffortAccess,
+        )
+    }
+
+    @Test
+    fun whenReasoningEffortAccessEntryOmitsAccessTierThenFieldIsNull() {
+        val json = """
+            {
+              "id":"m",
+              "name":"n",
+              "reasoningEffortAccess":[{"id":"low","entityHasAccess":true}]
+            }
+        """.trimIndent()
+        val parsed = adapter.fromJson(json)!!
+        val entry = parsed.reasoningEffortAccess!!.single()
+        assertEquals("low", entry.id)
+        assertNull(entry.accessTier)
+        assertEquals(true, entry.entityHasAccess)
+    }
+
+    @Test
+    fun whenReasoningEffortAccessEntryHasUnknownFieldsThenIgnoredAndKnownFieldsDecoded() {
+        val json = """
+            {
+              "id":"m",
+              "name":"n",
+              "reasoningEffortAccess":[
+                {"id":"low","accessTier":["free"],"entityHasAccess":true,"futureField":"ignoreMe"}
+              ]
+            }
+        """.trimIndent()
+        val parsed = adapter.fromJson(json)!!
+        assertEquals(
+            listOf(RemoteReasoningEffortAccess(id = "low", accessTier = listOf("free"), entityHasAccess = true)),
+            parsed.reasoningEffortAccess,
+        )
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/AIChatModelTest.kt
@@ -22,66 +22,85 @@ import org.junit.Test
 
 class AIChatModelTest {
 
+    // ---- requiredTier wrapper smoke tests ----
+    // Confirm AIChatModel.requiredTier forwards both fields to lowestRequiredTier.
+    // Branch coverage for the resolution logic itself lives in the lowestRequiredTier tests below.
+
     @Test
-    fun whenAccessTierIsEmptyThenRequiredTierIsFree() {
-        assertEquals(UserTier.FREE, model(accessTier = emptyList()).requiredTier)
+    fun requiredTierForwardsAccessTierToHelper() {
+        assertEquals(UserTier.PLUS, model(accessTier = listOf("plus"), isAccessible = false).requiredTier)
     }
 
     @Test
-    fun whenAccessTierContainsOnlyFreeThenRequiredTierIsFree() {
-        assertEquals(UserTier.FREE, model(accessTier = listOf("free")).requiredTier)
+    fun requiredTierForwardsIsAccessibleToHelper() {
+        assertEquals(UserTier.FREE, model(accessTier = emptyList(), isAccessible = true).requiredTier)
+    }
+
+    // ---- lowestRequiredTier helper ----
+
+    @Test
+    fun whenAccessTierIsEmptyAndNotAccessibleThenLowestRequiredTierIsNull() {
+        assertNull(lowestRequiredTier(accessTier = emptyList(), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsOnlyPlusThenRequiredTierIsPlus() {
-        assertEquals(UserTier.PLUS, model(accessTier = listOf("plus")).requiredTier)
+    fun whenAccessTierIsEmptyAndAccessibleThenLowestRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, lowestRequiredTier(accessTier = emptyList(), isAccessible = true))
     }
 
     @Test
-    fun whenAccessTierContainsOnlyProThenRequiredTierIsPro() {
-        assertEquals(UserTier.PRO, model(accessTier = listOf("pro")).requiredTier)
+    fun whenAccessTierContainsOnlyFreeThenLowestRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, lowestRequiredTier(accessTier = listOf("free"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsFreeAndPlusThenRequiredTierIsFree() {
-        // FREE has priority over PLUS in the lookup.
-        assertEquals(UserTier.FREE, model(accessTier = listOf("plus", "free")).requiredTier)
+    fun whenAccessTierContainsOnlyPlusThenLowestRequiredTierIsPlus() {
+        assertEquals(UserTier.PLUS, lowestRequiredTier(accessTier = listOf("plus"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsPlusAndProThenRequiredTierIsPlus() {
-        // PLUS has priority over PRO in the lookup.
-        assertEquals(UserTier.PLUS, model(accessTier = listOf("pro", "plus")).requiredTier)
+    fun whenAccessTierContainsOnlyProThenLowestRequiredTierIsPro() {
+        assertEquals(UserTier.PRO, lowestRequiredTier(accessTier = listOf("pro"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsFreePlusProThenRequiredTierIsFree() {
-        assertEquals(UserTier.FREE, model(accessTier = listOf("pro", "plus", "free")).requiredTier)
+    fun whenAccessTierContainsFreeAndPlusThenLowestRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, lowestRequiredTier(accessTier = listOf("plus", "free"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsOnlyNonPublicTierThenRequiredTierIsNull() {
-        assertNull(model(accessTier = listOf("internal")).requiredTier)
+    fun whenAccessTierContainsPlusAndProThenLowestRequiredTierIsPlus() {
+        assertEquals(UserTier.PLUS, lowestRequiredTier(accessTier = listOf("pro", "plus"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierContainsMultipleNonPublicTiersThenRequiredTierIsNull() {
-        assertNull(model(accessTier = listOf("internal", "enterprise")).requiredTier)
+    fun whenAccessTierContainsFreePlusProThenLowestRequiredTierIsFree() {
+        assertEquals(UserTier.FREE, lowestRequiredTier(accessTier = listOf("pro", "plus", "free"), isAccessible = false))
     }
 
     @Test
-    fun whenAccessTierMixesPublicAndNonPublicTiersThenRequiredTierIsTheLowestPublic() {
-        assertEquals(UserTier.PLUS, model(accessTier = listOf("internal", "plus")).requiredTier)
-        assertEquals(UserTier.PRO, model(accessTier = listOf("internal", "pro")).requiredTier)
-        assertEquals(UserTier.FREE, model(accessTier = listOf("internal", "free")).requiredTier)
+    fun whenAccessTierContainsOnlyNonPublicTierThenLowestRequiredTierIsNull() {
+        assertNull(lowestRequiredTier(accessTier = listOf("internal"), isAccessible = false))
     }
 
-    private fun model(accessTier: List<String>) = AIChatModel(
+    @Test
+    fun whenAccessTierContainsMultipleNonPublicTiersThenLowestRequiredTierIsNull() {
+        assertNull(lowestRequiredTier(accessTier = listOf("internal", "enterprise"), isAccessible = false))
+    }
+
+    @Test
+    fun whenAccessTierMixesPublicAndNonPublicTiersThenLowestRequiredTierIsTheLowestPublic() {
+        assertEquals(UserTier.PLUS, lowestRequiredTier(accessTier = listOf("internal", "plus"), isAccessible = false))
+        assertEquals(UserTier.PRO, lowestRequiredTier(accessTier = listOf("internal", "pro"), isAccessible = false))
+        assertEquals(UserTier.FREE, lowestRequiredTier(accessTier = listOf("internal", "free"), isAccessible = false))
+    }
+
+    private fun model(accessTier: List<String>, isAccessible: Boolean) = AIChatModel(
         id = "id",
         name = "name",
         displayName = "name",
         shortName = "name",
         accessTier = accessTier,
-        isAccessible = false,
+        isAccessible = isAccessible,
     )
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -689,6 +689,7 @@ class RealDuckAiModelManagerTest {
         supportsImageUpload: Boolean = false,
         supportedFileTypes: List<String>? = null,
         supportedReasoningEffort: List<String>? = null,
+        reasoningEffortAccess: List<RemoteReasoningEffortAccess>? = null,
     ) = RemoteAIChatModel(
         id = id,
         name = id,
@@ -700,6 +701,7 @@ class RealDuckAiModelManagerTest {
         supportsImageUpload = supportsImageUpload,
         supportedFileTypes = supportedFileTypes,
         supportedReasoningEffort = supportedReasoningEffort,
+        reasoningEffortAccess = reasoningEffortAccess,
     )
 
     @Test
@@ -724,6 +726,110 @@ class RealDuckAiModelManagerTest {
 
         val resolved = testee.modelState.value.models.single()
         assertEquals(listOf(ReasoningEffort.LOW, ReasoningEffort.HIGH), resolved.supportedReasoningEfforts)
+    }
+
+    @Test
+    fun whenRemoteReasoningEffortAccessMissingThenDomainListIsEmpty() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(remoteModel("id", reasoningEffortAccess = null)),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertEquals(emptyList<ReasoningEffortAccess>(), testee.modelState.value.models.single().reasoningEffortAccess)
+    }
+
+    @Test
+    fun whenRemoteReasoningEffortAccessHasUnknownIdThenUnknownDropped() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "id",
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "low", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                            RemoteReasoningEffortAccess(id = "very_high", accessTier = listOf("pro"), entityHasAccess = false),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val efforts = testee.modelState.value.models.single().reasoningEffortAccess.map { it.effort }
+        assertEquals(listOf(ReasoningEffort.LOW), efforts)
+    }
+
+    @Test
+    fun whenRemoteReasoningEffortAccessResolvedAgainstPlusUserThenAccessibilityFollowsAccessTier() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "id",
+                        accessTier = listOf("free", "plus", "pro"),
+                        entityHasAccess = true,
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "low", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                            RemoteReasoningEffortAccess(id = "medium", accessTier = listOf("pro"), entityHasAccess = false),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val access = testee.modelState.value.models.single().reasoningEffortAccess
+        assertEquals(
+            listOf(
+                ReasoningEffortAccess(effort = ReasoningEffort.LOW, accessTier = listOf("free", "plus", "pro"), isAccessible = true),
+                ReasoningEffortAccess(effort = ReasoningEffort.MEDIUM, accessTier = listOf("pro"), isAccessible = false),
+            ),
+            access,
+        )
+    }
+
+    @Test
+    fun whenModelInaccessibleButEffortAccessTierIncludesUserThenEffortIsAccessibleNotClampedByModel() = runTest {
+        // Locks in Option A: per-effort isAccessible is resolved independently of model.isAccessible.
+        // The "model takes precedence" rule lives at tap-handling time, not in the data layer.
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "id",
+                        accessTier = listOf("plus", "pro"),
+                        entityHasAccess = false,
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "low", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val resolved = testee.modelState.value.models.single()
+        assertEquals(false, resolved.isAccessible)
+        assertEquals(true, resolved.reasoningEffortAccess.single().isAccessible)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningEffortAccessTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningEffortAccessTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReasoningEffortAccessTest {
+
+    @Test
+    fun requiredTierForwardsAccessTierToHelper() {
+        assertEquals(UserTier.PLUS, entry(accessTier = listOf("plus"), isAccessible = false).requiredTier)
+    }
+
+    @Test
+    fun requiredTierForwardsIsAccessibleToHelper() {
+        assertEquals(UserTier.FREE, entry(accessTier = emptyList(), isAccessible = true).requiredTier)
+    }
+
+    private fun entry(accessTier: List<String>, isAccessible: Boolean) = ReasoningEffortAccess(
+        effort = ReasoningEffort.LOW,
+        accessTier = accessTier,
+        isAccessible = isAccessible,
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214834451409694?focus=true 

### Description

**Part 1 of 2 - Schema support for per-reasoning-effort access metadata.**

The `/duckchat/v1/models` endpoint is being extended with a new optional `reasoningEffortAccess` array per model, carrying per-effort `accessTier` + `entityHasAccess` so clients can determine which subscription tier(s) can access each individual reasoning effort within a model.

This PR adds parsing and domain-model support for the new field. It does **not** wire up any UI or upsell behaviour yet - that lands in Part 2.

**What changed:**

- New optional `reasoningEffortAccess` field on `RemoteAIChatModel`. Each entry decodes the API shape as raw strings
- New domain type `ReasoningEffortAccess(effort, accessTier, isAccessible)` exposed on `AIChatModel.reasoningEffortAccess`, with a derived `requiredTier` mirroring the model-level helper.
- Mapping in `DuckAiModelManager.resolveModel` drops entries whose `id` doesn't match a known `ReasoningEffort`, and resolves `isAccessible` against the locally-resolved user tier using the same rule the model-level mapping uses (consistent with the existing model behavior).
- Cleanup applied to both `AIChatModel.requiredTier` and `ReasoningEffortAccess.requiredTier`: when `accessTier` is empty, the getter now uses `isAccessible` as a tiebreaker (`FREE` if accessible, `null` if not), this ensures alignment in behaviour between iOS and Android. Shared internal helper `lowestRequiredTier(accessTier, isAccessible)` so the resolution logic lives in one place

**Forward-compatibility:**

- `reasoningEffortAccess` is optional: missing field → empty domain list → consumers preserve today's behaviour (efforts inherit model-level access).
- Unknown effort ids are dropped at mapping time, not propagated.
- Unknown fields inside each entry are ignored by Moshi.

**Part 2 (next PR)** will wire the upsell trigger: tapping a gated reasoning effort routes the user into the existing `SubscriptionPurchase` / `SubscriptionUpgrade` flows, mirroring the model-level upsell already shipped on `feature/youssef/upsell_ai_model`.

### Steps to test this PR

_No UI changes in this PR - it's data-layer only._

- [ ] Duck.ai model picker still loads models and the reasoning mode dropdown still works (no regression)
- [ ] Upsell flow still triggers when selected a pro model using a free user

### UI changes

_N/A — no UI changes in Part 1._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes tier/access resolution logic (including a new `isAccessible`/empty-tier fallback) and adds new model-mapping behavior that downstream gating/upsell flows will rely on.
> 
> **Overview**
> Adds schema + domain support for an optional `reasoningEffortAccess` list on models, exposing per-effort tier requirements and accessibility via new `RemoteReasoningEffortAccess`, `ReasoningEffortAccess`, and `AIChatModel.reasoningEffortAccess`.
> 
> Updates `RealDuckAiModelManager.resolveModel` to map the new field, drop unknown effort IDs, and compute per-effort `isAccessible` based on resolved user tier (with `entityHasAccess` used when no tiers are provided).
> 
> Refactors tier resolution into shared `lowestRequiredTier(accessTier, isAccessible)` and changes the empty-`accessTier` behavior to return `FREE` *only when accessible* (otherwise `null`), with expanded unit coverage for JSON decoding and mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578759065c181ea8cff4fbaa56f67b1d6b7245b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->