### PR TITLE
Update content scope scripts to version 14.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.11.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.12.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.84.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.84.0.tgz",
-      "integrity": "sha512-bXTYDIyDytvK8f+9BRTU9QF5KmJuj7Qg7aE9GckPYmRAQvDBbm+I1OaoAWsw9nyzq6aCs2q6PeAa3YNXHApEEA==",
+      "version": "14.84.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.84.1.tgz",
+      "integrity": "sha512-0XASSabqGAcsBetIWQ2hD6GjdSVa0NdYZByMnKjwOzuLaZ/ffGDzYQ3Pd+wdVQdxQKiTRX4Gp745iz98TQazTg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#474bbc4a3a44c52cd572d034fc7e462f72f4e92b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d3d2daabba2846b667184bf6896f1e51dc9b9aa1",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.11.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.12.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215042577173220?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main risk is behavior changes introduced by the updated `content-scope-scripts` package impacting runtime content blocking/injection behavior.
> 
> **Overview**
> Updates the `@duckduckgo/content-scope-scripts` dependency from `14.11.0` to `14.12.0` in `package.json` and aligns `package-lock.json` to the new git commit.
> 
> The lockfile update also pulls in patch-level bumps for `@duckduckgo/autoconsent` and `terser` as part of dependency resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74f4c0b4f0ba78f70b75947a6580f45c7cc097e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->