### PR TITLE
Optimize  release_upload_play_store.yml by only building playRelease

### DIFF
--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -94,7 +94,7 @@ jobs:
           MALICIOUS_SITE_PROTECTION_AUTH_TOKEN: ${{ secrets.MALICIOUS_SITE_PROTECTION_AUTH_TOKEN }}
           DUCKSANS_PACKAGE_AUTH_USER: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION_USER }}
           DUCKSANS_PACKAGE_AUTH_TOKEN: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
-        run: ./gradlew bundleRelease -PuseUploadSigning -Pbuild-date-time
+        run: ./gradlew bundlePlayRelease -PuseUploadSigning -Pbuild-date-time
 
       - name: Capture App Bundle Path
         id: capture_output


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214967521716669?focus=true

### Description
We only need the `Play` bundle here, but we're using `bundleRelease`, which also builds FDroid and Internal, which we don't need here

### Steps to test this PR
n/a

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main risk is the Play Store pipeline failing if the `bundlePlayRelease` task/output path differs from what the workflow expects.
> 
> **Overview**
> Updates the Play Store release GitHub Actions workflow to build only the Play Store variant by switching the Gradle task from `bundleRelease` to `bundlePlayRelease`, avoiding unnecessary FDroid/internal bundle builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1844c9a706cc05718be319ce009fd51d5abb4227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->