### PR TITLE
Smooth widget transitions

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -309,9 +309,15 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val materialCard = card as? MaterialCardView
         val savedRadius = materialCard?.radius ?: 0f
         val savedMaxElevation = materialCard?.maxCardElevation ?: 0f
-        materialCard?.apply { radius = widgetCornerRadius; maxCardElevation = savedMaxElevation }
+        materialCard?.apply {
+            radius = widgetCornerRadius
+            maxCardElevation = savedMaxElevation
+        }
         val fullHeight = measureUnconstrainedHeight(card, fullWidth)
-        materialCard?.apply { radius = savedRadius; maxCardElevation = savedMaxElevation }
+        materialCard?.apply {
+            radius = savedRadius
+            maxCardElevation = savedMaxElevation
+        }
 
         runAnimator(
             cleanup = { omnibarCard.alpha = 1f },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -295,7 +295,16 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
         val params = card.layoutParams as FrameLayout.LayoutParams
         val fullWidth = (card.parent as View).width - params.leftMargin - params.rightMargin
+        // MaterialCardView compat padding scales with corner radius, but setRadius doesn't
+        // trigger updatePadding — only setMaxCardElevation does. Measure with the final radius
+        // (re-set maxCardElevation to force the padding update); otherwise fullHeight is short
+        // by the padding delta and lands as a bottom step after restoreLayout's wrap_content.
+        val materialCard = card as? MaterialCardView
+        val savedRadius = materialCard?.radius ?: 0f
+        val savedMaxElevation = materialCard?.maxCardElevation ?: 0f
+        materialCard?.apply { radius = widgetCornerRadius; maxCardElevation = savedMaxElevation }
         val fullHeight = measureUnconstrainedHeight(card, fullWidth)
+        materialCard?.apply { radius = savedRadius; maxCardElevation = savedMaxElevation }
 
         runAnimator(
             cleanup = { omnibarCard.alpha = 1f },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -143,17 +143,17 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         (widgetView as? ViewGroup)?.clipChildren = false
         (widgetView.parent as? ViewGroup)?.clipChildren = false
 
-        val snapshot = snapshotBeforeExit(widgetCard, omnibarCard)
+        val snapshot = snapshotBeforeExit(widgetCard, omnibarCard, isBottom)
 
         waitForLayout(widgetCard) {
             performExitAnimation(widgetCard, omnibarCard, snapshot, isBottom, onUpdate, onCancel, onComplete)
         }
     }
 
-    private fun snapshotBeforeExit(widgetCard: View, omnibarCard: View): ExitSnapshot {
+    private fun snapshotBeforeExit(widgetCard: View, omnibarCard: View, isBottom: Boolean): ExitSnapshot {
         val preSurface = visibleSurfacePosition(widgetCard)
         val omnibarPosition = visibleSurfacePosition(omnibarCard)
-        val visibleBounds = stripCompatPadding(widgetCard)
+        val visibleBounds = stripCompatPadding(widgetCard, isBottom)
 
         val params = widgetCard.layoutParams as FrameLayout.LayoutParams
 
@@ -184,11 +184,18 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         widgetCard.translationX = holdTranslation.x
         widgetCard.translationY = holdTranslation.y
 
-        val bottomAnchorShift = if (isBottom) snapshot.visibleBounds.height - snapshot.targetHeight else 0
-        val endTranslation = Offset(
-            x = (snapshot.omnibarPosition.x - postPosition.x).toFloat(),
-            y = (snapshot.omnibarPosition.y - postPosition.y).toFloat() - bottomAnchorShift,
-        )
+        // For bottom mode the snapshot's omnibarPosition is stale: the omnibar view is GONE
+        // during IME-up state and returns its last-known coords. stripCompatPadding preserves
+        // the card's bottomMargin in bottom mode, so widgetView's bottom-anchored wrap_content
+        // shrinks down to exactly the omnibar's eventual position — translationY=0 lands there.
+        val endTranslation = if (isBottom) {
+            Offset(x = (snapshot.omnibarPosition.x - postPosition.x).toFloat(), y = 0f)
+        } else {
+            Offset(
+                x = (snapshot.omnibarPosition.x - postPosition.x).toFloat(),
+                y = (snapshot.omnibarPosition.y - postPosition.y).toFloat(),
+            )
+        }
 
         val widgetContent = widgetCard.findViewById<View?>(R.id.inputModeWidget)
         omnibarCard.alpha = 0f
@@ -346,7 +353,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         return offset
     }
 
-    private fun stripCompatPadding(card: View): Bounds {
+    private fun stripCompatPadding(card: View, isBottom: Boolean): Bounds {
         val visibleWidth = card.width - card.paddingLeft - card.paddingRight
         val visibleHeight = card.height - card.paddingTop - card.paddingBottom
 
@@ -358,7 +365,12 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         params.width = visibleWidth
         params.height = visibleHeight
         params.topMargin = 0
-        params.bottomMargin = 0
+        // For bottom mode keep the card's bottomMargin (keyline_2) so that widgetView
+        // (wrap_content, bottom-anchored) ends at activityContentBottom - bottomMargin —
+        // the same place the omnibar sits when it reappears post-IME-hide.
+        if (!isBottom) {
+            params.bottomMargin = 0
+        }
         params.marginEnd = 0
         card.layoutParams = params
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -617,7 +617,7 @@ class RealNativeInputManager @Inject constructor(
         val omnibarCard = omnibarController.getCardView() ?: return false
         // Apply focused-state layout so the widget is measured at its final size; otherwise
         // padding/bottom-row/toggle-row visibility land after the 200ms enter as a second step.
-        widgetFrom(widgetView)?.prepareForEnterAnimation()
+        widgetFrom(widgetView)?.beginEnterAnimationPreview()
         val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 
@@ -630,7 +630,18 @@ class RealNativeInputManager @Inject constructor(
             onUpdate = { layoutCoordinator.onWidgetAnimationFrame(widgetCard) },
             onCancel = {
                 layoutCoordinator.setWidgetAnimating(false)
-                widgetFrom(widgetView)?.endEnterAnimationPreview()
+                widgetFrom(widgetView)?.let { widget ->
+                    widget.endEnterAnimationPreview()
+                    // Symmetric teardown for bottom mode: beginEnterAnimationPreview's
+                    // showKeyboard() requested focus + raised the IME. onEnterComplete is what
+                    // "owns" the focused state on success, so on cancel we undo it here —
+                    // otherwise the widget is left half-entered (focused, IME up) without the
+                    // animation having completed.
+                    if (widget.isWidgetBottom()) {
+                        widget.hideKeyboard()
+                        widget.clearInputFocus()
+                    }
+                }
             },
             onComplete = {
                 layoutCoordinator.setWidgetAnimating(false)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -199,6 +199,12 @@ class RealNativeInputManager @Inject constructor(
         val isBottom = widgetFrom(widgetView)?.isWidgetBottom() ?: false
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
+            if (isBottom) {
+                // Bottom omnibar: trigger IME hide synchronously so the activity resizes
+                // (adjustResize), letting the bottom-anchored widgetView descend to its
+                // post-IME-hide layout position before the exit animation captures its snapshot.
+                widgetFrom(widgetView)?.hideKeyboard()
+            }
             layoutCoordinator.setWidgetAnimating(true)
             animator.animateExit(
                 widgetCard = card,

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -609,6 +609,9 @@ class RealNativeInputManager @Inject constructor(
         if (omnibarController.isDuckAiMode()) return false
         val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return false
         val omnibarCard = omnibarController.getCardView() ?: return false
+        // Apply focused-state layout so the widget is measured at its final size; otherwise
+        // padding/bottom-row/toggle-row visibility land after the 200ms enter as a second step.
+        widgetFrom(widgetView)?.prepareForEnterAnimation()
         val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 
@@ -619,7 +622,10 @@ class RealNativeInputManager @Inject constructor(
             widgetView = widgetView,
             margins = margins,
             onUpdate = { layoutCoordinator.onWidgetAnimationFrame(widgetCard) },
-            onCancel = { layoutCoordinator.setWidgetAnimating(false) },
+            onCancel = {
+                layoutCoordinator.setWidgetAnimating(false)
+                widgetFrom(widgetView)?.endEnterAnimationPreview()
+            },
             onComplete = {
                 layoutCoordinator.setWidgetAnimating(false)
                 onEnterComplete(widgetView)
@@ -632,7 +638,10 @@ class RealNativeInputManager @Inject constructor(
         layoutCoordinator.enableContentLayoutTransition()
         if (omnibarController.isDuckAiMode()) return
         omnibarController.hide()
-        widgetFrom(widgetView)?.focusInput(rootView.context as? Activity)
+        widgetFrom(widgetView)?.apply {
+            focusInput(rootView.context as? Activity)
+            endEnterAnimationPreview()
+        }
     }
 
     private fun bindChatSuggestions(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -101,6 +101,7 @@ interface NativeInputWidget {
     fun endEnterAnimationPreview()
     fun selectAllText()
     fun hideKeyboard()
+    fun showKeyboard()
     fun selectChatTab()
     fun applyDefaultTogglePosition()
     fun saveLastUsedTogglePosition(isChat: Boolean)
@@ -674,6 +675,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
         previewEnterFocus = true
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
+        // Bottom omnibar: trigger the IME slide-up now so it overlaps the enter animation,
+        // letting the activity shrink (and the widget's bottom-anchored FrameLayout slide up)
+        // alongside the widget's expansion instead of pushing it up afterwards as a second step.
+        // Top omnibar: keyboard's vertical position is independent of the widget, so its show
+        // stays deferred to focusInput in onEnterComplete.
+        if (isWidgetBottom()) {
+            showKeyboard()
+        }
     }
 
     override fun endEnterAnimationPreview() {
@@ -685,6 +694,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun hideKeyboard() {
         (context as? Activity)?.hideKeyboard(inputField)
+    }
+
+    override fun showKeyboard() {
+        (context as? Activity)?.showKeyboard(inputField)
     }
 
     override fun selectChatTab() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -97,6 +97,8 @@ interface NativeInputWidget {
     fun hasInputFocus(): Boolean
     fun clearInputFocus()
     fun requestInputFocus()
+    fun prepareForEnterAnimation()
+    fun endEnterAnimationPreview()
     fun selectAllText()
     fun hideKeyboard()
     fun selectChatTab()
@@ -247,6 +249,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     // with inputContext=BROWSER and toggleVisible=true/false that would otherwise show the
     // toggle row and reset the parent card's corners.
     private var isContextualWidget: Boolean = false
+
+    // Held during the enter animation so padding/bottom-row compute as if focused; without
+    // it they'd flip from 4dp→8dp after focusInput and look like a second step.
+    private var previewEnterFocus = false
 
     private var attachmentView: AttachmentView? = null
 
@@ -440,7 +446,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateBottomRowVisibility() {
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
-        val visible = isChatTabSelected() && (inputField.hasFocus() || isStreaming)
+        val visible = isChatTabSelected() && (inputField.hasFocus() || previewEnterFocus || isStreaming)
         bottomRow.visibility = if (visible) VISIBLE else GONE
     }
 
@@ -463,7 +469,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val isBrowserOmnibarMinimized = nativeInputState?.let {
             it.inputContext == NativeInputState.InputContext.BROWSER && !it.toggleVisible
         } ?: true
-        val expanded = !isBrowserOmnibarMinimized && inputField.hasFocus()
+        val expanded = !isBrowserOmnibarMinimized && (inputField.hasFocus() || previewEnterFocus)
         val verticalPadAttr = if (expanded) {
             com.duckduckgo.mobile.android.R.dimen.keyline_2
         } else {
@@ -656,6 +662,25 @@ class NativeInputModeWidget @JvmOverloads constructor(
         if (!inputField.hasFocus()) {
             inputField.requestFocus()
         }
+    }
+
+    override fun prepareForEnterAnimation() {
+        if (inputField.hasFocus()) return
+        // State observation is async; apply it synchronously so toggle-row visibility etc. are
+        // in their final positions before the enter animation measures the widget.
+        if (nativeInputState == null) {
+            activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }?.let(::applyState)
+        }
+        previewEnterFocus = true
+        updateBottomRowVisibility()
+        applyVerticalPaddingForFocus()
+    }
+
+    override fun endEnterAnimationPreview() {
+        if (!previewEnterFocus) return
+        previewEnterFocus = false
+        updateBottomRowVisibility()
+        applyVerticalPaddingForFocus()
     }
 
     override fun hideKeyboard() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -97,7 +97,7 @@ interface NativeInputWidget {
     fun hasInputFocus(): Boolean
     fun clearInputFocus()
     fun requestInputFocus()
-    fun prepareForEnterAnimation()
+    fun beginEnterAnimationPreview()
     fun endEnterAnimationPreview()
     fun selectAllText()
     fun hideKeyboard()
@@ -665,7 +665,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    override fun prepareForEnterAnimation() {
+    override fun beginEnterAnimationPreview() {
         if (inputField.hasFocus()) return
         // State observation is async; apply it synchronously so toggle-row visibility etc. are
         // in their final positions before the enter animation measures the widget.
@@ -675,11 +675,18 @@ class NativeInputModeWidget @JvmOverloads constructor(
         previewEnterFocus = true
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
-        // Bottom omnibar: trigger the IME slide-up now so it overlaps the enter animation,
-        // letting the activity shrink (and the widget's bottom-anchored FrameLayout slide up)
-        // alongside the widget's expansion instead of pushing it up afterwards as a second step.
-        // Top omnibar: keyboard's vertical position is independent of the widget, so its show
-        // stays deferred to focusInput in onEnterComplete.
+        // Bottom omnibar only: trigger the IME slide-up now so it overlaps the enter animation —
+        // the activity shrinks (and the widget's bottom-anchored FrameLayout slides up) alongside
+        // the widget's expansion instead of pushing it up afterwards as a second step. Top omnibar
+        // keyboard position is independent of the widget, so its show stays deferred to focusInput
+        // in onEnterComplete.
+        //
+        // Side effect to be aware of: Activity.showKeyboard() calls inputField.requestFocus()
+        // under the hood, so the input field gains focus here — ~200ms earlier than in top mode
+        // (where focus is set in onEnterComplete via focusInput). The onFocusChangeListener will
+        // therefore fire synchronously inside showKeyboard(). The asymmetry is intentional, but
+        // it does mean any cancel path has to undo focus + IME for bottom mode (see the manager's
+        // animateEnter.onCancel).
         if (isWidgetBottom()) {
             showKeyboard()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214707697514291?focus=true,
 https://app.asana.com/1/137249556945/task/1214156122159472?focus=true

### Steps to test this PR
- Observe the launch/close of the input-widget in top/bottom omnibar modes.

### UI changes
Launch is one smooth transition, before it was happening on a 2 step, giving janky impression.
| Before  | After |
| ------ | ----- |
<img width="280" height="607" alt="before_expand" src="https://github.com/user-attachments/assets/459067e1-a2f6-44f9-aa73-2ef68c5a2cff" />|<img width="280" height="607" alt="after_expand" src="https://github.com/user-attachments/assets/9127bb71-2319-4d27-801b-f297665a3d00" />|



Collapsing keyboard used to happen at the bottom first, then pushed up, now it's one smooth animation. 
| Before  | After |
| ------ | ----- |
<img width="280" height="607" alt="before_keyboard_bot" src="https://github.com/user-attachments/assets/40a0bf0e-626c-4c86-be71-9ec50d80f78e" />|<img width="280" height="607" alt="after_keyboard_bot" src="https://github.com/user-attachments/assets/c23db00f-030c-4a09-9103-2a939c9bc700" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts keyboard focus/IME timing and card measurement during animations, which can regress layout or leave the widget in an inconsistent focus state on cancel—especially in bottom-omnibar mode.
> 
> **Overview**
> Improves native input widget enter/exit smoothness by making bottom-omnibar transitions account for IME-driven layout changes and MaterialCardView compat padding.
> 
> For **enter**, the widget now applies a focused-state *preview* (including early IME show for bottom mode) so the animation measures/expands to the final layout without a second “step”, and adds symmetric cancel/complete cleanup (`beginEnterAnimationPreview`/`endEnterAnimationPreview`). For **exit**, bottom mode now hides the keyboard before snapshotting, preserves bottom margins when stripping compat padding, and avoids using stale omnibar Y-coordinates when the omnibar is `GONE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a92a7f9ed78700132ad21be5f3b4f7565be4a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->