### PR TITLE
Onboarding Brand Design Update: Ship review fixes

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-rebrand-onboarding-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-rebrand-onboarding-theming.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="NewApi">
 
     <attr name="onboardingTextPrimary" format="color" />
     <attr name="onboardingTextSecondary" format="color" />
@@ -183,7 +183,8 @@
     <style name="Typography.DuckDuckGo.Onboarding.WelcomeTitle">
         <item name="android:textSize">44sp</item>
         <item name="android:textColor">?attr/onboardingTextPrimary</item>
-        <item name="android:lineSpacingExtra">-10sp</item>
+        <item name="android:lineHeight">44sp</item>
+        <item name="android:lineSpacingExtra">0sp</item>
         <item name="android:fontFamily">@font/ducksansdisplay_medium</item>
     </style>
 

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
@@ -25,7 +25,9 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -73,6 +75,8 @@ class NewTabPageViewModel @AssistedInject constructor(
     private val lowPriorityMessagingModel: LowPriorityMessagingModel,
     private val appTrackingProtection: AppTrackingProtection,
     private val pixel: Pixel,
+    private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
+    private val ctaViewModel: CtaViewModel,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -177,9 +181,14 @@ class NewTabPageViewModel @AssistedInject constructor(
 
     // We only want to show New Tab when the Home CTAs from Onboarding has finished
     // https://app.asana.com/0/1157893581871903/1207769731595075/f
-    private fun isHomeOnboardingComplete(): Boolean {
+    private suspend fun isHomeOnboardingComplete(): Boolean {
         val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
-        return dismissedCtaDao.exists(CtaId.DAX_END) ||
+        val lastDialogShown = if (onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()) {
+            ctaViewModel.areBubbleDaxDialogsCompleted()
+        } else {
+            dismissedCtaDao.exists(CtaId.DAX_END)
+        }
+        return lastDialogShown ||
             noBrowserCtaExperiment ||
             settingsDataStore.hideTips ||
             dismissedCtaDao.exists(CtaId.ADD_WIDGET)

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.common.ui.view.setAndPropagateUpFitsSystemWindows
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.dataclearing.api.fire.FireDialog
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.di.scopes.FragmentScope
@@ -311,10 +312,10 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
 
         val subtitleParts = buildList {
             if (state.isSiteDataSubtitleVisible) {
-                add(getString(R.string.singleTabFireDialogSubtitleSiteData))
+                add(getString(R.string.singleTabFireDialogSubtitleSiteData).preventWidows())
             }
             if (state.isDownloadsSubtitleVisible) {
-                add(getString(R.string.singleTabFireDialogSubtitleDownloads))
+                add(getString(R.string.singleTabFireDialogSubtitleDownloads).preventWidows())
             }
         }
         if (subtitleParts.isNotEmpty()) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -117,16 +117,16 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val _commands = Channel<Command>(1, DROP_OLDEST)
     val commands: Flow<Command> = _commands.receiveAsFlow()
 
-    private var maxPageCount: Int = 2
+    private var inputScreenOnboardingEnabled: Boolean? = null
 
-    init {
-        viewModelScope.launch(dispatchers.io()) {
-            maxPageCount = if (androidBrowserConfigFeature.showInputScreenOnboarding().isEnabled()) {
-                3
-            } else {
-                2
-            }
+    private suspend fun resolveInputScreenOnboardingEnabled(): Boolean {
+        val cached = inputScreenOnboardingEnabled
+        if (cached != null) return cached
+        val value = withContext(dispatchers.io()) {
+            androidBrowserConfigFeature.showInputScreenOnboarding().isEnabled()
         }
+        inputScreenOnboardingEnabled = value
+        return value
     }
 
     sealed interface Command {
@@ -154,6 +154,13 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private fun setCurrentDialog(dialogType: PreOnboardingDialogType) {
         _viewState.update { it.copy(currentDialog = dialogType, hasAnimatedCurrentDialog = false) }
         fireDialogShownPixel(dialogType)
+    }
+
+    private fun navigateToComparisonChart() {
+        viewModelScope.launch {
+            resolveInputScreenOnboardingEnabled()
+            setCurrentDialog(COMPARISON_CHART)
+        }
     }
 
     private fun setInputScreenPreviewDialog(isSearchDefault: Boolean) {
@@ -217,7 +224,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             }
 
             INITIAL_REINSTALL_USER, INITIAL -> {
-                setCurrentDialog(COMPARISON_CHART)
+                navigateToComparisonChart()
             }
 
             COMPARISON_CHART -> {
@@ -272,10 +279,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                             settingsDataStore.omnibarType = OmnibarType.SINGLE_TOP
                         }
                     }
-                    val showInputScreen = withContext(dispatchers.io()) {
-                        androidBrowserConfigFeature.showInputScreenOnboarding().isEnabled()
-                    }
-                    if (showInputScreen) {
+                    if (resolveInputScreenOnboardingEnabled()) {
                         setCurrentDialog(INPUT_SCREEN)
                     } else {
                         _commands.send(Command.Finish)
@@ -349,7 +353,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             }
 
             SKIP_ONBOARDING_OPTION -> {
-                setCurrentDialog(COMPARISON_CHART)
+                navigateToComparisonChart()
                 pixel.fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
             }
 
@@ -399,7 +403,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     }
 
     fun getMaxPageCount(): Int {
-        return maxPageCount
+        return if (inputScreenOnboardingEnabled == true) 3 else 2
     }
 
     private suspend fun isAppReinstall(): Boolean =

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -73,6 +73,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -96,6 +98,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val inputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent,
     private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager,
     private val onboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager,
+    inputScreenOnboardingStateProvider: InputScreenOnboardingStateProvider,
 ) : ViewModel() {
 
     data class ViewState(
@@ -103,13 +106,16 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         val hasAnimatedCurrentDialog: Boolean = false,
         val currentDialog: PreOnboardingDialogType? = null,
         val selectedAddressBarPosition: OmnibarType = OmnibarType.SINGLE_TOP,
+        val inputScreenOnboardingEnabled: Boolean = false,
         val inputScreenSelected: Boolean = true,
         val showSplitOption: Boolean = false,
         val isReinstallUser: Boolean = false,
         val inputScreenPreviewSearchSuggestions: List<DaxDialogIntroOption> = emptyList(),
         val inputScreenPreviewChatSuggestions: List<DaxDialogIntroOption> = emptyList(),
         val inputScreenPreviewIsSearchSelected: Boolean = false,
-    )
+    ) {
+        val maxPageCount = if (inputScreenOnboardingEnabled) 3 else 2
+    }
 
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
@@ -117,16 +123,10 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val _commands = Channel<Command>(1, DROP_OLDEST)
     val commands: Flow<Command> = _commands.receiveAsFlow()
 
-    private var inputScreenOnboardingEnabled: Boolean? = null
-
-    private suspend fun resolveInputScreenOnboardingEnabled(): Boolean {
-        val cached = inputScreenOnboardingEnabled
-        if (cached != null) return cached
-        val value = withContext(dispatchers.io()) {
-            androidBrowserConfigFeature.showInputScreenOnboarding().isEnabled()
-        }
-        inputScreenOnboardingEnabled = value
-        return value
+    init {
+        inputScreenOnboardingStateProvider.isEnabled.onEach { isInputScreenOnboardingEnabled ->
+            _viewState.update { it.copy(inputScreenOnboardingEnabled = isInputScreenOnboardingEnabled) }
+        }.launchIn(viewModelScope)
     }
 
     sealed interface Command {
@@ -154,13 +154,6 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private fun setCurrentDialog(dialogType: PreOnboardingDialogType) {
         _viewState.update { it.copy(currentDialog = dialogType, hasAnimatedCurrentDialog = false) }
         fireDialogShownPixel(dialogType)
-    }
-
-    private fun navigateToComparisonChart() {
-        viewModelScope.launch {
-            resolveInputScreenOnboardingEnabled()
-            setCurrentDialog(COMPARISON_CHART)
-        }
     }
 
     private fun setInputScreenPreviewDialog(isSearchDefault: Boolean) {
@@ -224,7 +217,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             }
 
             INITIAL_REINSTALL_USER, INITIAL -> {
-                navigateToComparisonChart()
+                setCurrentDialog(COMPARISON_CHART)
             }
 
             COMPARISON_CHART -> {
@@ -279,7 +272,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                             settingsDataStore.omnibarType = OmnibarType.SINGLE_TOP
                         }
                     }
-                    if (resolveInputScreenOnboardingEnabled()) {
+                    if (viewState.value.inputScreenOnboardingEnabled) {
                         setCurrentDialog(INPUT_SCREEN)
                     } else {
                         _commands.send(Command.Finish)
@@ -353,7 +346,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             }
 
             SKIP_ONBOARDING_OPTION -> {
-                navigateToComparisonChart()
+                setCurrentDialog(COMPARISON_CHART)
                 pixel.fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
             }
 
@@ -400,10 +393,6 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             AppPixelName.NOTIFICATIONS_ENABLED,
             mapOf(PixelParameter.FROM_ONBOARDING to true.toString()),
         )
-    }
-
-    fun getMaxPageCount(): Int {
-        return if (inputScreenOnboardingEnabled == true) 3 else 2
     }
 
     private suspend fun isAppReinstall(): Boolean =

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1089,7 +1089,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     TransitionManager.beginDelayedTransition(binding.root as ViewGroup, transition)
 
                     binding.daxDialogCta.root.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                        if (deviceInfo.isTablet()) {
+                        if (showLeftWingAnimation && deviceInfo.isTablet()) {
                             verticalBias = 0.5f
                             bottomToTop = binding.leftWingAnimation.id
                             bottomToBottom = ConstraintLayout.LayoutParams.UNSET
@@ -1099,6 +1099,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
                         }
                     }
+                    binding.daxDialogCta.cardView.setArrowDepthFraction(if (showLeftWingAnimation) 1f else 0f)
 
                     binding.welcomeScreenWalkingDax.isVisible = false
                     binding.daxDialogCta.comparisonChartContent.root.isVisible = false
@@ -1491,7 +1492,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 binding.welcomeScreenWalkingDax.isVisible = false
                 (binding.daxDialogCta.root.layoutParams as ConstraintLayout.LayoutParams).apply {
-                    if (deviceInfo.isTablet()) {
+                    if (showLeftWing && deviceInfo.isTablet()) {
                         verticalBias = 0.5f
                         bottomToTop = binding.leftWingAnimation.id
                         bottomToBottom = ConstraintLayout.LayoutParams.UNSET
@@ -1505,6 +1506,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 val cardView = binding.daxDialogCta.cardView
                 cardView.setArrowAnimationTarget(ARROW_TARGET_OFFSET_END_DP.toPx().toFloat())
                 cardView.setArrowAnimationFraction(1f)
+                cardView.setArrowDepthFraction(if (showLeftWing) 1f else 0f)
                 binding.daxDialogCta.welcomeContent.root.isVisible = false
                 binding.daxDialogCta.secondaryCta.isVisible = false
                 binding.daxDialogCta.comparisonChartContent.root.isVisible = false

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -823,6 +823,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
                         }
                     }
+                    binding.daxDialogCta.cardView.setArrowDepthFraction(if (showBottomWingAnimation) 1f else 0f)
 
                     val transition = ChangeBounds().apply {
                         duration = DIALOG_TRANSITION_DURATION
@@ -1325,6 +1326,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
                     }
                 }
+                binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWing) 1f else 0f)
                 binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.cancelAnimation()
                 binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.text =
                     getString(R.string.preOnboardingDaxDialog2Title).preventWidows()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1879,6 +1879,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             binding.daxDialogCta.comparisonChartContent.check5,
         ).sortedBy { comparisonTable.indexOfChild(it.parent as View) }
 
+        // Reset trimPathEnd up-front: the alpha fade-in completes ~50ms before the postDelayed AVD start,
+        // so any stale trimPathEnd=1 from a previous run would render the tick fully drawn during the gap.
+        checkViews.forEach { checkView ->
+            (checkView.drawable?.mutate() as? AnimatedVectorDrawable)?.reset()
+        }
+
         val iconAnimators = checkViews.mapIndexed { index, checkView ->
             AnimatorSet().apply {
                 playTogether(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -959,8 +959,16 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 ADDRESS_BAR_POSITION -> {
                     dismissBottomWingAnimation()
+                    binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+                    binding.daxDialogCta.addressBarContent.root.isVisible = true
+
+                    val showBobbingDax = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
+                        rootView = binding.root,
+                        dialogView = binding.daxDialogCta.root,
+                        decorationView = binding.bobbingDaxAnimation,
+                    )
                     (binding.daxDialogCta.root.layoutParams as ConstraintLayout.LayoutParams).apply {
-                        if (deviceInfo.isTablet()) {
+                        if (showBobbingDax && deviceInfo.isTablet()) {
                             verticalBias = 0.5f
                             bottomToTop = binding.bobbingDaxAnimation.id
                             bottomToBottom = ConstraintLayout.LayoutParams.UNSET
@@ -974,7 +982,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         step = OnboardingBackgroundStep.AddressBar,
                     )
 
-                    animateBobbingDaxIn()
+                    if (showBobbingDax) {
+                        animateBobbingDaxIn()
+                    } else {
+                        binding.bobbingDaxAnimation.isVisible = false
+                    }
+                    binding.daxDialogCta.cardView.setArrowDepthFraction(if (showBobbingDax) 1f else 0f)
 
                     binding.daxDialogCta.stepIndicator.animateToNextStep()
 
@@ -1014,9 +1027,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     binding.daxDialogCta.root.translationZ = 1f.toPx()
                     TransitionManager.beginDelayedTransition(binding.daxDialogCta.root as ViewGroup, transition)
-
-                    binding.daxDialogCta.comparisonChartContent.root.isVisible = false
-                    binding.daxDialogCta.addressBarContent.root.isVisible = true
 
                     binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingAddressBarOkButton)
                     binding.daxDialogCta.primaryCta.alpha = 0f

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -482,6 +482,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                 selectedAddressBarPosition = state.selectedAddressBarPosition,
                                 showSplitOption = state.showSplitOption,
                                 inputScreenSelected = state.inputScreenSelected,
+                                maxPageCount = state.maxPageCount,
                             )
                         }
                     }
@@ -492,6 +493,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             selectedAddressBarPosition = state.selectedAddressBarPosition,
                             showSplitOption = state.showSplitOption,
                             inputScreenSelected = state.inputScreenSelected,
+                            maxPageCount = state.maxPageCount,
                         )
                     }
                 }
@@ -632,6 +634,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         selectedAddressBarPosition: OmnibarType,
         showSplitOption: Boolean,
         inputScreenSelected: Boolean,
+        maxPageCount: Int,
     ) {
         context?.let {
             isAnimating = true
@@ -863,7 +866,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                     changeBoundsTransitionListener = listener
                     transition.addListener(listener)
-                    binding.daxDialogCta.stepIndicator.setSteps(viewModel.getMaxPageCount(), 1)
+                    binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 1)
                     binding.daxDialogCta.stepIndicator.isVisible = true
                     binding.daxDialogCta.stepIndicator.alpha = 0f
                     TransitionManager.beginDelayedTransition(binding.root as ViewGroup, transition)
@@ -995,6 +998,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showBobbingDax) 1f else 0f)
 
+                    binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 1)
                     binding.daxDialogCta.stepIndicator.animateToNextStep()
 
                     val transition = ChangeBounds().apply {
@@ -1109,6 +1113,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     changeBoundsTransitionListener = listener
                     transition.addListener(listener)
 
+                    binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 2)
                     binding.daxDialogCta.stepIndicator.animateToNextStep()
 
                     TransitionManager.beginDelayedTransition(binding.root as ViewGroup, transition)
@@ -1262,6 +1267,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         selectedAddressBarPosition: OmnibarType,
         showSplitOption: Boolean,
         inputScreenSelected: Boolean,
+        maxPageCount: Int,
     ) {
         snapToIntroEndState()
 
@@ -1364,7 +1370,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 binding.daxDialogCta.stepIndicator.isVisible = true
                 binding.daxDialogCta.stepIndicator.alpha = 1f
-                binding.daxDialogCta.stepIndicator.setSteps(viewModel.getMaxPageCount(), 1)
+                binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 1)
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog2Button)
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
@@ -1464,7 +1470,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 binding.daxDialogCta.stepIndicator.isVisible = true
                 binding.daxDialogCta.stepIndicator.alpha = 1f
-                binding.daxDialogCta.stepIndicator.setSteps(viewModel.getMaxPageCount(), 2)
+                binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 2)
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingAddressBarOkButton)
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
@@ -1560,7 +1566,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 binding.daxDialogCta.stepIndicator.isVisible = true
                 binding.daxDialogCta.stepIndicator.alpha = 1f
-                binding.daxDialogCta.stepIndicator.setSteps(viewModel.getMaxPageCount(), 3)
+                binding.daxDialogCta.stepIndicator.setSteps(totalSteps = maxPageCount, currentStep = 3)
 
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingInputScreenButton)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -961,6 +961,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     dismissBottomWingAnimation()
                     binding.daxDialogCta.comparisonChartContent.root.isVisible = false
                     binding.daxDialogCta.addressBarContent.root.isVisible = true
+                    setAddressBarPositionOptions(selectedAddressBarPosition, showSplitOption, animate = false)
 
                     val showBobbingDax = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
                         rootView = binding.root,
@@ -1435,6 +1436,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.comparisonChartContent.root.isVisible = false
 
                 binding.daxDialogCta.addressBarContent.root.isVisible = true
+                setAddressBarPositionOptions(selectedAddressBarPosition, showSplitOption, animate = false)
                 val showBobbingDax = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
                     rootView = binding.root,
                     dialogView = binding.daxDialogCta.root,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -654,6 +654,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
                     val showWalkingDax = applyWalkingDaxLayout()
+                    binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
 
                     playOutroAnimation(
                         nextStep = OnboardingBackgroundStep.Welcome,
@@ -1268,6 +1269,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         translationX = -WALKING_DAX_FINAL_X_DP.toPx().toFloat()
                     }
                 }
+                binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
 
                 binding.daxDialogCta.root.isVisible = true
                 binding.daxDialogCta.daxCtaContainer.alpha = 1f
@@ -1380,6 +1382,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         translationX = -WALKING_DAX_FINAL_X_DP.toPx().toFloat()
                     }
                 }
+                binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
 
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
                 binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingDaxDialog3Title)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1907,8 +1907,13 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         quickSetupFadeInAnimatorSet?.end()
         suggestionButtonsAnimatorSet?.end()
 
-        // Snap check icons to final state — the postDelayed AVD runnables would otherwise animate them in one by one
-        snapCheckIconsToFinalState()
+        // Snap check icons to final state — the postDelayed AVD runnables would otherwise animate them in one by one.
+        // Only do this on the comparison chart: those runnables are only ever scheduled by playCheckIconAnimation(),
+        // and snapping outside that screen leaves the check views at alpha=1/scale=1 with a static drawable, which
+        // makes them appear pre-rendered when the comparison chart later fades in.
+        if (viewModel.viewState.value.currentDialog == COMPARISON_CHART) {
+            snapCheckIconsToFinalState()
+        }
     }
 
     private fun snapCheckIconsToFinalState() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1425,8 +1425,18 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.AddressBar)
 
                 binding.welcomeScreenWalkingDax.isVisible = false
+                binding.daxDialogCta.welcomeContent.root.isVisible = false
+                binding.daxDialogCta.secondaryCta.isVisible = false
+                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+
+                binding.daxDialogCta.addressBarContent.root.isVisible = true
+                val showBobbingDax = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
+                    rootView = binding.root,
+                    dialogView = binding.daxDialogCta.root,
+                    decorationView = binding.bobbingDaxAnimation,
+                )
                 binding.daxDialogCta.root.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                    if (deviceInfo.isTablet()) {
+                    if (showBobbingDax && deviceInfo.isTablet()) {
                         verticalBias = 0.5f
                         bottomToTop = binding.bobbingDaxAnimation.id
                         bottomToBottom = ConstraintLayout.LayoutParams.UNSET
@@ -1439,11 +1449,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 val cardView = binding.daxDialogCta.cardView
                 cardView.setArrowAnimationTarget(ARROW_TARGET_OFFSET_END_DP.toPx().toFloat())
                 cardView.setArrowAnimationFraction(1f)
-                binding.daxDialogCta.welcomeContent.root.isVisible = false
-                binding.daxDialogCta.secondaryCta.isVisible = false
-                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
-
-                binding.daxDialogCta.addressBarContent.root.isVisible = true
+                cardView.setArrowDepthFraction(if (showBobbingDax) 1f else 0f)
                 binding.daxDialogCta.addressBarContent.root.alpha = 1f
                 binding.daxDialogCta.addressBarContent.addressBarTitle.cancelAnimation()
                 binding.daxDialogCta.addressBarContent.addressBarTitle.text =
@@ -1461,11 +1467,18 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.root.translationZ = 1f.toPx()
                 binding.daxDialogCta.daxCtaContainer.alpha = 1f
 
-                binding.bobbingDaxAnimation.apply {
-                    isVisible = true
-                    alpha = 1f
-                    translationX = 0f
-                    if (!this.isAnimating) playAnimation()
+                if (showBobbingDax) {
+                    binding.bobbingDaxAnimation.apply {
+                        isVisible = true
+                        alpha = 1f
+                        translationX = 0f
+                        if (!this.isAnimating) playAnimation()
+                    }
+                } else {
+                    binding.bobbingDaxAnimation.apply {
+                        if (this.isAnimating) cancelAnimation()
+                        isVisible = false
+                    }
                 }
 
                 setAddressBarPositionOptions(selectedAddressBarPosition, showSplitOption, animate = false)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -985,7 +985,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     if (showBobbingDax) {
                         animateBobbingDaxIn()
                     } else {
-                        binding.bobbingDaxAnimation.isVisible = false
+                        bobbingDaxAnimator?.cancel()
+                        bobbingDaxAnimator = null
+                        binding.bobbingDaxAnimation.apply {
+                            if (this.isAnimating) cancelAnimation()
+                            isVisible = false
+                        }
                     }
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showBobbingDax) 1f else 0f)
 
@@ -1475,6 +1480,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         if (!this.isAnimating) playAnimation()
                     }
                 } else {
+                    bobbingDaxAnimator?.cancel()
+                    bobbingDaxAnimator = null
                     binding.bobbingDaxAnimation.apply {
                         if (this.isAnimating) cancelAnimation()
                         isVisible = false

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -1047,6 +1047,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     animateBobbingDaxOut()
 
+                    binding.welcomeScreenWalkingDax.isVisible = false
+                    binding.daxDialogCta.welcomeContent.root.isVisible = false
+                    binding.daxDialogCta.secondaryCta.isVisible = false
+                    binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+                    binding.daxDialogCta.addressBarContent.root.isVisible = false
+                    binding.daxDialogCta.inputScreenContent.root.isVisible = true
+                    updateAiChatToggleState(binding, withAi = inputScreenSelected, transition = InputToggleTransition.NONE)
+
                     val leftWingView = binding.leftWingAnimation
                     val showLeftWingAnimation = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
                         rootView = binding.root,
@@ -1118,21 +1126,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showLeftWingAnimation) 1f else 0f)
 
-                    binding.welcomeScreenWalkingDax.isVisible = false
-                    binding.daxDialogCta.comparisonChartContent.root.isVisible = false
-                    binding.daxDialogCta.addressBarContent.root.isVisible = false
-
                     val descriptionText = getString(R.string.preOnboardingInputScreenDescription).preventWidows()
                     binding.daxDialogCta.inputScreenContent.inputScreenDescription.text = descriptionText.html(requireContext())
-
-                    binding.daxDialogCta.inputScreenContent.root.isVisible = true
 
                     binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingInputScreenButton)
                     binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
                     binding.daxDialogCta.primaryCta.alpha = 0f
-
-                    // set the toggle state without crossfade, and do not start lottie animations yet, we'll start them once the view fully fades in
-                    updateAiChatToggleState(binding, withAi = inputScreenSelected, transition = InputToggleTransition.NONE)
                 }
 
                 INPUT_SCREEN_PREVIEW -> {
@@ -1503,6 +1502,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 binding.bottomWingAnimation.isVisible = false
 
+                binding.welcomeScreenWalkingDax.isVisible = false
+                binding.daxDialogCta.welcomeContent.root.isVisible = false
+                binding.daxDialogCta.secondaryCta.isVisible = false
+                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
+                binding.daxDialogCta.addressBarContent.root.isVisible = false
+                binding.daxDialogCta.inputScreenContent.root.isVisible = true
+                updateAiChatToggleState(binding, withAi = inputScreenSelected, transition = InputToggleTransition.NONE)
+
                 val leftWingView = binding.leftWingAnimation
                 val showLeftWing = BrandDesignUpdateOnboardingLayoutHelper.hasSpaceForAnimation(
                     rootView = binding.root,
@@ -1525,7 +1532,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.InputType)
 
-                binding.welcomeScreenWalkingDax.isVisible = false
                 (binding.daxDialogCta.root.layoutParams as ConstraintLayout.LayoutParams).apply {
                     if (showLeftWing && deviceInfo.isTablet()) {
                         verticalBias = 0.5f
@@ -1542,15 +1548,10 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 cardView.setArrowAnimationTarget(ARROW_TARGET_OFFSET_END_DP.toPx().toFloat())
                 cardView.setArrowAnimationFraction(1f)
                 cardView.setArrowDepthFraction(if (showLeftWing) 1f else 0f)
-                binding.daxDialogCta.welcomeContent.root.isVisible = false
-                binding.daxDialogCta.secondaryCta.isVisible = false
-                binding.daxDialogCta.comparisonChartContent.root.isVisible = false
-                binding.daxDialogCta.addressBarContent.root.isVisible = false
 
                 val descriptionText = getString(R.string.preOnboardingInputScreenDescription).preventWidows()
                 binding.daxDialogCta.inputScreenContent.inputScreenDescription.text = descriptionText.html(requireContext())
 
-                binding.daxDialogCta.inputScreenContent.root.isVisible = true
                 binding.daxDialogCta.inputScreenContent.inputScreenTitle.cancelAnimation()
                 binding.daxDialogCta.inputScreenContent.inputScreenTitle.text =
                     getString(R.string.preOnboardingInputScreenTitleUpdated)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -425,6 +425,14 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
     ) {
         super.onViewCreated(view, savedInstanceState)
 
+        with(binding.daxDialogCta.comparisonChartContent) {
+            comparisonChartItem1.text = getString(R.string.preOnboardingComparisonChartItem1).preventWidows()
+            comparisonChartDuckAi.text = getString(R.string.preOnboardingComparisonChartDuckAi).preventWidows()
+            comparisonChartItem2.text = getString(R.string.preOnboardingComparisonChartItem2).preventWidows()
+            comparisonChartItem3.text = getString(R.string.preOnboardingComparisonChartItem3).preventWidows()
+            comparisonChartItem4.text = getString(R.string.preOnboardingComparisonChartItem4).preventWidows()
+        }
+
         ViewGroupCompat.installCompatInsetsDispatch(binding.root)
         if (deviceInfo.isTablet()) {
             ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
@@ -827,7 +835,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                             // not a synchronous stop.
                             if (view == null) return
                             binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.startOnboardingTypingAnimation(
-                                getString(R.string.preOnboardingDaxDialog2Title),
+                                getString(R.string.preOnboardingDaxDialog2Title).preventWidows(),
                             ) {
                                 comparisonChartFadeInAnimatorSet = AnimatorSet().apply {
                                     playTogether(
@@ -1319,7 +1327,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
                 binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.cancelAnimation()
                 binding.daxDialogCta.comparisonChartContent.comparisonChartTitle.text =
-                    getString(R.string.preOnboardingDaxDialog2Title)
+                    getString(R.string.preOnboardingDaxDialog2Title).preventWidows()
                 binding.daxDialogCta.comparisonChartContent.comparisonTable.alpha = 1f
                 listOf(
                     binding.daxDialogCta.comparisonChartContent.check1,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/InputScreenOnboardingStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/InputScreenOnboardingStateProvider.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+interface InputScreenOnboardingStateProvider {
+    val isEnabled: StateFlow<Boolean>
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = InputScreenOnboardingStateProvider::class)
+@ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+class InputScreenOnboardingStateProviderImpl @Inject constructor(
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : InputScreenOnboardingStateProvider, PrivacyConfigCallbackPlugin {
+
+    private val _isEnabled = MutableStateFlow(false)
+    override val isEnabled = _isEnabled.asStateFlow()
+
+    init {
+        cacheState()
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        cacheState()
+    }
+
+    private fun cacheState() {
+        coroutineScope.launch(context = dispatcherProvider.io()) {
+            _isEnabled.value = androidBrowserConfigFeature.showInputScreenOnboarding().isEnabled()
+        }
+    }
+}

--- a/app/src/main/res/layout/content_onboarding_welcome_page_update.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome_page_update.xml
@@ -60,13 +60,13 @@
 
     <TextView
         android:id="@+id/welcomeTitle"
+        style="@style/Typography.DuckDuckGo.Onboarding.WelcomeTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:alpha="0"
         android:gravity="center"
         android:text="@string/onboardingWelcomeTitle"
-        android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.WelcomeTitle"
         app:layout_constraintBottom_toTopOf="@id/textGuideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/include_brand_design_comparison_chart.xml
+++ b/app/src/main/res/layout/include_brand_design_comparison_chart.xml
@@ -105,12 +105,13 @@
                 app:srcCompat="@drawable/ic_vpn_color_24_rebrand" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/comparisonChartItem1"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
-                android:text="@string/preOnboardingComparisonChartItem1"
-                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison" />
+                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison"
+                tools:text="@string/preOnboardingComparisonChartItem1" />
 
             <ImageView
                 android:layout_width="40dp"
@@ -158,12 +159,13 @@
                 app:srcCompat="@drawable/ic_duck_ai_color_24_rebrand" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/comparisonChartDuckAi"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
-                android:text="@string/preOnboardingComparisonChartDuckAi"
-                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison" />
+                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison"
+                tools:text="@string/preOnboardingComparisonChartDuckAi" />
 
             <ImageView
                 android:layout_width="40dp"
@@ -212,12 +214,13 @@
                 app:srcCompat="@drawable/ic_shield_color_24_rebrand" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/comparisonChartItem2"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
-                android:text="@string/preOnboardingComparisonChartItem2"
-                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison" />
+                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison"
+                tools:text="@string/preOnboardingComparisonChartItem2" />
 
             <ImageView
                 android:layout_width="40dp"
@@ -265,12 +268,13 @@
                 app:srcCompat="@drawable/ic_cookies_color_24_rebrand" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/comparisonChartItem3"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
-                android:text="@string/preOnboardingComparisonChartItem3"
-                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison" />
+                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison"
+                tools:text="@string/preOnboardingComparisonChartItem3" />
 
             <ImageView
                 android:layout_width="40dp"
@@ -319,12 +323,13 @@
                 app:srcCompat="@drawable/ic_profile_blocker_color_24_rebrand" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/comparisonChartItem4"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="12dp"
                 android:layout_weight="1"
-                android:text="@string/preOnboardingComparisonChartItem4"
-                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison" />
+                android:textAppearance="@style/Typography.DuckDuckGo.Onboarding.ChartComparison"
+                tools:text="@string/preOnboardingComparisonChartItem4" />
 
             <ImageView
                 android:layout_width="40dp"

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
@@ -22,7 +22,9 @@ import com.duckduckgo.app.browser.newtab.NewTabPageViewModel.Command
 import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
+import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -74,6 +76,8 @@ class NewTabPageViewModelTest {
     private val mockLowPriorityMessagingModel: LowPriorityMessagingModel = mock()
     private val mockAppTrackingProtection: AppTrackingProtection = mock()
     private val pixel: Pixel = mock()
+    private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val mockCtaViewModel: CtaViewModel = mock()
 
     private lateinit var testee: NewTabPageViewModel
 
@@ -81,6 +85,7 @@ class NewTabPageViewModelTest {
     fun setUp() = runTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(null))
         whenever(mockAppTrackingProtection.isEnabled()).thenReturn(false)
@@ -103,6 +108,8 @@ class NewTabPageViewModelTest {
             lowPriorityMessagingModel = mockLowPriorityMessagingModel,
             appTrackingProtection = mockAppTrackingProtection,
             pixel = pixel,
+            onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
+            ctaViewModel = mockCtaViewModel,
         )
     }
 
@@ -157,6 +164,43 @@ class NewTabPageViewModelTest {
                 assertTrue(it.newMessage)
                 assertTrue(it.onboardingComplete)
                 assertNull(it.messageImageFilePath)
+            }
+        }
+    }
+
+    @Test
+    fun whenBrandDesignUpdateEnabledAndBubbleDaxDialogsNotCompleteThenOnboardingNotComplete() = runTest {
+        val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+        whenever(mockCtaViewModel.areBubbleDaxDialogsCompleted()).thenReturn(false)
+        val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), listOf(Surface.NEW_TAB_PAGE))
+        whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(remoteMessage))
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testee = createTestee()
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.onboardingComplete)
+            }
+        }
+    }
+
+    @Test
+    fun whenBrandDesignUpdateEnabledAndBubbleDaxDialogsCompleteThenOnboardingComplete() = runTest {
+        val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+        whenever(mockCtaViewModel.areBubbleDaxDialogsCompleted()).thenReturn(true)
+        val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), listOf(Surface.NEW_TAB_PAGE))
+        whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(remoteMessage))
+
+        testee = createTestee()
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.onboardingComplete)
             }
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -57,6 +57,9 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboardingWideEvent
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -90,6 +93,7 @@ class BrandDesignUpdatePageViewModelTest {
     private val mockInputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent = mock()
     private val mockDuckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager = mock()
     private val mockOnboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager = mock()
+    private val fakeInputScreenOnboardingStateProvider = FakeInputScreenOnboardingStateProvider()
 
     private fun createViewModel(): BrandDesignUpdatePageViewModel {
         return BrandDesignUpdatePageViewModel(
@@ -106,7 +110,13 @@ class BrandDesignUpdatePageViewModelTest {
             mockInputScreenOnboardingWideEvent,
             mockDuckAiOnboardingExperimentManager,
             mockOnboardingQuickSetupExperimentManager,
+            fakeInputScreenOnboardingStateProvider,
         )
+    }
+
+    private class FakeInputScreenOnboardingStateProvider : InputScreenOnboardingStateProvider {
+        val state = MutableStateFlow(false)
+        override val isEnabled: StateFlow<Boolean> = state.asStateFlow()
     }
 
     // region hasPlayedIntroAnimation
@@ -329,7 +339,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromAddressBarPositionWithTopThenSaveTopAndSendFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        fakeInputScreenOnboardingStateProvider.state.value = false
         val testee = createViewModel()
         // Navigate to ADDRESS_BAR_POSITION via onDefaultBrowserSet
         testee.onDefaultBrowserSet()
@@ -344,7 +354,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromAddressBarPositionWithBottomThenSaveBottomAndFirePixelAndFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        fakeInputScreenOnboardingStateProvider.state.value = false
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_BOTTOM)
@@ -393,7 +403,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithAiSelectedThenFireAiPixelAndStoreAndFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
@@ -412,7 +422,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithSearchOnlySelectedThenFireSearchOnlyPixelAndStoreAndFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
@@ -432,7 +442,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithReinstallUserTrueAndAiSelectedThenCallWideEventWithReinstallTrue() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
         val testee = createViewModel()
         testee.loadDaxDialog() // sets isReinstallUser = true
@@ -579,39 +589,43 @@ class BrandDesignUpdatePageViewModelTest {
     // region maxPageCount
 
     @Test
-    fun whenInputScreenOnboardingEnabledAtComparisonChartEntryThenMaxPageCountIs3() = runTest {
-        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+    fun whenInputScreenOnboardingEnabledThenMaxPageCountIs3() = runTest {
+        fakeInputScreenOnboardingStateProvider.state.value = true
         val testee = createViewModel()
-        testee.loadDaxDialog()
-        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART (resolves input-screen toggle)
         advanceUntilIdle()
-        assertEquals(3, testee.getMaxPageCount())
+        assertEquals(3, testee.viewState.value.maxPageCount)
     }
 
     @Test
-    fun whenInputScreenOnboardingDisabledAtComparisonChartEntryThenMaxPageCountIs2() = runTest {
-        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+    fun whenInputScreenOnboardingDisabledThenMaxPageCountIs2() = runTest {
+        fakeInputScreenOnboardingStateProvider.state.value = false
         val testee = createViewModel()
-        testee.loadDaxDialog()
-        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART (resolves input-screen toggle)
         advanceUntilIdle()
-        assertEquals(2, testee.getMaxPageCount())
+        assertEquals(2, testee.viewState.value.maxPageCount)
     }
 
     @Test
-    fun whenToggleFlipsTrueAfterComparisonChartEntryThenMaxPageCountStaysAtCachedValue() = runTest {
-        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+    fun whenStateProviderEmitsTrueAfterCreationThenMaxPageCountUpdatesTo3AndAddressBarPositionRoutesToInputScreen() = runTest {
+        fakeInputScreenOnboardingStateProvider.state.value = false
         val testee = createViewModel()
-        testee.loadDaxDialog()
-        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART captures toggle=false
+        testee.onDefaultBrowserSet()
+        testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
+        advanceUntilIdle()
+        assertEquals(2, testee.viewState.value.maxPageCount)
+
+        // Privacy config arrives and the provider re-emits with the flag enabled.
+        fakeInputScreenOnboardingStateProvider.state.value = true
         advanceUntilIdle()
 
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
-
-        assertEquals(2, testee.getMaxPageCount())
+        testee.viewState.test {
+            testee.onPrimaryCtaClicked() // ADDRESS_BAR_POSITION -> reads updated ViewState, routes to INPUT_SCREEN
+            var state = awaitItem()
+            while (state.currentDialog != PreOnboardingDialogType.INPUT_SCREEN) {
+                state = awaitItem()
+            }
+            cancelAndConsumeRemainingEvents()
+        }
+        assertEquals(3, testee.viewState.value.maxPageCount)
     }
 
     // endregion
@@ -734,7 +748,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenInputScreenDialogShownThenFiresChooseSearchExperiencePixel() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
@@ -748,7 +762,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsNullThenFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(null)
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
@@ -764,7 +778,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsControlThenFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.CONTROL)
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
@@ -780,7 +794,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsTreatmentDuckAiThenShowInputScreenPreview() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_DUCK_AI_DEFAULT)
         val searchOptions = listOf(DaxDialogIntroOption("search1", 0, "link1"))
         val chatSuggestions = listOf(DaxDialogIntroOption("chat1", 0, "link2"))
@@ -806,7 +820,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithAiSelectedAndEnrollReturnsTreatmentSearchThenShowInputScreenPreviewWithSearchDefault() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_SEARCH_DEFAULT)
         val searchOptions = listOf(DaxDialogIntroOption("search1", 0, "link1"))
         val chatSuggestions = listOf(DaxDialogIntroOption("chat1", 0, "link2"))
@@ -832,7 +846,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenWithSearchOnlySelectedThenDoNotEnrollAndFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         val testee = createViewModel()
         testee.onDefaultBrowserSet()
         testee.onAddressBarPositionOptionSelected(OmnibarType.SINGLE_TOP)
@@ -852,7 +866,7 @@ class BrandDesignUpdatePageViewModelTest {
 
     @Test
     fun whenPrimaryCtaFromInputScreenPreviewThenFinish() = runTest {
-        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        fakeInputScreenOnboardingStateProvider.state.value = true
         whenever(mockDuckAiOnboardingExperimentManager.enroll()).thenReturn(DuckAiOnboardingExperimentVariant.TREATMENT_WITH_SEARCH_DEFAULT)
         whenever(mockOnboardingStore.getSearchOptions()).thenReturn(emptyList())
         whenever(mockOnboardingStore.getChatSuggestions()).thenReturn(emptyList())

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -579,18 +579,38 @@ class BrandDesignUpdatePageViewModelTest {
     // region maxPageCount
 
     @Test
-    fun whenInputScreenOnboardingEnabledThenMaxPageCountIs3() = runTest {
+    fun whenInputScreenOnboardingEnabledAtComparisonChartEntryThenMaxPageCountIs3() = runTest {
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
         mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
         val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART (resolves input-screen toggle)
         advanceUntilIdle()
         assertEquals(3, testee.getMaxPageCount())
     }
 
     @Test
-    fun whenInputScreenOnboardingDisabledThenMaxPageCountIs2() = runTest {
+    fun whenInputScreenOnboardingDisabledAtComparisonChartEntryThenMaxPageCountIs2() = runTest {
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
         mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
         val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART (resolves input-screen toggle)
         advanceUntilIdle()
+        assertEquals(2, testee.getMaxPageCount())
+    }
+
+    @Test
+    fun whenToggleFlipsTrueAfterComparisonChartEntryThenMaxPageCountStaysAtCachedValue() = runTest {
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onPrimaryCtaClicked() // INITIAL -> COMPARISON_CHART captures toggle=false
+        advanceUntilIdle()
+
+        mockAndroidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+
         assertEquals(2, testee.getMaxPageCount())
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenOnboardingStateProviderImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/InputScreenOnboardingStateProviderImplTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.ui.page
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@SuppressLint("DenyListedApi")
+class InputScreenOnboardingStateProviderImplTest {
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(
+        AndroidBrowserConfigFeature::class.java,
+    )
+
+    private fun createProvider() = InputScreenOnboardingStateProviderImpl(
+        coroutineScope = coroutineRule.testScope,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        androidBrowserConfigFeature = androidBrowserConfigFeature,
+    )
+
+    @Test
+    fun whenCreatedAndToggleEnabledThenIsEnabledIsTrue() = runTest {
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        val provider = createProvider()
+        advanceUntilIdle()
+        assertTrue(provider.isEnabled.value)
+    }
+
+    @Test
+    fun whenCreatedAndToggleDisabledThenIsEnabledIsFalse() = runTest {
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        val provider = createProvider()
+        advanceUntilIdle()
+        assertFalse(provider.isEnabled.value)
+    }
+
+    @Test
+    fun whenToggleFlipsAfterCreationAndOnPrivacyConfigDownloadedThenIsEnabledRefreshes() = runTest {
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        val provider = createProvider()
+        advanceUntilIdle()
+        assertFalse(provider.isEnabled.value)
+
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        provider.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(provider.isEnabled.value)
+    }
+
+    @Test
+    fun whenToggleFlipsAfterCreationWithoutCallbackThenIsEnabledDoesNotChange() = runTest {
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = false))
+        val provider = createProvider()
+        advanceUntilIdle()
+
+        androidBrowserConfigFeature.showInputScreenOnboarding().setRawStoredState(Toggle.State(enable = true))
+        advanceUntilIdle()
+
+        assertFalse(provider.isEnabled.value)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1214906614116189

### Description

Ship-review polish for the Onboarding Brand Design Update — typography, layout-fit handling for the Dax/wing decorations, and a handful of small bugs.

- Reset comparison-chart check AVDs before each play so the green ticks aren't already drawn when the animation starts.
- Defer the new-tab RMF until the onboarding subscription dialog has been shown, preventing a brief RMF flash behind it.
- Read the input-screen routing toggle once and reuse it, so the step-indicator total matches the flow that will actually be shown.
- Prevent widow words on the comparison-chart title and row labels.
- Prevent widow words on the single-tab fire dialog subtitle.
- Match Figma's 100% line-height on the welcome title.
- Collapse the dialog tail when the comparison-chart bottom wing animation has no room to render.
- Re-anchor the input-screen dialog and collapse its tail when the left-wing animation has no room.
- Collapse the welcome dialog tail when the walking-Dax illustration is hidden.
- Space-check the bobbing-Dax cloud before showing it on the address-bar dialog (animated entry).
- Same space-check on the address-bar dialog snap path.
- Cancel the bobbing-Dax ValueAnimator when it's hidden for lack of space, so no animation runs against an invisible Lottie.
- Pre-load the address-bar toggle icons before measuring the dialog, so the bobbing-Dax fit check uses the dialog's true height.
- Swap input-screen content and pre-load the AI-chat toggle drawable before measuring, so the left-wing fit check uses the dialog's true height.

### Steps to test this PR

_Pre-requisites_
- [x] Use an **Internal** build. The `onboardingBrandDesignUpdate` feature toggle defaults to ON for internal builds, so no manual flip is needed
- [x] Clear app data (or fresh install) so the onboarding flow runs from the start.

_Welcome dialog_
- [x] Title has no widow words (no single word dangling on the last line).
- [x] Title line height looks balanced — roughly equal to font size, not loose.
- [x] When the walking-Dax illustration is visible below the dialog, the dialog tail extends down toward it. On screens where the walking Dax is hidden, the tail is flat (no dangling tail pointing at nothing).

_Comparison chart_
- [x] No widow words on the chart title or row labels.
- [x] Green check ticks animate in cleanly — they must not appear already drawn before the stroke animation plays.
- [x] Step indicator shows the correct total step count for the flow about to be shown.
- [x] Bottom wing animation appears when there's room; when there isn't, the dialog tail is flat (not pointing at empty space).

_Address-bar position dialog_
- [x] On entry (animated path) the bobbing-Dax cloud either fits cleanly above the dialog tail or is omitted — it must never overlap the dialog.
- [x] Repeat with a process restart on the same screen (snap path) — same correct behaviour.
- [ ] If the bobbing-Dax is hidden, no Lottie animation runs in the background.

_Input-screen dialog_
- [x] Dialog measures correctly on entry — the AI-chat toggle row should not pop in / cause the dialog to grow after it appears.
- [ ] Left-wing animation appears when there's room; when there isn't, the dialog re-anchors to the bottom of the screen and the tail is flat.

_Single-tab fire dialog_
- [x] Open the fire dialog with only one tab open. Subtitle has no widow words.

_Subscription onboarding dialog_
- [x] When the subscription dialog is shown during onboarding, no new-tab RMF flashes behind it.

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes onboarding flow control (step count/routing) and gates New Tab remote messaging based on new completion conditions, which can affect when users see onboarding and home content.
> 
> **Overview**
> **Polishes the Brand Design Update onboarding UI/animations**: updates welcome-title typography to match Figma line height, applies `preventWidows()` to comparison-chart labels/titles and single-tab fire dialog subtitles, and tweaks layout/animation behavior to collapse the dialog tail and hide/cancel decorative Lottie/arrow depth when there isn’t space.
> 
> **Fixes onboarding flow consistency and new-tab timing**: introduces `InputScreenOnboardingStateProvider` (privacy-config-callback-backed) so the input-screen toggle is cached and the step indicator/routing stays consistent as config updates arrive, and updates `NewTabPageViewModel` to treat onboarding as complete via bubble-dialog completion when the brand-design-update toggle is enabled (preventing remote-message flashes during onboarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5a1d581ebb0b658086afd88437d5b77c4ed967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->