### PR TITLE
Return empty JSON response rather than null when page context not available

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -218,17 +218,17 @@ class RealDuckChatJSHelper @Inject constructor(
                                 if (duckChat.isAutomaticContextAttachmentEnabled()) {
                                     getPageContextResponse(featureName, method, it, pageContext, tabId)
                                 } else {
-                                    null
+                                    getEmptyPageContextResponse(featureName, method, it)
                                 }
                             }
 
                             else -> {
-                                null
+                                getEmptyPageContextResponse(featureName, method, it)
                             }
                         }
                     } else {
                         logcat { "Duck.ai Contextual: page context is empty, can't add it" }
-                        null
+                        getEmptyPageContextResponse(featureName, method, it)
                     }
                 }
             }
@@ -450,6 +450,17 @@ class RealDuckChatJSHelper @Inject constructor(
             }
         }
         return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
+    private fun getEmptyPageContextResponse(
+        featureName: String,
+        method: String,
+        id: String,
+    ): JsCallbackData {
+        val params = JSONObject().apply {
+            put(PAGE_CONTEXT, JSONObject.NULL)
+        }
+        return JsCallbackData(params, featureName, method, id)
     }
 
     private suspend fun getPageContextResponse(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -313,7 +313,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetPageContextInitAndAutomaticDisabledThenReturnsNull() = runTest {
+    fun whenGetPageContextInitAndAutomaticDisabledThenReturnsEmptyPageContext() = runTest {
         whenever(mockDuckChat.isAutomaticContextAttachmentEnabled()).thenReturn(false)
 
         val result =
@@ -326,7 +326,9 @@ class RealDuckChatJSHelperTest {
                 pageContext = viewModel.updatedPageContext,
             )
 
-        assertNull(result)
+        assertNotNull(result)
+        assertTrue(result!!.params.has("pageContext"))
+        assertTrue(result.params.isNull("pageContext"))
     }
 
     @Test
@@ -354,7 +356,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetPageContextWithoutDataThenReturnsNull() = runTest {
+    fun whenGetPageContextWithoutDataThenReturnsEmptyPageContext() = runTest {
         whenever(mockDuckChat.isAutomaticContextAttachmentEnabled()).thenReturn(true)
 
         val result =
@@ -367,7 +369,9 @@ class RealDuckChatJSHelperTest {
                 pageContext = "",
             )
 
-        assertNull(result)
+        assertNotNull(result)
+        assertTrue(result!!.params.has("pageContext"))
+        assertTrue(result.params.isNull("pageContext"))
     }
 
     @Test
@@ -428,7 +432,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetPageContextWithUnknownReasonThenReturnsNull() = runTest {
+    fun whenGetPageContextWithUnknownReasonThenReturnsEmptyPageContext() = runTest {
         whenever(mockDuckChat.isAutomaticContextAttachmentEnabled()).thenReturn(true)
 
         val result =
@@ -441,7 +445,9 @@ class RealDuckChatJSHelperTest {
                 pageContext = viewModel.updatedPageContext,
             )
 
-        assertNull(result)
+        assertNotNull(result)
+        assertTrue(result!!.params.has("pageContext"))
+        assertTrue(result.params.isNull("pageContext"))
     }
 
     @Test
@@ -615,7 +621,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun `when get AI chat page context for init without automatic attachment then return null`() = runTest {
+    fun `when get AI chat page context for init without automatic attachment then return empty page context`() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatPageContext"
         val id = "123"
@@ -630,7 +636,9 @@ class RealDuckChatJSHelperTest {
             pageContext = viewModel.updatedPageContext,
         )
 
-        assertNull(result)
+        assertNotNull(result)
+        assertTrue(result!!.params.has("pageContext"))
+        assertTrue(result.params.isNull("pageContext"))
     }
 
     @Test
@@ -680,7 +688,7 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun `when get AI chat page context without context then return null`() = runTest {
+    fun `when get AI chat page context without context then return empty page context`() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatPageContext"
         val id = "123"
@@ -696,7 +704,9 @@ class RealDuckChatJSHelperTest {
             pageContext = "",
         )
 
-        assertNull(result)
+        assertNotNull(result)
+        assertTrue(result!!.params.has("pageContext"))
+        assertTrue(result.params.isNull("pageContext"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214463053803990/task/1214967250820968?focus=true

### Description
This PR returns an empty json response rather than just `null` to let JS promise resolve and then get the page context via the subscription

### Steps to test this PR
Smoke test the contextual sheet experience. It's hard to repro the timeout scenario

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change in the JS bridge contract for `getAIChatPageContext`; callers that relied on a `null` callback now receive a resolved response with `pageContext: null`.
> 
> **Overview**
> **Changes `getAIChatPageContext` to always resolve with a JSON payload** when context can’t/shouldn’t be attached (e.g., empty `pageContext`, unknown `reason`, or `init` when automatic attachment is disabled), returning `{"pageContext": null}` instead of `null`.
> 
> Adds `getEmptyPageContextResponse` helper and updates unit tests to assert the new non-null callback behavior with `pageContext` explicitly set to JSON null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3deb77ea1315a2b3991ecf71287a1a25c2823c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->