### PR TITLE
Publish active chatId to NativeInputState (per-tab)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -493,16 +493,18 @@ class RealNativeInputManager @Inject constructor(
             if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())
             }
+            // Per-tab chatId (null on new chats) published into NativeInputState for
+            // consumers (reasoning picker, submission) to resolve per-chat state.
+            val chatIdFlow = currentTabUrl.map { extractDuckAiChatId(it) }
+            // Picker tied to whether the current tab is a Duck.ai page that already has a chatId (existing chat) or new chat.
+            bindModelPickerEnabledSource(chatIdFlow.map { it == null })
+            bindChatIdSource(chatIdFlow)
         }
         bindSearchCallbacks(widgetView, callbacks)
         bindAutocompleteVisibility(widgetView)
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         bindVoiceButtons(widgetView, callbacks)
-        // Picker tied to whether the current tab is a Duck.ai page that already has a chatId (existing chat) or new chat.
-        widgetFrom(widgetView)?.bindModelPickerEnabledSource(
-            currentTabUrl.map { !isExistingDuckAiChat(it) },
-        )
     }
 
     private fun bindVoiceButtons(
@@ -745,11 +747,14 @@ class RealNativeInputManager @Inject constructor(
     }
 
     /** True if [rawUrl] points at an in-progress Duck.ai chat (Duck.ai URL with a non-blank `chatID`). */
-    internal fun isExistingDuckAiChat(rawUrl: String?): Boolean {
-        if (rawUrl.isNullOrBlank()) return false
-        val uri = runCatching { rawUrl.toUri() }.getOrNull() ?: return false
-        if (!duckChat.isDuckChatUrl(uri)) return false
-        return !uri.getQueryParameter("chatID").isNullOrBlank()
+    internal fun isExistingDuckAiChat(rawUrl: String?): Boolean = extractDuckAiChatId(rawUrl) != null
+
+    /** Returns the `chatID` query param if [rawUrl] is a Duck.ai chat URL, else `null`. */
+    internal fun extractDuckAiChatId(rawUrl: String?): String? {
+        if (rawUrl.isNullOrBlank()) return null
+        val uri = runCatching { rawUrl.toUri() }.getOrNull() ?: return null
+        if (!duckChat.isDuckChatUrl(uri)) return null
+        return uri.getQueryParameter("chatID")?.takeIf { it.isNotBlank() }
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -23,7 +23,9 @@ import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.voice.api.VoiceSearchAvailability
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -104,5 +106,40 @@ class RealNativeInputManagerTest {
         testee.isExistingDuckAiChat(raw)
 
         verify(duckChat).isDuckChatUrl(Uri.parse(raw))
+    }
+
+    @Test
+    fun whenUrlIsNullThenExtractDuckAiChatIdNull() {
+        assertNull(testee.extractDuckAiChatId(null))
+    }
+
+    @Test
+    fun whenUrlIsBlankThenExtractDuckAiChatIdNull() {
+        assertNull(testee.extractDuckAiChatId(""))
+        assertNull(testee.extractDuckAiChatId("   "))
+    }
+
+    @Test
+    fun whenUrlIsNotDuckAiThenExtractDuckAiChatIdNull() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(false)
+        assertNull(testee.extractDuckAiChatId("https://example.com/?chatID=abcd"))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithoutChatIdThenExtractDuckAiChatIdNull() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        assertNull(testee.extractDuckAiChatId("https://duck.ai/"))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithBlankChatIdThenExtractDuckAiChatIdNull() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        assertNull(testee.extractDuckAiChatId("https://duck.ai/?chatID="))
+    }
+
+    @Test
+    fun whenDuckAiUrlWithChatIdThenExtractDuckAiChatIdReturnsValue() {
+        whenever(duckChat.isDuckChatUrl(any())).thenReturn(true)
+        assertEquals("abc-123", testee.extractDuckAiChatId("https://duck.ai/?chatID=abc-123"))
     }
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -22,6 +22,8 @@ data class NativeInputState(
     val inputPosition: InputPosition = InputPosition.TOP,
     val toggleSelection: ToggleSelection = defaultToggleFor(inputContext),
     val selectedTool: String? = null,
+    /** Set when the active tab is a Duck.ai page already attached to an existing chat. */
+    val chatId: String? = null,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.Inject
 
 data class ChatTabSuggestions(
@@ -120,6 +121,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     private val _modelPickerEnabled = MutableStateFlow(true)
     val modelPickerEnabled: StateFlow<Boolean> = _modelPickerEnabled.asStateFlow()
+
+    private val _chatId = MutableStateFlow<String?>(null)
 
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
     val commands = commandChannel.receiveAsFlow()
@@ -207,6 +210,18 @@ class NativeInputModeWidgetViewModel @Inject constructor(
                     }
                 }
         }
+
+        // Publish chatId to per-tab state. setActiveChatId can fire during widget attach before
+        // configure() sets activeTabId — _chatId holds the value until then.
+        viewModelScope.launch {
+            combine(_chatId, activeTabId.filterNotNull()) { chatId, tabId -> tabId to chatId }
+                .collect { (tabId, chatId) ->
+                    nativeInputStatePublisher.update(tabId) { it.copy(chatId = chatId) }
+                    // TODO: logs the chatId observers will see for this tab. Added for testing.
+                    //  Remove once consumer logic is implemented.
+                    logcat { "Duck.ai native input: active chatId for tab=$tabId is now $chatId" }
+                }
+        }
     }
 
     val chatState: Flow<ChatState> = duckChatInternal.chatState
@@ -245,6 +260,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     fun setSelectedTool(tool: String?) {
         val tabId = activeTabId.value ?: return
         nativeInputStatePublisher.update(tabId) { it.copy(selectedTool = tool) }
+    }
+
+    fun setActiveChatId(chatId: String?) {
+        _chatId.value = chatId
     }
 
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -134,6 +134,12 @@ interface NativeInputWidget {
     fun setWidgetPosition(isBottom: Boolean)
     fun setWidgetRootView(view: View)
 
+    /**
+     * Binds a reactive source of the active chat id for this tab.
+     * The widget forwards changes into the [NativeInputState] so observers can react.
+     */
+    fun bindChatIdSource(source: Flow<String?>)
+
     fun bindAttachmentCallbacks(
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
@@ -203,6 +209,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var pluginsJob: Job? = null
     private var modelPickerEnabledJob: Job? = null
     private var modelPickerEnabledSource: Flow<Boolean>? = null
+    private var chatIdJob: Job? = null
+    private var chatIdSource: Flow<String?>? = null
     private var modelPickerView: ModelPicker? = null
     private var optionsView: OptionsView? = null
     private var chatSuggestionsUserEnabled: Boolean = true
@@ -260,6 +268,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         super.onAttachedToWindow()
         setupPlugins()
         observeModelPickerEnabledSource()
+        observeChatIdSource()
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
@@ -358,6 +367,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         pluginsJob = null
         modelPickerEnabledJob?.cancel()
         modelPickerEnabledJob = null
+        chatIdJob?.cancel()
+        chatIdJob = null
         modelPickerView = null
         optionsView = null
         widgetRoot = null
@@ -810,6 +821,21 @@ class NativeInputModeWidget @JvmOverloads constructor(
         modelPickerEnabledJob = source
             .distinctUntilChanged()
             .onEach { viewModel.setModelPickerEnabled(it) }
+            .launchIn(scope)
+    }
+
+    override fun bindChatIdSource(source: Flow<String?>) {
+        chatIdSource = source
+        if (isAttachedToWindow) observeChatIdSource()
+    }
+
+    private fun observeChatIdSource() {
+        val source = chatIdSource ?: return
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        chatIdJob?.cancel()
+        chatIdJob = source
+            .distinctUntilChanged()
+            .onEach { viewModel.setActiveChatId(it) }
             .launchIn(scope)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -817,6 +817,49 @@ class NativeInputModeWidgetViewModelTest {
 
     // endregion
 
+    // region setActiveChatId
+
+    @Test
+    fun whenSetActiveChatIdThenPublisherUpdatesChatIdForActiveTab() = runTest {
+        val tabId = "tab-A"
+        testee.configure(tabId = tabId, isDuckAiMode = false, isBottom = false)
+        testee.setActiveChatId("chat-123")
+        advanceUntilIdle()
+
+        assertEquals("chat-123", nativeInputStateProvider.stateForTab(tabId).value.chatId)
+    }
+
+    @Test
+    fun whenSetActiveChatIdWithNullThenPublisherClearsChatId() = runTest {
+        val tabId = "tab-A"
+        testee.configure(tabId = tabId, isDuckAiMode = false, isBottom = false)
+        testee.setActiveChatId("chat-123")
+        advanceUntilIdle()
+
+        testee.setActiveChatId(null)
+        advanceUntilIdle()
+
+        assertNull(nativeInputStateProvider.stateForTab(tabId).value.chatId)
+    }
+
+    @Test
+    fun whenSetActiveChatIdBeforeConfigureThenChatIdIsBufferedAndPublishedOnConfigure() = runTest {
+        // Regression for the attach race: bindChatIdSource can fire setActiveChatId synchronously
+        // during widget attach, before configure() sets activeTabId.value. The buffered value must
+        // be replayed once a tabId becomes available.
+        val freshViewModel = createViewModel()
+
+        freshViewModel.setActiveChatId("chat-123")
+        advanceUntilIdle()
+
+        freshViewModel.configure(tabId = "tab-A", isDuckAiMode = false, isBottom = false)
+        advanceUntilIdle()
+
+        assertEquals("chat-123", nativeInputStateProvider.stateForTab("tab-A").value.chatId)
+    }
+
+    // endregion
+
     // region fireChatHistorySelectedPixel
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215004327619963?focus=true 

### Description

Tech Design: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214935104654912?focus=true (Do not merge until approved)

**Per-chat reasoning persistence groundwork (2 of 3).**

https://github.com/duckduckgo/Android/pull/8659 added the `reasoningMode` field on `DuckAiChat` and a `getChatById` lookup on the store. This PR adds the runtime signal: per-tab `NativeInputState` now carries the chat id of the active Duck.ai chat (if any), produced from the active tab's URL. Nothing consumes the field yet. The data-layer publish is verified in isolation. The next PR (3/3) will wire the consumers (reasoning picker derives modes from the chat's model).

**What changed:**

- **`NativeInputState`** adds a `chatId: String?` (default `null`) in `duckchat-api`.
- **`NativeInputModeWidget`** interface adds `bindChatIdSource`
- **`NativeInputModeWidgetViewModel`** publishes the chat id into per-tab state.
- `extractDuckAiChatId(rawUrl)` in **`NativeInputManager`**

**Out of scope (deferred to PR 3/3):**

- Reasoning picker reading the chat id to derive available modes from the chat's stored model.
- Submission code reading chat id to send the chat's stored model and effort.

### Steps to test this PR

- [ ] Filter logcat by `"Duck.ai native input: active chatId"`:
  - [ ] Open Duck.ai with no existing chat → expect a log line with `chatId=null`.
  - [ ] Tap an existing chat from history → expect a log line with the chat's id.
  - [ ] Switch to another chat in the same tab→ expect `chatId=` changes to the new chat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes per-tab native input state publication and adds a new `chatId` field that downstream consumers may start relying on; includes a temporary log that could be noisy if left in production.
> 
> **Overview**
> Publishes the active Duck.ai `chatId` into per-tab `NativeInputState` so native-input consumers can resolve per-chat state.
> 
> `RealNativeInputManager` now extracts `chatID` from the current tab URL (via new `extractDuckAiChatId`) and binds it into the widget; the widget forwards this flow to the `NativeInputModeWidgetViewModel`, which buffers and writes `chatId` to the per-tab state store (handling the attach/configure race).
> 
> Adds unit coverage for `extractDuckAiChatId` parsing and for `setActiveChatId` state publishing/clearing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9437246f9c81ec31da5469a763c6f9cca6443b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->