### PR TITLE
Add .kotlin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ out/
 .gradle/
 build/
 .externalNativeBuild/
+.kotlin/
 
 #Autoconsent
 /node_modules/@duckduckgo/autoconsent/


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215003191712216?focus=true

### Description
Ignores the `.kotlin` folder anywhere in the project. See also: https://youtrack.jetbrains.com/issue/KTIJ-30076/Add-.kotlin-folder-in-.gitignore-in-the-wizard-generated-Gradle-projects

### Steps to test this PR
- n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only `.gitignore` to exclude local Kotlin/Gradle artifacts, with no runtime or build-logic changes.
> 
> **Overview**
> Adds `.kotlin/` to `.gitignore` so locally generated Kotlin/Gradle metadata isn’t accidentally committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a95bf158095fb52deec3eb1169005d8a86c65e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->