### PR TITLE
Fix nativeInputStateProvider UninitializedPropertyAccessException

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -684,29 +684,31 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun beginEnterAnimationPreview() {
-        if (inputField.hasFocus()) return
-        // State observation is async; apply it synchronously so toggle-row visibility etc. are
-        // in their final positions before the enter animation measures the widget.
-        if (nativeInputState == null) {
-            activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }?.let(::applyState)
-        }
-        previewEnterFocus = true
-        updateBottomRowVisibility()
-        applyVerticalPaddingForFocus()
-        // Bottom omnibar only: trigger the IME slide-up now so it overlaps the enter animation —
-        // the activity shrinks (and the widget's bottom-anchored FrameLayout slides up) alongside
-        // the widget's expansion instead of pushing it up afterwards as a second step. Top omnibar
-        // keyboard position is independent of the widget, so its show stays deferred to focusInput
-        // in onEnterComplete.
-        //
-        // Side effect to be aware of: Activity.showKeyboard() calls inputField.requestFocus()
-        // under the hood, so the input field gains focus here — ~200ms earlier than in top mode
-        // (where focus is set in onEnterComplete via focusInput). The onFocusChangeListener will
-        // therefore fire synchronously inside showKeyboard(). The asymmetry is intentional, but
-        // it does mean any cancel path has to undo focus + IME for bottom mode (see the manager's
-        // animateEnter.onCancel).
-        if (isWidgetBottom()) {
-            showKeyboard()
+        doOnAttach {
+            if (inputField.hasFocus()) return@doOnAttach
+            // State observation is async; apply it synchronously so toggle-row visibility etc. are
+            // in their final positions before the enter animation measures the widget.
+            if (nativeInputState == null) {
+                activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }?.let(::applyState)
+            }
+            previewEnterFocus = true
+            updateBottomRowVisibility()
+            applyVerticalPaddingForFocus()
+            // Bottom omnibar only: trigger the IME slide-up now so it overlaps the enter animation —
+            // the activity shrinks (and the widget's bottom-anchored FrameLayout slides up) alongside
+            // the widget's expansion instead of pushing it up afterwards as a second step. Top omnibar
+            // keyboard position is independent of the widget, so its show stays deferred to focusInput
+            // in onEnterComplete.
+            //
+            // Side effect to be aware of: Activity.showKeyboard() calls inputField.requestFocus()
+            // under the hood, so the input field gains focus here — ~200ms earlier than in top mode
+            // (where focus is set in onEnterComplete via focusInput). The onFocusChangeListener will
+            // therefore fire synchronously inside showKeyboard(). The asymmetry is intentional, but
+            // it does mean any cancel path has to undo focus + IME for bottom mode (see the manager's
+            // animateEnter.onCancel).
+            if (isWidgetBottom()) {
+                showKeyboard()
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215028347828035?focus=true

### Description

- Fixes a crash when changing the system theme

### Steps to test this PR

_With the native input enabled_
- [ ] Change the system theme
- [ ] Verify that the app does not crash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-lifecycle change: it delays enter-animation preview work (including `nativeInputStateProvider` access and optional IME show) until the view is attached, reducing crashes but potentially affecting timing of focus/keyboard during the enter animation.
> 
> **Overview**
> Fixes a lifecycle crash in `NativeInputModeWidget.beginEnterAnimationPreview` by deferring the preview setup until the view is attached via `doOnAttach`.
> 
> This prevents early access to `nativeInputStateProvider` (and related focus/IME side effects) when the widget is invoked before injection/attachment, while keeping the existing preview behavior once attached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316eaacdff52e907a6e9360d26c61d80e2edb5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->