### PR TITLE
Update asana task name for metro failure

### DIFF
--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -316,6 +316,6 @@ jobs:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
           asana-section: ${{ secrets.GH_ASANA_INCOMING_ID }}
-          asana-task-name: GH Workflow Failure - End to End tests${{ env.DDG_DI == 'AnvilDagger' && ' (Release Blockers)' || format(' ({0}, Release Blockers)', env.DDG_DI) }}
+          asana-task-name: GH Workflow Failure - End to End tests${{ env.DDG_DI == 'AnvilDagger' && ' (Release Blockers)' || format(' ({0})', env.DDG_DI) }}
           asana-task-description: The end to end workflow${{ env.DI_PAREN_SUFFIX }} has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214960343573557?focus=true

### Description
Updates asana task title in the GitHub Actions workflow from "GH Workflow Failure - End to End tests (Metro, Release Blockers)" to "GH Workflow Failure - End to End tests (Metro)" since they are not release blockers.

### Steps to test this PR
No QA needed

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects only the naming of created Asana tasks on e2e workflow failure.
> 
> **Overview**
> Updates the `e2e-nightly-full-suite.yml` failure handler so Asana tasks created for non-default DI runs (e.g., Metro) are titled `GH Workflow Failure - End to End tests (Metro)` instead of implying they are *Release Blockers*, while keeping the *Release Blockers* suffix for `AnvilDagger` failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d169c65d2ae30abac8410387a44a1cd43a993663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->