### PR TITLE
Upsell ai reasoning effort

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -132,8 +132,11 @@ class RealDuckAiModelManager @Inject constructor(
                 stateMutex.withLock {
                     val selectedModelId = validateAndPersistSelection(models)
                     val selectedModel = models.find { it.id == selectedModelId }
-                    val available = ReasoningResolver.availableModes(selectedModel?.supportedReasoningEfforts.orEmpty())
-                    val nextReasoningMode = clearStaleReasoningModeIfNeeded(_modelState.value.selectedReasoningMode, available)
+                    val available = ReasoningResolver.availableModes(
+                        supported = selectedModel?.supportedReasoningEfforts.orEmpty(),
+                        effortAccess = selectedModel?.reasoningEffortAccess.orEmpty(),
+                    )
+                    val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
 
                     _modelState.value = ModelState(
                         models = models,
@@ -176,8 +179,11 @@ class RealDuckAiModelManager @Inject constructor(
         withContext(dispatcherProvider.io()) {
             stateMutex.withLock {
                 dataStore.setSelectedModel(SelectedModel(model.id, model.shortName))
-                val available = ReasoningResolver.availableModes(model.supportedReasoningEfforts)
-                val nextReasoningMode = clearStaleReasoningModeIfNeeded(_modelState.value.selectedReasoningMode, available)
+                val available = ReasoningResolver.availableModes(
+                    supported = model.supportedReasoningEfforts,
+                    effortAccess = model.reasoningEffortAccess,
+                )
+                val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
                 _modelState.value = _modelState.value.copy(
                     selectedModelId = model.id,
                     selectedModelShortName = model.shortName,
@@ -192,8 +198,8 @@ class RealDuckAiModelManager @Inject constructor(
     override suspend fun selectReasoningMode(mode: ReasoningMode) {
         withContext(dispatcherProvider.io()) {
             stateMutex.withLock {
-                val available = _modelState.value.availableReasoningModes
-                if (available.none { it.mode == mode }) return@withLock
+                val match = _modelState.value.availableReasoningModes.firstOrNull { it.mode == mode }
+                if (match == null || !match.isAccessible) return@withLock
                 dataStore.setSelectedReasoningMode(mode.rawValue)
                 _modelState.value = _modelState.value.copy(selectedReasoningMode = mode)
                 logcat { "Duck.ai Model Manager: selected reasoning mode ${mode.rawValue}" }
@@ -208,14 +214,17 @@ class RealDuckAiModelManager @Inject constructor(
         return ReasoningResolver.effortFor(state.selectedReasoningMode, state.availableReasoningModes)?.rawValue
     }
 
-    private suspend fun clearStaleReasoningModeIfNeeded(
+    private suspend fun validateAndPersistReasoningMode(
         persisted: ReasoningMode?,
         available: List<AvailableReasoningMode>,
     ): ReasoningMode? {
-        if (persisted == null) return null
-        if (available.any { it.mode == persisted }) return persisted
-        dataStore.setSelectedReasoningMode(null)
-        return null
+        val match = available.firstOrNull { it.mode == persisted }
+        if (match != null && match.isAccessible) return persisted
+        val next = available.firstOrNull { it.isAccessible }?.mode
+        if (next?.rawValue != persisted?.rawValue) {
+            dataStore.setSelectedReasoningMode(next?.rawValue)
+        }
+        return next
     }
 
     private suspend fun resolveUserTier(): UserTier {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -124,7 +124,7 @@ class RealDuckAiModelManager @Inject constructor(
         withContext(dispatcherProvider.io()) {
             try {
                 val userTier = resolveUserTier()
-                val response = fetchModelsResponse()
+                val response = fetchModelsResponse().withHardcodedReasoningGates()
                 val models = response.models
                     .map { resolveModel(it, userTier) }
                     .filterNot { it.accessTier.isEmpty() && !it.isAccessible }
@@ -310,6 +310,21 @@ class RealDuckAiModelManager @Inject constructor(
         return currentSelectedId
     }
 }
+
+// TODO: Remove this hardcoded gate once the backend ships per-effort `reasoningEffortAccess` for gpt-5.2.
+//  EXTENDED_REASONING on gpt-5.2 is PRO-only. We gate every candidate effort of EXTENDED_REASONING.
+//  To remove: delete this function and the `.withHardcodedReasoningGates()` call in fetchModels.
+//  Follow up task: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214980387692321?focus=true
+private fun AIChatModelsResponse.withHardcodedReasoningGates(): AIChatModelsResponse = copy(
+    models = models.map { model ->
+        if (model.id != "gpt-5.2") return@map model
+        model.copy(
+            reasoningEffortAccess = ReasoningMode.EXTENDED_REASONING.candidateEfforts.map { effort ->
+                RemoteReasoningEffortAccess(id = effort.rawValue, accessTier = listOf("pro"), entityHasAccess = false)
+            },
+        )
+    },
+)
 
 private fun com.duckduckgo.subscriptions.api.SubscriptionStatus.isActiveOrWaiting(): Boolean {
     return this == com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE ||

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
@@ -46,7 +46,10 @@ enum class ReasoningMode(
 data class AvailableReasoningMode(
     val mode: ReasoningMode,
     val effort: ReasoningEffort,
-)
+    val access: ReasoningEffortAccess? = null,
+) {
+    val isAccessible: Boolean get() = access == null || access.isAccessible
+}
 
 data class ReasoningEffortAccess(
     val effort: ReasoningEffort,
@@ -59,20 +62,39 @@ data class ReasoningEffortAccess(
 
 object ReasoningResolver {
 
-    fun availableModes(supported: List<ReasoningEffort>): List<AvailableReasoningMode> =
-        ReasoningMode.entries.mapNotNull { mode ->
-            mode.candidateEfforts.firstOrNull { it in supported }?.let { effort ->
-                AvailableReasoningMode(mode, effort)
-            }
+    /**
+     * For each [ReasoningMode], picks the first candidate effort that is supported and accessible.
+     * If no candidate is accessible, falls back to the first supported one so the row still renders
+     * for upsell routing. If no candidate is supported, the mode is omitted.
+     *
+     * When [effortAccess] does not contain an entry for a chosen effort, the mode is treated as accessible.
+     */
+    fun availableModes(
+        supported: List<ReasoningEffort>,
+        effortAccess: List<ReasoningEffortAccess> = emptyList(),
+    ): List<AvailableReasoningMode> {
+        val accessByEffort = effortAccess.associateBy { it.effort }
+        return ReasoningMode.entries.mapNotNull { mode ->
+            val supportedCandidates = mode.candidateEfforts.filter { it in supported }
+            if (supportedCandidates.isEmpty()) return@mapNotNull null
+            val chosen = supportedCandidates.firstOrNull { effort ->
+                val access = accessByEffort[effort]
+                access == null || access.isAccessible
+            } ?: supportedCandidates.first()
+            AvailableReasoningMode(mode, chosen, accessByEffort[chosen])
         }
+    }
 
     fun resolveMode(
         persisted: ReasoningMode?,
         available: List<AvailableReasoningMode>,
-    ): ReasoningMode? = when {
-        available.isEmpty() -> null
-        persisted != null && available.any { it.mode == persisted } -> persisted
-        else -> available.first().mode
+    ): ReasoningMode? {
+        val accessible = available.filter { it.isAccessible }
+        return when {
+            accessible.isEmpty() -> null
+            persisted != null && accessible.any { it.mode == persisted } -> persisted
+            else -> accessible.first().mode
+        }
     }
 
     fun effortFor(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -40,8 +40,7 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor(
 
     override val containerId: Int = R.id.reasoningModePickerContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View =
-        ReasoningModePickerView(context).also { it.setHost(host) }
+    override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
 
     override fun getPromptContribution(): PromptContribution? =
         modelManager.getResolvedReasoningEffort()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/ReasoningModePickerNativeInputPlugin.kt
@@ -40,7 +40,8 @@ class ReasoningModePickerNativeInputPlugin @Inject constructor(
 
     override val containerId: Int = R.id.reasoningModePickerContainer
 
-    override fun createView(context: Context, host: NativeInputHost): View = ReasoningModePickerView(context)
+    override fun createView(context: Context, host: NativeInputHost): View =
+        ReasoningModePickerView(context).also { it.setHost(host) }
 
     override fun getPromptContribution(): PromptContribution? =
         modelManager.getResolvedReasoningEffort()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -172,19 +172,19 @@ class ModelPickerView @JvmOverloads constructor(
             .launchIn(scope)
     }
 
-    private fun processCommand(command: ModelPickerViewModel.Command) {
+    private fun processCommand(command: UpsellCommand) {
         when (command) {
-            is ModelPickerViewModel.Command.LaunchPurchase ->
+            is UpsellCommand.LaunchPurchase ->
                 globalActivityStarter.start(context, SubscriptionPurchase(origin = command.origin, featurePage = DUCK_AI_FEATURE_PAGE))
-            is ModelPickerViewModel.Command.LaunchUpgrade ->
+            is UpsellCommand.LaunchUpgrade ->
                 globalActivityStarter.start(context, SubscriptionUpgrade(origin = command.origin))
         }
     }
 
-    private fun currentSurface(): ModelPickerViewModel.PickerSurface =
+    private fun currentSurface(): PickerSurface =
         when (lastInputContext) {
-            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> ModelPickerViewModel.PickerSurface.DUCK_AI_TAB
-            InputContext.BROWSER -> ModelPickerViewModel.PickerSurface.ADDRESS_BAR
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.MODEL_PICKER_DUCK_AI_TAB
+            InputContext.BROWSER -> PickerSurface.MODEL_PICKER_ADDRESS_BAR
         }
 
     private fun showMenu() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -63,8 +63,8 @@ class ModelPickerViewModel @Inject constructor(
         }
     }
 
-    private val command = Channel<Command>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    val commands: Flow<Command> = command.receiveAsFlow()
+    private val command = Channel<UpsellCommand>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val commands: Flow<UpsellCommand> = command.receiveAsFlow()
 
     fun onModelTapped(model: AIChatModel, surface: PickerSurface) {
         if (model.isAccessible) {
@@ -76,16 +76,7 @@ class ModelPickerViewModel @Inject constructor(
             logcat { "Duck.ai picker: tapped model has no public required tier (id=${model.id}, accessTier=${model.accessTier}), ignoring." }
             return
         }
-        when {
-            requiredTier == UserTier.FREE -> {
-                logcat { "Duck.ai picker: inaccessible model with FREE required tier (id=${model.id}), no upsell route." }
-            }
-            userTier == UserTier.FREE -> command.trySend(Command.LaunchPurchase(surface.origin))
-            userTier == UserTier.PLUS && requiredTier == UserTier.PRO -> command.trySend(Command.LaunchUpgrade(surface.origin))
-            else -> {
-                logcat { "Duck.ai picker: no native subscription flow for tap (userTier=$userTier, requiredTier=$requiredTier, id=${model.id})." }
-            }
-        }
+        routeUpsell(userTier, requiredTier, surface.origin)?.let { command.trySend(it) }
     }
 
     fun buildSections(state: ModelState): List<ModelSection> {
@@ -107,16 +98,6 @@ class ModelPickerViewModel @Inject constructor(
         ModelProvider.META -> R.drawable.ic_ai_model_llama_16
         ModelProvider.OSS -> R.drawable.ic_ai_model_oss_16
         ModelProvider.UNKNOWN -> null
-    }
-
-    sealed class Command {
-        data class LaunchPurchase(val origin: String) : Command()
-        data class LaunchUpgrade(val origin: String) : Command()
-    }
-
-    enum class PickerSurface(val origin: String) {
-        ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
-        DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
     }
 
     private fun List<AIChatModel>.toSectionOrNull(@StringRes headerRes: Int?): ModelSection? =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import com.duckduckgo.duckchat.impl.models.UserTier
+
+enum class PickerSurface(val origin: String) {
+    MODEL_PICKER_ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
+    MODEL_PICKER_DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
+    REASONING_PICKER_ADDRESS_BAR("funnel_nativeinput_androidapp__reasoningpicker"),
+    REASONING_PICKER_DUCK_AI_TAB("funnel_duckai_androidapp__reasoningpicker"),
+}
+
+sealed class UpsellCommand {
+    data class LaunchPurchase(val origin: String) : UpsellCommand()
+    data class LaunchUpgrade(val origin: String) : UpsellCommand()
+}
+
+/**
+ * Maps a (userTier, requiredTier) pair to the upsell flow that should fire, or `null` when no
+ * native subscription flow applies (FREE-required gating, or a tier transition we don't route).
+ */
+internal fun routeUpsell(
+    userTier: UserTier,
+    requiredTier: UserTier,
+    origin: String,
+): UpsellCommand? = when {
+    requiredTier == UserTier.FREE -> null
+    userTier == UserTier.FREE -> UpsellCommand.LaunchPurchase(origin)
+    userTier == UserTier.PLUS && requiredTier == UserTier.PRO -> UpsellCommand.LaunchUpgrade(origin)
+    else -> null
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -35,8 +35,14 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
@@ -52,13 +58,21 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     @Inject lateinit var viewModelFactory: ViewViewModelFactory
 
+    @Inject lateinit var globalActivityStarter: GlobalActivityStarter
+
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[ReasoningModePickerViewModel::class.java]
     }
 
     private val button: ImageView by lazy { findViewById(R.id.reasoningModePickerButton) }
     private var stateJob: Job? = null
+    private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
+    private lateinit var host: NativeInputHost
+
+    fun setHost(host: NativeInputHost) {
+        this.host = host
+    }
 
     init {
         inflate(context, R.layout.view_reasoning_mode_picker, this)
@@ -75,6 +89,8 @@ class ReasoningModePickerView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         stateJob?.cancel()
         stateJob = null
+        commandJob?.cancel()
+        commandJob = null
         dismissPopup()
     }
 
@@ -83,17 +99,39 @@ class ReasoningModePickerView @JvmOverloads constructor(
         stateJob?.cancel()
         stateJob = viewModel.state
             .onEach { state ->
-                isVisible = state.availableReasoningModes.size > 1
+                isVisible = state.availableReasoningModes.size > 1 &&
+                    state.availableReasoningModes.any { it.isAccessible }
                 viewModel.resolvedMode(state)?.let { mode ->
                     button.setImageResource(viewModel.iconResFor(mode))
                 }
             }
             .launchIn(scope)
+
+        commandJob?.cancel()
+        commandJob = viewModel.commands
+            .onEach { processCommand(it) }
+            .launchIn(scope)
     }
+
+    private fun processCommand(command: UpsellCommand) {
+        when (command) {
+            is UpsellCommand.LaunchPurchase ->
+                globalActivityStarter.start(context, SubscriptionPurchase(origin = command.origin, featurePage = DUCK_AI_FEATURE_PAGE))
+            is UpsellCommand.LaunchUpgrade ->
+                globalActivityStarter.start(context, SubscriptionUpgrade(origin = command.origin))
+        }
+    }
+
+    private fun currentSurface(): PickerSurface =
+        when (host.getInputState().inputContext) {
+            InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.REASONING_PICKER_DUCK_AI_TAB
+            InputContext.BROWSER -> PickerSurface.REASONING_PICKER_ADDRESS_BAR
+        }
 
     private fun showMenu() {
         val state = viewModel.state.value
         if (state.availableReasoningModes.size <= 1) return
+        if (state.availableReasoningModes.none { it.isAccessible }) return
 
         val container = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
@@ -129,7 +167,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
             trailingIcon.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_check_24)
             trailingIcon.visibility = if (row.selected) VISIBLE else INVISIBLE
             item.setOnClickListener {
-                viewModel.selectMode(row.mode)
+                viewModel.onModeTapped(row.mode, currentSurface())
                 popup.dismiss()
             }
             container.addView(item)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -36,10 +36,10 @@ import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.ModelState
-import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
@@ -60,19 +60,21 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     @Inject lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject lateinit var nativeInputStateProvider: NativeInputStateProvider
+
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[ReasoningModePickerViewModel::class.java]
     }
 
     private val button: ImageView by lazy { findViewById(R.id.reasoningModePickerButton) }
     private var stateJob: Job? = null
+    private var inputContextJob: Job? = null
     private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
-    private lateinit var host: NativeInputHost
 
-    fun setHost(host: NativeInputHost) {
-        this.host = host
-    }
+    // Mirrors the input context from the per-tab native input state so currentSurface() can be
+    // read synchronously from popup callbacks. Updated by observeInputContext().
+    private var lastInputContext: InputContext = InputContext.BROWSER
 
     init {
         inflate(context, R.layout.view_reasoning_mode_picker, this)
@@ -83,15 +85,26 @@ class ReasoningModePickerView @JvmOverloads constructor(
         super.onAttachedToWindow()
         button.setOnClickListener { showMenu() }
         observeState()
+        observeInputContext()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         stateJob?.cancel()
         stateJob = null
+        inputContextJob?.cancel()
+        inputContextJob = null
         commandJob?.cancel()
         commandJob = null
         dismissPopup()
+    }
+
+    private fun observeInputContext() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        inputContextJob?.cancel()
+        inputContextJob = nativeInputStateProvider.state
+            .onEach { lastInputContext = it.inputContext }
+            .launchIn(scope)
     }
 
     private fun observeState() {
@@ -123,7 +136,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
     }
 
     private fun currentSurface(): PickerSurface =
-        when (host.getInputState().inputContext) {
+        when (lastInputContext) {
             InputContext.DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL -> PickerSurface.REASONING_PICKER_DUCK_AI_TAB
             InputContext.BROWSER -> PickerSurface.REASONING_PICKER_ADDRESS_BAR
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -28,8 +28,13 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.models.ReasoningResolver
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 
 data class ReasoningModeRow(
@@ -50,8 +55,25 @@ class ReasoningModePickerViewModel @Inject constructor(
     fun resolvedMode(state: ModelState): ReasoningMode? =
         ReasoningResolver.resolveMode(state.selectedReasoningMode, state.availableReasoningModes)
 
-    fun selectMode(mode: ReasoningMode) {
-        viewModelScope.launch { modelManager.selectReasoningMode(mode) }
+    private val command = Channel<UpsellCommand>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val commands: Flow<UpsellCommand> = command.receiveAsFlow()
+
+    fun onModeTapped(mode: ReasoningMode, surface: PickerSurface) {
+        val available = modelManager.modelState.value.availableReasoningModes.firstOrNull { it.mode == mode }
+        if (available == null) {
+            logcat { "Duck.ai reasoning picker: tapped mode $mode not in available list, ignoring." }
+            return
+        }
+        if (available.isAccessible) {
+            viewModelScope.launch { modelManager.selectReasoningMode(mode) }
+            return
+        }
+        val userTier = modelManager.modelState.value.userTier
+        val requiredTier = available.access?.requiredTier ?: run {
+            logcat { "Duck.ai reasoning picker: gated mode $mode has no public required tier, ignoring." }
+            return
+        }
+        routeUpsell(userTier, requiredTier, surface.origin)?.let { command.trySend(it) }
     }
 
     fun rows(state: ModelState): List<ReasoningModeRow> {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -916,7 +916,7 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
-    fun whenFetchAndSelectedModelDoesNotSupportPersistedModeThenStaleClearedFromStateAndStore() = runTest {
+    fun whenFetchAndSelectedModelDoesNotSupportPersistedModeThenStaleReplacedWithFirstAccessible() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
         whenever(dataStore.getSelectedReasoningMode()).thenReturn(ReasoningMode.EXTENDED_REASONING.rawValue)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
@@ -936,12 +936,44 @@ class RealDuckAiModelManagerTest {
         testee = createManager()
         testee.fetchModels()
 
-        assertNull(testee.modelState.value.selectedReasoningMode)
-        verify(dataStore).setSelectedReasoningMode(null)
+        assertEquals(ReasoningMode.FAST, testee.modelState.value.selectedReasoningMode)
+        verify(dataStore).setSelectedReasoningMode(ReasoningMode.FAST.rawValue)
     }
 
     @Test
-    fun whenSelectModelClearsStaleReasoningWhenNewModelLacksSupport() = runTest {
+    fun whenAccessibleModelHasAllReasoningEffortsGatedThenSelectedModeClearedAndNoEffortResolved() = runTest {
+        // Edge case: model accessible to FREE user, but every supported reasoning effort is gated to PRO.
+        // Expected: selectedReasoningMode is cleared, getResolvedReasoningEffort returns null (no effort submitted).
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
+        whenever(dataStore.getSelectedReasoningMode()).thenReturn(ReasoningMode.REASONING.rawValue)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "m",
+                        accessTier = listOf("free", "plus", "pro"),
+                        entityHasAccess = true,
+                        supportedReasoningEffort = listOf("none", "low"),
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "none", accessTier = listOf("pro"), entityHasAccess = false),
+                            RemoteReasoningEffortAccess(id = "low", accessTier = listOf("pro"), entityHasAccess = false),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        assertNull(testee.modelState.value.selectedReasoningMode)
+        verify(dataStore).setSelectedReasoningMode(null)
+        assertNull(testee.getResolvedReasoningEffort())
+    }
+
+    @Test
+    fun whenSelectModelReplacesStaleReasoningWithFirstAccessibleOnNewModel() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
         whenever(dataStore.getSelectedReasoningMode()).thenReturn(ReasoningMode.FAST.rawValue)
         testee = createManager()
@@ -958,8 +990,8 @@ class RealDuckAiModelManagerTest {
 
         testee.selectModel(newModel)
 
-        assertNull(testee.modelState.value.selectedReasoningMode)
-        verify(dataStore).setSelectedReasoningMode(null)
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.selectedReasoningMode)
+        verify(dataStore).setSelectedReasoningMode(ReasoningMode.REASONING.rawValue)
     }
 
     @Test
@@ -987,6 +1019,7 @@ class RealDuckAiModelManagerTest {
     @Test
     fun whenSelectReasoningModeAndSupportedThenPersistedAndStateUpdated() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
+        whenever(dataStore.getSelectedReasoningMode()).thenReturn(ReasoningMode.REASONING.rawValue)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
         whenever(modelsService.getModels(any())).thenReturn(
             AIChatModelsResponse(
@@ -1027,11 +1060,46 @@ class RealDuckAiModelManagerTest {
         )
         testee = createManager()
         testee.fetchModels()
+        // fetchModels auto-promotes the persisted-null state to REASONING (only accessible mode).
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.selectedReasoningMode)
 
         testee.selectReasoningMode(ReasoningMode.FAST)
 
-        assertNull(testee.modelState.value.selectedReasoningMode)
+        // FAST isn't in available → refused, state stays REASONING.
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.selectedReasoningMode)
         verify(dataStore, never()).setSelectedReasoningMode(ReasoningMode.FAST.rawValue)
+    }
+
+    @Test
+    fun whenSelectReasoningModeAndModeIsGatedThenIgnoredAndNotPersisted() = runTest {
+        // Defends against direct calls bypassing the picker's tap handler: gated modes must not be persistable.
+        whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
+        whenever(dataStore.getSelectedReasoningMode()).thenReturn(ReasoningMode.FAST.rawValue)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "m",
+                        accessTier = listOf("free", "plus", "pro"),
+                        entityHasAccess = true,
+                        supportedReasoningEffort = listOf("none", "low"),
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "none", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                            RemoteReasoningEffortAccess(id = "low", accessTier = listOf("pro"), entityHasAccess = false),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        testee = createManager()
+        testee.fetchModels()
+        assertEquals(ReasoningMode.FAST, testee.modelState.value.selectedReasoningMode)
+
+        testee.selectReasoningMode(ReasoningMode.REASONING)
+
+        assertEquals(ReasoningMode.FAST, testee.modelState.value.selectedReasoningMode)
+        verify(dataStore, never()).setSelectedReasoningMode(ReasoningMode.REASONING.rawValue)
     }
 
     @Test
@@ -1058,7 +1126,9 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
-    fun whenGetResolvedReasoningEffortAndNoPersistedThenReturnsNull() = runTest {
+    fun whenGetResolvedReasoningEffortAndNoPersistedThenReturnsAutoPromotedEffort() = runTest {
+        // Mirrors validateSelection's first-launch behavior for models: with nothing persisted,
+        // we auto-select the first accessible mode and submit its effort.
         whenever(dataStore.getSelectedReasoningMode()).thenReturn(null)
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
@@ -1077,6 +1147,6 @@ class RealDuckAiModelManagerTest {
         testee = createManager()
         testee.fetchModels()
 
-        assertNull(testee.getResolvedReasoningEffort())
+        assertEquals("low", testee.getResolvedReasoningEffort())
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningResolverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningResolverTest.kt
@@ -172,4 +172,85 @@ class ReasoningResolverTest {
         assertNull(ReasoningMode.from("EXTENDED"))
         assertNull(ReasoningMode.from(null))
     }
+
+    // ---- per-effort access integration ----
+
+    @Test
+    fun whenEffortAccessMissingForSupportedEffortThenModeIsAccessibleByDefault() {
+        // No per-effort gating data → modes inherit model access, surfaced as `access=null` and `isAccessible=true`.
+        val result = ReasoningResolver.availableModes(supported = listOf(NONE, LOW), effortAccess = emptyList())
+        assertEquals(listOf(AvailableReasoningMode(FAST, NONE), AvailableReasoningMode(REASONING, LOW)), result)
+        assertEquals(true, result.all { it.isAccessible })
+    }
+
+    @Test
+    fun whenAllEffortsAccessibleThenAccessIsCarriedThroughAndModesAccessible() {
+        val access = listOf(
+            ReasoningEffortAccess(NONE, listOf("free", "plus", "pro"), isAccessible = true),
+            ReasoningEffortAccess(LOW, listOf("free", "plus", "pro"), isAccessible = true),
+        )
+        val result = ReasoningResolver.availableModes(listOf(NONE, LOW), access)
+        assertEquals(access[0], result[0].access)
+        assertEquals(true, result[0].isAccessible)
+        assertEquals(access[1], result[1].access)
+        assertEquals(true, result[1].isAccessible)
+    }
+
+    @Test
+    fun whenPreferredCandidateGatedAndFallbackAccessibleThenFallbackUsed() {
+        // EXTENDED_REASONING candidates = [HIGH, MEDIUM]. HIGH gated to PRO, MEDIUM accessible → MEDIUM chosen.
+        val access = listOf(
+            ReasoningEffortAccess(HIGH, listOf("pro"), isAccessible = false),
+            ReasoningEffortAccess(MEDIUM, listOf("free", "plus", "pro"), isAccessible = true),
+        )
+        val result = ReasoningResolver.availableModes(listOf(MEDIUM, HIGH), access)
+        val extended = result.single { it.mode == EXTENDED_REASONING }
+        assertEquals(MEDIUM, extended.effort)
+        assertEquals(true, extended.isAccessible)
+    }
+
+    @Test
+    fun whenAllCandidatesGatedThenFirstSupportedReturnedAsGatedRow() {
+        // Both candidates gated → preferred (HIGH) returned with its gated access entry; row shows for upsell.
+        val highAccess = ReasoningEffortAccess(HIGH, listOf("pro"), isAccessible = false)
+        val mediumAccess = ReasoningEffortAccess(MEDIUM, listOf("pro"), isAccessible = false)
+        val result = ReasoningResolver.availableModes(listOf(MEDIUM, HIGH), listOf(highAccess, mediumAccess))
+        val extended = result.single { it.mode == EXTENDED_REASONING }
+        assertEquals(HIGH, extended.effort)
+        assertEquals(highAccess, extended.access)
+        assertEquals(false, extended.isAccessible)
+    }
+
+    @Test
+    fun whenAllAvailableModesGatedThenResolveReturnsNull() {
+        // Model is accessible but every reasoning effort is gated to a higher tier → no fallback mode to auto-select.
+        val available = listOf(
+            AvailableReasoningMode(FAST, NONE, ReasoningEffortAccess(NONE, listOf("pro"), isAccessible = false)),
+            AvailableReasoningMode(REASONING, LOW, ReasoningEffortAccess(LOW, listOf("pro"), isAccessible = false)),
+        )
+        assertNull(ReasoningResolver.resolveMode(persisted = FAST, available = available))
+        assertNull(ReasoningResolver.resolveMode(persisted = null, available = available))
+    }
+
+    @Test
+    fun whenPersistedModeIsGatedAndOthersAccessibleThenResolveFallsBackToFirstAccessible() {
+        val available = listOf(
+            AvailableReasoningMode(FAST, NONE, ReasoningEffortAccess(NONE, listOf("pro"), isAccessible = false)),
+            AvailableReasoningMode(REASONING, LOW, ReasoningEffortAccess(LOW, listOf("free", "plus", "pro"), isAccessible = true)),
+        )
+        assertEquals(REASONING, ReasoningResolver.resolveMode(persisted = FAST, available = available))
+    }
+
+    @Test
+    fun whenSomeEffortsHaveAccessAndOthersDoNotThenMissingAreTreatedAsAccessible() {
+        // Only MEDIUM has gating data (Pro-only); LOW has none → REASONING accessible (inherits), EXTENDED gated.
+        val access = listOf(ReasoningEffortAccess(MEDIUM, listOf("pro"), isAccessible = false))
+        val result = ReasoningResolver.availableModes(listOf(LOW, MEDIUM), access)
+        val reasoning = result.single { it.mode == REASONING }
+        val extended = result.single { it.mode == EXTENDED_REASONING }
+        assertEquals(true, reasoning.isAccessible)
+        assertNull(reasoning.access)
+        assertEquals(false, extended.isAccessible)
+        assertEquals(access[0], extended.access)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -26,7 +26,8 @@ import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
-import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel.PickerSurface
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
@@ -205,7 +206,7 @@ class ModelPickerViewModelTest {
         val model = freeModel("f")
 
         testee.commands.test {
-            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
             runCurrent()
 
             verify(modelManager).selectModel(model)
@@ -220,10 +221,10 @@ class ModelPickerViewModelTest {
         val model = plusModel("p")
 
         testee.commands.test {
-            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchPurchase(PickerSurface.ADDRESS_BAR.origin),
+                UpsellCommand.LaunchPurchase(PickerSurface.MODEL_PICKER_ADDRESS_BAR.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -236,10 +237,10 @@ class ModelPickerViewModelTest {
         val model = proModel("pr")
 
         testee.commands.test {
-            testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchPurchase(PickerSurface.DUCK_AI_TAB.origin),
+                UpsellCommand.LaunchPurchase(PickerSurface.MODEL_PICKER_DUCK_AI_TAB.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -252,10 +253,10 @@ class ModelPickerViewModelTest {
         val model = proModel("pr")
 
         testee.commands.test {
-            testee.onModelTapped(model, PickerSurface.ADDRESS_BAR)
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchUpgrade(PickerSurface.ADDRESS_BAR.origin),
+                UpsellCommand.LaunchUpgrade(PickerSurface.MODEL_PICKER_ADDRESS_BAR.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -268,10 +269,10 @@ class ModelPickerViewModelTest {
         val model = proModel("pr")
 
         testee.commands.test {
-            testee.onModelTapped(model, PickerSurface.DUCK_AI_TAB)
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
 
             assertEquals(
-                ModelPickerViewModel.Command.LaunchUpgrade(PickerSurface.DUCK_AI_TAB.origin),
+                UpsellCommand.LaunchUpgrade(PickerSurface.MODEL_PICKER_DUCK_AI_TAB.origin),
                 awaitItem(),
             )
             cancelAndConsumeRemainingEvents()
@@ -291,7 +292,7 @@ class ModelPickerViewModelTest {
         )
 
         testee.commands.test {
-            testee.onModelTapped(ghost, PickerSurface.ADDRESS_BAR)
+            testee.onModelTapped(ghost, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
@@ -311,7 +312,7 @@ class ModelPickerViewModelTest {
         )
 
         testee.commands.test {
-            testee.onModelTapped(internalModel, PickerSurface.ADDRESS_BAR)
+            testee.onModelTapped(internalModel, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
@@ -331,7 +332,7 @@ class ModelPickerViewModelTest {
         )
 
         testee.commands.test {
-            testee.onModelTapped(internalModel, PickerSurface.DUCK_AI_TAB)
+            testee.onModelTapped(internalModel, PickerSurface.MODEL_PICKER_DUCK_AI_TAB)
 
             expectNoEvents()
             cancelAndConsumeRemainingEvents()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -16,15 +16,21 @@
 
 package com.duckduckgo.duckchat.impl.ui
 
+import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.models.AvailableReasoningMode
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningEffort
+import com.duckduckgo.duckchat.impl.models.ReasoningEffortAccess
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
+import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerViewModel
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -77,13 +83,6 @@ class ReasoningModePickerViewModelTest {
     }
 
     @Test
-    fun whenSelectModeThenDelegatesToManager() = runTest {
-        testee.selectMode(ReasoningMode.REASONING)
-        coroutineRule.testScope.testScheduler.advanceUntilIdle()
-        verify(modelManager).selectReasoningMode(ReasoningMode.REASONING)
-    }
-
-    @Test
     fun whenIconResForEachModeThenReturnsExpectedDrawable() {
         assertEquals(
             com.duckduckgo.duckchat.impl.R.drawable.ic_reasoning_fast_24,
@@ -115,4 +114,151 @@ class ReasoningModePickerViewModelTest {
         assertEquals(false, rows[0].selected)
         assertEquals(true, rows[1].selected)
     }
+
+    // ---- onModeTapped upsell routing ----
+
+    @Test
+    fun whenAccessibleModeTappedThenSelectModeInvokedAndNoCommandEmitted() = runTest {
+        state.value = ModelState(
+            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW)),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+            runCurrent()
+
+            verify(modelManager).selectReasoningMode(ReasoningMode.REASONING)
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreeUserTapsGatedModeRequiringPlusFromAddressBarThenLaunchPurchaseEmitted() = runTest {
+        state.value = ModelState(
+            userTier = UserTier.FREE,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("plus", "pro"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+
+            assertEquals(
+                UpsellCommand.LaunchPurchase(PickerSurface.REASONING_PICKER_ADDRESS_BAR.origin),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenFreeUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchPurchaseEmittedWithDuckAiOrigin() = runTest {
+        state.value = ModelState(
+            userTier = UserTier.FREE,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+
+            assertEquals(
+                UpsellCommand.LaunchPurchase(PickerSurface.REASONING_PICKER_DUCK_AI_TAB.origin),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPlusUserTapsGatedModeRequiringProFromAddressBarThenLaunchUpgradeEmitted() = runTest {
+        state.value = ModelState(
+            userTier = UserTier.PLUS,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+
+            assertEquals(
+                UpsellCommand.LaunchUpgrade(PickerSurface.REASONING_PICKER_ADDRESS_BAR.origin),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenPlusUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchUpgradeEmittedWithDuckAiOrigin() = runTest {
+        state.value = ModelState(
+            userTier = UserTier.PLUS,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+
+            assertEquals(
+                UpsellCommand.LaunchUpgrade(PickerSurface.REASONING_PICKER_DUCK_AI_TAB.origin),
+                awaitItem(),
+            )
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenGatedModeRequiresFreeTierThenNoCommandEmitted() = runTest {
+        // Pathological: a "gated" entry whose access list still includes FREE → no upsell route.
+        state.value = ModelState(
+            userTier = UserTier.FREE,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("free", "plus", "pro"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenGatedModeAccessHasNoPublicTierThenNoCommandEmitted() = runTest {
+        // Only non-public tiers in the access list → requiredTier is null → no upsell route.
+        state.value = ModelState(
+            userTier = UserTier.FREE,
+            availableReasoningModes = listOf(gatedExtended(requires = listOf("internal"))),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenTappedModeNotInAvailableListThenNoCommandEmittedAndManagerNotCalled() = runTest {
+        state.value = ModelState(
+            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE)),
+        )
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+            runCurrent()
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    private fun gatedExtended(requires: List<String>) = AvailableReasoningMode(
+        mode = ReasoningMode.EXTENDED_REASONING,
+        effort = ReasoningEffort.MEDIUM,
+        access = ReasoningEffortAccess(
+            effort = ReasoningEffort.MEDIUM,
+            accessTier = requires,
+            isAccessible = false,
+        ),
+    )
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214635053937863?focus=true 

### Description

**Part 2 of 2 — Subscription upsell trigger for gated reasoning efforts.**

Part 1 added schema support for the new `reasoningEffortAccess` field on the `/duckchat/v1/models` response. This PR wires the user-facing upsell: tapping a gated reasoning mode on an accessible model now routes the user into the native `SubscriptionPurchase` (FREE → PLUS/PRO) or `SubscriptionUpgrade` (PLUS → PRO) flow, mirroring the model-level upsell already shipped on #8625.

**What changed:**

- **Data layer plumbing**: `AvailableReasoningMode` now carries an optional `access: ReasoningEffortAccess?` plus a derived `isAccessible` flag. `ReasoningResolver.availableModes(supported, effortAccess)` picks the first candidate effort per mode that is *supported* **and** *accessible*; if none are accessible, it falls back to the first supported one so the row still renders for upsell routing. Missing per-effort access metadata is treated as accessible. 
- **Reasoning picker upsell wiring**: `ReasoningModePickerViewModel.onModeTapped(mode, surface)` runs the same decision table as the model picker: accessible → select; gated → route to `LaunchPurchase`/`LaunchUpgrade` based on `access.requiredTier` + current `userTier`. 
- **Shared upsell types**: `PickerSurface` and `UpsellCommand` live in a new shared file. The model picker was re-pointed to use these instead of its previously nested types.

### Notes:
- Product request: **Hardcoded gate for gpt-5.2 EXTENDED_REASONING** until BE is ready.

### Steps to test this PR

- [ ] **Free account, gated model tap (already shipped, regression check):** Tap a PLUS-only model from the model picker → `SubscriptionPurchase` opens with the model-picker funnel origin.
- [ ] **Plus account, PRO-gated reasoning tap:** Open GPT-5.2, tap EXTENDED_REASONING → `SubscriptionUpgrade` opens.
- [ ] **Tier downgrade:** While on PLUS/PRO with a gated reasoning mode selected, downgrade by removing the subscription. The picker auto-selects the first accessible model/mode and submitting a prompt sends that mode's effort, not the previously-cached gated effort.

### UI changes


https://github.com/user-attachments/assets/340d2f47-0671-47e3-a699-c73990ee77f7




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new per-effort accessibility logic for reasoning modes and routes users into purchase/upgrade flows, which can affect subscription funnel behavior and persisted selection state. Also adds a temporary hardcoded gate for `gpt-5.2` that could mis-gate if model IDs or backend behavior change.
> 
> **Overview**
> Adds per-reasoning-effort access awareness and upsell routing: `AvailableReasoningMode` now carries optional access metadata and `ReasoningResolver.availableModes` selects the first *supported + accessible* effort per mode (falling back to a gated effort so the row can still render for upsell).
> 
> Updates `RealDuckAiModelManager` to validate persisted reasoning selections against accessibility (auto-selecting/persisting the first accessible mode, refusing gated selections, and allowing `selectedReasoningMode` to become `null` when all efforts are gated). The reasoning-mode picker now triggers the native `SubscriptionPurchase`/`SubscriptionUpgrade` flows when a user taps a gated mode, using shared `PickerSurface`/`UpsellCommand` types (also adopted by the model picker).
> 
> Includes a temporary, hardcoded PRO-only gate for `gpt-5.2` `EXTENDED_REASONING` until backend per-effort gating ships, and expands tests to cover gating/auto-promotion/upsell behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92886a8b8c381108a0b3eea436127143085c725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->