### PR TITLE
Prevent hardcoded reasoning efforts to override server values

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -221,7 +221,7 @@ class RealDuckAiModelManager @Inject constructor(
         val match = available.firstOrNull { it.mode == persisted }
         if (match != null && match.isAccessible) return persisted
         val next = available.firstOrNull { it.isAccessible }?.mode
-        if (next?.rawValue != persisted?.rawValue) {
+        if (next != persisted) {
             dataStore.setSelectedReasoningMode(next?.rawValue)
         }
         return next
@@ -318,11 +318,16 @@ class RealDuckAiModelManager @Inject constructor(
 private fun AIChatModelsResponse.withHardcodedReasoningGates(): AIChatModelsResponse = copy(
     models = models.map { model ->
         if (model.id != "gpt-5.2") return@map model
-        model.copy(
-            reasoningEffortAccess = ReasoningMode.EXTENDED_REASONING.candidateEfforts.map { effort ->
+        // Server entries win, hardcode only fills gaps. Lets the gate auto-deactivate as
+        // the backend rolls out, and avoids dropping unrelated server-side data.
+        val existing = model.reasoningEffortAccess.orEmpty()
+        val existingIds = existing.mapTo(mutableSetOf()) { it.id }
+        val hardcoded = ReasoningMode.EXTENDED_REASONING.candidateEfforts
+            .filter { it.rawValue !in existingIds }
+            .map { effort ->
                 RemoteReasoningEffortAccess(id = effort.rawValue, accessTier = listOf("pro"), entityHasAccess = false)
-            },
-        )
+            }
+        model.copy(reasoningEffortAccess = existing + hardcoded)
     },
 )
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import com.duckduckgo.duckchat.impl.models.UserTier
+import logcat.logcat
 
 enum class PickerSurface(val origin: String) {
     MODEL_PICKER_ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
@@ -42,5 +43,12 @@ internal fun routeUpsell(
     requiredTier == UserTier.FREE -> null
     userTier == UserTier.FREE -> UpsellCommand.LaunchPurchase(origin)
     userTier == UserTier.PLUS && requiredTier == UserTier.PRO -> UpsellCommand.LaunchUpgrade(origin)
-    else -> null
+    else -> {
+        // Only reachable on data inconsistency. The user already covers the required tier so the
+        // upsell shouldn't have been requested. Logging a breadcrumb for tracking.
+        logcat(tag = "PickerUpsell") {
+            "Duck.ai upsell: no native subscription flow for tap (userTier=$userTier, requiredTier=$requiredTier, origin=$origin)"
+        }
+        null
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -729,6 +729,67 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
+    fun whenModelIsGpt52AndServerProvidesAccessForExtendedCandidateThenHardcodeDoesNotOverwriteIt() = runTest {
+        // Guards the merge: when the backend ships an entry for an EXTENDED candidate, the hardcode
+        // must defer to it. MEDIUM has no server entry, so the hardcode still fills that gap.
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "gpt-5.2",
+                        accessTier = listOf("free", "plus", "pro"),
+                        entityHasAccess = true,
+                        supportedReasoningEffort = listOf("medium", "high"),
+                        reasoningEffortAccess = listOf(
+                            RemoteReasoningEffortAccess(id = "high", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val access = testee.modelState.value.models.single().reasoningEffortAccess
+        val high = access.single { it.effort == ReasoningEffort.HIGH }
+        val medium = access.single { it.effort == ReasoningEffort.MEDIUM }
+        assertEquals(listOf("free", "plus", "pro"), high.accessTier)
+        assertEquals(listOf("pro"), medium.accessTier)
+    }
+
+    @Test
+    fun whenModelIsGpt52ThenExtendedReasoningCandidatesAreHardcodedToPro() = runTest {
+        // Locks in the temporary hardcoded gate for gpt-5.2 — catches a slug rename or refactor that
+        // silently drops the gate. Remove this test when `withHardcodedReasoningGates` is removed.
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel(
+                        "gpt-5.2",
+                        accessTier = listOf("free", "plus", "pro"),
+                        entityHasAccess = true,
+                        supportedReasoningEffort = listOf("none", "low", "medium", "high"),
+                    ),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val access = testee.modelState.value.models.single().reasoningEffortAccess
+        ReasoningMode.EXTENDED_REASONING.candidateEfforts.forEach { effort ->
+            val entry = access.single { it.effort == effort }
+            assertEquals(listOf("pro"), entry.accessTier)
+        }
+    }
+
+    @Test
     fun whenRemoteReasoningEffortAccessMissingThenDomainListIsEmpty() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214635053937863?focus=true 

### Description

Addressing comments from https://github.com/duckduckgo/Android/pull/8648

### Steps to test this PR

- [ ] Sign in with a PLUS account -> Try to select GPT 5.2 with extended reasoning —> Upsell flow should trigger
- [ ] All other models should behave as expected. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model/effort access gating and persistence used to drive upsell behavior, so mistakes could incorrectly block or unlock reasoning modes; changes are small and backed by new targeted tests.
> 
> **Overview**
> Prevents the temporary hardcoded `gpt-5.2` EXTENDED reasoning effort gate from **overwriting backend-provided** `reasoningEffortAccess` by merging: server entries are preserved and hardcoding only fills missing effort IDs.
> 
> Tightens reasoning-mode persistence by comparing `ReasoningMode` values directly (avoids unnecessary writes when raw values match), and adds a defensive log breadcrumb when an upsell is requested for a tier transition that has no native flow.
> 
> Adds unit tests to lock in the new merge behavior and ensure EXTENDED reasoning candidates remain hardcoded to `pro` until the backend gate is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9b8f4d5b53b71708c3d26aeee190d06c298843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->