### PR TITLE
Remove getPromptContribution from native input plugins

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -22,12 +22,6 @@ import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 
-sealed class PromptContribution {
-    data class ModelSelection(val modelId: String) : PromptContribution()
-    data class ReasoningEffortSelection(val effort: String) : PromptContribution()
-    data class ToolSelection(val tool: String) : PromptContribution()
-}
-
 /**
  * Communication surface from a plugin back to the host widget. Plugins use it to act on the host
  * (e.g. [submit]) without coupling to the widget class directly. State that depends on the active
@@ -56,8 +50,6 @@ interface NativeInputPlugin : ActivePlugin {
     val containerId: Int
 
     fun createView(context: Context, host: NativeInputHost): View
-
-    fun getPromptContribution(): PromptContribution?
 }
 
 @ContributesActivePluginPoint(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/AttachmentNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.AttachmentView
 import javax.inject.Inject
 
@@ -39,6 +38,4 @@ class AttachmentNativeInputPlugin @Inject constructor() : NativeInputPlugin {
 
     override fun createView(context: Context, host: NativeInputHost): View =
         AttachmentView(context).also { it.host = host }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ModelPickerNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerView
 import javax.inject.Inject
 
@@ -43,6 +42,4 @@ class ModelPickerNativeInputPlugin @Inject constructor() : NativeInputPlugin {
             picker.setPickerEnabled(true)
         }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/OptionsNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.OptionsView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class OptionsNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override val containerId: Int = R.id.optionsButtonContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = OptionsView(context, host)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerView
 import javax.inject.Inject
 
@@ -38,6 +37,4 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor() : NativeInputPl
     override val containerId: Int = R.id.reasoningModePickerContainer
 
     override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StartChatNativeInputPlugin.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StartChatView
 import javax.inject.Inject
 
@@ -40,6 +39,4 @@ class StartChatNativeInputPlugin @Inject constructor() : NativeInputPlugin {
     override fun createView(context: Context, host: NativeInputHost): View = StartChatView(context).apply {
         onIconClicked = { host.submit() }
     }
-
-    override fun getPromptContribution(): PromptContribution? = null
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSugges
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
-import com.duckduckgo.duckchat.impl.nativeinput.PromptContribution
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.subscriptions.api.Product
@@ -598,7 +597,6 @@ class NativeInputModeWidgetViewModelTest {
         return object : NativeInputPlugin {
             override val containerId: Int = containerId
             override fun createView(context: Context, host: NativeInputHost): View = View(context)
-            override fun getPromptContribution(): PromptContribution? = null
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214973137403819?focus=true
Stacked on: #8646

### Description

Final step in the native input state refactor: with every plugin migrated off the pull-based contribution path, drop the read API entirely.

- `NativeInputPlugin.getPromptContribution()` removed from the interface.
- `PromptContribution` sealed class (`ModelSelection`, `ReasoningEffortSelection`, `ToolSelection`) deleted.
- The five plugin implementations (`StartChat`, `Options`, `Attachment`, `ReasoningModePicker`, `ModelPicker`) drop their overrides and the now-unused `PromptContribution` imports.
- Widget VM test's `fakePlugin` helper trimmed to match the new interface; the `PromptContribution` import is gone.

`NativeInputHost.getInputState()` was already removed in an earlier PR in this stack — this closes out the read-path migration described in the plan: plugins observe `NativeInputStateProvider.state` for tab-keyed state, the widget VM reads `DuckAiModelManager` directly for the user-global model / reasoning effort, and `selectedTool` lives on `NativeInputState`. No code path needs `getPromptContribution` any more.

Follows the StartChat (#8570), Options (#8627), Attachment (#8644), ReasoningModePicker (#8645), and ModelPicker (#8646) migrations.

### Steps to test this PR

Pure deletion of unused surface — no behaviour change expected. Worth a quick sanity sweep:

- [x] Install internal build with input-screen enabled and Duck.ai available.
- [x] Submit a prompt with a model selected — request still carries the model id.
- [x] Pick a non-default reasoning mode and submit — request still carries the resolved effort.
- [x] Pick a tool (Web Search / Image Generation) on a tab and submit — request carries the tool.
- [x] Switch tabs and confirm tool selection is per-tab as before.

### UI changes
| Before  | After |
| ------ | ----- |
| N/A — internal API cleanup, no user-visible change | N/A — internal API cleanup, no user-visible change |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a pure API surface cleanup removing an unused method/type; main risk is compile/runtime issues if any downstream plugin still depended on `getPromptContribution()`.
> 
> **Overview**
> Removes the legacy pull-based prompt contribution API from native input plugins by deleting the `PromptContribution` sealed class and dropping `NativeInputPlugin.getPromptContribution()`.
> 
> Updates all in-tree native input plugins (StartChat, Options, Attachment, ReasoningModePicker, ModelPicker) and `NativeInputModeWidgetViewModelTest` to match the slimmer `NativeInputPlugin` interface, removing now-unused overrides/imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac83233b183f107e63d8cbecb9ea32f0aede7b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->