### PR TITLE
Migrate ReasoningModePicker plugin off getPromptContribution

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -22,12 +22,6 @@ import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 
-sealed class PromptContribution {
-    data class ModelSelection(val modelId: String) : PromptContribution()
-    data class ReasoningEffortSelection(val effort: String) : PromptContribution()
-    data class ToolSelection(val tool: String) : PromptContribution()
-}
-
 /**
  * Communication surface from a plugin back to the host widget. Plugins use it to act on the host
  * (e.g. [submit]) without coupling to the widget class directly. State that depends on the active
@@ -56,8 +50,6 @@ interface NativeInputPlugin : ActivePlugin {
     val containerId: Int
 
     fun createView(context: Context, host: NativeInputHost): View
-
-    fun getPromptContribution(): PromptContribution?
 }
 
 @ContributesActivePluginPoint(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
@@ -98,6 +99,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val pixel: Pixel,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val nativeInputStateProvider: NativeInputStateProvider,
+    private val modelManager: DuckAiModelManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -147,11 +149,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
     }
 
-    fun getResolvedReasoningEffort(): String? {
-        return _plugins.value.firstNotNullOfOrNull { plugin ->
-            (plugin.getPromptContribution() as? PromptContribution.ReasoningEffortSelection)?.effort
-        }
-    }
+    fun getResolvedReasoningEffort(): String? = modelManager.getResolvedReasoningEffort()
 
     fun getSelectedTool(): String? {
         val tabId = activeTabId.value ?: return null

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -52,7 +52,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
@@ -144,9 +143,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun getSelectedModelId(): String? {
         if (!_modelPickerEnabled.value) return null
-        return _plugins.value.firstNotNullOfOrNull { plugin ->
-            (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
-        }
+        return modelManager.getSelectedModelId()
     }
 
     fun getResolvedReasoningEffort(): String? = modelManager.getResolvedReasoningEffort()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.AttachmentView
 import javax.inject.Inject
 
@@ -39,6 +38,4 @@ class AttachmentNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override fun createView(context: Context, host: NativeInputHost): View =
         AttachmentView(context).also { it.host = host }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -23,10 +23,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
-import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -39,18 +36,10 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.modelPickerContainer
 
-    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
-
     override fun createView(context: Context, host: NativeInputHost): View {
         return ModelPickerView(context).also { picker ->
-            modelPicker = WeakReference(picker)
             picker.setHost(host)
             picker.setPickerEnabled(true)
         }
-    }
-
-    override fun getPromptContribution(): PromptContribution? {
-        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
-        return PromptContribution.ModelSelection(modelId)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.optionsButtonContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPl
     override val containerId: Int = R.id.reasoningModePickerContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -21,7 +21,6 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
@@ -34,15 +33,11 @@ import javax.inject.Inject
     featureName = "pluginReasoningModePickerNativeInput",
     parentFeatureName = "pluginPointNativeInput",
 )
-class ReasoningModePickerNativeInputPlugin @Inject constructor(
-    private val modelManager: DuckAiModelManager,
-) : NativeInputPlugin {
+class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.reasoningModePickerContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
 
-    override fun getPromptContribution(): PromptContribution? =
-        modelManager.getResolvedReasoningEffort()
-            ?.let { PromptContribution.ReasoningEffortSelection(it) }
+    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
 import javax.inject.Inject
 
@@ -40,6 +39,4 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override fun createView(context: Context, host: NativeInputHost): View = StartChatView(context).apply {
         onIconClicked = { host.submit() }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
@@ -96,6 +97,7 @@ class NativeInputModeWidgetViewModelTest {
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private val pixel: Pixel = mock()
+    private val modelManager: DuckAiModelManager = mock()
 
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabRepository: TabRepository = mock<TabRepository>().also {
@@ -152,6 +154,7 @@ class NativeInputModeWidgetViewModelTest {
             pixel = pixel,
             nativeInputStatePublisher = nativeInputStatePublisher,
             nativeInputStateProvider = nativeInputStateProvider,
+            modelManager = modelManager,
             appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
@@ -530,17 +533,17 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenPluginReturnsReasoningEffortSelectionThenGetResolvedReasoningEffortReturnsIt() = runTest {
-        val plugin = fakeReasoningPlugin(containerId = 7, effort = "low")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerResolvesReasoningEffortThenGetResolvedReasoningEffortReturnsIt() = runTest {
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("low")
+        val viewModel = createViewModel()
 
         assertEquals("low", viewModel.getResolvedReasoningEffort())
     }
 
     @Test
-    fun whenNoPluginContributesReasoningEffortThenGetResolvedReasoningEffortReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerReturnsNoReasoningEffortThenGetResolvedReasoningEffortReturnsNull() = runTest {
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn(null)
+        val viewModel = createViewModel()
 
         assertNull(viewModel.getResolvedReasoningEffort())
     }
@@ -582,15 +585,6 @@ class NativeInputModeWidgetViewModelTest {
         viewModel.storePendingPrompt("hello", "model-1", null, selectedTool = "GenerateImage")
 
         verify(pendingNativePromptStore).store("hello", "model-1", null, "GenerateImage", emptyList(), emptyList())
-    }
-
-    private fun fakeReasoningPlugin(containerId: Int, effort: String?): NativeInputPlugin {
-        return object : NativeInputPlugin {
-            override val containerId: Int = containerId
-            override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? =
-                effort?.let { PromptContribution.ReasoningEffortSelection(it) }
-        }
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSugges
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.subscriptions.api.Product
@@ -363,7 +362,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "model-1")
+        val plugin = fakePlugin(containerId = 1)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.storePendingPrompt("hello", "model-1", null)
@@ -479,7 +478,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenPluginsExistThenPluginsStateContainsThem() = runTest {
-        val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
+        val plugin = fakePlugin(containerId = 42)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         val plugins = viewModel.plugins.value
@@ -488,32 +487,25 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
-        val viewModel = createViewModel(plugins = emptyList())
+    fun whenModelManagerHasNoSelectedModelThenGetSelectedModelIdReturnsNull() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn(null)
+        val viewModel = createViewModel()
 
         assertNull(viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerReportsSelectedModelThenGetSelectedModelIdReturnsIt() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         assertEquals("claude-3", viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = null)
-        val viewModel = createViewModel(plugins = listOf(plugin))
-
-        assertNull(viewModel.getSelectedModelId())
-    }
-
-    @Test
     fun whenModelPickerDisabledThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
 
@@ -522,8 +514,8 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenModelPickerReEnabledThenGetSelectedModelIdReturnsSelection() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
         assertNull(viewModel.getSelectedModelId())
@@ -589,7 +581,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
-        val plugin = fakePlugin(containerId = 99, modelId = null)
+        val plugin = fakePlugin(containerId = 99)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.updatePluginContainerVisibility(isChatTab = true)
@@ -601,12 +593,10 @@ class NativeInputModeWidgetViewModelTest {
         assertTrue(update.visible)
     }
 
-    private fun fakePlugin(containerId: Int, modelId: String?): NativeInputPlugin {
+    private fun fakePlugin(containerId: Int): NativeInputPlugin {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? =
-                modelId?.let { PromptContribution.ModelSelection(it) }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214973164012896?focus=true
Stacked on: #8644

### Description

Migrate the ReasoningModePicker plugin so it no longer contributes through `NativeInputPlugin.getPromptContribution()`. The widget VM now reads the resolved reasoning effort directly from `DuckAiModelManager`, which already owns it.

Reasoning effort is a user-global setting (`DuckChatDataStore.selectedReasoningMode`), not per-tab — so unlike `selectedTool` for Options, it doesn't fit on `NativeInputState`. Keeping the lookup on `DuckAiModelManager` preserves the single source of truth without introducing a synthetic per-tab field.

- `NativeInputModeWidgetViewModel.getResolvedReasoningEffort()` calls `modelManager.getResolvedReasoningEffort()` instead of iterating plugins.
- `NativeInputModeWidgetViewModel` injects `DuckAiModelManager`.
- `ReasoningModePickerNativeInputPlugin.getPromptContribution()` returns `null`; its constructor no longer depends on `DuckAiModelManager`.
- Widget VM tests updated to stub `modelManager.getResolvedReasoningEffort()` instead of providing a fake plugin contribution; obsolete `fakeReasoningPlugin` helper removed.

Follows the StartChat (#8570), Options (#8627), and Attachment (#8644) migrations. After this, only ModelPicker still uses `getPromptContribution`.

### Steps to test this PR

_Reasoning effort flows into the submitted prompt_
- [x] Install internal build with input-screen enabled and Duck.ai available.
- [x] Open the input on a Duck.ai tab, open the reasoning mode picker, and choose a non-default mode that resolves to a real effort (e.g. "low" / "high" depending on the selected model).
- [x] Submit a prompt and verify in proxy logs / Charles that the request carries the expected reasoning effort parameter.

_Default reasoning still works_
- [x] Without changing reasoning mode, submit a prompt — request carries the default-resolved effort (or none, depending on model).

_Selection survives tab switches_
- [x] Pick a reasoning effort, switch to a different tab, switch back — the picker still shows the chosen mode (this is global, not per-tab).

_No regressions_
- [x] Switching model in the model picker still updates available reasoning modes; submitting after a model switch carries the freshly-resolved effort.
- [x] Reasoning picker UI shows / hides the same way as develop (model-dependent).

### UI changes
| Before  | After |
| ------ | ----- |
| N/A — internal refactor, no user-visible change | N/A — internal refactor, no user-visible change |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `NativeInputPlugin` API and shifts model/reasoning selection reads to `DuckAiModelManager`, which could affect prompt metadata if wiring or DI is misconfigured. Scope is limited to the native input widget/plugins with updated tests covering the new behavior.
> 
> **Overview**
> Refactors native input plugins to stop contributing prompt metadata via `NativeInputPlugin.getPromptContribution()` by removing the `PromptContribution` type and the method from the plugin interface.
> 
> `NativeInputModeWidgetViewModel` now injects `DuckAiModelManager` and reads `getSelectedModelId()` and `getResolvedReasoningEffort()` directly from it, and all native input plugins (including `ReasoningModePickerNativeInputPlugin` and `ModelPickerNativeInputPlugin`) drop their prompt-contribution logic accordingly. Tests are updated to mock `DuckAiModelManager` instead of using fake plugin contributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c717606bfa6518ea2d3a32232f2c254e2c23812b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->