### PR TITLE
Fix failing Android Design System maestro test

### DIFF
--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -124,12 +124,30 @@ tags:
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/close"
             index: 0
+        - scrollUntilVisible:
+            timeout: 50000
+            speed: 60
+            element:
+              text: "Medium Message"
+            direction: DOWN
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/close"
             index: 0
+        - scrollUntilVisible:
+            timeout: 50000
+            speed: 60
+            element:
+              text: "Big Single Message"
+            direction: DOWN
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/close"
             index: 0
+        - scrollUntilVisible:
+            timeout: 50000
+            speed: 60
+            element:
+              text: "Big Two Actions Message"
+            direction: DOWN
         - tapOn:
             id: "com.duckduckgo.mobile.android:id/secondaryActionButton"
             index: 0

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -168,7 +168,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
             val smallMessage = Message(title = "Small Message", subtitle = "Body text goes here. This component doesn't have buttons")
             val bigSingleMessage = Message(
                 topIllustration = CommonR.drawable.ic_announce,
-                title = "Big Single  Message",
+                title = "Big Single Message",
                 subtitle = "Body text goes here. This component has one button",
                 action = "Primary",
             )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214992581194414

### Description

The Android Design System maestro test was failing on the MESSAGING section after the DaxMessage composable PR landed. That PR added Compose-based remote message previews interleaved between the existing View-based ones, which made the messaging list longer and pushed the View-based close/action buttons below the viewport. The test was tapping `id: com.duckduckgo.mobile.android:id/close index: 0` without scrolling, so the targets weren't visible. The new Compose close buttons don't carry the `:id/close` resource id (a Compose node only exposes a `contentDescription`), so there's no equivalent id-based tap for them — and we don't need one, since the View-based messages already cover every variant of close/primary/secondary/promo we exercise.

Fix: add `scrollUntilVisible` keyed on each View-based message title before its corresponding close/action tap.

### Steps to test this PR

_Android Design System maestro test_
- [ ] Build internal-release: `./gradlew installInternalRelease`
- [ ] Run `maestro test .maestro/ads_preview_flows/1-_design-system-components.yaml` locally, or run with `--include-tags androidDesignSystemTest` in Maestro Cloud
- [ ] Confirm the test passes through the MESSAGING section

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to UI test flow sequencing (adding `scrollUntilVisible`) plus a minor preview string fix; no production logic or data handling is affected.
> 
> **Overview**
> Fixes the failing Android Design System Maestro flow in the **MESSAGING** section by scrolling to each target message title (e.g., `Medium Message`, `Big Single Message`, `Big Two Actions Message`) before tapping the corresponding close/action buttons.
> 
> Also corrects a minor typo in the design-system preview message title (`Big Single Message`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb784eb679f3812f775d86476261251eed27dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->