### PR TITLE
PIR: Add email fallback

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
@@ -125,6 +125,7 @@ interface PirRunStateHandler {
             val lastActionId: String,
             val durationMs: Long,
             val currentActionAttemptCount: Int,
+            val generatedEmail: String? = null,
         ) : PirRunState(broker)
 
         data class BrokerRecordEmailConfirmationStarted(
@@ -626,11 +627,16 @@ class RealPirRunStateHandler @Inject constructor(
     }
 
     private suspend fun handleBrokerRecordEmailConfirmationNeeded(pirRunState: BrokerRecordEmailConfirmationNeeded) {
+        // Fall back to the generated email when the extracted profile has none. Brokers that use an
+        // explicit generateEmail action (e.g. SpyFly) store the address on the state's generatedEmailData
+        // rather than on extractedProfile, and the polling worker keys off this value to fetch the
+        // confirmation link.
+        val email = pirRunState.extractedProfile.email.ifEmpty { pirRunState.generatedEmail.orEmpty() }
         jobRecordUpdater.markOptOutAsWaitingForEmailConfirmation(
             profileQueryId = pirRunState.extractedProfile.profileQueryId,
             extractedProfileId = pirRunState.extractedProfile.dbId,
             brokerName = pirRunState.broker.name,
-            email = pirRunState.extractedProfile.email,
+            email = email,
             attemptId = pirRunState.attemptId,
         )
         pixelSender.reportStagePendingEmailConfirmation(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandler.kt
@@ -73,6 +73,7 @@ class BrokerStepCompletedEventHandler @Inject constructor(
                     lastActionId = currentBrokerStep.step.actions[state.currentActionIndex].id,
                     durationMs = currentTimeProvider.currentTimeMillis() - state.stageStatus.stageStartMs,
                     currentActionAttemptCount = state.actionRetryCount + 1,
+                    generatedEmail = state.generatedEmailData?.emailAddress,
                 ),
             )
         } else {

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
@@ -596,6 +596,32 @@ class RealPirRunStateHandlerTest {
         }
 
     @Test
+    fun whenHandleBrokerRecordEmailConfirmationNeededAndExtractedProfileEmailEmptyThenUsesGeneratedEmail() =
+        runTest {
+            val state =
+                BrokerRecordEmailConfirmationNeeded(
+                    broker = testBroker,
+                    extractedProfile = testExtractedProfile.copy(email = ""),
+                    attemptId = "c9982ded-021a-4251-9e03-2c58b130410f",
+                    lastActionId = "hello82ded-021a-4251-9e03-2c58b130410f",
+                    durationMs = testTotalTimeMillis,
+                    currentActionAttemptCount = 1,
+                    generatedEmail = "generated@duck.com",
+                )
+            whenever(mockRepository.getBrokerForName(testBrokerName)).thenReturn(testBroker)
+
+            testee.handleState(state)
+
+            verify(mockJobRecordUpdater).markOptOutAsWaitingForEmailConfirmation(
+                profileQueryId = testProfileQueryId,
+                extractedProfileId = testExtractedProfileId,
+                brokerName = testBrokerName,
+                email = "generated@duck.com",
+                attemptId = "c9982ded-021a-4251-9e03-2c58b130410f",
+            )
+        }
+
+    @Test
     fun whenHandleBrokerRecordEmailConfirmationStartedThenUpdateEmailJobRecordAndEmitPixel() =
         runTest {
             val state =

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerStepCompletedEventHandlerTest.kt
@@ -204,6 +204,45 @@ class BrokerStepCompletedEventHandlerTest {
         assertEquals("action-3", capturedState.firstValue.lastActionId)
         assertEquals(testCurrentTimeInMillis - testStageStartMs, capturedState.firstValue.durationMs)
         assertEquals(2, capturedState.firstValue.currentActionAttemptCount)
+        assertNull(capturedState.firstValue.generatedEmail)
+    }
+
+    @Test
+    fun whenNeedsEmailConfirmationTrueAndGeneratedEmailDataPresentThenForwardsGeneratedEmail() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testAction1, testAction2, testAction3),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 2,
+            actionRetryCount = 1,
+            attemptId = "attempt-123",
+            brokerStepStartTime = testBrokerStartTime,
+            generatedEmailData = testGeneratedEmailData,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.FILL_FORM,
+                stageStartMs = testStageStartMs,
+            ),
+        )
+        val event = BrokerStepCompleted(
+            needsEmailConfirmation = true,
+            stepStatus = StepStatus.Success,
+        )
+
+        testee.invoke(state, event)
+
+        val capturedState = argumentCaptor<BrokerRecordEmailConfirmationNeeded>()
+        verify(mockPirRunStateHandler).handleState(capturedState.capture())
+        assertEquals("generated@example.com", capturedState.firstValue.generatedEmail)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214973541222181?focus=true

### Description
Adds email fallback for the email confirmation job record.

### Steps to test this PR
See https://app.asana.com/1/137249556945/task/1214973541222183?focus=true

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which email is stored for the email-confirmation worker; incorrect fallback could break opt-out completion for generateEmail brokers, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes PIR opt-out flows where **email confirmation** was recorded with an empty address when the broker used a **`generateEmail`** action (e.g. SpyFly) instead of putting the address on the extracted profile.
> 
> `BrokerRecordEmailConfirmationNeeded` now carries an optional **`generatedEmail`**, set from runner **`generatedEmailData`** when a broker step completes and confirmation is required. **`handleBrokerRecordEmailConfirmationNeeded`** still prefers `extractedProfile.email`, but falls back to that generated address when persisting the email confirmation job via **`markOptOutAsWaitingForEmailConfirmation`**, so downstream polling can fetch the confirmation link.
> 
> Unit tests cover the handler fallback and forwarding from **`BrokerStepCompletedEventHandler`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f016bf6c41eb077c03591bb5416b596cd85678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->