### PR TITLE
Fix Duck.ai page context pixels to report granular failure reasons

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
+import org.json.JSONException
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -458,7 +459,13 @@ class DuckChatContextualViewModel @Inject constructor(
             if (reportInvalidPixels) duckChatPixels.reportContextualPageContextInvalidEmpty()
             return false
         }
-        val json = JSONObject(pageContext)
+        val json = try {
+            JSONObject(pageContext)
+        } catch (_: JSONException) {
+            logcat { "Duck.ai: pageContext is not valid JSON" }
+            if (reportInvalidPixels) duckChatPixels.reportContextualPageContextCollectionEmpty()
+            return false
+        }
         val title = json.optString("title").takeIf { it.isNotBlank() }
         val content = json.optString("content").takeIf { it.isNotBlank() }
         if (reportInvalidPixels) {
@@ -543,7 +550,7 @@ class DuckChatContextualViewModel @Inject constructor(
             return
         }
 
-        if (isContextValid(pageContext)) {
+        if (isContextValid(pageContext, reportInvalidPixels = true)) {
             updatedPageContext = pageContext
             val json = JSONObject(updatedPageContext)
             val title = json.optString("title")
@@ -588,7 +595,6 @@ class DuckChatContextualViewModel @Inject constructor(
             }
         } else {
             updatedPageContext = ""
-            duckChatPixels.reportContextualPageContextCollectionEmpty()
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -581,7 +581,7 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
-    fun `when page context received without content then state unchanged`() =
+    fun `when page context received without content then state unchanged and invalid no content pixel fired`() =
         runTest {
             val serializedPageData =
                 """
@@ -599,7 +599,47 @@ class DuckChatContextualViewModelTest {
             assertEquals("", state.contextUrl)
             assertEquals("", state.tabId)
             assertEquals("", testee.updatedPageContext)
+            verify(duckChatPixels).reportContextualPageContextInvalidNoContent()
+            verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
+        }
+
+    @Test
+    fun `when page context received without title then invalid no title pixel fired`() =
+        runTest {
+            val serializedPageData =
+                """
+                {
+                    "url": "https://ctx.com",
+                    "content": "some content"
+                }
+                """.trimIndent()
+
+            testee.onPageContextReceived("tab-1", serializedPageData)
+
+            assertEquals("", testee.updatedPageContext)
+            verify(duckChatPixels).reportContextualPageContextInvalidNoTitle()
+            verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
+        }
+
+    @Test
+    fun `when page context received empty then invalid empty pixel fired`() =
+        runTest {
+            testee.onPageContextReceived("tab-1", "")
+
+            assertEquals("", testee.updatedPageContext)
+            verify(duckChatPixels).reportContextualPageContextInvalidEmpty()
+            verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
+        }
+
+    @Test
+    fun `when page context received with malformed json then collection empty pixel fired and no crash`() =
+        runTest {
+            testee.onPageContextReceived("tab-1", "{not valid json")
+
+            assertEquals("", testee.updatedPageContext)
             verify(duckChatPixels).reportContextualPageContextCollectionEmpty()
+            verify(duckChatPixels, never()).reportContextualPageContextInvalidNoTitle()
+            verify(duckChatPixels, never()).reportContextualPageContextInvalidNoContent()
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214988348069251?focus=true 

### Description

Fixes the Duck.ai page context extraction analytics so the failure breakdown is distinguishable on the dashboard.

Previously every extraction failure ended up as `invalid_empty`, with `invalid_no_title` / `invalid_no_content` permanently at 0 and `collection_empty` acting as a generic catchall.

Root cause was in `DuckChatContextualViewModel.isContextValid()`: the `reportInvalidPixels` flag that gates the granular pixels was only set to `true` from `addPageContext()` (the user-tap path), never from `onPageContextReceived()` (the C-S-S extraction path). And by the time the user tapped Add, `updatedPageContext` had already been reset to `""`, so the validator always hit the empty string early return never reaching the title/content checks.

Changes in `DuckChatContextualViewModel`:
- `onPageContextReceived` now passes `reportInvalidPixels = true` so the granular pixels fire from where the raw JSON is actually observed.
- Removed the blanket `collection_empty` call in the else branch; the granular pixels now carry the breakdown.
- Wrapped `JSONObject(...)` parsing in try/catch. `collection_empty` is now specifically the "malformed/unparseable C-S-S payload" signal (also protects again a crash on bad JSON).
- Added unit tests for those cases.

After this change, each failure routes to exactly one (or both, for missing-title + missing-content) pixel: `invalid_empty`, `invalid_no_title`, `invalid_no_content`, or `collection_empty`.

Note: I did not properly test this change as I need to find web pages that actually cause some of those pixels to fire (missing title, content, or empty). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to page-context validation/pixel reporting and add JSON parse guarding to avoid crashes; behavior impact is mainly analytics and when context is accepted/rejected.
> 
> **Overview**
> **Improves Duck.ai page context validation and telemetry.** `isContextValid` now guards `JSONObject` parsing with a `try/catch` and reports more specific invalid reasons (empty, malformed JSON, missing title, missing content).
> 
> `onPageContextReceived` now invokes validation with `reportInvalidPixels=true` and stops emitting the generic “collection empty” pixel for non-JSON validation failures, with tests updated/added to assert the new pixel behavior and that malformed JSON no longer crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df3baa2a23cf44657971c6b2649a9ad316787c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->