### PR TITLE
Update file attachment UI (native input)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/file/FileAttachmentsContainerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/file/FileAttachmentsContainerView.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.duckchat.impl.ui.nativeinput.file
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.widget.ImageView
 import android.widget.LinearLayout
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.duckchat.impl.R
@@ -54,17 +53,11 @@ class FileAttachmentsContainerView @JvmOverloads constructor(
 
     fun getAttachments(): List<FileAttachment> = attachments.toList()
 
-    fun clearAttachments() {
-        attachments.clear()
-        removeAllViews()
-    }
-
     private fun addFileItemView(attachment: FileAttachment) {
         val itemView = LayoutInflater.from(context).inflate(R.layout.view_file_attachment_item, this, false)
         val fileNameText = itemView.findViewById<DaxTextView>(R.id.fileName)
-        val removeButton = itemView.findViewById<ImageView>(R.id.fileRemove)
         fileNameText.text = attachment.fileName
-        removeButton.setOnClickListener {
+        itemView.setOnClickListener {
             removeAttachment(attachment)
             onAttachmentRemoved?.invoke(attachment)
         }

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_document_color_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_document_color_24.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5.125,5.75C5.125,4.024 6.524,2.625 8.25,2.625H11.956C12.784,2.625 13.579,2.954 14.165,3.54L17.96,7.335C18.546,7.921 18.875,8.716 18.875,9.544V18.25C18.875,19.976 17.476,21.375 15.75,21.375H8.25C6.524,21.375 5.125,19.976 5.125,18.25V5.75Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M12.786,2.625C13.283,2.625 13.76,2.823 14.112,3.174L18.326,7.388C18.677,7.74 18.875,8.217 18.875,8.714V8.875H15.125C13.744,8.875 12.625,7.756 12.625,6.375V2.625H12.786Z"
+      android:fillColor="#DADADA"/>
+  <path
+      android:pathData="M12.268,2C13.263,2 14.216,2.395 14.92,3.098L18.402,6.58C19.105,7.284 19.5,8.237 19.5,9.232V18.25C19.5,20.321 17.821,22 15.75,22H8.25C6.179,22 4.5,20.321 4.5,18.25V5.75C4.5,3.679 6.179,2 8.25,2H12.268ZM8.25,3.25C6.869,3.25 5.75,4.369 5.75,5.75V18.25C5.75,19.631 6.869,20.75 8.25,20.75H15.75C17.131,20.75 18.25,19.631 18.25,18.25V9.5H15.75C13.679,9.5 12,7.821 12,5.75V3.25H8.25ZM13.25,5.75C13.25,7.131 14.369,8.25 15.75,8.25H18.049C17.925,7.959 17.746,7.692 17.518,7.464L14.036,3.982C13.808,3.754 13.541,3.575 13.25,3.451V5.75Z">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="12"
+          android:startY="22"
+          android:endX="12"
+          android:endY="2"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF888888"/>
+        <item android:offset="1" android:color="#FFAAAAAA"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_file_attachment_item.xml
@@ -15,66 +15,47 @@
   ~ limitations under the License.
   -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:padding="4dp">
+    android:layout_marginStart="@dimen/keyline_1"
+    android:background="@drawable/background_image_attachment_chip"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/keyline_2"
+    android:paddingEnd="@dimen/keyline_3"
+    android:paddingTop="@dimen/keyline_1"
+    android:paddingBottom="@dimen/keyline_1">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/fileAttachmentCard"
+    <ImageView
+        android:id="@+id/fileIcon"
+        android:layout_width="@dimen/keyline_6"
+        android:layout_height="@dimen/keyline_6"
+        android:importantForAccessibility="no"
+        app:srcCompat="@drawable/ic_document_color_24" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/fileName"
         android:layout_width="wrap_content"
-        android:layout_height="36dp"
-        android:minWidth="80dp"
-        app:cardCornerRadius="8dp"
-        app:cardElevation="0dp"
-        app:strokeWidth="1dp"
-        app:strokeColor="?attr/daxColorLines"
-        app:cardBackgroundColor="?attr/daxColorSurface">
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="8dp"
-            android:paddingEnd="8dp">
-
-            <ImageView
-                android:id="@+id/fileIcon"
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:importantForAccessibility="no"
-                app:srcCompat="@drawable/ic_attach_16"
-                app:tint="?attr/daxColorPrimaryIcon" />
-
-            <com.duckduckgo.common.ui.view.text.DaxTextView
-                android:id="@+id/fileName"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:ellipsize="middle"
-                android:maxWidth="120dp"
-                android:maxLines="1"
-                app:textType="primary"
-                app:typography="caption" />
-
-        </LinearLayout>
-
-    </com.google.android.material.card.MaterialCardView>
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_1"
+        android:ellipsize="middle"
+        android:maxWidth="120dp"
+        android:maxLines="1"
+        app:textType="primary"
+        app:typography="body2_bold" />
 
     <ImageView
         android:id="@+id/fileRemove"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_gravity="top|end"
-        android:background="@drawable/background_image_attachment_remove"
+        android:layout_width="@dimen/keyline_4"
+        android:layout_height="@dimen/keyline_4"
+        android:layout_marginStart="@dimen/keyline_2"
         android:contentDescription="@string/duckChatFileAttachmentRemoveContentDescription"
-        android:padding="2dp"
         android:scaleType="center"
         app:srcCompat="@drawable/ic_close_16"
-        app:tint="?attr/daxColorPrimaryIcon" />
+        app:tint="?attr/daxColorSecondaryIcon" />
 
-</FrameLayout>
+</LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214997752721224?focus=true

### Description

- Updates the file attachment card UI to be inline with the image attachments

### Steps to test this PR

_With the native input enabled
- [ ] Attach a file
- [ ] Verify that the UI looks correct

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="571" alt="Screenshot_20260521_125442" src="https://github.com/user-attachments/assets/483bae02-5019-4588-b45d-659924f84dec" />|<img width="1080" height="565" alt="Screenshot_20260521_125341" src="https://github.com/user-attachments/assets/d59d86b6-4057-4875-8d93-a73865ca4c94" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes, but it changes the tap target for removing a file attachment (entire chip instead of the remove icon), which could affect usability or accidental removals.
> 
> **Overview**
> Updates the native input file-attachment “chip” UI to a new design: replaces the card-based layout with a clickable horizontal chip, updates spacing/typography/tinting, and introduces a new colored document icon (`ic_document_color_24`).
> 
> Changes removal interaction in `FileAttachmentsContainerView` by removing the dedicated `fileRemove` click handling and instead removing attachments when the whole chip is tapped, and drops the unused `clearAttachments` helper from this view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6938d56bed08e30aaac4a1d52f882039661032d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->