### PR TITLE
Fix pixel report for menu opened

### DIFF
--- a/PixelDefinitions/pixels/definitions/browser_menu.json5
+++ b/PixelDefinitions/pixels/definitions/browser_menu.json5
@@ -6,6 +6,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "atb",
             "vpnMenuItemStatus",
             {
                 "key": "from_focused_ntp",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214864368587060?focus=true

### Description
Add missing pixel parameter to definition

### Steps to test this PR
- [ ] Privacy Triage is approved

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a pixel definition to include a missing parameter, with no runtime logic changes.
> 
> **Overview**
> Fixes analytics reporting for the browser overflow menu open event by adding the missing `atb` parameter to the `m_nav_pm_o` pixel definition in `browser_menu.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdb22018de6ced69b8ae4bc318e19c11920afc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->