### PR TITLE
Fallback to automatic render mode for trackers animation when software-rendering isn't mandated

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationManager.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
@@ -39,10 +40,10 @@ interface AddressBarTrackersAnimationManager {
     suspend fun isFeatureEnabled(): Boolean
 
     /**
-     * Returns the cached software rendering mode state if available, otherwise fetches and caches it.
-     * @return true if the shield animation should use Lottie's SOFTWARE render mode, false otherwise
+     * Observes the software rendering mode kill-switch.
+     * If the emitted value is true, the shield animation should use Lottie's SOFTWARE render mode; otherwise the default.
      */
-    suspend fun isSoftwareRenderingModeEnabled(): Boolean
+    val softwareRenderingModeEnabled: Flow<Boolean>
 
     /**
      * Determines if the tracker animation should be shown based on the current URL
@@ -66,24 +67,19 @@ class RealAddressBarTrackersAnimationManager @Inject constructor(
 ) : AddressBarTrackersAnimationManager {
 
     private var cachedFeatureState: Boolean? = null
-    private var cachedSoftwareRenderingMode: Boolean? = null
+
+    override val softwareRenderingModeEnabled: Flow<Boolean> =
+        addressBarTrackersAnimationFeatureToggle.softwareRenderingMode().enabled()
 
     override suspend fun fetchFeatureState() {
         withContext(dispatcherProvider.io()) {
             cachedFeatureState = addressBarTrackersAnimationFeatureToggle.feature().isEnabled()
-            cachedSoftwareRenderingMode = addressBarTrackersAnimationFeatureToggle.softwareRenderingMode().isEnabled()
         }
     }
 
     override suspend fun isFeatureEnabled(): Boolean = withContext(dispatcherProvider.io()) {
         cachedFeatureState ?: addressBarTrackersAnimationFeatureToggle.feature().isEnabled().also {
             cachedFeatureState = it
-        }
-    }
-
-    override suspend fun isSoftwareRenderingModeEnabled(): Boolean = withContext(dispatcherProvider.io()) {
-        cachedSoftwareRenderingMode ?: addressBarTrackersAnimationFeatureToggle.softwareRenderingMode().isEnabled().also {
-            cachedSoftwareRenderingMode = it
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -141,7 +141,7 @@ class OmnibarLayoutViewModel @Inject constructor(
             _viewState,
             tabRepository.flowTabs,
             flow { emit(addressBarTrackersAnimationManager.isFeatureEnabled()) },
-            flow { emit(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()) },
+            addressBarTrackersAnimationManager.softwareRenderingModeEnabled,
             browserMenuHighlight.shouldShowHighlightForMode(mode),
         ) { state, tabs, isAddressBarTrackersAnimationEnabled, useSoftwareRenderingMode, showHighlight ->
             state.copy(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
@@ -82,8 +82,10 @@ class AddressBarTrackersAnimator @Inject constructor(
         this.onAnimationComplete = onAnimationComplete
         this.customBackgroundColor = customBackgroundColor
 
-        if (useSoftwareRenderingMode) {
-            addressBarTrackersBlockedAnimationShieldIcon.renderMode = RenderMode.SOFTWARE
+        addressBarTrackersBlockedAnimationShieldIcon.renderMode = if (useSoftwareRenderingMode) {
+            RenderMode.SOFTWARE
+        } else {
+            RenderMode.AUTOMATIC
         }
         addressBarTrackersBlockedAnimationShieldIcon.show()
         addressBarTrackersBlockedAnimationShieldIcon.progress = 0F

--- a/app/src/test/java/com/duckduckgo/app/browser/animations/RealAddressBarTrackersAnimationManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/animations/RealAddressBarTrackersAnimationManagerTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.animations
 
 import android.annotation.SuppressLint
+import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
@@ -107,45 +108,37 @@ class RealAddressBarTrackersAnimationManagerTest {
     }
 
     @Test
-    fun whenSoftwareRenderingModeEnabledThenIsSoftwareRenderingModeEnabledReturnsTrue() = runTest {
+    fun whenSoftwareRenderingModeEnabledThenFlowEmitsTrue() = runTest {
         fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
 
-        val result = testee.isSoftwareRenderingModeEnabled()
-
-        assertTrue(result)
+        testee.softwareRenderingModeEnabled.test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
-    fun whenSoftwareRenderingModeDisabledThenIsSoftwareRenderingModeEnabledReturnsFalse() = runTest {
+    fun whenSoftwareRenderingModeDisabledThenFlowEmitsFalse() = runTest {
         fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
 
-        val result = testee.isSoftwareRenderingModeEnabled()
-
-        assertFalse(result)
+        testee.softwareRenderingModeEnabled.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
-    fun whenFetchFeatureStateCalledThenCachesSoftwareRenderingModeState() = runTest {
+    fun whenSoftwareRenderingModeChangesThenFlowEmitsNewValue() = runTest {
         fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
 
-        testee.fetchFeatureState()
+        testee.softwareRenderingModeEnabled.test {
+            assertTrue(awaitItem())
 
-        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
+            fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
+            assertFalse(awaitItem())
 
-        val result = testee.isSoftwareRenderingModeEnabled()
-        assertTrue(result)
-    }
-
-    @Test
-    fun whenIsSoftwareRenderingModeEnabledCalledMultipleTimesThenUseCachedValue() = runTest {
-        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = true))
-
-        assertTrue(testee.isSoftwareRenderingModeEnabled())
-
-        fakeFeatureToggle.softwareRenderingMode().setRawStoredState(State(enable = false))
-
-        assertTrue(testee.isSoftwareRenderingModeEnabled())
-        assertTrue(testee.isSoftwareRenderingModeEnabled())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -116,7 +116,10 @@ class OmnibarLayoutViewModelTest {
     private val favouriteLogoFlow = MutableStateFlow<String?>(null)
     private val setFavouriteFeatureEnabledFlow = MutableStateFlow(false)
 
-    private val addressBarTrackersAnimationManager: AddressBarTrackersAnimationManager = mock()
+    private val softwareRenderingModeEnabledFlow = MutableStateFlow(false)
+    private val addressBarTrackersAnimationManager: AddressBarTrackersAnimationManager = mock {
+        on { softwareRenderingModeEnabled } doReturn softwareRenderingModeEnabledFlow
+    }
     private val fakeProgressBarUpgradeFeature = FakeFeatureToggleFactory.create(ProgressBarUpgradeFeature::class.java)
 
     private lateinit var fakeStandardizedLeadingIconToggle: StandardizedLeadingIconFeatureToggle
@@ -147,7 +150,6 @@ class OmnibarLayoutViewModelTest {
         whenever(serpEasterEggLogosToggles.setFavourite().enabled()).thenReturn(setFavouriteFeatureEnabledFlow)
         runBlocking {
             whenever(addressBarTrackersAnimationManager.isFeatureEnabled()).thenReturn(false)
-            whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(false)
         }
 
         fakeStandardizedLeadingIconToggle = FeatureToggles.Builder(
@@ -1188,7 +1190,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenSoftwareRenderingModeEnabledThenStartTrackersAnimationCommandForwardsFlag() = runTest {
-        whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(true)
+        softwareRenderingModeEnabledFlow.value = true
         initializeViewModel()
 
         testee.viewState.test {
@@ -1209,7 +1211,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenSoftwareRenderingModeDisabledThenStartTrackersAnimationCommandForwardsFlag() = runTest {
-        whenever(addressBarTrackersAnimationManager.isSoftwareRenderingModeEnabled()).thenReturn(false)
+        softwareRenderingModeEnabledFlow.value = false
         initializeViewModel()
 
         testee.viewState.test {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214963910617164?focus=true

### Description
Follow up to https://github.com/duckduckgo/Android/pull/8595 to set renderer mode back to `automatic` if the FF to force software rendering is disabled.

### Steps to test this PR

> [!NOTE]
> Logcat filter: `Shield animation render mode requested`

- [x] Apply patch (adds logging and allows FF to be configured)
- [x] Fresh install `internal` build
- [x] Visit cnn.com, verify the shield animation plays ok. Verify `software` renderer is used (in logcat)
- [x] Open FF inventory and **disable** `softwareRenderingMode`
- [x] Visit klook.com and verify shield animation plays ok. Verify `automatic` renderer is used (in logcat)

### Patch
```
Index: app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt b/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt	(revision Staged)
+++ b/app/src/main/java/com/duckduckgo/app/browser/animations/AddressBarTrackersAnimationFeatureToggle.kt	(date 1779271322717)
@@ -34,7 +34,6 @@
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun feature(): Toggle
 
-    @Toggle.InternalAlwaysEnabled
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun softwareRenderingMode(): Toggle
 }
Index: app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt	(revision Staged)
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/AddressBarTrackersAnimator.kt	(date 1779271494568)
@@ -39,6 +39,7 @@
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import logcat.logcat
 import javax.inject.Inject
 
 class AddressBarTrackersAnimator @Inject constructor(
@@ -83,9 +84,9 @@
         this.customBackgroundColor = customBackgroundColor
 
         addressBarTrackersBlockedAnimationShieldIcon.renderMode = if (useSoftwareRenderingMode) {
-            RenderMode.SOFTWARE
+            RenderMode.SOFTWARE.also { logcat { "Shield animation render mode requested: software" } }
         } else {
-            RenderMode.AUTOMATIC
+            RenderMode.AUTOMATIC.also { logcat { "Shield animation render mode requested: automatic" } }
         }
         addressBarTrackersBlockedAnimationShieldIcon.show()
         addressBarTrackersBlockedAnimationShieldIcon.progress = 0F
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the software-rendering kill-switch from a cached suspend check to a live `Flow`, which can affect when/if UI updates and animation commands pick up toggle changes at runtime. Rendering mode switching in the trackers animation is user-visible but localized to the omnibar animation path.
> 
> **Overview**
> Ensures the trackers shield animation **falls back to Lottie `RenderMode.AUTOMATIC`** whenever the software-rendering kill-switch is disabled, instead of leaving the view in software mode.
> 
> Refactors the software-rendering kill-switch API from `isSoftwareRenderingModeEnabled()` to a `softwareRenderingModeEnabled: Flow<Boolean>` and wires `OmnibarLayoutViewModel` to observe it so toggle changes propagate without manual refetching. Unit tests are updated to validate flow emissions and runtime toggle changes, and viewmodel tests now drive the flag via a `MutableStateFlow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74f5a89435b198d4525e44ebb5719a842611ed9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->