### PR TITLE
Don't fire metrics pixels when toggle is disabled

### DIFF
--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSender.kt
@@ -47,6 +47,7 @@ class RealMetricsPixelSender @Inject constructor(
 ) : MetricsPixelExtension {
 
     override suspend fun send(metricsPixel: MetricsPixel) {
+        if (!metricsPixel.toggle.isEnabled()) return
         val definitions = metricsPixel.getPixelDefinitions()
         if (definitions.isEmpty()) return
         withContext(dispatcherProvider.io()) {

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealMetricsPixelSenderTest.kt
@@ -100,6 +100,20 @@ class RealMetricsPixelSenderTest {
     }
 
     @Test
+    fun `NORMAL - pixel not fired when toggle disabled`() = runTest {
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = false,
+                enable = false,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+        sender.send(metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1))
+        assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
     fun `NORMAL - pixel not fired on second send`() = runTest {
         val pixel = metricsPixel(type = MetricType.NORMAL, lowerWindow = 0, upperWindow = 1)
         sender.send(pixel)
@@ -193,6 +207,23 @@ class RealMetricsPixelSenderTest {
         assertTrue(fakePixel.firedPixels.isEmpty())
     }
 
+    @Test
+    fun `COUNT_WHEN_IN_WINDOW - pixel not fired and count not incremented when toggle disabled`() = runTest {
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = false,
+                enable = false,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+        val pixel = metricsPixel(type = MetricType.COUNT_WHEN_IN_WINDOW, value = "1", lowerWindow = 0, upperWindow = 1)
+        repeat(3) { sender.send(pixel) }
+        assertTrue(fakePixel.firedPixels.isEmpty())
+        val definition = pixel.getPixelDefinitions().first()
+        assertEquals(0, store.getMetricForPixelDefinition(definition))
+    }
+
     // COUNT_ALWAYS type tests
 
     @Test
@@ -239,6 +270,23 @@ class RealMetricsPixelSenderTest {
         )
         sender.send(metricsPixel(type = MetricType.COUNT_ALWAYS, value = "1", lowerWindow = 0, upperWindow = 1))
         assertTrue(fakePixel.firedPixels.isEmpty())
+    }
+
+    @Test
+    fun `COUNT_ALWAYS - pixel not fired and count not incremented when toggle disabled`() = runTest {
+        val enrollmentDate = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = false,
+                enable = false,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = enrollmentDate),
+            ),
+        )
+        val pixel = metricsPixel(type = MetricType.COUNT_ALWAYS, value = "1", lowerWindow = 0, upperWindow = 1)
+        repeat(3) { sender.send(pixel) }
+        assertTrue(fakePixel.firedPixels.isEmpty())
+        val definition = pixel.getPixelDefinitions().first()
+        assertEquals(0, store.getMetricForPixelDefinition(definition))
     }
 
     private fun metricsPixel(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215026841068543

### Description

`RealMetricsPixelSender.send()` previously fired metrics pixels without checking whether the underlying experiment toggle was enabled. As long as a cohort was assigned and the conversion window matched, pixels would fire — even if the toggle had been remotely turned off.

This adds a short-circuit at the top of `send()`: if `metricsPixel.toggle.isEnabled()` returns `false`, no pixel is fired and (for `COUNT_*` types) no count is incremented.

### Steps to test this PR

_Toggle disabled — no pixels fired_
- [ ] Run \`./gradlew :feature-toggles-impl:testDebugUnitTest --tests \"com.duckduckgo.feature.toggles.impl.RealMetricsPixelSenderTest\"\`
- [ ] All 24 tests pass, including the three new toggle-disabled cases (\`NORMAL\`, \`COUNT_WHEN_IN_WINDOW\`, \`COUNT_ALWAYS\`)

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple enablement gate and accompanying tests; impact is limited to analytics emission/counting when toggles are off.
> 
> **Overview**
> **Prevents metrics emission when a toggle is off.** `RealMetricsPixelSender.send` now returns immediately if `metricsPixel.toggle.isEnabled()` is false, so pixels and metric counters are not processed for disabled experiments.
> 
> **Test coverage updated** to assert that `NORMAL`, `COUNT_WHEN_IN_WINDOW`, and `COUNT_ALWAYS` pixels neither fire nor increment stored counts when the toggle is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d06cc548f91c119ce1f637e42c7d0fed3dd1b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->