### PR TITLE
Migrate Attachment plugin to per-tab NativeInputStateProvider

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -22,12 +22,6 @@ import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 
-sealed class PromptContribution {
-    data class ModelSelection(val modelId: String) : PromptContribution()
-    data class ReasoningEffortSelection(val effort: String) : PromptContribution()
-    data class ToolSelection(val tool: String) : PromptContribution()
-}
-
 /**
  * Communication surface from a plugin back to the host widget. Plugins use it to act on the host
  * (e.g. [submit]) without coupling to the widget class directly. State that depends on the active
@@ -56,8 +50,6 @@ interface NativeInputPlugin : ActivePlugin {
     val containerId: Int
 
     fun createView(context: Context, host: NativeInputHost): View
-
-    fun getPromptContribution(): PromptContribution?
 }
 
 @ContributesActivePluginPoint(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -30,6 +30,8 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
@@ -42,6 +44,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -63,6 +66,7 @@ class AttachmentViewModel @Inject constructor(
     private val fileAttachmentProcessor: FileAttachmentProcessor,
     private val context: Context,
     private val appBuildConfig: AppBuildConfig,
+    nativeInputStateProvider: NativeInputStateProvider,
 ) : ViewModel() {
 
     data class AttachmentState(
@@ -89,13 +93,16 @@ class AttachmentViewModel @Inject constructor(
     @VisibleForTesting
     internal val imageAttachments = MutableStateFlow<List<ImageAttachment>>(emptyList())
     private val _fileAttachments = MutableStateFlow<List<FileAttachment>>(emptyList())
-    private val _isDuckAiMode = MutableStateFlow(false)
+
+    private val isDuckAiModeFlow: StateFlow<Boolean> = nativeInputStateProvider.state
+        .map { it.inputContext != NativeInputState.InputContext.BROWSER }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     val attachmentState: StateFlow<AttachmentState> = combine(
         combine(imageAttachments, _fileAttachments) { images, files -> Pair(images, files) },
         modelManager.modelState,
         combine(limitsHandler.conversationImagesSent, limitsHandler.conversationFilesUsed) { imgSent, filesUsed -> Pair(imgSent, filesUsed) },
-        _isDuckAiMode,
+        isDuckAiModeFlow,
     ) { (images, files), modelState, (conversationImagesSent, conversationFilesUsed), isDuckAiMode ->
         val conversationFilesSent = conversationFilesUsed.count
         val conversationFileSizeSentBytes = conversationFilesUsed.sizeBytes
@@ -182,10 +189,6 @@ class AttachmentViewModel @Inject constructor(
         clearAttachments()
         limitsHandler.setConversationImagesUsed(0)
         limitsHandler.setConversationFilesUsed(0, 0L)
-    }
-
-    fun setDuckAiMode(enabled: Boolean) {
-        _isDuckAiMode.value = enabled
     }
 
     fun getImageAttachments(): List<ImageAttachment> = imageAttachments.value

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -50,8 +50,8 @@ import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
@@ -98,6 +98,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val pixel: Pixel,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val nativeInputStateProvider: NativeInputStateProvider,
+    private val modelManager: DuckAiModelManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -142,16 +143,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun getSelectedModelId(): String? {
         if (!_modelPickerEnabled.value) return null
-        return _plugins.value.firstNotNullOfOrNull { plugin ->
-            (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
-        }
+        return modelManager.getSelectedModelId()
     }
 
-    fun getResolvedReasoningEffort(): String? {
-        return _plugins.value.firstNotNullOfOrNull { plugin ->
-            (plugin.getPromptContribution() as? PromptContribution.ReasoningEffortSelection)?.effort
-        }
-    }
+    fun getResolvedReasoningEffort(): String? = modelManager.getResolvedReasoningEffort()
 
     fun getSelectedTool(): String? {
         val tabId = activeTabId.value ?: return null

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.AttachmentView
 import javax.inject.Inject
 
@@ -39,6 +38,4 @@ class AttachmentNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override fun createView(context: Context, host: NativeInputHost): View =
         AttachmentView(context).also { it.host = host }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -23,10 +23,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
-import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -39,18 +36,10 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.modelPickerContainer
 
-    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
-
     override fun createView(context: Context, host: NativeInputHost): View {
         return ModelPickerView(context).also { picker ->
-            modelPicker = WeakReference(picker)
             picker.setHost(host)
             picker.setPickerEnabled(true)
         }
-    }
-
-    override fun getPromptContribution(): PromptContribution? {
-        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
-        return PromptContribution.ModelSelection(modelId)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.optionsButtonContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -21,10 +21,8 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerView
 import javax.inject.Inject
 
@@ -34,15 +32,9 @@ import javax.inject.Inject
     featureName = "pluginReasoningModePickerNativeInput",
     parentFeatureName = "pluginPointNativeInput",
 )
-class ReasoningModePickerNativeInputPlugin @Inject constructor(
-    private val modelManager: DuckAiModelManager,
-) : NativeInputPlugin {
+class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.reasoningModePickerContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
-
-    override fun getPromptContribution(): PromptContribution? =
-        modelManager.getResolvedReasoningEffort()
-            ?.let { PromptContribution.ReasoningEffortSelection(it) }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
 import javax.inject.Inject
 
@@ -40,6 +39,4 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override fun createView(context: Context, host: NativeInputHost): View = StartChatView(context).apply {
         onIconClicked = { host.submit() }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -90,8 +90,6 @@ class AttachmentView(
 
     fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()
 
-    fun setDuckAiMode(enabled: Boolean) = viewModel?.setDuckAiMode(enabled)
-
     private fun buildAttachButton(): ImageView {
         val iconSize = context.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.toolbarIcon)
         return ImageView(context).apply {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -241,7 +241,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private var pendingCameraCaptureCallback: ((ValueCallback<Array<Uri>>) -> Unit)? = null
     private var pendingFilePickerCallback: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
-    private var pendingIsDuckAiMode: Boolean = false
 
     // True when this widget instance hosts the contextual sheet. Set in configureContextual();
     // never reset. Used to prevent the shared per-tab NativeInputStateProvider from leaking
@@ -325,7 +324,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             pluginView.onCameraCaptureRequested = pendingCameraCaptureCallback
             pluginView.onFilePickerRequested = pendingFilePickerCallback
             pluginView.bind(scope, viewModelFactory)
-            pluginView.setDuckAiMode(pendingIsDuckAiMode)
         }
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
@@ -835,22 +833,18 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {
         activeTabId = tabId
-        pendingIsDuckAiMode = isDuckAiMode
         doOnAttach {
             viewModel.configure(tabId, isDuckAiMode, isBottom)
             if (isDuckAiMode) selectChatTab()
-            attachmentView?.setDuckAiMode(isDuckAiMode)
         }
     }
 
     override fun configureContextual(tabId: String) {
         activeTabId = tabId
-        pendingIsDuckAiMode = true
         isContextualWidget = true
         doOnAttach {
             viewModel.configureContextual(tabId)
             selectChatTab()
-            attachmentView?.setDuckAiMode(true)
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -20,8 +20,11 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.AttachmentLimits
@@ -29,6 +32,7 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.FileLimits
 import com.duckduckgo.duckchat.impl.models.ImageLimits
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ConversationFileUsage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
@@ -89,6 +93,12 @@ class AttachmentViewModelTest {
             .thenReturn("Total file size limit exceeded")
     }
 
+    private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val tabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
+    }
+    private val nativeInputStateStore = RealNativeInputStateStore { tabRepository }
+
     private lateinit var viewModel: AttachmentViewModel
 
     @Before
@@ -101,7 +111,16 @@ class AttachmentViewModelTest {
             fileAttachmentProcessor = fileAttachmentProcessor,
             context = context,
             appBuildConfig = appBuildConfig,
+            nativeInputStateProvider = nativeInputStateStore,
         )
+    }
+
+    private fun selectDuckAiTab(tabId: String = "tab-duckai") {
+        nativeInputStateStore.publish(
+            tabId,
+            NativeInputState.zero().copy(inputContext = NativeInputState.InputContext.DUCK_AI),
+        )
+        selectedTabFlow.value = TabEntity(tabId = tabId, position = 0)
     }
 
     @Test
@@ -186,7 +205,8 @@ class AttachmentViewModelTest {
     fun whenTotalImagesOverConversationLimitThenConversationErrorShown() = runTest {
         val limits = ImageLimits(maxPerTurn = 10, maxPerConversation = 5)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(images = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationImagesSent(3)
         addImages(3)
 
@@ -206,7 +226,8 @@ class AttachmentViewModelTest {
     fun whenConversationImagesSentCountedInTotal() = runTest {
         val limits = ImageLimits(maxPerTurn = 10, maxPerConversation = 5)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(images = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationImagesSent(4)
         addImages(2)
 
@@ -331,7 +352,8 @@ class AttachmentViewModelTest {
     fun whenTotalFilesOverConversationLimitThenFileLimitErrorShown() = runTest {
         val limits = FileLimits(maxPerConversation = 2)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationFilesSent(2)
         addFiles(aFileAttachment())
 
@@ -342,7 +364,8 @@ class AttachmentViewModelTest {
     fun whenConversationFilesSentCountedInTotal() = runTest {
         val limits = FileLimits(maxPerConversation = 3)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationFilesSent(2)
         addFiles(aFileAttachment(), aFileAttachment())
 
@@ -471,7 +494,8 @@ class AttachmentViewModelTest {
         val maxTotal = 5L * 1024 * 1024
         val limits = FileLimits(maxTotalFileSizeBytes = maxTotal)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationFileSizeSent(4L * 1024 * 1024)
         addFiles(aFileAttachment(sizeBytes = 2L * 1024 * 1024))
 
@@ -483,7 +507,8 @@ class AttachmentViewModelTest {
         val maxTotal = 5L * 1024 * 1024
         val limits = FileLimits(maxTotalFileSizeBytes = maxTotal)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationFileSizeSent(maxTotal + 1)
 
         assertEquals("Total file size limit exceeded", viewModel.attachmentState.value.fileTotalSizeError)
@@ -519,7 +544,8 @@ class AttachmentViewModelTest {
         val maxTotal = 5L * 1024 * 1024
         val limits = FileLimits(maxTotalFileSizeBytes = maxTotal)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
-        viewModel.setDuckAiMode(true)
+        selectDuckAiTab()
+        advanceUntilIdle()
         limitsHandler.addConversationFileSizeSent(maxTotal + 1)
 
         viewModel.clearAttachmentsForNewChat()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -45,9 +45,9 @@ import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.subscriptions.api.Product
@@ -96,6 +96,7 @@ class NativeInputModeWidgetViewModelTest {
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private val pixel: Pixel = mock()
+    private val modelManager: DuckAiModelManager = mock()
 
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabRepository: TabRepository = mock<TabRepository>().also {
@@ -152,6 +153,7 @@ class NativeInputModeWidgetViewModelTest {
             pixel = pixel,
             nativeInputStatePublisher = nativeInputStatePublisher,
             nativeInputStateProvider = nativeInputStateProvider,
+            modelManager = modelManager,
             appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
@@ -360,7 +362,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "model-1")
+        val plugin = fakePlugin(containerId = 1)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.storePendingPrompt("hello", "model-1", null)
@@ -476,7 +478,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenPluginsExistThenPluginsStateContainsThem() = runTest {
-        val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
+        val plugin = fakePlugin(containerId = 42)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         val plugins = viewModel.plugins.value
@@ -485,32 +487,25 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
-        val viewModel = createViewModel(plugins = emptyList())
+    fun whenModelManagerHasNoSelectedModelThenGetSelectedModelIdReturnsNull() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn(null)
+        val viewModel = createViewModel()
 
         assertNull(viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerReportsSelectedModelThenGetSelectedModelIdReturnsIt() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         assertEquals("claude-3", viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = null)
-        val viewModel = createViewModel(plugins = listOf(plugin))
-
-        assertNull(viewModel.getSelectedModelId())
-    }
-
-    @Test
     fun whenModelPickerDisabledThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
 
@@ -519,8 +514,8 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenModelPickerReEnabledThenGetSelectedModelIdReturnsSelection() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
         assertNull(viewModel.getSelectedModelId())
@@ -530,17 +525,17 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenPluginReturnsReasoningEffortSelectionThenGetResolvedReasoningEffortReturnsIt() = runTest {
-        val plugin = fakeReasoningPlugin(containerId = 7, effort = "low")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerResolvesReasoningEffortThenGetResolvedReasoningEffortReturnsIt() = runTest {
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val viewModel = createViewModel()
 
         assertEquals("low", viewModel.getResolvedReasoningEffort())
     }
 
     @Test
-    fun whenNoPluginContributesReasoningEffortThenGetResolvedReasoningEffortReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerReturnsNoReasoningEffortThenGetResolvedReasoningEffortReturnsNull() = runTest {
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn(null)
+        val viewModel = createViewModel()
 
         assertNull(viewModel.getResolvedReasoningEffort())
     }
@@ -584,18 +579,9 @@ class NativeInputModeWidgetViewModelTest {
         verify(pendingNativePromptStore).store("hello", "model-1", null, "GenerateImage", emptyList(), emptyList())
     }
 
-    private fun fakeReasoningPlugin(containerId: Int, effort: String?): NativeInputPlugin {
-        return object : NativeInputPlugin {
-            override val containerId: Int = containerId
-            override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? =
-                effort?.let { PromptContribution.ReasoningEffortSelection(it) }
-        }
-    }
-
     @Test
     fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
-        val plugin = fakePlugin(containerId = 99, modelId = null)
+        val plugin = fakePlugin(containerId = 99)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.updatePluginContainerVisibility(isChatTab = true)
@@ -607,12 +593,10 @@ class NativeInputModeWidgetViewModelTest {
         assertTrue(update.visible)
     }
 
-    private fun fakePlugin(containerId: Int, modelId: String?): NativeInputPlugin {
+    private fun fakePlugin(containerId: Int): NativeInputPlugin {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? =
-                modelId?.let { PromptContribution.ModelSelection(it) }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214973164012895?focus=true

### Description

Migrate the Attachment plugin onto the per-tab `NativeInputStateProvider`. `AttachmentViewModel` now derives `isDuckAiMode` from `state.inputContext` (any non-`BROWSER` context — `DUCK_AI` or `DUCK_AI_CONTEXTUAL` — counts as Duck.ai for limit accounting), instead of receiving it through an imperative setter the widget had to fan out to the plugin view.

- `AttachmentViewModel` injects `NativeInputStateProvider`; the `_isDuckAiMode: MutableStateFlow` field and `setDuckAiMode(enabled: Boolean)` setter are removed.
- `AttachmentView.setDuckAiMode(...)` removed (only the VM setter delegated to).
- `NativeInputModeWidget` no longer calls `attachmentView?.setDuckAiMode(...)` from `configure(...)` / `configureContextual(...)`, and the `pendingIsDuckAiMode` field is gone.
- No public API change. The plugin's `getPromptContribution()` already returns `null`; this PR removes the remaining push-based coupling between widget and plugin.

Follows the same shape as the StartChat (#8570) and Options (#8627) migrations.

### Steps to test this PR

_Conversation limits still apply in Duck.ai mode_
- [ ] Install internal build with input-screen enabled and Duck.ai available.
- [ ] Open a Duck.ai tab and start a conversation that includes at least one image/file attachment.
- [ ] Re-open the input on the same Duck.ai tab — conversation-history attachments should count toward the limits (e.g. limit-reached error appears once the conversation-wide limit would be exceeded).

_Browser/search mode ignores conversation history_
- [ ] Switch to a browser tab.
- [ ] Open the input — attachment limits should not include any Duck.ai conversation history (you can attach up to the per-message limit fresh).

_Contextual sheet treats the prompt as Duck.ai_
- [ ] Open the contextual sheet over a tab.
- [ ] Attach images/files — limit behaviour matches a Duck.ai tab (conversation history counts).

_No regressions_
- [ ] Switching between Duck.ai and browser tabs flips the limit-accounting behaviour live, without rebuilding the widget.
- [ ] Attaching, removing, and submitting attachments works identically to develop.

### UI changes
| Before  | After |
| ------ | ----- |
| N/A — internal refactor, no user-visible change | N/A — internal refactor, no user-visible change |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how attachment limit accounting and model/reasoning selections are sourced (reactive per-tab state instead of imperative/plugin callbacks), which could affect chat submission behavior across tab/context switches.
> 
> **Overview**
> **Migrates attachment limit accounting to per-tab `NativeInputStateProvider`.** `AttachmentViewModel` now derives Duck.ai vs browser mode from `state.inputContext` (non-`BROWSER` counts as Duck.ai) and removes the widget-driven `setDuckAiMode` plumbing.
> 
> **Simplifies native input plugin contracts and prompt sourcing.** Removes `PromptContribution`/`getPromptContribution()` from `NativeInputPlugin` and updates plugins accordingly; `NativeInputModeWidgetViewModel` now reads selected model/reasoning effort directly from `DuckAiModelManager` instead of querying plugins.
> 
> Widget and tests are updated to stop fanning out “Duck.ai mode” into the attachment view and to drive mode-dependent behavior via the real per-tab native input state store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43a2cb389ceae1943a58b5cac295a303bac76b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->