### PR TITLE
[Android] Crash android.os.BadParcelableException in com.duckduckgo.app.notification.NotificationLaunchModalReporter.onActivityCreated

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.customtabs.CustomTabActivity
 import com.duckduckgo.app.browser.mode.ExternalUrl
 import com.duckduckgo.app.browser.mode.InAppNavigation
 import com.duckduckgo.app.dispatchers.IntentDispatcherViewModel.ViewState
+import com.duckduckgo.app.global.sanitize
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -44,6 +45,9 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
     lateinit var globalActivityStarter: GlobalActivityStarter
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Sanitize before super.onCreate so lifecycle callbacks dispatched from there don't trip over
+        // Parcelable extras whose classes are absent from our classpath.
+        intent?.sanitize()
         super.onCreate(savedInstanceState)
 
         logcat { "onCreate called with intent $intent" }

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationLaunchModalReporter.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationLaunchModalReporter.kt
@@ -23,6 +23,9 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.modalcoordinator.api.ModalShownReporter
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import logcat.LogPriority.ERROR
+import logcat.asLog
+import logcat.logcat
 import javax.inject.Inject
 
 @ContributesMultibinding(
@@ -38,7 +41,19 @@ class NotificationLaunchModalReporter @Inject constructor(
         activity: Activity,
         savedInstanceState: Bundle?,
     ) {
-        if (activity.intent?.getBooleanExtra(EXTRA_LAUNCHED_FROM_NOTIFICATION, false) == true && savedInstanceState == null) {
+        if (savedInstanceState != null) return
+
+        // This callback runs for every activity in the process, including ones launched from external apps
+        // (e.g. IntentDispatcherActivity receiving a share intent). Reading any extra triggers full Bundle
+        // unparcelling, which throws when the foreign intent carries a Parcelable whose class is absent
+        // from our classpath, so we guard the read here even though our own notification intents are safe.
+        val launchedFromNotification = try {
+            activity.intent?.getBooleanExtra(EXTRA_LAUNCHED_FROM_NOTIFICATION, false) == true
+        } catch (e: RuntimeException) {
+            logcat(ERROR) { "Failed to read launched-from-notification extra: ${e.asLog()}" }
+            false
+        }
+        if (launchedFromNotification) {
             modalShownReporter.reportModalShown()
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/notification/NotificationLaunchModalReporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/notification/NotificationLaunchModalReporterTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.notification
+
+import android.app.Activity
+import android.content.Intent
+import android.os.BadParcelableException
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.modalcoordinator.api.ModalShownReporter
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class NotificationLaunchModalReporterTest {
+
+    private val modalShownReporter: ModalShownReporter = mock()
+    private val activity: Activity = mock()
+    private val intent: Intent = mock()
+
+    private lateinit var reporter: NotificationLaunchModalReporter
+
+    @Before
+    fun setUp() {
+        whenever(activity.intent).thenReturn(intent)
+        reporter = NotificationLaunchModalReporter(modalShownReporter)
+    }
+
+    @Test
+    fun whenLaunchedFromNotificationAndNoSavedInstanceStateThenReportsModalShown() {
+        whenever(intent.getBooleanExtra(eq(EXTRA_LAUNCHED_FROM_NOTIFICATION), any())).thenReturn(true)
+
+        reporter.onActivityCreated(activity, savedInstanceState = null)
+
+        verify(modalShownReporter).reportModalShown()
+    }
+
+    @Test
+    fun whenLaunchedFromNotificationButHasSavedInstanceStateThenDoesNotReport() {
+        whenever(intent.getBooleanExtra(eq(EXTRA_LAUNCHED_FROM_NOTIFICATION), any())).thenReturn(true)
+
+        reporter.onActivityCreated(activity, savedInstanceState = mock())
+
+        verify(modalShownReporter, never()).reportModalShown()
+    }
+
+    @Test
+    fun whenNotLaunchedFromNotificationThenDoesNotReport() {
+        whenever(intent.getBooleanExtra(eq(EXTRA_LAUNCHED_FROM_NOTIFICATION), any())).thenReturn(false)
+
+        reporter.onActivityCreated(activity, savedInstanceState = null)
+
+        verify(modalShownReporter, never()).reportModalShown()
+    }
+
+    @Test
+    fun whenActivityIntentIsNullThenDoesNotReport() {
+        whenever(activity.intent).thenReturn(null)
+
+        reporter.onActivityCreated(activity, savedInstanceState = null)
+
+        verify(modalShownReporter, never()).reportModalShown()
+    }
+
+    @Test
+    fun whenIntentExtrasThrowBadParcelableExceptionThenDoesNotCrashAndDoesNotReport() {
+        whenever(intent.getBooleanExtra(eq(EXTRA_LAUNCHED_FROM_NOTIFICATION), any()))
+            .thenThrow(BadParcelableException("ClassNotFoundException when unmarshalling: zxh"))
+
+        reporter.onActivityCreated(activity, savedInstanceState = null)
+
+        verify(modalShownReporter, never()).reportModalShown()
+    }
+
+    @Test
+    fun whenIntentExtrasThrowRuntimeExceptionThenDoesNotCrashAndDoesNotReport() {
+        whenever(intent.getBooleanExtra(eq(EXTRA_LAUNCHED_FROM_NOTIFICATION), any()))
+            .thenThrow(RuntimeException("Parcel deserialization failed"))
+
+        reporter.onActivityCreated(activity, savedInstanceState = null)
+
+        verify(modalShownReporter, never()).reportModalShown()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214965912649712?focus=true

### Description

Wrap the getBooleanExtra read in NotificationLaunchModalReporter.onActivityCreated with a try/catch and add an early return when savedInstanceState != null. Also call intent?.sanitize() at the top of IntentDispatcherActivity.onCreate (before super.onCreate) for defense in depth.

The reporter is registered as a process-wide Application.ActivityLifecycleCallbacks, so it fires for every activity — including IntentDispatcherActivity, which receives intents from external apps. Reading any extra triggers full Bundle unparcelling, which throws BadParcelableException when the foreign intent carries a Parcelable whose class is absent from our classpath (e.g. an obfuscated zxh class from the sender). That crashed activity creation and brought the app down on launch.

### Steps to test this PR

- [x] Check out the branch and install
- [x] Run the new unit tests:

./gradlew :app:testPlayDebugUnitTest --tests "com.duckduckgo.app.notification.NotificationLaunchModalReporterTest"

All 6 cases should pass, including the two that simulate BadParcelableException / RuntimeException on extras read.

- [x] (Optional) Reproduce the original crash on develop first to confirm the fix:

adb shell am start -n com.duckduckgo.mobile.android.debug/com.duckduckgo.app.dispatchers.IntentDispatcherActivity -a android.intent.action.VIEW -d "https://duckduckgo.com" --es "junk_key" "junk" --ez  com.duckduckgo.notification.launched_from_notification" false

- [x] Confirm you don't see the crash on the branch using the same command as above

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-wide activity lifecycle callbacks and intent handling; while behavior is guarded and covered by tests, it changes how intents with malformed/foreign parcelables are handled at app launch.
> 
> **Overview**
> Prevents app crashes caused by unparcelling foreign `Intent` extras in `NotificationLaunchModalReporter` by skipping work on recreation (`savedInstanceState != null`), wrapping the `getBooleanExtra` read in `try/catch`, and logging failures instead of crashing.
> 
> Adds defense-in-depth by calling `intent?.sanitize()` at the start of `IntentDispatcherActivity.onCreate` (before `super.onCreate`) to clear problematic extras early. Includes new unit tests covering normal notification launches and exception scenarios (e.g., `BadParcelableException`/`RuntimeException`) to ensure the reporter never crashes or misreports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5097d15b15a2fb5e1c3625129d9620aedf8330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->