### PR TITLE
Update content scope scripts to version 14.11.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -53,6 +53,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -801,6 +802,35 @@
       }
     });
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -809,15 +839,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {
@@ -4155,16 +4182,21 @@
         return true;
       }
       if (change.type === "descriptor") {
-        if (change.enumerable && typeof change.enumerable !== "boolean") {
+        if ("enumerable" in change && typeof change.enumerable !== "boolean") {
           return false;
         }
-        if (change.configurable && typeof change.configurable !== "boolean") {
+        if ("configurable" in change && typeof change.configurable !== "boolean") {
           return false;
         }
         if ("define" in change && typeof change.define !== "boolean") {
           return false;
         }
-        return typeof change.getterValue !== "undefined";
+        const hasGetterValue = typeof change.getterValue !== "undefined";
+        const hasSetterValue = typeof change.setterValue !== "undefined";
+        const hasValue = typeof change.value !== "undefined";
+        const isAccessorShape = hasGetterValue || hasSetterValue;
+        const isValueShape = hasValue;
+        return isAccessorShape !== isValueShape;
       }
       return false;
     }
@@ -4175,9 +4207,11 @@
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type
      * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
+     * @property {import('../utils.js').ConfigSetting} [setterValue] - The function invoked when the property is assigned. Used alongside (or instead of) getterValue to override accessor-style properties such as event handlers (e.g., `MediaDevices.prototype.ondevicechange`).
+     * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it does not exist.
+     * @property {boolean} [define] - When true, define a new own property if the key is absent from `api` and its entire prototype chain. When false (default), skip changes for properties that do not exist at all; override own properties via `wrapProperty`; override inherited properties by shadow-defining an own property on `api`.
      */
     /**
      * Applies a change to DOM APIs.
@@ -4218,27 +4252,163 @@
      */
     wrapApiDescriptor(api, key, change) {
       const getterValue = change.getterValue;
-      if (getterValue) {
-        const descriptor = {
-          get: () => processAttr(getterValue, void 0)
-        };
-        if ("enumerable" in change) {
-          descriptor.enumerable = change.enumerable;
-        }
-        if ("configurable" in change) {
-          descriptor.configurable = change.configurable;
-        }
-        if (change.define === true && !(key in api)) {
-          const defineDescriptor = {
-            ...descriptor,
-            enumerable: typeof descriptor.enumerable !== "boolean" ? true : descriptor.enumerable,
-            configurable: typeof descriptor.configurable !== "boolean" ? true : descriptor.configurable
-          };
-          this.defineProperty(api, key, defineDescriptor);
-          return;
-        }
-        this.wrapProperty(api, key, descriptor);
+      const setterValue = change.setterValue;
+      const value = change.value;
+      const descriptorKind = getterValue !== void 0 || setterValue !== void 0 ? "getter" : value !== void 0 ? "value" : void 0;
+      const configSetting = descriptorKind === "getter" ? getterValue : value;
+      if (!descriptorKind || descriptorKind === "value" && configSetting === void 0) {
+        return;
       }
+      const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
+      const origDescriptor = this.findPropertyDescriptor(api, key);
+      if (!origDescriptor) {
+        if (change.define === true) {
+          this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+        }
+        return;
+      }
+      if (descriptorKind === "value") {
+        const valueDescriptor = (
+          /** @type {{ value?: any }} */
+          descriptor
+        );
+        if (typeof valueDescriptor.value === "function" && typeof origDescriptor.value === "function") {
+          valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
+        }
+      } else if (descriptorKind === "getter") {
+        const accessorDescriptor = (
+          /** @type {{ get?: () => any, set?: (v: any) => void }} */
+          descriptor
+        );
+        if (typeof accessorDescriptor.set === "function" && typeof origDescriptor.set === "function") {
+          accessorDescriptor.set = /** @type {(v: any) => void} */
+          this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set);
+        }
+      }
+      if (hasOwnProperty.call(api, key)) {
+        this.wrapProperty(api, key, descriptor);
+      } else {
+        const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+        if (merged) {
+          this.defineProperty(api, key, merged);
+        }
+      }
+    }
+    /**
+     * Returns the property descriptor for `key` on `obj` or an ancestor in its prototype chain.
+     * @param {object} obj
+     * @param {string} key
+     * @returns {PropertyDescriptor | undefined}
+     */
+    findPropertyDescriptor(obj, key) {
+      let current = obj;
+      while (current) {
+        const descriptor = getOwnPropertyDescriptor(current, key);
+        if (descriptor) {
+          return descriptor;
+        }
+        current = Object.getPrototypeOf(current);
+      }
+      return void 0;
+    }
+    /**
+     * Wraps a config-supplied function so its observable identity (`toString`,
+     * `toString.toString`, `name`, `length`) mirrors the original DOM method it is
+     * replacing. The call itself still executes the configured replacement.
+     *
+     * Note: `processAttr` may return a shared function (e.g. `functionMap.noop`),
+     * so we always create a fresh wrapper before redefining `name`/`length` to
+     * avoid mutating module-level singletons.
+     *
+     * @param {Function} replacementFn - configured replacement to invoke
+     * @param {Function} origFn - original DOM method we are masking against
+     * @returns {Function}
+     */
+    maskMethodReplacement(replacementFn, origFn) {
+      const wrapper = function() {
+        return ReflectApply(replacementFn, this, arguments);
+      };
+      objectDefineProperty(wrapper, "name", { value: origFn.name, configurable: true });
+      objectDefineProperty(wrapper, "length", { value: origFn.length, configurable: true });
+      return wrapToString(wrapper, origFn);
+    }
+    /**
+     * @param {'getter' | 'value'} descriptorKind
+     * @param {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[] | undefined} configSetting
+     * @param {APIChange} change
+     * @returns {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>}
+     */
+    createApiDescriptor(descriptorKind, configSetting, change) {
+      let descriptor;
+      if (descriptorKind === "value") {
+        const valueSetting = (
+          /** @type {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[]} */
+          configSetting
+        );
+        descriptor = { value: processAttr(valueSetting, void 0) };
+      } else {
+        descriptor = {};
+        if (configSetting !== void 0) {
+          const getterSetting = configSetting;
+          descriptor.get = () => processAttr(getterSetting, void 0);
+        }
+        if (change.setterValue !== void 0) {
+          const setterSetting = (
+            /** @type {import('../utils.js').ConfigSetting} */
+            change.setterValue
+          );
+          descriptor.set = function setter(v2) {
+            const fn = processAttr(setterSetting, void 0);
+            if (typeof fn === "function") {
+              ReflectApply(fn, this, [v2]);
+            }
+          };
+        }
+      }
+      if ("enumerable" in change) {
+        descriptor.enumerable = change.enumerable;
+      }
+      if ("configurable" in change) {
+        descriptor.configurable = change.configurable;
+      }
+      return (
+        /** @type {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} */
+        descriptor
+      );
+    }
+    /**
+     * @param {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} descriptor
+     * @param {'getter' | 'value'} descriptorKind
+     * @returns {import('../wrapper-utils.js').StrictPropertyDescriptor}
+     */
+    createDefineDescriptor(descriptor, descriptorKind) {
+      if (descriptorKind === "value") {
+        const valueDescriptor = (
+          /** @type {{ value: any, enumerable?: boolean, configurable?: boolean }} */
+          descriptor
+        );
+        return {
+          value: valueDescriptor.value,
+          writable: true,
+          enumerable: typeof valueDescriptor.enumerable !== "boolean" ? true : valueDescriptor.enumerable,
+          configurable: typeof valueDescriptor.configurable !== "boolean" ? true : valueDescriptor.configurable
+        };
+      }
+      const getterDescriptor = (
+        /** @type {{ get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */
+        descriptor
+      );
+      const result = {
+        enumerable: typeof getterDescriptor.enumerable !== "boolean" ? true : getterDescriptor.enumerable,
+        configurable: typeof getterDescriptor.configurable !== "boolean" ? true : getterDescriptor.configurable
+      };
+      if (typeof getterDescriptor.get === "function") {
+        result.get = getterDescriptor.get;
+      }
+      if (typeof getterDescriptor.set === "function") {
+        result.set = getterDescriptor.set;
+      }
+      return result;
     }
     /**
      * Looks up a global object from a scope, e.g. 'Navigator.prototype'.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1576,6 +1576,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -2332,6 +2333,35 @@
       return Reflect.get(target, prop, receiver);
     };
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -2340,15 +2370,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1576,6 +1576,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -2301,6 +2302,35 @@
       return Reflect.get(target, prop, receiver);
     };
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -2309,15 +2339,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -821,6 +821,7 @@
     Promise: () => Promise2,
     Proxy: () => Proxy2,
     Reflect: () => Reflect2,
+    ReflectApply: () => ReflectApply,
     ReflectDeleteProperty: () => ReflectDeleteProperty,
     Set: () => Set2,
     String: () => String2,
@@ -898,6 +899,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -2200,6 +2202,35 @@
       }
     });
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -2208,15 +2239,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {
@@ -6982,16 +7010,21 @@
         return true;
       }
       if (change.type === "descriptor") {
-        if (change.enumerable && typeof change.enumerable !== "boolean") {
+        if ("enumerable" in change && typeof change.enumerable !== "boolean") {
           return false;
         }
-        if (change.configurable && typeof change.configurable !== "boolean") {
+        if ("configurable" in change && typeof change.configurable !== "boolean") {
           return false;
         }
         if ("define" in change && typeof change.define !== "boolean") {
           return false;
         }
-        return typeof change.getterValue !== "undefined";
+        const hasGetterValue = typeof change.getterValue !== "undefined";
+        const hasSetterValue = typeof change.setterValue !== "undefined";
+        const hasValue = typeof change.value !== "undefined";
+        const isAccessorShape = hasGetterValue || hasSetterValue;
+        const isValueShape = hasValue;
+        return isAccessorShape !== isValueShape;
       }
       return false;
     }
@@ -7002,9 +7035,11 @@
      * @typedef {Object} APIChange
      * @property {"remove"|"descriptor"} type
      * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
+     * @property {import('../utils.js').ConfigSetting} [setterValue] - The function invoked when the property is assigned. Used alongside (or instead of) getterValue to override accessor-style properties such as event handlers (e.g., `MediaDevices.prototype.ondevicechange`).
+     * @property {import('../utils.js').ConfigSetting} [value] - The value assigned to a value descriptor, including methods.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
-     * @property {boolean} [define] - Whether to define the property if it does not exist.
+     * @property {boolean} [define] - When true, define a new own property if the key is absent from `api` and its entire prototype chain. When false (default), skip changes for properties that do not exist at all; override own properties via `wrapProperty`; override inherited properties by shadow-defining an own property on `api`.
      */
     /**
      * Applies a change to DOM APIs.
@@ -7045,27 +7080,163 @@
      */
     wrapApiDescriptor(api, key, change) {
       const getterValue = change.getterValue;
-      if (getterValue) {
-        const descriptor = {
-          get: () => processAttr(getterValue, void 0)
-        };
-        if ("enumerable" in change) {
-          descriptor.enumerable = change.enumerable;
-        }
-        if ("configurable" in change) {
-          descriptor.configurable = change.configurable;
-        }
-        if (change.define === true && !(key in api)) {
-          const defineDescriptor = {
-            ...descriptor,
-            enumerable: typeof descriptor.enumerable !== "boolean" ? true : descriptor.enumerable,
-            configurable: typeof descriptor.configurable !== "boolean" ? true : descriptor.configurable
-          };
-          this.defineProperty(api, key, defineDescriptor);
-          return;
-        }
-        this.wrapProperty(api, key, descriptor);
+      const setterValue = change.setterValue;
+      const value = change.value;
+      const descriptorKind = getterValue !== void 0 || setterValue !== void 0 ? "getter" : value !== void 0 ? "value" : void 0;
+      const configSetting = descriptorKind === "getter" ? getterValue : value;
+      if (!descriptorKind || descriptorKind === "value" && configSetting === void 0) {
+        return;
       }
+      const descriptor = this.createApiDescriptor(descriptorKind, configSetting, change);
+      const origDescriptor = this.findPropertyDescriptor(api, key);
+      if (!origDescriptor) {
+        if (change.define === true) {
+          this.defineProperty(api, key, this.createDefineDescriptor(descriptor, descriptorKind));
+        }
+        return;
+      }
+      if (descriptorKind === "value") {
+        const valueDescriptor = (
+          /** @type {{ value?: any }} */
+          descriptor
+        );
+        if (typeof valueDescriptor.value === "function" && typeof origDescriptor.value === "function") {
+          valueDescriptor.value = this.maskMethodReplacement(valueDescriptor.value, origDescriptor.value);
+        }
+      } else if (descriptorKind === "getter") {
+        const accessorDescriptor = (
+          /** @type {{ get?: () => any, set?: (v: any) => void }} */
+          descriptor
+        );
+        if (typeof accessorDescriptor.set === "function" && typeof origDescriptor.set === "function") {
+          accessorDescriptor.set = /** @type {(v: any) => void} */
+          this.maskMethodReplacement(accessorDescriptor.set, origDescriptor.set);
+        }
+      }
+      if (hasOwnProperty.call(api, key)) {
+        this.wrapProperty(api, key, descriptor);
+      } else {
+        const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+        if (merged) {
+          this.defineProperty(api, key, merged);
+        }
+      }
+    }
+    /**
+     * Returns the property descriptor for `key` on `obj` or an ancestor in its prototype chain.
+     * @param {object} obj
+     * @param {string} key
+     * @returns {PropertyDescriptor | undefined}
+     */
+    findPropertyDescriptor(obj, key) {
+      let current = obj;
+      while (current) {
+        const descriptor = getOwnPropertyDescriptor(current, key);
+        if (descriptor) {
+          return descriptor;
+        }
+        current = Object.getPrototypeOf(current);
+      }
+      return void 0;
+    }
+    /**
+     * Wraps a config-supplied function so its observable identity (`toString`,
+     * `toString.toString`, `name`, `length`) mirrors the original DOM method it is
+     * replacing. The call itself still executes the configured replacement.
+     *
+     * Note: `processAttr` may return a shared function (e.g. `functionMap.noop`),
+     * so we always create a fresh wrapper before redefining `name`/`length` to
+     * avoid mutating module-level singletons.
+     *
+     * @param {Function} replacementFn - configured replacement to invoke
+     * @param {Function} origFn - original DOM method we are masking against
+     * @returns {Function}
+     */
+    maskMethodReplacement(replacementFn, origFn) {
+      const wrapper = function() {
+        return ReflectApply(replacementFn, this, arguments);
+      };
+      objectDefineProperty(wrapper, "name", { value: origFn.name, configurable: true });
+      objectDefineProperty(wrapper, "length", { value: origFn.length, configurable: true });
+      return wrapToString(wrapper, origFn);
+    }
+    /**
+     * @param {'getter' | 'value'} descriptorKind
+     * @param {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[] | undefined} configSetting
+     * @param {APIChange} change
+     * @returns {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>}
+     */
+    createApiDescriptor(descriptorKind, configSetting, change) {
+      let descriptor;
+      if (descriptorKind === "value") {
+        const valueSetting = (
+          /** @type {import('../utils.js').ConfigSetting | import('../utils.js').ConfigSetting[]} */
+          configSetting
+        );
+        descriptor = { value: processAttr(valueSetting, void 0) };
+      } else {
+        descriptor = {};
+        if (configSetting !== void 0) {
+          const getterSetting = configSetting;
+          descriptor.get = () => processAttr(getterSetting, void 0);
+        }
+        if (change.setterValue !== void 0) {
+          const setterSetting = (
+            /** @type {import('../utils.js').ConfigSetting} */
+            change.setterValue
+          );
+          descriptor.set = function setter(v2) {
+            const fn = processAttr(setterSetting, void 0);
+            if (typeof fn === "function") {
+              ReflectApply(fn, this, [v2]);
+            }
+          };
+        }
+      }
+      if ("enumerable" in change) {
+        descriptor.enumerable = change.enumerable;
+      }
+      if ("configurable" in change) {
+        descriptor.configurable = change.configurable;
+      }
+      return (
+        /** @type {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} */
+        descriptor
+      );
+    }
+    /**
+     * @param {Partial<import('../wrapper-utils.js').StrictPropertyDescriptor>} descriptor
+     * @param {'getter' | 'value'} descriptorKind
+     * @returns {import('../wrapper-utils.js').StrictPropertyDescriptor}
+     */
+    createDefineDescriptor(descriptor, descriptorKind) {
+      if (descriptorKind === "value") {
+        const valueDescriptor = (
+          /** @type {{ value: any, enumerable?: boolean, configurable?: boolean }} */
+          descriptor
+        );
+        return {
+          value: valueDescriptor.value,
+          writable: true,
+          enumerable: typeof valueDescriptor.enumerable !== "boolean" ? true : valueDescriptor.enumerable,
+          configurable: typeof valueDescriptor.configurable !== "boolean" ? true : valueDescriptor.configurable
+        };
+      }
+      const getterDescriptor = (
+        /** @type {{ get?: () => any, set?: (v: any) => void, enumerable?: boolean, configurable?: boolean }} */
+        descriptor
+      );
+      const result = {
+        enumerable: typeof getterDescriptor.enumerable !== "boolean" ? true : getterDescriptor.enumerable,
+        configurable: typeof getterDescriptor.configurable !== "boolean" ? true : getterDescriptor.configurable
+      };
+      if (typeof getterDescriptor.get === "function") {
+        result.get = getterDescriptor.get;
+      }
+      if (typeof getterDescriptor.set === "function") {
+        result.set = getterDescriptor.set;
+      }
+      return result;
     }
     /**
      * Looks up a global object from a scope, e.g. 'Navigator.prototype'.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -52,6 +52,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -765,6 +766,35 @@
       return Reflect.get(target, prop, receiver);
     };
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -773,15 +803,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -52,6 +52,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);
@@ -765,6 +766,35 @@
       return Reflect.get(target, prop, receiver);
     };
   }
+  function mergePropertyDescriptors(origDescriptor, partialDescriptor) {
+    if ("value" in origDescriptor && "value" in partialDescriptor || "get" in origDescriptor && "get" in partialDescriptor || "set" in origDescriptor && "set" in partialDescriptor) {
+      const merged = {
+        ...origDescriptor,
+        ...partialDescriptor
+      };
+      if ("value" in merged) {
+        return (
+          /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+          {
+            value: merged.value,
+            writable: typeof merged.writable === "boolean" ? merged.writable : true,
+            configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+            enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+          }
+        );
+      }
+      return (
+        /** @type {import('./wrapper-utils').StrictPropertyDescriptor} */
+        {
+          get: merged.get,
+          set: merged.set,
+          configurable: typeof merged.configurable === "boolean" ? merged.configurable : true,
+          enumerable: typeof merged.enumerable === "boolean" ? merged.enumerable : true
+        }
+      );
+    }
+    return void 0;
+  }
   function wrapProperty(object, propertyName, descriptor, definePropertyFn) {
     if (!object) {
       return;
@@ -773,15 +803,12 @@
     if (!origDescriptor) {
       return;
     }
-    if ("value" in origDescriptor && "value" in descriptor || "get" in origDescriptor && "get" in descriptor || "set" in origDescriptor && "set" in descriptor) {
-      definePropertyFn(object, propertyName, {
-        ...origDescriptor,
-        ...descriptor
-      });
-      return origDescriptor;
-    } else {
+    const merged = mergePropertyDescriptors(origDescriptor, descriptor);
+    if (!merged) {
       throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`);
     }
+    definePropertyFn(object, propertyName, merged);
+    return origDescriptor;
   }
   function wrapMethod(object, propertyName, wrapperFn, definePropertyFn) {
     if (!object) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -389,6 +389,7 @@
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
+  var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
   var generateKey = globalThis.crypto?.subtle?.generateKey?.bind(globalThis.crypto?.subtle);
   var exportKey = globalThis.crypto?.subtle?.exportKey?.bind(globalThis.crypto?.subtle);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.10.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.11.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#89ab4a1fa2292e40e8745e14f96706ddc7751fd1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#474bbc4a3a44c52cd572d034fc7e462f72f4e92b",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.10.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.11.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1214991695033307?focus=true
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bundled content-scope scripts that modify/wrap DOM APIs in the webview; regressions could impact site compatibility or privacy protections despite being largely vendored code.
> 
> **Overview**
> Bumps `@duckduckgo/content-scope-scripts` from `14.10.0` to `14.11.0` (updates `package.json`/`package-lock.json`) and refreshes the bundled Android build artifacts under `node_modules/`.
> 
> The updated scripts enhance API descriptor patching: support `setterValue` and `value` overrides (not just `getterValue`), stricter validation of descriptor shape, safer merging of property descriptors, and masking of replaced functions to preserve observable identity (`name`/`length`/`toString`) when overriding DOM methods or setters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874839374b89d43ba2ee40d2027343e1203318d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->