### PR TITLE
Add reasoningMode and getChatById to DuckAiChat Store

### DIFF
--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -46,6 +46,8 @@ data class DuckAiChat(
     val pinned: Boolean,
     /** UUIDs of files referenced by this chat, stored in the native file store */
     val fileRefs: List<String> = emptyList(),
+    /** Reasoning mode chosen for this chat, or `null` if the FE didn't record one. */
+    val reasoningMode: String? = null,
 )
 
 interface DuckAiChatStore {
@@ -54,6 +56,9 @@ interface DuckAiChatStore {
 
     /** Returns all chats currently in the native store. Skips entries with malformed JSON or missing chatId. */
     suspend fun getChats(): List<DuckAiChat>
+
+    /** Returns the chat with [chatId], or `null` if it doesn't exist or its stored JSON is malformed. */
+    suspend fun getChatById(chatId: String): DuckAiChat?
 
     /** Reactive equivalent of [getChats]. Re-emits on insert/update/delete via Room's Flow contract. */
     fun getChatsFlow(): Flow<List<DuckAiChat>>
@@ -91,6 +96,9 @@ class RealDuckAiChatStore @Inject constructor(
 
     override suspend fun getChats(): List<DuckAiChat> =
         withContext(dispatchers.io()) { chatsDao.getAll().mapNotNull { it.toDuckAiChat() } }
+
+    override suspend fun getChatById(chatId: String): DuckAiChat? =
+        withContext(dispatchers.io()) { chatsDao.getById(chatId)?.toDuckAiChat() }
 
     override fun getChatsFlow(): Flow<List<DuckAiChat>> =
         chatsDao.getAllAsFlow().map { entities -> entities.mapNotNull { it.toDuckAiChat() } }
@@ -176,6 +184,11 @@ class RealDuckAiChatStore @Inject constructor(
             fileRefs = json.optJSONArray("fileRefs")?.let { arr ->
                 (0 until arr.length()).map { arr.getString(it) }
             } ?: emptyList(),
+            reasoningMode = if (json.isNull("reasoningMode")) {
+                null
+            } else {
+                json.optString("reasoningMode").takeIf { it.isNotEmpty() }
+            },
         )
     }.getOrNull()
 }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -112,6 +113,63 @@ class RealDuckAiChatStoreTest {
         whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
 
         assertEquals(listOf("uuid1", "uuid2"), store.getChats()[0].fileRefs)
+    }
+
+    @Test
+    fun `getChats parses reasoningMode when present`() = runTest {
+        val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"x","pinned":false,"reasoningMode":"reasoning"}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertEquals("reasoning", store.getChats()[0].reasoningMode)
+    }
+
+    @Test
+    fun `getChats returns null reasoningMode when field missing`() = runTest {
+        val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"x","pinned":false}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertNull(store.getChats()[0].reasoningMode)
+    }
+
+    @Test
+    fun `getChats returns null reasoningMode when field is empty string`() = runTest {
+        val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"x","pinned":false,"reasoningMode":""}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertNull(store.getChats()[0].reasoningMode)
+    }
+
+    @Test
+    fun `getChats returns null reasoningMode when field is JSON null`() = runTest {
+        // JSONObject.optString returns the literal string "null" for explicit JSON null; guard via isNull.
+        val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"x","pinned":false,"reasoningMode":null}"""
+        whenever(chatsDao.getAll()).thenReturn(listOf(DuckAiBridgeChatEntity("abc", json)))
+
+        assertNull(store.getChats()[0].reasoningMode)
+    }
+
+    @Test
+    fun `getChatById returns parsed chat when found`() = runTest {
+        val json = """{"chatId":"abc","title":"Test","model":"gpt-5-mini","lastEdit":"x","pinned":false,"reasoningMode":"reasoning"}"""
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", json))
+
+        val chat = store.getChatById("abc")
+
+        assertEquals("abc", chat?.chatId)
+        assertEquals("gpt-5-mini", chat?.model)
+        assertEquals("reasoning", chat?.reasoningMode)
+    }
+
+    @Test
+    fun `getChatById returns null when chat not found`() = runTest {
+        whenever(chatsDao.getById("missing")).thenReturn(null)
+        assertNull(store.getChatById("missing"))
+    }
+
+    @Test
+    fun `getChatById returns null when stored JSON is malformed`() = runTest {
+        whenever(chatsDao.getById("abc")).thenReturn(DuckAiBridgeChatEntity("abc", "not json"))
+        assertNull(store.getChatById("abc"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215002056518125?focus=true 

### Description

**Per-chat reasoning persistence groundwork (1 of 3).**

The FE has been storing a `reasoningMode` field per chat in the JSON blob it pushes to native storage, but Android wasn't reading it. This PR starts extracting that field on the read side so it's available to consumers, and adds a single-chat lookup API to the store. No behavioural change yet - the new field isn't consumed by any feature in this PR.

The follow-up PR will use this data to populate the reasoning picker correctly when the user opens an existing chat (showing the chat's stored mode rather than the global default).

**What changed:**

- **`DuckAiChat`** Added a nullable `reasoningMode: String?` field.
- **New API: `getChatById** on `DuckAiChatStore`. Wraps the existing `chatsDao.getById(chatId)`.

**No migration required.** Room only stores `(chatId, data)` where `data` is the raw FE blob, we just parse a new field at read time.

### Steps to test this PR

- [ ] Submit a duck.ai chat after selecting a model and reasoning effort (e.g. gpt 5 mini - fast)
- [ ] Go to Settings -> Duck.ai in developer settings -> Enable Native Storage Debug
- [ ] Validate that the chat is now stored with the selected “reasoningMode"

### UI changes

_N/A — data-layer only._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-layer change that only extends the parsed chat metadata and adds a read-only lookup API; main risk is minor integration/consumer expectations around null/empty `reasoningMode` handling.
> 
> **Overview**
> Adds per-chat `reasoningMode: String?` to `DuckAiChat` and updates JSON parsing to populate it while treating missing, empty, or explicit JSON `null` as `null`.
> 
> Extends `DuckAiChatStore` with `getChatById(chatId)` (implemented in `RealDuckAiChatStore`) to fetch and parse a single chat, and adds unit tests covering `reasoningMode` parsing and the new lookup behavior (not found / malformed JSON).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a380f284e86282097ba36bd7d69dec8864dc8459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->