### PR TITLE
PIR: Fix email data handling

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandler.kt
@@ -50,8 +50,11 @@ import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GenerateEmail
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GetCaptchaInfo
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.GetEmailData
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction.SolveCaptcha
+import com.duckduckgo.pir.impl.scripts.models.DataSource.EMAIL_DATA
 import com.duckduckgo.pir.impl.scripts.models.DataSource.EXTRACTED_PROFILE
+import com.duckduckgo.pir.impl.scripts.models.DataSource.FETCHED_EMAIL
 import com.duckduckgo.pir.impl.scripts.models.ExtractedProfileParams
+import com.duckduckgo.pir.impl.scripts.models.FetchedEmail
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
@@ -296,33 +299,32 @@ class ExecuteBrokerStepActionEventHandler @Inject constructor(
         state: State,
         requestData: PirScriptRequestData,
     ): PirScriptRequestData {
-        if (requestData !is UserProfile || requestData.extractedProfile != null) {
+        if (requestData !is UserProfile) {
             return requestData
         }
-        if (actionToExecute.dataSource != EXTRACTED_PROFILE) {
-            return requestData
+        return when (actionToExecute.dataSource) {
+            FETCHED_EMAIL -> {
+                val email = state.generatedEmailData?.emailAddress ?: return requestData
+                requestData.copy(fetchedEmail = FetchedEmail(email = email))
+            }
+            EMAIL_DATA -> {
+                if (state.emailExtractedData.isEmpty()) return requestData
+                requestData.copy(emailData = state.emailExtractedData)
+            }
+            EXTRACTED_PROFILE -> {
+                if (requestData.extractedProfile != null) return requestData
+                val baseParams: ExtractedProfileParams = when (brokerStep) {
+                    is OptOutStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
+                    is EmailConfirmationStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
+                    is ScanStep -> if (state.generatedEmailData != null) ExtractedProfileParams() else return requestData
+                }
+                val withEmail = state.generatedEmailData?.let {
+                    baseParams.copy(email = it.emailAddress)
+                } ?: baseParams
+                requestData.copy(extractedProfile = withEmail)
+            }
+            else -> requestData
         }
-
-        val baseParams: ExtractedProfileParams = when (brokerStep) {
-            is OptOutStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
-            is EmailConfirmationStep -> brokerStep.profileToOptOut.toParams(state.profileQuery.fullName)
-            is ScanStep -> if (state.generatedEmailData != null) ExtractedProfileParams() else return requestData
-        }
-
-        val withEmail = state.generatedEmailData?.let {
-            baseParams.copy(email = it.emailAddress)
-        } ?: baseParams
-
-        val withEmailExtractedData = if (state.emailExtractedData.isNotEmpty()) {
-            withEmail.copy(emailExtractedData = state.emailExtractedData)
-        } else {
-            withEmail
-        }
-
-        return UserProfile(
-            userProfile = requestData.userProfile,
-            extractedProfile = withEmailExtractedData,
-        )
     }
 
     companion object {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/BrokerAction.kt
@@ -179,6 +179,14 @@ enum class DataSource {
     // Uses the profile scraped via the extract action
     @Json(name = "extractedProfile")
     EXTRACTED_PROFILE,
+
+    // Uses the email address generated via the generateEmail action
+    @Json(name = "fetchedEmail")
+    FETCHED_EMAIL,
+
+    // Uses the data extracted from an email (e.g. verification code) via the getEmailData action
+    @Json(name = "emailData")
+    EMAIL_DATA,
 }
 
 fun BrokerAction.asActionType(): String {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scripts/models/PirScriptRequestParams.kt
@@ -35,6 +35,8 @@ sealed class PirScriptRequestData {
     data class UserProfile(
         val userProfile: ProfileQuery? = null,
         val extractedProfile: ExtractedProfileParams? = null,
+        val fetchedEmail: FetchedEmail? = null,
+        val emailData: Map<String, String>? = null,
     ) : PirScriptRequestData()
 }
 
@@ -44,5 +46,9 @@ data class ExtractedProfileParams(
     val profileUrl: String? = null,
     val email: String? = null,
     val fullName: String? = null,
-    val emailExtractedData: Map<String, String>? = null,
+)
+
+// Wraps the generated email as { "email": "..." } so C-S-S can resolve it via data[dataSource].email.
+data class FetchedEmail(
+    val email: String,
 )

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ExecuteBrokerStepActionEventHandlerTest.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.DataSource
 import com.duckduckgo.pir.impl.scripts.models.ElementSelector
+import com.duckduckgo.pir.impl.scripts.models.FetchedEmail
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData
 import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
@@ -1102,7 +1103,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
         assertEquals(testProfileQuery, userData.userProfile)
         assertEquals("scan-generated@example.com", userData.extractedProfile?.email)
         assertNull(userData.extractedProfile?.name)
-        assertNull(userData.extractedProfile?.emailExtractedData)
     }
 
     @Test
@@ -1143,51 +1143,12 @@ class ExecuteBrokerStepActionEventHandlerTest {
     }
 
     @Test
-    fun whenOptOutFillFormWithEmailExtractedDataThenIncludesItInRequestData() = runTest {
+    fun whenFillFormDataSourceIsFetchedEmailThenIncludesFetchedEmailInRequestData() = runTest {
         val action = BrokerAction.FillForm(
             id = "action-fill",
             elements = emptyList(),
             selector = "form",
-            dataSource = DataSource.EXTRACTED_PROFILE,
-        )
-        val optOutStep = OptOutStep(
-            broker = testBroker,
-            step = OptOutStepActions(
-                stepType = "optout",
-                actions = listOf(action),
-                optOutType = "form",
-            ),
-            profileToOptOut = testExtractedProfile,
-        )
-        val state = State(
-            runType = RunType.OPTOUT,
-            brokerStepsToExecute = listOf(optOutStep),
-            profileQuery = testProfileQuery,
-            currentBrokerStepIndex = 0,
-            currentActionIndex = 0,
-            emailExtractedData = mapOf("verificationCode" to "123456"),
-            stageStatus = PirStageStatus(
-                currentStage = PirStage.OTHER,
-                stageStartMs = 0,
-            ),
-        )
-        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
-
-        val result = testee.invoke(state, event)
-
-        val sideEffect = result.sideEffect as PushJsAction
-        val userData = sideEffect.requestParamsData as UserProfile
-        assertEquals("John Doe", userData.extractedProfile?.name)
-        assertEquals(mapOf("verificationCode" to "123456"), userData.extractedProfile?.emailExtractedData)
-    }
-
-    @Test
-    fun whenScanStepFillFormWithGeneratedEmailAndEmailExtractedDataThenIncludesBoth() = runTest {
-        val action = BrokerAction.FillForm(
-            id = "action-fill",
-            elements = emptyList(),
-            selector = "form",
-            dataSource = DataSource.EXTRACTED_PROFILE,
+            dataSource = DataSource.FETCHED_EMAIL,
         )
         val scanStep = ScanStep(
             broker = testBroker,
@@ -1207,7 +1168,6 @@ class ExecuteBrokerStepActionEventHandlerTest {
                 emailAddress = "scan-generated@example.com",
                 pattern = "pattern-123",
             ),
-            emailExtractedData = mapOf("verificationCode" to "654321"),
             stageStatus = PirStageStatus(
                 currentStage = PirStage.OTHER,
                 stageStartMs = 0,
@@ -1219,12 +1179,127 @@ class ExecuteBrokerStepActionEventHandlerTest {
 
         val sideEffect = result.sideEffect as PushJsAction
         val userData = sideEffect.requestParamsData as UserProfile
-        assertEquals("scan-generated@example.com", userData.extractedProfile?.email)
-        assertEquals(mapOf("verificationCode" to "654321"), userData.extractedProfile?.emailExtractedData)
+        assertEquals(testProfileQuery, userData.userProfile)
+        assertEquals(FetchedEmail(email = "scan-generated@example.com"), userData.fetchedEmail)
+        assertNull(userData.extractedProfile)
+        assertNull(userData.emailData)
     }
 
     @Test
-    fun whenEmailExtractedDataIsEmptyThenFieldIsNull() = runTest {
+    fun whenFillFormDataSourceIsFetchedEmailButNoGeneratedEmailThenFetchedEmailIsNull() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-fill",
+            elements = emptyList(),
+            selector = "form",
+            dataSource = DataSource.FETCHED_EMAIL,
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            generatedEmailData = null,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val userData = sideEffect.requestParamsData as UserProfile
+        assertNull(userData.fetchedEmail)
+    }
+
+    @Test
+    fun whenFillFormDataSourceIsEmailDataThenIncludesEmailDataInRequestData() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-fill",
+            elements = emptyList(),
+            selector = "form",
+            dataSource = DataSource.EMAIL_DATA,
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            emailExtractedData = mapOf("verificationCode" to "483921"),
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val userData = sideEffect.requestParamsData as UserProfile
+        assertEquals(mapOf("verificationCode" to "483921"), userData.emailData)
+        assertNull(userData.extractedProfile)
+        assertNull(userData.fetchedEmail)
+    }
+
+    @Test
+    fun whenFillFormDataSourceIsEmailDataButStateEmailExtractedDataIsEmptyThenEmailDataIsNull() = runTest {
+        val action = BrokerAction.FillForm(
+            id = "action-fill",
+            elements = emptyList(),
+            selector = "form",
+            dataSource = DataSource.EMAIL_DATA,
+        )
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(action),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            emailExtractedData = emptyMap(),
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery))
+
+        val result = testee.invoke(state, event)
+
+        val sideEffect = result.sideEffect as PushJsAction
+        val userData = sideEffect.requestParamsData as UserProfile
+        assertNull(userData.emailData)
+    }
+
+    @Test
+    fun whenFillFormDataSourceIsExtractedProfileThenEmailDataAndFetchedEmailAreNotIncluded() = runTest {
         val action = BrokerAction.FillForm(
             id = "action-fill",
             elements = emptyList(),
@@ -1246,7 +1321,11 @@ class ExecuteBrokerStepActionEventHandlerTest {
             profileQuery = testProfileQuery,
             currentBrokerStepIndex = 0,
             currentActionIndex = 0,
-            emailExtractedData = emptyMap(),
+            generatedEmailData = GeneratedEmailData(
+                emailAddress = "should-not-leak@example.com",
+                pattern = "pattern-123",
+            ),
+            emailExtractedData = mapOf("verificationCode" to "654321"),
             stageStatus = PirStageStatus(
                 currentStage = PirStage.OTHER,
                 stageStartMs = 0,
@@ -1258,6 +1337,8 @@ class ExecuteBrokerStepActionEventHandlerTest {
 
         val sideEffect = result.sideEffect as PushJsAction
         val userData = sideEffect.requestParamsData as UserProfile
-        assertNull(userData.extractedProfile?.emailExtractedData)
+        assertEquals("John Doe", userData.extractedProfile?.name)
+        assertNull(userData.fetchedEmail)
+        assertNull(userData.emailData)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214973541222175?focus=true

### Description
Fix email data handling so email codes are properly passed along to the web layer.

### Steps to test this PR
Will be testable on upstack PRs.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how opt-out/scan automation data is serialized to the in-WebView script layer; wrong mapping could break form fills or email confirmation, but scope is limited to PIR request assembly with strong unit coverage.
> 
> **Overview**
> **PIR broker script payloads** now map each `fillForm` **`dataSource`** to its own field on `UserProfile`, instead of folding generated email and polled email fields into `extractedProfile`.
> 
> New **`DataSource`** values **`fetchedEmail`** and **`emailData`** drive **`completeRequestData`**: generated addresses go in **`FetchedEmail`**, verification codes and similar keys from **`getEmailData`** go in **`emailData`**, and **`extractedProfile`** is only populated for **`extractedProfile`**. **`emailExtractedData`** was removed from **`ExtractedProfileParams`** so the web layer can resolve `data[dataSource]` the way broker JSON expects.
> 
> Unit tests were updated to assert per-source isolation (e.g. verification codes are not leaked on extracted-profile fills).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d0efa0a1ba616424288908eee4ceb107c34c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->