### PR TITLE
Migrate ModelPicker plugin off getPromptContribution

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -22,12 +22,6 @@ import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 
-sealed class PromptContribution {
-    data class ModelSelection(val modelId: String) : PromptContribution()
-    data class ReasoningEffortSelection(val effort: String) : PromptContribution()
-    data class ToolSelection(val tool: String) : PromptContribution()
-}
-
 /**
  * Communication surface from a plugin back to the host widget. Plugins use it to act on the host
  * (e.g. [submit]) without coupling to the widget class directly. State that depends on the active
@@ -56,8 +50,6 @@ interface NativeInputPlugin : ActivePlugin {
     val containerId: Int
 
     fun createView(context: Context, host: NativeInputHost): View
-
-    fun getPromptContribution(): PromptContribution?
 }
 
 @ContributesActivePluginPoint(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -52,7 +52,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.subscriptions.api.Product
@@ -144,9 +143,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun getSelectedModelId(): String? {
         if (!_modelPickerEnabled.value) return null
-        return _plugins.value.firstNotNullOfOrNull { plugin ->
-            (plugin.getPromptContribution() as? PromptContribution.ModelSelection)?.modelId
-        }
+        return modelManager.getSelectedModelId()
     }
 
     fun getResolvedReasoningEffort(): String? = modelManager.getResolvedReasoningEffort()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.AttachmentView
 import javax.inject.Inject
 
@@ -39,6 +38,4 @@ class AttachmentNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override fun createView(context: Context, host: NativeInputHost): View =
         AttachmentView(context).also { it.host = host }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -24,9 +24,7 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPicker
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
-import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -39,18 +37,12 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override val containerId: Int = R.id.modelPickerContainer
 
-    private var modelPicker: WeakReference<ModelPicker> = WeakReference(null)
-
     override fun createView(context: Context, host: NativeInputHost): View {
         return ModelPickerView(context).also { picker ->
-            modelPicker = WeakReference(picker)
             picker.setHost(host)
             picker.setPickerEnabled(true)
         }
     }
 
-    override fun getPromptContribution(): PromptContribution? {
-        val modelId = modelPicker.get()?.getSelectedModelId() ?: return null
-        return PromptContribution.ModelSelection(modelId)
-    }
+    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
 import javax.inject.Inject
 
@@ -43,6 +42,4 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
             picker.setPickerEnabled(true)
         }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.optionsButtonContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPl
     override val containerId: Int = R.id.reasoningModePickerContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
 import javax.inject.Inject
 
@@ -40,6 +39,4 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override fun createView(context: Context, host: NativeInputHost): View = StartChatView(context).apply {
         onIconClicked = { host.submit() }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -363,7 +363,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenStorePendingPromptThenDelegatesToStoreWithModelId() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "model-1")
+        val plugin = fakePlugin(containerId = 1)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.storePendingPrompt("hello", "model-1", null)
@@ -479,7 +479,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenPluginsExistThenPluginsStateContainsThem() = runTest {
-        val plugin = fakePlugin(containerId = 42, modelId = "gpt-4o")
+        val plugin = fakePlugin(containerId = 42)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         val plugins = viewModel.plugins.value
@@ -488,32 +488,25 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenNoPluginsThenGetSelectedModelIdReturnsNull() = runTest {
-        val viewModel = createViewModel(plugins = emptyList())
+    fun whenModelManagerHasNoSelectedModelThenGetSelectedModelIdReturnsNull() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn(null)
+        val viewModel = createViewModel()
 
         assertNull(viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsModelSelectionThenGetSelectedModelIdReturnsIt() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+    fun whenModelManagerReportsSelectedModelThenGetSelectedModelIdReturnsIt() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         assertEquals("claude-3", viewModel.getSelectedModelId())
     }
 
     @Test
-    fun whenPluginReturnsNullContributionThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = null)
-        val viewModel = createViewModel(plugins = listOf(plugin))
-
-        assertNull(viewModel.getSelectedModelId())
-    }
-
-    @Test
     fun whenModelPickerDisabledThenGetSelectedModelIdReturnsNull() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
 
@@ -522,8 +515,8 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenModelPickerReEnabledThenGetSelectedModelIdReturnsSelection() = runTest {
-        val plugin = fakePlugin(containerId = 1, modelId = "claude-3")
-        val viewModel = createViewModel(plugins = listOf(plugin))
+        whenever(modelManager.getSelectedModelId()).thenReturn("claude-3")
+        val viewModel = createViewModel()
 
         viewModel.setModelPickerEnabled(false)
         assertNull(viewModel.getSelectedModelId())
@@ -589,7 +582,7 @@ class NativeInputModeWidgetViewModelTest {
 
     @Test
     fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
-        val plugin = fakePlugin(containerId = 99, modelId = null)
+        val plugin = fakePlugin(containerId = 99)
         val viewModel = createViewModel(plugins = listOf(plugin))
 
         viewModel.updatePluginContainerVisibility(isChatTab = true)
@@ -601,12 +594,11 @@ class NativeInputModeWidgetViewModelTest {
         assertTrue(update.visible)
     }
 
-    private fun fakePlugin(containerId: Int, modelId: String?): NativeInputPlugin {
+    private fun fakePlugin(containerId: Int): NativeInputPlugin {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? =
-                modelId?.let { PromptContribution.ModelSelection(it) }
+            override fun getPromptContribution(): PromptContribution? = null
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSugges
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.subscriptions.api.Product
@@ -598,7 +597,6 @@ class NativeInputModeWidgetViewModelTest {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? = null
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214973164012897?focus=true
Stacked on: #8645

### Description

Migrate the ModelPicker plugin so it no longer contributes through `NativeInputPlugin.getPromptContribution()`. The widget VM reads the selected model id directly from `DuckAiModelManager`, which is the single source of truth.

- `NativeInputModeWidgetViewModel.getSelectedModelId()` calls `modelManager.getSelectedModelId()` instead of iterating plugins for `PromptContribution.ModelSelection`. The `_modelPickerEnabled` gate is preserved.
- `ModelPickerNativeInputPlugin.getPromptContribution()` returns `null`; the `WeakReference<ModelPicker>` it kept just to pull the selected model id is gone. `createView()` still calls `picker.setHost(host)` / `picker.setPickerEnabled(true)`.
- Widget VM tests stub `modelManager.getSelectedModelId()` directly; the `fakePlugin` helper drops its now-unused `modelId` parameter and always returns a null contribution.

Same shape as ReasoningModePicker (#8645): model selection is a user-global setting on `DuckAiModelManager`, not a per-tab field, so it doesn't land on `NativeInputState`.

After this PR, no plugin contributes through `getPromptContribution`. The follow-up can remove `NativeInputHost.getInputState()` and `NativeInputPlugin.getPromptContribution()` from the API entirely.

### Steps to test this PR

_Selected model flows into the submitted prompt_
- [ ] Install internal build with input-screen enabled and Duck.ai available.
- [ ] Open the input on a Duck.ai tab and pick a non-default model from the model picker.
- [ ] Submit a prompt and verify (proxy logs / Charles) that the request carries the expected model id.

_Disabled picker still nulls the selection_
- [ ] In a flow that disables the model picker (e.g. while a tool is being applied), confirm the submitted request does not carry a model id even if one was previously selected.

_Re-enable restores selection_
- [ ] After the picker is re-enabled, the previously-chosen model is used on the next submit.

_No regressions_
- [ ] Open / close the model picker menu — UI unchanged.
- [ ] Switching the model still updates dependent UI (reasoning modes, options/tool capabilities).

### UI changes
| Before  | After |
| ------ | ----- |
| N/A — internal refactor, no user-visible change | N/A — internal refactor, no user-visible change |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk internal refactor that changes where the selected model id is sourced; behavior should be equivalent but could affect prompts if model selection is no longer propagated correctly.
> 
> **Overview**
> **Model selection is no longer sourced from native input plugins.** `NativeInputModeWidgetViewModel.getSelectedModelId()` now reads directly from `DuckAiModelManager` (while preserving the `_modelPickerEnabled` gate) instead of iterating plugins for a `PromptContribution`.
> 
> This removes the `PromptContribution` sealed class and the `NativeInputPlugin.getPromptContribution()` API, simplifying all native input plugins (notably `ModelPickerNativeInputPlugin`, which drops its `WeakReference`/selection lookup). Tests are updated to stub `modelManager.getSelectedModelId()` and simplify the `fakePlugin` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8f7f58b9aa0750fe14c7c7bb03b10bbd5ae246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->