### PR TITLE
Add native sync queue for Duck.ai chat updates

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPlugin.kt
@@ -65,6 +65,7 @@ class DuckChatDataClearingPlugin @Inject constructor(
             val timestamp = duckChatFeatureRepository.getAppBackgroundTimestamp() ?: currentTimeProvider.currentTimeMillis()
             duckChatSyncRepository.recordDuckAiChatsDeleted(timestamp)
             duckChatSyncRepository.clearPendingChatDeletions()
+            duckChatSyncRepository.clearPendingChatUpdates()
             syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -243,6 +243,13 @@ interface DuckChatFeature {
     fun chatSuggestionTypeIcon(): Toggle
 
     /**
+     * @return `true` when the per-row Rename affordance on the Duck.ai chat history screen is visible.
+     * If the remote feature is not present defaults to `false`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun renameChat(): Toggle
+
+    /**
      * Kill switch for opening Duck.ai voice chat when the digital assistant intent is received.
      * @return `true` when the remote config has the "digitalAssistantDuckAi"
      * sub-feature flag enabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -86,6 +86,11 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         viewLifecycleOwner.lifecycleScope.launch { chatHistoryReader.refresh() }
     }
 
+    override fun onDestroyView() {
+        chatHistoryReader.tearDown()
+        super.onDestroyView()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -57,6 +57,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     @Inject
     lateinit var fireDialogProvider: FireDialogProvider
 
+    @Inject
+    lateinit var chatHistoryReader: ChatHistoryReader
+
     private val binding: FragmentChatHistoryBinding by viewBinding()
     private val viewModel: ChatHistoryViewModel by lazy {
         ViewModelProvider(this, viewModelFactory)[ChatHistoryViewModel::class.java]
@@ -76,6 +79,11 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
                 viewModel.isSelectMode() -> viewModel.onSelectModeCancelled()
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewLifecycleOwner.lifecycleScope.launch { chatHistoryReader.refresh() }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.ui.view.SearchBar
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.dataclearing.api.fire.FireDialog
@@ -41,10 +42,12 @@ import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentChatHistoryBinding
+import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
@@ -59,6 +62,12 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     @Inject
     lateinit var chatHistoryReader: ChatHistoryReader
+
+    @Inject
+    lateinit var duckChatFeature: DuckChatFeature
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
 
     private val binding: FragmentChatHistoryBinding by viewBinding()
     private val viewModel: ChatHistoryViewModel by lazy {
@@ -322,18 +331,27 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     }
 
     private fun showRowPopup(item: ChatHistoryItem, anchor: View) {
-        val popup = PopupMenu(layoutInflater, R.layout.popup_chat_history_row)
-        val view = popup.contentView
-        val pinAction = view.findViewById<PopupMenuItemView>(R.id.pin)
-        val pinLabel = if (item.pinned) R.string.duck_ai_chat_history_action_unpin else R.string.duck_ai_chat_history_action_pin
-        pinAction.setPrimaryText(getString(pinLabel))
-        popup.onMenuItemClicked(pinAction) { viewModel.onTogglePin(item.chatId) }
-        popup.onMenuItemClicked(view.findViewById(R.id.rename)) {
-            viewModel.onRenameRequested(item.chatId, item.displayTitle)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val isRenameEnabled = withContext(dispatchers.io()) { duckChatFeature.renameChat().isEnabled() }
+            val popup = PopupMenu(layoutInflater, R.layout.popup_chat_history_row)
+            val view = popup.contentView
+            val pinAction = view.findViewById<PopupMenuItemView>(R.id.pin)
+            val pinLabel = if (item.pinned) R.string.duck_ai_chat_history_action_unpin else R.string.duck_ai_chat_history_action_pin
+            pinAction.setPrimaryText(getString(pinLabel))
+            popup.onMenuItemClicked(pinAction) { viewModel.onTogglePin(item.chatId) }
+            val renameAction = view.findViewById<PopupMenuItemView>(R.id.rename)
+            if (isRenameEnabled) {
+                renameAction.show()
+                popup.onMenuItemClicked(renameAction) {
+                    viewModel.onRenameRequested(item.chatId, item.displayTitle)
+                }
+            } else {
+                renameAction.gone()
+            }
+            popup.onMenuItemClicked(view.findViewById(R.id.download)) { showComingSoonSnackbar() }
+            popup.onMenuItemClicked(view.findViewById(R.id.delete)) { viewModel.onDeleteSingleChat(item.chatId) }
+            popup.show(binding.root, anchor)
         }
-        popup.onMenuItemClicked(view.findViewById(R.id.download)) { showComingSoonSnackbar() }
-        popup.onMenuItemClicked(view.findViewById(R.id.delete)) { viewModel.onDeleteSingleChat(item.chatId) }
-        popup.show(binding.root, anchor)
     }
 
     private fun showComingSoonSnackbar() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebSettings
+import android.webkit.WebView
+import com.duckduckgo.app.di.ActivityContext
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
+import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import logcat.logcat
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Named
+
+interface ChatHistoryReader {
+    /**
+     * Opens Duck.ai in an attached but invisible WebView so the FE SPA fetches /sync/ai_chats,
+     * decrypts JWE titles, and writes each chat into native Room via the duckAiNativeStorage.putChat
+     * bridge. Errors are silent.
+     */
+    suspend fun refresh()
+
+    fun tearDown()
+}
+
+@ContributesBinding(ActivityScope::class)
+@SingleInstanceIn(ActivityScope::class)
+class RealChatHistoryReader @Inject constructor(
+    @ActivityContext private val context: Context,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    @Named("ContentScopeScripts") private val contentScopeScripts: JsMessaging,
+    private val duckChatWebViewClient: DuckChatWebViewClient,
+    private val duckChatJSHelper: DuckChatJSHelper,
+    private val subscriptionsJSHelper: SubscriptionsJSHelper,
+) : ChatHistoryReader {
+
+    private var webView: WebView? = null
+    private var pageLoadDeferred: CompletableDeferred<Unit>? = null
+
+    override suspend fun refresh() {
+        runCatching {
+            withContext(dispatchers.main()) {
+                val wv = getOrCreateWebView() ?: return@withContext
+                pageLoadDeferred = CompletableDeferred()
+                logcat { "ChatHistoryReader: loading $DUCK_AI_URL" }
+                wv.loadUrl(DUCK_AI_URL)
+                val loaded = withTimeoutOrNull(PAGE_LOAD_TIMEOUT_MS) { pageLoadDeferred?.await() }
+                if (loaded == null) {
+                    logcat { "ChatHistoryReader: page load timed out after ${PAGE_LOAD_TIMEOUT_MS}ms" }
+                    return@withContext
+                }
+                logcat { "ChatHistoryReader: page loaded, settling ${SYNC_SETTLE_MS}ms for FE sync" }
+                delay(SYNC_SETTLE_MS)
+                logcat { "ChatHistoryReader: settle done" }
+            }
+        }.onFailure {
+            logcat { "ChatHistoryReader: refresh failed — ${it.message}" }
+        }
+    }
+
+    override fun tearDown() {
+        pageLoadDeferred?.cancel()
+        pageLoadDeferred = null
+        webView?.let { wv ->
+            (wv.parent as? ViewGroup)?.removeView(wv)
+            wv.destroy()
+        }
+        webView = null
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun getOrCreateWebView(): WebView? {
+        webView?.let { return it }
+
+        val activity = context as? Activity ?: run {
+            logcat { "ChatHistoryReader: ActivityContext is not an Activity; cannot create WebView" }
+            return null
+        }
+        val container = activity.findViewById<ViewGroup>(android.R.id.content) ?: run {
+            logcat { "ChatHistoryReader: activity has no android.R.id.content; cannot attach WebView" }
+            return null
+        }
+
+        val wv = WebView(context).apply {
+            settings.apply {
+                userAgentString = CUSTOM_UA
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                loadWithOverviewMode = true
+                useWideViewPort = true
+                mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+                cacheMode = WebSettings.LOAD_DEFAULT
+            }
+
+            CookieManager.getInstance().setAcceptCookie(true)
+            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+            duckChatWebViewClient.onPageFinishedListener = { url ->
+                logcat { "ChatHistoryReader: onPageFinished $url" }
+                pageLoadDeferred?.complete(Unit)
+            }
+            webViewClient = duckChatWebViewClient
+
+            contentScopeScripts.register(
+                this,
+                object : JsMessageCallback() {
+                    override fun process(
+                        featureName: String,
+                        method: String,
+                        id: String?,
+                        data: JSONObject?,
+                    ) {
+                        logcat { "ChatHistoryReader: bridge $featureName.$method id=$id" }
+                        when (featureName) {
+                            DUCK_CHAT_FEATURE_NAME -> handleDuckChatMessage(featureName, method, id, data)
+                            SUBSCRIPTIONS_FEATURE_NAME -> handleSubscriptionsMessage(featureName, method, id, data)
+                        }
+                    }
+                },
+            )
+        }
+
+        container.addView(wv, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        wv.visibility = View.INVISIBLE
+        webView = wv
+        return wv
+    }
+
+    private fun handleDuckChatMessage(featureName: String, method: String, id: String?, data: JSONObject?) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)?.let { response ->
+                withContext(dispatchers.main()) {
+                    contentScopeScripts.onResponse(response)
+                }
+            }
+        }
+    }
+
+    private fun handleSubscriptionsMessage(featureName: String, method: String, id: String?, data: JSONObject?) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data, context)?.let { response ->
+                withContext(dispatchers.main()) {
+                    contentScopeScripts.onResponse(response)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val DUCK_AI_URL = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
+        private const val CUSTOM_UA =
+            "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"
+        private const val PAGE_LOAD_TIMEOUT_MS = 10000L
+        private const val SYNC_SETTLE_MS = 5000L
+        private const val DUCK_CHAT_FEATURE_NAME = "aiChat"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
@@ -32,13 +32,10 @@ import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
-import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
-import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -48,11 +45,6 @@ import javax.inject.Inject
 import javax.inject.Named
 
 interface ChatHistoryReader {
-    /**
-     * Opens Duck.ai in an attached but invisible WebView so the FE SPA fetches /sync/ai_chats,
-     * decrypts JWE titles, and writes each chat into native Room via the duckAiNativeStorage.putChat
-     * bridge. Errors are silent.
-     */
     suspend fun refresh()
 
     fun tearDown()
@@ -67,8 +59,8 @@ class RealChatHistoryReader @Inject constructor(
     @Named("ContentScopeScripts") private val contentScopeScripts: JsMessaging,
     private val duckChatWebViewClient: DuckChatWebViewClient,
     private val duckChatJSHelper: DuckChatJSHelper,
-    private val subscriptionsJSHelper: SubscriptionsJSHelper,
 ) : ChatHistoryReader {
+    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
 
     private var webView: WebView? = null
     private var pageLoadDeferred: CompletableDeferred<Unit>? = null
@@ -85,9 +77,7 @@ class RealChatHistoryReader @Inject constructor(
                     logcat { "ChatHistoryReader: page load timed out after ${PAGE_LOAD_TIMEOUT_MS}ms" }
                     return@withContext
                 }
-                logcat { "ChatHistoryReader: page loaded, settling ${SYNC_SETTLE_MS}ms for FE sync" }
-                delay(SYNC_SETTLE_MS)
-                logcat { "ChatHistoryReader: settle done" }
+                logcat { "ChatHistoryReader: page loaded; SPA fan-out continues in the WebView" }
             }
         }.onFailure {
             logcat { "ChatHistoryReader: refresh failed — ${it.message}" }
@@ -128,15 +118,14 @@ class RealChatHistoryReader @Inject constructor(
                 cacheMode = WebSettings.LOAD_DEFAULT
             }
 
-            CookieManager.getInstance().setAcceptCookie(true)
-            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+            cookieManager.setAcceptCookie(true)
+            cookieManager.setAcceptThirdPartyCookies(this, true)
 
             duckChatWebViewClient.onPageFinishedListener = { url ->
                 logcat { "ChatHistoryReader: onPageFinished $url" }
                 pageLoadDeferred?.complete(Unit)
             }
             webViewClient = duckChatWebViewClient
-
             contentScopeScripts.register(
                 this,
                 object : JsMessageCallback() {
@@ -147,9 +136,8 @@ class RealChatHistoryReader @Inject constructor(
                         data: JSONObject?,
                     ) {
                         logcat { "ChatHistoryReader: bridge $featureName.$method id=$id" }
-                        when (featureName) {
-                            DUCK_CHAT_FEATURE_NAME -> handleDuckChatMessage(featureName, method, id, data)
-                            SUBSCRIPTIONS_FEATURE_NAME -> handleSubscriptionsMessage(featureName, method, id, data)
+                        if (featureName == DUCK_CHAT_FEATURE_NAME) {
+                            handleDuckChatMessage(featureName, method, id, data)
                         }
                     }
                 },
@@ -172,22 +160,11 @@ class RealChatHistoryReader @Inject constructor(
         }
     }
 
-    private fun handleSubscriptionsMessage(featureName: String, method: String, id: String?, data: JSONObject?) {
-        appCoroutineScope.launch(dispatchers.io()) {
-            subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data, context)?.let { response ->
-                withContext(dispatchers.main()) {
-                    contentScopeScripts.onResponse(response)
-                }
-            }
-        }
-    }
-
     companion object {
         private const val DUCK_AI_URL = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
         private const val CUSTOM_UA =
             "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"
         private const val PAGE_LOAD_TIMEOUT_MS = 10000L
-        private const val SYNC_SETTLE_MS = 5000L
         private const val DUCK_CHAT_FEATURE_NAME = "aiChat"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
@@ -17,10 +17,7 @@
 package com.duckduckgo.duckchat.impl.history
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
-import android.view.View
-import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -68,7 +65,7 @@ class RealChatHistoryReader @Inject constructor(
     override suspend fun refresh() {
         runCatching {
             withContext(dispatchers.main()) {
-                val wv = getOrCreateWebView() ?: return@withContext
+                val wv = getOrCreateWebView()
                 pageLoadDeferred = CompletableDeferred()
                 logcat { "ChatHistoryReader: loading $DUCK_AI_URL" }
                 wv.loadUrl(DUCK_AI_URL)
@@ -87,25 +84,13 @@ class RealChatHistoryReader @Inject constructor(
     override fun tearDown() {
         pageLoadDeferred?.cancel()
         pageLoadDeferred = null
-        webView?.let { wv ->
-            (wv.parent as? ViewGroup)?.removeView(wv)
-            wv.destroy()
-        }
+        webView?.destroy()
         webView = null
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    private fun getOrCreateWebView(): WebView? {
+    private fun getOrCreateWebView(): WebView {
         webView?.let { return it }
-
-        val activity = context as? Activity ?: run {
-            logcat { "ChatHistoryReader: ActivityContext is not an Activity; cannot create WebView" }
-            return null
-        }
-        val container = activity.findViewById<ViewGroup>(android.R.id.content) ?: run {
-            logcat { "ChatHistoryReader: activity has no android.R.id.content; cannot attach WebView" }
-            return null
-        }
 
         val wv = WebView(context).apply {
             settings.apply {
@@ -144,8 +129,6 @@ class RealChatHistoryReader @Inject constructor(
             )
         }
 
-        container.addView(wv, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
-        wv.visibility = View.INVISIBLE
         webView = wv
         return wv
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -63,7 +64,7 @@ class RealChatHistoryReader @Inject constructor(
     private var pageLoadDeferred: CompletableDeferred<Unit>? = null
 
     override suspend fun refresh() {
-        runCatching {
+        try {
             withContext(dispatchers.main()) {
                 val wv = getOrCreateWebView()
                 pageLoadDeferred = CompletableDeferred()
@@ -76,8 +77,10 @@ class RealChatHistoryReader @Inject constructor(
                 }
                 logcat { "ChatHistoryReader: page loaded; SPA fan-out continues in the WebView" }
             }
-        }.onFailure {
-            logcat { "ChatHistoryReader: refresh failed — ${it.message}" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logcat { "ChatHistoryReader: refresh failed — ${e.message}" }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -21,8 +21,10 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.toChatType
+import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.sync.api.engine.SyncEngine
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
@@ -46,6 +48,8 @@ class RealChatHistoryRepository @Inject constructor(
     private val chatStore: DuckAiChatStore,
     private val dispatchers: DispatcherProvider,
     private val context: Context,
+    private val duckChatSyncRepository: DuckChatSyncRepository,
+    private val syncEngine: SyncEngine,
 ) : ChatHistoryRepository {
 
     private val fallbackTitle: String by lazy { context.getString(R.string.duck_ai_chat_history_untitled) }
@@ -63,7 +67,14 @@ class RealChatHistoryRepository @Inject constructor(
     }
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean =
-        withContext(dispatchers.io()) { chatStore.renameChat(chatId, newTitle) }
+        withContext(dispatchers.io()) {
+            val updated = chatStore.renameChat(chatId, newTitle)
+            if (updated) {
+                duckChatSyncRepository.recordSingleChatUpdate(chatId)
+                syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+            }
+            updated
+        }
 
     override suspend fun setPinned(chatId: String, pinned: Boolean) {
         withContext(dispatchers.io()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -79,6 +79,8 @@ class RealChatHistoryRepository @Inject constructor(
     override suspend fun setPinned(chatId: String, pinned: Boolean) {
         withContext(dispatchers.io()) {
             if (pinned) chatStore.pinChat(chatId) else chatStore.unpinChat(chatId)
+            duckChatSyncRepository.recordSingleChatUpdate(chatId)
+            syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -68,12 +68,7 @@ class RealChatHistoryRepository @Inject constructor(
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean =
         withContext(dispatchers.io()) {
-            val updated = chatStore.renameChat(chatId, newTitle)
-            if (updated) {
-                duckChatSyncRepository.recordSingleChatUpdate(chatId)
-                syncEngine.triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
-            }
-            updated
+            chatStore.renameChat(chatId, newTitle)
         }
 
     override suspend fun setPinned(chatId: String, pinned: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncDataManager.Adapters.Companion.patchResponseAdapter
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
-import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.api.engine.DeletableDataManager
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.ModifiedSince
@@ -65,7 +64,6 @@ class DuckChatSyncDataManager @Inject constructor(
     private val duckChatFeature: DuckChatFeature,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val duckAiChatStore: DuckAiChatStore,
-    private val syncCrypto: SyncCrypto,
 ) : DeletableDataManager, SyncableDataProvider, SyncableDataPersister {
 
     override fun getDeletableType(): DeletableType = DeletableType.DUCK_AI_CHATS

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
@@ -219,8 +219,7 @@ class DuckChatSyncDataManager @Inject constructor(
                         put("id", chat.chatId)
                         put("client_last_modified", now)
                         put("edit_timestamp", now)
-                        put("title", syncCrypto.encrypt(chat.title))
-                        // FE wire format: "pinned" when set, JSON null when unset (not boolean).
+                        // Title is omitted until JWE encryption lands on native.
                         put("pinned", if (chat.pinned) "pinned" else org.json.JSONObject.NULL)
                     },
                 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.sync.DuckChatSyncDataManager.Adapters.Companion.patchResponseAdapter
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.api.engine.DeletableDataManager
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.ModifiedSince
@@ -62,6 +64,8 @@ class DuckChatSyncDataManager @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val duckChatFeature: DuckChatFeature,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val duckAiChatStore: DuckAiChatStore,
+    private val syncCrypto: SyncCrypto,
 ) : DeletableDataManager, SyncableDataProvider, SyncableDataPersister {
 
     override fun getDeletableType(): DeletableType = DeletableType.DUCK_AI_CHATS
@@ -82,8 +86,10 @@ class DuckChatSyncDataManager @Inject constructor(
                 return@runBlocking getEmptyRequest()
             }
 
-            val pendingIds = duckChatSyncRepository.getPendingChatDeletions()
-            formatPatchRequest(pendingIds)
+            val pendingDeletions = duckChatSyncRepository.getPendingChatDeletions()
+            // Deletion wins over update when a chatId is in both queues.
+            val pendingUpdates = duckChatSyncRepository.getPendingChatUpdates() - pendingDeletions
+            formatPatchRequest(pendingDeletions, pendingUpdates)
         }
     }
 
@@ -136,10 +142,11 @@ class DuckChatSyncDataManager @Inject constructor(
                 return SyncMergeResult.Error(reason = "Error parsing patch response ${it.message}")
             }
 
-            val entryIds = response.aiChats.entries.map { it.id }
+            val entryIds = response.aiChats.entries.map { it.id }.toSet()
             logcat { "DuckChat-Sync: patch successful for ${entryIds.size} entries" }
             appCoroutineScope.launch(dispatchers.io()) {
-                duckChatSyncRepository.removePendingChatDeletions(entryIds.toSet())
+                duckChatSyncRepository.removePendingChatDeletions(entryIds)
+                duckChatSyncRepository.removePendingChatUpdates(entryIds)
             }
         }
         return SyncMergeResult.Success()
@@ -155,6 +162,7 @@ class DuckChatSyncDataManager @Inject constructor(
     override fun onSyncDisabled() {
         appCoroutineScope.launch(dispatchers.io()) {
             duckChatSyncRepository.clearPendingChatDeletions()
+            duckChatSyncRepository.clearPendingChatUpdates()
         }
     }
 
@@ -178,16 +186,21 @@ class DuckChatSyncDataManager @Inject constructor(
         )
     }
 
-    private fun formatPatchRequest(pendingIds: Set<String>): SyncChangesRequest {
-        if (pendingIds.isEmpty()) {
-            logcat(LogPriority.DEBUG) { "DuckChat-Sync: no pending chat deletions to patch" }
+    private suspend fun formatPatchRequest(
+        pendingDeletions: Set<String>,
+        pendingUpdates: Set<String>,
+    ): SyncChangesRequest {
+        if (pendingDeletions.isEmpty() && pendingUpdates.isEmpty()) {
+            logcat(LogPriority.DEBUG) { "DuckChat-Sync: no pending chat changes to patch" }
             return getEmptyRequest()
         }
 
-        logcat { "DuckChat-Sync: formatting patch request for ${pendingIds.size} pending chat deletions" }
+        logcat {
+            "DuckChat-Sync: formatting patch request — ${pendingDeletions.size} deletion(s), ${pendingUpdates.size} update(s)"
+        }
 
         val jsonArray = org.json.JSONArray()
-        pendingIds.forEach { chatId ->
+        pendingDeletions.forEach { chatId ->
             jsonArray.put(
                 org.json.JSONObject().apply {
                     put("id", chatId)
@@ -195,6 +208,25 @@ class DuckChatSyncDataManager @Inject constructor(
                 },
             )
         }
+
+        if (pendingUpdates.isNotEmpty()) {
+            val now = SyncDateProvider.now()
+            val byId = duckAiChatStore.getChats().associateBy { it.chatId }
+            pendingUpdates.forEach { chatId ->
+                val chat = byId[chatId] ?: return@forEach
+                jsonArray.put(
+                    org.json.JSONObject().apply {
+                        put("id", chat.chatId)
+                        put("client_last_modified", now)
+                        put("title", syncCrypto.encrypt(chat.title))
+                        put("pinned", chat.pinned)
+                    },
+                )
+            }
+        }
+
+        // Every update may have been skipped above if its chat was concurrently deleted.
+        if (jsonArray.length() == 0) return getEmptyRequest()
 
         return SyncChangesRequest(
             type = SyncableType.DUCK_AI_CHATS,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
@@ -218,8 +218,10 @@ class DuckChatSyncDataManager @Inject constructor(
                     org.json.JSONObject().apply {
                         put("id", chat.chatId)
                         put("client_last_modified", now)
+                        put("edit_timestamp", now)
                         put("title", syncCrypto.encrypt(chat.title))
-                        put("pinned", chat.pinned)
+                        // FE wire format: "pinned" when set, JSON null when unset (not boolean).
+                        put("pinned", if (chat.pinned) "pinned" else org.json.JSONObject.NULL)
                     },
                 )
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncMetadataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncMetadataStore.kt
@@ -27,6 +27,7 @@ import javax.inject.Inject
 interface DuckChatSyncMetadataStore {
     var deletionTimestamp: String?
     var pendingChatDeletions: Set<String>
+    var pendingChatUpdates: Set<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -51,6 +52,12 @@ class RealDuckChatSyncMetadataStore @Inject constructor(
             putStringSet(KEY_PENDING_CHAT_DELETIONS, value)
         }
 
+    override var pendingChatUpdates: Set<String>
+        get() = preferences.getStringSet(KEY_PENDING_CHAT_UPDATES, emptySet()) ?: emptySet()
+        set(value) = preferences.edit(true) {
+            putStringSet(KEY_PENDING_CHAT_UPDATES, value)
+        }
+
     private val preferences: SharedPreferences by lazy {
         sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
@@ -63,5 +70,6 @@ class RealDuckChatSyncMetadataStore @Inject constructor(
         const val FILENAME = "com.duckduckgo.duckchat.sync.store"
         private const val KEY_DELETION_TIMESTAMP = "KEY_DELETION_TIMESTAMP"
         private const val KEY_PENDING_CHAT_DELETIONS = "KEY_PENDING_CHAT_DELETIONS"
+        private const val KEY_PENDING_CHAT_UPDATES = "KEY_PENDING_CHAT_UPDATES"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncRepository.kt
@@ -50,6 +50,11 @@ interface DuckChatSyncRepository {
     suspend fun getPendingChatDeletions(): Set<String>
     suspend fun removePendingChatDeletions(ids: Set<String>)
     suspend fun clearPendingChatDeletions()
+
+    suspend fun recordSingleChatUpdate(chatId: String)
+    suspend fun getPendingChatUpdates(): Set<String>
+    suspend fun removePendingChatUpdates(ids: Set<String>)
+    suspend fun clearPendingChatUpdates()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -110,6 +115,35 @@ class RealDuckChatSyncRepository @Inject constructor(
         withContext(dispatchers.io()) {
             duckChatSyncMetadataStore.pendingChatDeletions = emptySet()
             logcat { "DuckChat-Sync: cleared all pending chat deletions" }
+        }
+    }
+
+    override suspend fun recordSingleChatUpdate(chatId: String) {
+        withContext(dispatchers.io()) {
+            val current = duckChatSyncMetadataStore.pendingChatUpdates
+            duckChatSyncMetadataStore.pendingChatUpdates = current + chatId
+            logcat { "DuckChat-Sync: recorded pending chat update for $chatId, queue size: ${current.size + 1}" }
+        }
+    }
+
+    override suspend fun getPendingChatUpdates(): Set<String> {
+        return withContext(dispatchers.io()) {
+            duckChatSyncMetadataStore.pendingChatUpdates
+        }
+    }
+
+    override suspend fun removePendingChatUpdates(ids: Set<String>) {
+        withContext(dispatchers.io()) {
+            val current = duckChatSyncMetadataStore.pendingChatUpdates
+            duckChatSyncMetadataStore.pendingChatUpdates = current - ids
+            logcat { "DuckChat-Sync: removed ${ids.size} pending chat updates, remaining: ${(current - ids).size}" }
+        }
+    }
+
+    override suspend fun clearPendingChatUpdates() {
+        withContext(dispatchers.io()) {
+            duckChatSyncMetadataStore.pendingChatUpdates = emptySet()
+            logcat { "DuckChat-Sync: cleared all pending chat updates" }
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_rename_chat.xml
@@ -44,7 +44,6 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/keyline_4"
         android:hint="@string/duck_ai_chat_history_rename_chat_title_hint"
-        app:capitalizeKeyboard="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/appBarLayout"

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.FeatureSyncError
 import com.duckduckgo.sync.api.engine.SyncChangesResponse
@@ -61,8 +60,6 @@ class DuckChatSyncDataManagerTest {
 
     private val duckAiChatStore: DuckAiChatStore = mock()
 
-    private val syncCrypto: SyncCrypto = mock()
-
     private lateinit var testee: DuckChatSyncDataManager
 
     private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
@@ -72,7 +69,6 @@ class DuckChatSyncDataManagerTest {
         whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
         whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(emptySet())
         whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(emptySet())
-        whenever(syncCrypto.encrypt(any<String>())).thenAnswer { "ENC:${it.arguments[0]}" }
         testee = DuckChatSyncDataManager(
             duckChatSyncRepository = duckChatSyncRepository,
             duckChatFeatureRepository = duckChatFeatureRepository,
@@ -81,7 +77,6 @@ class DuckChatSyncDataManagerTest {
             duckChatFeature = duckChatFeature,
             appCoroutineScope = coroutineTestRule.testScope,
             duckAiChatStore = duckAiChatStore,
-            syncCrypto = syncCrypto,
         )
     }
 

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
@@ -279,7 +279,7 @@ class DuckChatSyncDataManagerTest {
         assertEquals(SyncableType.DUCK_AI_CHATS, result.type)
         assertTrue(result.jsonString.contains("chat1"))
         assertTrue(result.jsonString.contains("\"pinned\":\"pinned\""))
-        // Title is intentionally omitted until JWE encryption lands on native.
+        // Title is omitted until JWE encryption lands on native.
         assertFalse(result.jsonString.contains("\"title\""))
     }
 
@@ -341,7 +341,7 @@ class DuckChatSyncDataManagerTest {
         assertTrue(result.jsonString.contains("delMe"))
         assertTrue(result.jsonString.contains("\"deleted\":\"true\""))
         assertTrue(result.jsonString.contains("renameMe"))
-        // Title is intentionally omitted from update entries until JWE encryption lands on native.
+        // Title is omitted from update entries until JWE encryption lands on native.
         assertFalse(result.jsonString.contains("\"title\""))
     }
 

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
@@ -264,7 +264,7 @@ class DuckChatSyncDataManagerTest {
     }
 
     @Test
-    fun whenGetChangesAndPendingUpdatesExistThenReturnsRequestWithEncryptedTitle() = runTest {
+    fun whenGetChangesAndPendingUpdatesExistThenReturnsRequestWithoutTitle() = runTest {
         duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
         whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
         whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(emptySet())
@@ -278,8 +278,9 @@ class DuckChatSyncDataManagerTest {
         assertFalse(result.isEmpty())
         assertEquals(SyncableType.DUCK_AI_CHATS, result.type)
         assertTrue(result.jsonString.contains("chat1"))
-        assertTrue(result.jsonString.contains("ENC:Hello"))
         assertTrue(result.jsonString.contains("\"pinned\":\"pinned\""))
+        // Title is intentionally omitted until JWE encryption lands on native.
+        assertFalse(result.jsonString.contains("\"title\""))
     }
 
     @Test
@@ -340,7 +341,8 @@ class DuckChatSyncDataManagerTest {
         assertTrue(result.jsonString.contains("delMe"))
         assertTrue(result.jsonString.contains("\"deleted\":\"true\""))
         assertTrue(result.jsonString.contains("renameMe"))
-        assertTrue(result.jsonString.contains("ENC:New name"))
+        // Title is intentionally omitted from update entries until JWE encryption lands on native.
+        assertFalse(result.jsonString.contains("\"title\""))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
@@ -279,7 +279,36 @@ class DuckChatSyncDataManagerTest {
         assertEquals(SyncableType.DUCK_AI_CHATS, result.type)
         assertTrue(result.jsonString.contains("chat1"))
         assertTrue(result.jsonString.contains("ENC:Hello"))
-        assertTrue(result.jsonString.contains("\"pinned\":true"))
+        assertTrue(result.jsonString.contains("\"pinned\":\"pinned\""))
+    }
+
+    @Test
+    fun whenGetChangesAndUpdatedChatIsUnpinnedThenPinnedFieldIsNull() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("chat1"))
+        whenever(duckAiChatStore.getChats()).thenReturn(
+            listOf(stubChat(chatId = "chat1", title = "Hello", pinned = false)),
+        )
+
+        val result = testee.getChanges()
+
+        assertTrue(result.jsonString.contains("\"pinned\":null"))
+    }
+
+    @Test
+    fun whenGetChangesProducesUpdateEntryThenIncludesEditTimestampMatchingClientLastModified() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("chat1"))
+        whenever(duckAiChatStore.getChats()).thenReturn(
+            listOf(stubChat(chatId = "chat1", title = "Hello")),
+        )
+
+        val result = testee.getChanges()
+
+        val entry = org.json.JSONArray(result.jsonString).getJSONObject(0)
+        assertEquals(entry.getString("client_last_modified"), entry.getString("edit_timestamp"))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManagerTest.kt
@@ -21,8 +21,11 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.FeatureSyncError
 import com.duckduckgo.sync.api.engine.SyncChangesResponse
@@ -39,6 +42,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -55,6 +59,10 @@ class DuckChatSyncDataManagerTest {
 
     private val appBuildConfig: AppBuildConfig = mock()
 
+    private val duckAiChatStore: DuckAiChatStore = mock()
+
+    private val syncCrypto: SyncCrypto = mock()
+
     private lateinit var testee: DuckChatSyncDataManager
 
     private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
@@ -62,6 +70,9 @@ class DuckChatSyncDataManagerTest {
     @Before
     fun setUp() = runTest {
         whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(emptySet())
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(emptySet())
+        whenever(syncCrypto.encrypt(any<String>())).thenAnswer { "ENC:${it.arguments[0]}" }
         testee = DuckChatSyncDataManager(
             duckChatSyncRepository = duckChatSyncRepository,
             duckChatFeatureRepository = duckChatFeatureRepository,
@@ -69,6 +80,8 @@ class DuckChatSyncDataManagerTest {
             appBuildConfig = appBuildConfig,
             duckChatFeature = duckChatFeature,
             appCoroutineScope = coroutineTestRule.testScope,
+            duckAiChatStore = duckAiChatStore,
+            syncCrypto = syncCrypto,
         )
     }
 
@@ -141,7 +154,7 @@ class DuckChatSyncDataManagerTest {
 
         testee.onDeleteSuccess(response)
 
-        verify(duckChatSyncRepository, never()).clearDeletionTimestampIfMatches(org.mockito.kotlin.any())
+        verify(duckChatSyncRepository, never()).clearDeletionTimestampIfMatches(any())
     }
 
     @Test
@@ -153,7 +166,7 @@ class DuckChatSyncDataManagerTest {
 
         testee.onDeleteError(error)
 
-        verify(duckChatSyncRepository, never()).clearDeletionTimestampIfMatches(org.mockito.kotlin.any())
+        verify(duckChatSyncRepository, never()).clearDeletionTimestampIfMatches(any())
     }
 
     @Test
@@ -227,7 +240,7 @@ class DuckChatSyncDataManagerTest {
         testee.onError(error)
 
         verify(duckChatSyncRepository, never()).clearPendingChatDeletions()
-        verify(duckChatSyncRepository, never()).removePendingChatDeletions(org.mockito.kotlin.any())
+        verify(duckChatSyncRepository, never()).removePendingChatDeletions(any())
     }
 
     @Test
@@ -247,5 +260,100 @@ class DuckChatSyncDataManagerTest {
         testee.onSyncDisabled()
 
         verify(duckChatSyncRepository).clearPendingChatDeletions()
+        verify(duckChatSyncRepository).clearPendingChatUpdates()
     }
+
+    @Test
+    fun whenGetChangesAndPendingUpdatesExistThenReturnsRequestWithEncryptedTitle() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(emptySet())
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("chat1"))
+        whenever(duckAiChatStore.getChats()).thenReturn(
+            listOf(stubChat(chatId = "chat1", title = "Hello", pinned = true)),
+        )
+
+        val result = testee.getChanges()
+
+        assertFalse(result.isEmpty())
+        assertEquals(SyncableType.DUCK_AI_CHATS, result.type)
+        assertTrue(result.jsonString.contains("chat1"))
+        assertTrue(result.jsonString.contains("ENC:Hello"))
+        assertTrue(result.jsonString.contains("\"pinned\":true"))
+    }
+
+    @Test
+    fun whenGetChangesAndPendingUpdateMissingFromStoreThenEntryIsOmitted() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(emptySet())
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("ghost"))
+        whenever(duckAiChatStore.getChats()).thenReturn(emptyList())
+
+        val result = testee.getChanges()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun whenGetChangesWithBothDeletionsAndUpdatesThenPayloadContainsBoth() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(setOf("delMe"))
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("renameMe"))
+        whenever(duckAiChatStore.getChats()).thenReturn(
+            listOf(stubChat(chatId = "renameMe", title = "New name")),
+        )
+
+        val result = testee.getChanges()
+
+        assertFalse(result.isEmpty())
+        assertTrue(result.jsonString.contains("delMe"))
+        assertTrue(result.jsonString.contains("\"deleted\":\"true\""))
+        assertTrue(result.jsonString.contains("renameMe"))
+        assertTrue(result.jsonString.contains("ENC:New name"))
+    }
+
+    @Test
+    fun whenChatIdIsInBothQueuesThenDeletionWinsAndUpdateIsDropped() = runTest {
+        duckChatFeature.supportsSyncChatsDeletion().setRawStoredState(Toggle.State(enable = true))
+        whenever(duckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
+        whenever(duckChatSyncRepository.getPendingChatDeletions()).thenReturn(setOf("dupe"))
+        whenever(duckChatSyncRepository.getPendingChatUpdates()).thenReturn(setOf("dupe"))
+        whenever(duckAiChatStore.getChats()).thenReturn(
+            listOf(stubChat(chatId = "dupe", title = "Pre-delete rename")),
+        )
+
+        val result = testee.getChanges()
+
+        assertTrue(result.jsonString.contains("\"deleted\":\"true\""))
+        assertFalse(result.jsonString.contains("ENC:Pre-delete rename"))
+    }
+
+    @Test
+    fun whenOnPatchSuccessThenRemovesAcknowledgedUpdateIdsAlongsideDeletions() = runTest {
+        val response = SyncChangesResponse(
+            type = SyncableType.DUCK_AI_CHATS,
+            jsonString = """{"ai_chats":{"entries":[{"id":"chat1"},{"id":"chat2"}],"last_modified":"2026-01-01T00:00:00Z"}}""",
+        )
+
+        testee.onSuccess(response, SyncConflictResolution.DEDUPLICATION)
+
+        verify(duckChatSyncRepository).removePendingChatDeletions(setOf("chat1", "chat2"))
+        verify(duckChatSyncRepository).removePendingChatUpdates(setOf("chat1", "chat2"))
+    }
+
+    private fun stubChat(
+        chatId: String,
+        title: String = chatId,
+        model: String = "gpt-5-mini",
+        lastEdit: String = "2026-04-01T00:00:00.000Z",
+        pinned: Boolean = false,
+    ) = DuckAiChat(
+        chatId = chatId,
+        title = title,
+        model = model,
+        lastEdit = lastEdit,
+        pinned = pinned,
+    )
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/clearing/DuckChatDataClearingPluginTest.kt
@@ -69,6 +69,7 @@ class DuckChatDataClearingPluginTest {
         verify(duckChatDeleter).deleteAllChats()
         verify(duckChatSyncRepository).recordDuckAiChatsDeleted(any())
         verify(duckChatSyncRepository).clearPendingChatDeletions()
+        verify(duckChatSyncRepository).clearPendingChatUpdates()
         verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
     }
 
@@ -102,6 +103,7 @@ class DuckChatDataClearingPluginTest {
         verify(duckChatDeleter).deleteAllChats()
         verify(duckChatSyncRepository, never()).recordDuckAiChatsDeleted(any())
         verify(duckChatSyncRepository, never()).clearPendingChatDeletions()
+        verify(duckChatSyncRepository, never()).clearPendingChatUpdates()
         verify(syncEngine, never()).triggerSync(any())
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -21,8 +21,10 @@ import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.sync.DuckChatSyncRepository
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.sync.api.engine.SyncEngine
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -32,6 +34,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -42,6 +45,8 @@ class ChatHistoryRepositoryTest {
 
     private val chatStore: DuckAiChatStore = mock()
     private val context: Context = mock()
+    private val duckChatSyncRepository: DuckChatSyncRepository = mock()
+    private val syncEngine: SyncEngine = mock()
     private val source = MutableStateFlow<List<DuckAiChat>>(emptyList())
     private lateinit var repository: RealChatHistoryRepository
 
@@ -49,7 +54,13 @@ class ChatHistoryRepositoryTest {
     fun setup() {
         whenever(context.getString(R.string.duck_ai_chat_history_untitled)).thenReturn(FALLBACK)
         whenever(chatStore.getChatsFlow()).thenReturn(source)
-        repository = RealChatHistoryRepository(chatStore, coroutineRule.testDispatcherProvider, context)
+        repository = RealChatHistoryRepository(
+            chatStore = chatStore,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            context = context,
+            duckChatSyncRepository = duckChatSyncRepository,
+            syncEngine = syncEngine,
+        )
     }
 
     @Test
@@ -193,6 +204,26 @@ class ChatHistoryRepositoryTest {
         val result = repository.renameChat("missing", "New")
 
         assertFalse(result)
+    }
+
+    @Test
+    fun `renameChat records pending update and triggers sync on success`() = runTest {
+        whenever(chatStore.renameChat("abc", "New")).thenReturn(true)
+
+        repository.renameChat("abc", "New")
+
+        verify(duckChatSyncRepository).recordSingleChatUpdate("abc")
+        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
+    @Test
+    fun `renameChat does not record or trigger sync when store reports failure`() = runTest {
+        whenever(chatStore.renameChat("missing", "New")).thenReturn(false)
+
+        repository.renameChat("missing", "New")
+
+        verify(duckChatSyncRepository, never()).recordSingleChatUpdate("missing")
+        verify(syncEngine, never()).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
     }
 
     private fun chat(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -226,6 +226,24 @@ class ChatHistoryRepositoryTest {
         verify(syncEngine, never()).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
     }
 
+    @Test
+    fun `setPinned true delegates to pinChat and records sync update`() = runTest {
+        repository.setPinned("abc", pinned = true)
+
+        verify(chatStore).pinChat("abc")
+        verify(duckChatSyncRepository).recordSingleChatUpdate("abc")
+        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
+    @Test
+    fun `setPinned false delegates to unpinChat and records sync update`() = runTest {
+        repository.setPinned("abc", pinned = false)
+
+        verify(chatStore).unpinChat("abc")
+        verify(duckChatSyncRepository).recordSingleChatUpdate("abc")
+        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
+    }
+
     private fun chat(
         chatId: String,
         title: String = "Title",

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -207,26 +207,6 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
-    fun `renameChat records pending update and triggers sync on success`() = runTest {
-        whenever(chatStore.renameChat("abc", "New")).thenReturn(true)
-
-        repository.renameChat("abc", "New")
-
-        verify(duckChatSyncRepository).recordSingleChatUpdate("abc")
-        verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
-    }
-
-    @Test
-    fun `renameChat does not record or trigger sync when store reports failure`() = runTest {
-        whenever(chatStore.renameChat("missing", "New")).thenReturn(false)
-
-        repository.renameChat("missing", "New")
-
-        verify(duckChatSyncRepository, never()).recordSingleChatUpdate("missing")
-        verify(syncEngine, never()).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
-    }
-
-    @Test
     fun `setPinned true delegates to pinChat and records sync update`() = runTest {
         repository.setPinned("abc", pinned = true)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -34,7 +34,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1214962880887900?focus=true 

### Description

Wires Duck.ai chat **pin/unpin** into the existing native sync pipeline so the pinned state propagates to the user's other signed-in devices, and introduces a headless `ChatHistoryReader` so the chat-history screen picks up changes made elsewhere.

The **rename** UI is gated behind a new remote feature flag (`renameChat`, default OFF) — when enabled it persists locally, but cross-device propagation is intentionally deferred until JWE encryption lands on native (server requires titles to be JWE-encrypted, which native cannot produce today).

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [ ] Install Internal Debug.
> - [ ] Set up Sync between two devices (e.g. this Android + Duck.ai web, or two Android devices on the same account).
> - [ ] Create at least 2 chats in Duck.ai so there's something to rename / pin.

- [ ] On device A: 3-dot on a Recent row → **Pin** → on device B or web app, refresh the chat list → confirm the chat now appears in the Pinned section.
- [ ] On device A: 3-dot on a Pinned row → **Unpin** → on device B or web app → confirm the chat moves back to Recent.
- [ ] On device B: pin a chat → on device A, open the chat-history screen → confirm the chat appears in the Pinned section on device A.

### UI changes

https://github.com/user-attachments/assets/f51b78a5-3384-484c-84e6-d8bdea09c8d1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the sync patch payload/queueing logic and adds a headless WebView-based refresher that could affect performance and sync correctness.
> 
> **Overview**
> Adds a **new native sync queue for Duck.ai chat updates** (separate from deletions) and extends sync patch generation to send pinned-state changes, prioritizing deletions when a chatId is queued for both.
> 
> Pins/unpins now enqueue an update and trigger sync, bulk chat clearing also clears both deletion and update queues, and patch success removes acknowledged ids from both queues. The chat history screen additionally refreshes via a new headless `ChatHistoryReader`, and the per-row Rename action is now gated behind a new remote flag `renameChat` (default OFF).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6eef357921c9f825367e331eba16d4bf6d94d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->