### PR TITLE
Per-chat model and reasoning restoration on existing Duck.ai chats.

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -45,8 +45,15 @@ data class ModelState(
     val selectedModelShortName: String? = null,
     val userTier: UserTier = UserTier.FREE,
     val attachmentLimits: AttachmentLimits = AttachmentLimits(),
+    /** User's persisted global reasoning mode. Used for new chats. */
     val selectedReasoningMode: ReasoningMode? = null,
     val availableReasoningModes: List<AvailableReasoningMode> = emptyList(),
+    /** Reasoning mode for the current chat. Session only (not persisted)
+     * Note: if we ever want to preserve picks across unsubmitted chats
+     * (User selected a mode but navigated away or switched tab without submission)
+     * change this to a bounded Map<String, ReasoningMode> keyed by chatId.
+     * */
+    val chatScopedReasoningMode: ReasoningMode? = null,
 )
 
 interface DuckAiModelManager {
@@ -57,6 +64,8 @@ interface DuckAiModelManager {
     suspend fun selectModel(model: AIChatModel)
 
     suspend fun selectReasoningMode(mode: ReasoningMode)
+
+    fun setChatScopedReasoningMode(mode: ReasoningMode?)
 
     fun getSelectedModelId(): String?
 
@@ -138,7 +147,7 @@ class RealDuckAiModelManager @Inject constructor(
                     )
                     val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
 
-                    _modelState.value = ModelState(
+                    _modelState.value = _modelState.value.copy(
                         models = models,
                         selectedModelId = selectedModelId,
                         selectedModelShortName = selectedModel?.shortName,
@@ -205,6 +214,10 @@ class RealDuckAiModelManager @Inject constructor(
                 logcat { "Duck.ai Model Manager: selected reasoning mode ${mode.rawValue}" }
             }
         }
+    }
+
+    override fun setChatScopedReasoningMode(mode: ReasoningMode?) {
+        _modelState.value = _modelState.value.copy(chatScopedReasoningMode = mode)
     }
 
     override fun getSelectedModelId(): String? = _modelState.value.selectedModelId

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -65,7 +65,7 @@ interface DuckAiModelManager {
 
     suspend fun selectReasoningMode(mode: ReasoningMode)
 
-    fun setChatScopedReasoningMode(mode: ReasoningMode?)
+    suspend fun setChatScopedReasoningMode(mode: ReasoningMode?)
 
     fun getSelectedModelId(): String?
 
@@ -216,8 +216,10 @@ class RealDuckAiModelManager @Inject constructor(
         }
     }
 
-    override fun setChatScopedReasoningMode(mode: ReasoningMode?) {
-        _modelState.value = _modelState.value.copy(chatScopedReasoningMode = mode)
+    override suspend fun setChatScopedReasoningMode(mode: ReasoningMode?) {
+        stateMutex.withLock {
+            _modelState.value = _modelState.value.copy(chatScopedReasoningMode = mode)
+        }
     }
 
     override fun getSelectedModelId(): String? = _modelState.value.selectedModelId

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.duckchat.impl.models
 
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+
 enum class ReasoningEffort(val rawValue: String) {
     NONE("none"),
     MINIMAL("minimal"),
@@ -101,4 +103,21 @@ object ReasoningResolver {
         mode: ReasoningMode?,
         available: List<AvailableReasoningMode>,
     ): ReasoningEffort? = available.firstOrNull { it.mode == mode }?.effort
+
+    /** Reasoning data for [chat]; `null` if its model isn't in [modelState] (callers fall back to global). */
+    internal fun forChat(chat: DuckAiChat, modelState: ModelState): ChatReasoningResolution? {
+        val chatModel = modelState.models.firstOrNull { it.id == chat.model } ?: return null
+        val available = availableModes(
+            supported = chatModel.supportedReasoningEfforts,
+            effortAccess = chatModel.reasoningEffortAccess,
+        )
+        val mode = modelState.chatScopedReasoningMode ?: ReasoningMode.from(chat.reasoningMode)
+        return ChatReasoningResolution(available = available, mode = mode)
+    }
 }
+
+/** Resolved reasoning data for an existing chat: the rows that apply and the mode to use. */
+internal data class ChatReasoningResolution(
+    val available: List<AvailableReasoningMode>,
+    val mode: ReasoningMode?,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
@@ -111,7 +111,9 @@ object ReasoningResolver {
             supported = chatModel.supportedReasoningEfforts,
             effortAccess = chatModel.reasoningEffortAccess,
         )
-        val mode = modelState.chatScopedReasoningMode ?: ReasoningMode.from(chat.reasoningMode)
+        val mode = modelState.chatScopedReasoningMode
+            ?: ReasoningMode.from(chat.reasoningMode)
+            ?: modelState.selectedReasoningMode
         return ChatReasoningResolution(available = available, mode = mode)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -51,12 +51,16 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.ReasoningResolver
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -75,7 +79,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import logcat.logcat
 import javax.inject.Inject
 
 data class ChatTabSuggestions(
@@ -100,6 +103,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val nativeInputStateProvider: NativeInputStateProvider,
     private val modelManager: DuckAiModelManager,
+    private val duckAiChatStore: DuckAiChatStore,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -122,7 +126,8 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val _modelPickerEnabled = MutableStateFlow(true)
     val modelPickerEnabled: StateFlow<Boolean> = _modelPickerEnabled.asStateFlow()
 
-    private val _chatId = MutableStateFlow<String?>(null)
+    private val currentChat = MutableStateFlow<DuckAiChat?>(null)
+    private var currentChatJob: Job? = null
 
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
     val commands = commandChannel.receiveAsFlow()
@@ -144,12 +149,29 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         _modelPickerEnabled.value = enabled
     }
 
+    // currentChat can briefly hold the previous chat while a getChatById lookup is in flight.
+    // Returns it only when it matches the active tab's published chatId.
+    private fun validChat(): DuckAiChat? {
+        val activeChatId = activeTabId.value?.let { nativeInputStateProvider.stateForTab(it).value.chatId }
+        return currentChat.value?.takeIf { it.chatId == activeChatId }
+    }
+
     fun getSelectedModelId(): String? {
+        // Existing chat: send chat's stored model.
+        validChat()?.model?.let { return it }
+        // New chat with picker off: nothing to send.
         if (!_modelPickerEnabled.value) return null
+        // New chat with picker on: send what the user picked.
         return modelManager.getSelectedModelId()
     }
 
-    fun getResolvedReasoningEffort(): String? = modelManager.getResolvedReasoningEffort()
+    fun getResolvedReasoningEffort(): String? {
+        val chat = validChat() ?: return modelManager.getResolvedReasoningEffort()
+        val resolution = ReasoningResolver.forChat(chat, modelManager.modelState.value)
+            ?: return modelManager.getResolvedReasoningEffort()
+        val mode = ReasoningResolver.resolveMode(persisted = resolution.mode, available = resolution.available)
+        return ReasoningResolver.effortFor(mode, resolution.available)?.rawValue
+    }
 
     fun getSelectedTool(): String? {
         val tabId = activeTabId.value ?: return null
@@ -210,18 +232,6 @@ class NativeInputModeWidgetViewModel @Inject constructor(
                     }
                 }
         }
-
-        // Publish chatId to per-tab state. setActiveChatId can fire during widget attach before
-        // configure() sets activeTabId — _chatId holds the value until then.
-        viewModelScope.launch {
-            combine(_chatId, activeTabId.filterNotNull()) { chatId, tabId -> tabId to chatId }
-                .collect { (tabId, chatId) ->
-                    nativeInputStatePublisher.update(tabId) { it.copy(chatId = chatId) }
-                    // TODO: logs the chatId observers will see for this tab. Added for testing.
-                    //  Remove once consumer logic is implemented.
-                    logcat { "Duck.ai native input: active chatId for tab=$tabId is now $chatId" }
-                }
-        }
     }
 
     val chatState: Flow<ChatState> = duckChatInternal.chatState
@@ -263,7 +273,16 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     }
 
     fun setActiveChatId(chatId: String?) {
-        _chatId.value = chatId
+        val tabId = activeTabId.value ?: return
+        nativeInputStatePublisher.update(tabId) { it.copy(chatId = chatId) }
+        modelManager.setChatScopedReasoningMode(null)
+        currentChatJob?.cancel()
+        currentChat.value = null
+        if (chatId != null) {
+            currentChatJob = viewModelScope.launch {
+                currentChat.value = duckAiChatStore.getChatById(chatId)
+            }
+        }
     }
 
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -129,6 +129,11 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val currentChat = MutableStateFlow<DuckAiChat?>(null)
     private var currentChatJob: Job? = null
 
+    // Defensive buffer for the (rare) case where setActiveChatId fires before configure has set
+    // activeTabId. Replayed inside configure / configureContextual when activeTabId becomes known.
+    private var pendingChatId: String? = null
+    private var hasPendingChatId = false
+
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
     val commands = commandChannel.receiveAsFlow()
 
@@ -157,11 +162,14 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     }
 
     fun getSelectedModelId(): String? {
-        // Existing chat: send chat's stored model.
-        validChat()?.model?.let { return it }
-        // New chat with picker off: nothing to send.
-        if (!_modelPickerEnabled.value) return null
-        // New chat with picker on: send what the user picked.
+        // Existing chat with its model still in the list: send the chat's stored model.
+        val chat = validChat()
+        if (chat != null && ReasoningResolver.forChat(chat, modelManager.modelState.value) != null) {
+            return chat.model
+        }
+        // Existing chat whose model is no longer in the list: fall through to global so submission
+        // carries (global model, global effort). New chat with picker off: nothing to send.
+        if (chat == null && !_modelPickerEnabled.value) return null
         return modelManager.getSelectedModelId()
     }
 
@@ -273,15 +281,23 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     }
 
     fun setActiveChatId(chatId: String?) {
-        val tabId = activeTabId.value ?: return
+        val tabId = activeTabId.value
+        if (tabId == null) {
+            // configure hasn't run yet — buffer until activeTabId is known, replayed in configure.
+            pendingChatId = chatId
+            hasPendingChatId = true
+            return
+        }
+        applyChatId(tabId, chatId)
+    }
+
+    private fun applyChatId(tabId: String, chatId: String?) {
         nativeInputStatePublisher.update(tabId) { it.copy(chatId = chatId) }
-        modelManager.setChatScopedReasoningMode(null)
         currentChatJob?.cancel()
         currentChat.value = null
-        if (chatId != null) {
-            currentChatJob = viewModelScope.launch {
-                currentChat.value = duckAiChatStore.getChatById(chatId)
-            }
+        currentChatJob = viewModelScope.launch {
+            modelManager.setChatScopedReasoningMode(null)
+            if (chatId != null) currentChat.value = duckAiChatStore.getChatById(chatId)
         }
     }
 
@@ -290,6 +306,16 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         val context = if (isDuckAiMode) NativeInputState.InputContext.DUCK_AI else NativeInputState.InputContext.BROWSER
         val position = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP
         widgetConfig.value = WidgetConfig(inputContext = context, inputPosition = position)
+        replayPendingChatId(tabId)
+    }
+
+    private fun replayPendingChatId(tabId: String) {
+        if (hasPendingChatId) {
+            val pending = pendingChatId
+            pendingChatId = null
+            hasPendingChatId = false
+            applyChatId(tabId, pending)
+        }
     }
 
     fun storePendingPrompt(
@@ -306,6 +332,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     fun configureContextual(tabId: String) {
         activeTabId.value = tabId
         widgetConfig.update { it.copy(inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) }
+        replayPendingChatId(tabId)
     }
 
     fun cancelChatSuggestions() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
@@ -112,9 +111,11 @@ class ReasoningModePickerView @JvmOverloads constructor(
         stateJob?.cancel()
         stateJob = viewModel.state
             .onEach { state ->
-                isVisible = state.availableReasoningModes.size > 1 &&
-                    state.availableReasoningModes.any { it.isAccessible }
-                viewModel.resolvedMode(state)?.let { mode ->
+                isVisible = state.visible
+                // Popup is positioned by screen coordinates, not parented to the button. Dismiss
+                // it explicitly when picker hides or stale rows stay tappable for the new chat.
+                if (!state.visible) dismissPopup()
+                state.displayedMode?.let { mode ->
                     button.setImageResource(viewModel.iconResFor(mode))
                 }
             }
@@ -143,8 +144,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
 
     private fun showMenu() {
         val state = viewModel.state.value
-        if (state.availableReasoningModes.size <= 1) return
-        if (state.availableReasoningModes.none { it.isAccessible }) return
+        if (!state.visible) return
 
         val container = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
@@ -168,8 +168,8 @@ class ReasoningModePickerView @JvmOverloads constructor(
         showAtPosition(popup)
     }
 
-    private fun populate(container: LinearLayout, popup: PopupWindow, state: ModelState) {
-        viewModel.rows(state).forEach { row ->
+    private fun populate(container: LinearLayout, popup: PopupWindow, state: ReasoningModePickerState) {
+        state.rows.forEach { row ->
             val item = LayoutInflater.from(context)
                 .inflate(R.layout.view_reasoning_mode_picker_item, container, false)
             item.findViewById<ImageView>(R.id.reasoningModeItemLeadingIcon)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -102,9 +102,9 @@ class ReasoningModePickerViewModel @Inject constructor(
         nativeState: NativeInputState,
         chat: DuckAiChat?,
     ): ReasoningModePickerState {
-        val chatMatches = chat?.chatId == nativeState.chatId
-        val chatResolution = chat?.let { ReasoningResolver.forChat(it, modelState) }
-        if (nativeState.chatId != null && (!chatMatches || chatResolution == null)) {
+        val activeChat = chat?.takeIf { it.chatId == nativeState.chatId }
+        val chatResolution = activeChat?.let { ReasoningResolver.forChat(it, modelState) }
+        if (nativeState.chatId != null && chatResolution == null) {
             return ReasoningModePickerState(visible = false, rows = emptyList(), displayedMode = null)
         }
         val available = chatResolution?.available ?: modelState.availableReasoningModes
@@ -132,7 +132,7 @@ class ReasoningModePickerViewModel @Inject constructor(
         }
         if (match.isAccessible) {
             if (chatResolution != null) {
-                modelManager.setChatScopedReasoningMode(mode)
+                viewModelScope.launch { modelManager.setChatScopedReasoningMode(mode) }
             } else {
                 viewModelScope.launch { modelManager.selectReasoningMode(mode) }
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -22,17 +22,28 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AvailableReasoningMode
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.models.ReasoningResolver
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
@@ -45,40 +56,94 @@ data class ReasoningModeRow(
     val selected: Boolean,
 )
 
+/** Resolved snapshot the picker view renders from. */
+data class ReasoningModePickerState(
+    val visible: Boolean,
+    val rows: List<ReasoningModeRow>,
+    val displayedMode: ReasoningMode?,
+)
+
 @ContributesViewModel(ViewScope::class)
 class ReasoningModePickerViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
+    private val nativeInputStateProvider: NativeInputStateProvider,
+    private val duckAiChatStore: DuckAiChatStore,
 ) : ViewModel() {
 
-    val state: StateFlow<ModelState> = modelManager.modelState
+    private val currentChat = MutableStateFlow<DuckAiChat?>(null)
 
-    fun resolvedMode(state: ModelState): ReasoningMode? =
-        ReasoningResolver.resolveMode(state.selectedReasoningMode, state.availableReasoningModes)
+    init {
+        viewModelScope.launch {
+            // collectLatest: cancel in-flight lookup on chatId flip to avoid stale currentChat.
+            nativeInputStateProvider.state
+                .map { it.chatId }
+                .distinctUntilChanged()
+                .collectLatest { chatId ->
+                    currentChat.value = if (chatId == null) null else duckAiChatStore.getChatById(chatId)
+                }
+        }
+    }
+
+    /** Existing chat: rows derive from the chat's model. Otherwise: from the global selection. */
+    val state: StateFlow<ReasoningModePickerState> = combine(
+        modelManager.modelState,
+        nativeInputStateProvider.state,
+        currentChat,
+    ) { modelState, nativeState, chat ->
+        resolveState(modelState, nativeState, chat)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = ReasoningModePickerState(visible = false, rows = emptyList(), displayedMode = null),
+    )
+
+    private fun resolveState(
+        modelState: ModelState,
+        nativeState: NativeInputState,
+        chat: DuckAiChat?,
+    ): ReasoningModePickerState {
+        val chatMatches = chat?.chatId == nativeState.chatId
+        val chatResolution = chat?.let { ReasoningResolver.forChat(it, modelState) }
+        if (nativeState.chatId != null && (!chatMatches || chatResolution == null)) {
+            return ReasoningModePickerState(visible = false, rows = emptyList(), displayedMode = null)
+        }
+        val available = chatResolution?.available ?: modelState.availableReasoningModes
+        val persistedMode = chatResolution?.mode ?: modelState.selectedReasoningMode
+        val displayedMode = ReasoningResolver.resolveMode(persistedMode, available)
+        val visible = available.size > 1 && available.any { it.isAccessible }
+        val rows = available.map { it.toRow(selected = it.mode == displayedMode) }
+        return ReasoningModePickerState(visible = visible, rows = rows, displayedMode = displayedMode)
+    }
 
     private val command = Channel<UpsellCommand>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val commands: Flow<UpsellCommand> = command.receiveAsFlow()
 
     fun onModeTapped(mode: ReasoningMode, surface: PickerSurface) {
-        val available = modelManager.modelState.value.availableReasoningModes.firstOrNull { it.mode == mode }
-        if (available == null) {
+        // Drop taps that race past the picker hiding (loading, mismatch, no accessible rows).
+        if (!state.value.visible) return
+        val chat = currentChat.value
+        val chatResolution = chat?.let { ReasoningResolver.forChat(it, modelManager.modelState.value) }
+        val available = chatResolution?.available ?: modelManager.modelState.value.availableReasoningModes
+
+        val match = available.firstOrNull { it.mode == mode }
+        if (match == null) {
             logcat { "Duck.ai reasoning picker: tapped mode $mode not in available list, ignoring." }
             return
         }
-        if (available.isAccessible) {
-            viewModelScope.launch { modelManager.selectReasoningMode(mode) }
+        if (match.isAccessible) {
+            if (chatResolution != null) {
+                modelManager.setChatScopedReasoningMode(mode)
+            } else {
+                viewModelScope.launch { modelManager.selectReasoningMode(mode) }
+            }
             return
         }
         val userTier = modelManager.modelState.value.userTier
-        val requiredTier = available.access?.requiredTier ?: run {
+        val requiredTier = match.access?.requiredTier ?: run {
             logcat { "Duck.ai reasoning picker: gated mode $mode has no public required tier, ignoring." }
             return
         }
         routeUpsell(userTier, requiredTier, surface.origin)?.let { command.trySend(it) }
-    }
-
-    fun rows(state: ModelState): List<ReasoningModeRow> {
-        val resolved = resolvedMode(state)
-        return state.availableReasoningModes.map { it.toRow(selected = it.mode == resolved) }
     }
 
     @DrawableRes

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -1132,6 +1132,47 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
+    fun whenSetChatScopedReasoningModeThenStateUpdatedAndNotPersisted() = runTest {
+        testee = createManager()
+
+        testee.setChatScopedReasoningMode(ReasoningMode.REASONING)
+
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.chatScopedReasoningMode)
+        verify(dataStore, never()).setSelectedReasoningMode(any())
+    }
+
+    @Test
+    fun whenSetChatScopedReasoningModeToNullThenStateClearedAndNotPersisted() = runTest {
+        testee = createManager()
+        testee.setChatScopedReasoningMode(ReasoningMode.REASONING)
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.chatScopedReasoningMode)
+
+        testee.setChatScopedReasoningMode(null)
+
+        assertNull(testee.modelState.value.chatScopedReasoningMode)
+        verify(dataStore, never()).setSelectedReasoningMode(any())
+    }
+
+    @Test
+    fun whenFetchModelsThenChatScopedReasoningModeIsPreserved() = runTest {
+        // fetchModels rebuilds modelState — must not silently drop in-session chat-scoped picks.
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(remoteModel("id", accessTier = listOf("free"), entityHasAccess = true)),
+            ),
+        )
+        testee = createManager()
+        testee.setChatScopedReasoningMode(ReasoningMode.REASONING)
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.chatScopedReasoningMode)
+
+        testee.fetchModels()
+
+        assertEquals(ReasoningMode.REASONING, testee.modelState.value.chatScopedReasoningMode)
+    }
+
+    @Test
     fun whenSelectReasoningModeAndModeIsGatedThenIgnoredAndNotPersisted() = runTest {
         // Defends against direct calls bypassing the picker's tap handler: gated modes must not be persistable.
         whenever(dataStore.getSelectedModel()).thenReturn(SelectedModel("m", "M"))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -558,6 +558,10 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenChatIdSetThenGetSelectedModelIdReturnsChatsModel() = runTest {
         whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val modelStateFlow = MutableStateFlow(
+            ModelState(models = listOf(aiModel(id = "chat-model", supported = listOf(ReasoningEffort.NONE)))),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
             DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
         )
@@ -570,10 +574,38 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenChatModelNotInModelsListThenGetSelectedModelIdFallsBackToGlobal() = runTest {
+        // Chat references "missing-model" no longer offered server-side. Submission must fall back to
+        // global on both halves — chat-model + global-effort would be a mismatched pair.
+        // Picker is disabled here to mirror production (host binds modelPickerEnabled to chatId == null).
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val modelStateFlow = MutableStateFlow(
+            ModelState(
+                models = listOf(aiModel(id = "other-model", supported = listOf(ReasoningEffort.NONE))),
+            ),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "missing-model", lastEdit = "now", pinned = false),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        viewModel.setModelPickerEnabled(false)
+        advanceUntilIdle()
+
+        assertEquals("global-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
     fun whenChatIdSetAndPickerDisabledThenGetSelectedModelIdStillReturnsChatsModel() = runTest {
         // Production binds modelPickerEnabled to `chatId == null`, so existing chats always have the
         // picker disabled. Submission must still carry the chat's stored model.
         whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val modelStateFlow = MutableStateFlow(
+            ModelState(models = listOf(aiModel(id = "chat-model", supported = listOf(ReasoningEffort.NONE)))),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
         whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
             DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
         )
@@ -603,6 +635,15 @@ class NativeInputModeWidgetViewModelTest {
         // for chat-B is suspended. Submission must fall back to global rather than return chat-A's
         // model tagged to chat-B.
         whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val modelStateFlow = MutableStateFlow(
+            ModelState(
+                models = listOf(
+                    aiModel(id = "chat-A-model", supported = listOf(ReasoningEffort.NONE)),
+                    aiModel(id = "chat-B-model", supported = listOf(ReasoningEffort.NONE)),
+                ),
+            ),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
         whenever(duckAiChatStore.getChatById("chat-A")).thenReturn(
             DuckAiChat(chatId = "chat-A", title = "t", model = "chat-A-model", lastEdit = "now", pinned = false),
         )
@@ -634,6 +675,10 @@ class NativeInputModeWidgetViewModelTest {
         // setActiveChatId nulls currentChat synchronously and launches the lookup. During the in-
         // flight window, submission must fall back to global rather than return chat-A's data.
         whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val modelStateFlow = MutableStateFlow(
+            ModelState(models = listOf(aiModel(id = "chat-A-model", supported = listOf(ReasoningEffort.NONE)))),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
         whenever(duckAiChatStore.getChatById("chat-A")).thenReturn(
             DuckAiChat(chatId = "chat-A", title = "t", model = "chat-A-model", lastEdit = "now", pinned = false),
         )
@@ -1090,6 +1135,21 @@ class NativeInputModeWidgetViewModelTest {
         advanceUntilIdle()
 
         assertNull(nativeInputStateProvider.stateForTab(tabId).value.chatId)
+    }
+
+    @Test
+    fun whenSetActiveChatIdBeforeConfigureThenChatIdIsBufferedAndPublishedOnConfigure() = runTest {
+        // Defensive: setActiveChatId fires before activeTabId is set. The pending value must be
+        // replayed once configure runs.
+        val freshViewModel = createViewModel()
+
+        freshViewModel.setActiveChatId("chat-123")
+        advanceUntilIdle()
+
+        freshViewModel.configure(tabId = "tab-A", isDuckAiMode = false, isBottom = false)
+        advanceUntilIdle()
+
+        assertEquals("chat-123", nativeInputStateProvider.stateForTab("tab-A").value.chatId)
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -45,13 +45,21 @@ import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
+import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
+import com.duckduckgo.duckchat.impl.models.ModelState
+import com.duckduckgo.duckchat.impl.models.ReasoningEffort
+import com.duckduckgo.duckchat.impl.models.ReasoningEffortAccess
+import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -70,9 +78,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
@@ -97,6 +108,7 @@ class NativeInputModeWidgetViewModelTest {
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private val pixel: Pixel = mock()
     private val modelManager: DuckAiModelManager = mock()
+    private val duckAiChatStore: DuckAiChatStore = mock()
 
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabRepository: TabRepository = mock<TabRepository>().also {
@@ -154,6 +166,7 @@ class NativeInputModeWidgetViewModelTest {
             nativeInputStatePublisher = nativeInputStatePublisher,
             nativeInputStateProvider = nativeInputStateProvider,
             modelManager = modelManager,
+            duckAiChatStore = duckAiChatStore,
             appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
@@ -540,6 +553,243 @@ class NativeInputModeWidgetViewModelTest {
         assertNull(viewModel.getResolvedReasoningEffort())
     }
 
+    // region chat-aware submission getters
+
+    @Test
+    fun whenChatIdSetThenGetSelectedModelIdReturnsChatsModel() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        advanceUntilIdle()
+
+        assertEquals("chat-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatIdSetAndPickerDisabledThenGetSelectedModelIdStillReturnsChatsModel() = runTest {
+        // Production binds modelPickerEnabled to `chatId == null`, so existing chats always have the
+        // picker disabled. Submission must still carry the chat's stored model.
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        viewModel.setModelPickerEnabled(false)
+        advanceUntilIdle()
+
+        assertEquals("chat-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatIdNullAndPickerDisabledThenGetSelectedModelIdReturnsNull() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = false, isBottom = false)
+        viewModel.setModelPickerEnabled(false)
+        advanceUntilIdle()
+
+        assertNull(viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatIdFlipsAndNewLookupInFlightThenGetSelectedModelIdFallsBackToGlobalNotPreviousChat() = runTest {
+        // Warm transition: currentChat is still chat-A while _chatId is "chat-B" and the lookup
+        // for chat-B is suspended. Submission must fall back to global rather than return chat-A's
+        // model tagged to chat-B.
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        whenever(duckAiChatStore.getChatById("chat-A")).thenReturn(
+            DuckAiChat(chatId = "chat-A", title = "t", model = "chat-A-model", lastEdit = "now", pinned = false),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-A")
+        advanceUntilIdle()
+        assertEquals("chat-A-model", viewModel.getSelectedModelId())
+
+        val pending = CompletableDeferred<DuckAiChat?>()
+        duckAiChatStore.stub {
+            onBlocking { getChatById("chat-B") } doSuspendableAnswer { pending.await() }
+        }
+        viewModel.setActiveChatId("chat-B")
+        advanceUntilIdle()
+
+        // During the transition: currentChat is null, submission falls back to global.
+        assertEquals("global-model", viewModel.getSelectedModelId())
+
+        pending.complete(
+            DuckAiChat(chatId = "chat-B", title = "t", model = "chat-B-model", lastEdit = "now", pinned = false),
+        )
+        advanceUntilIdle()
+        assertEquals("chat-B-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatIdJustSetAndLookupInFlightThenSubmissionFallsBackToGlobal() = runTest {
+        // setActiveChatId nulls currentChat synchronously and launches the lookup. During the in-
+        // flight window, submission must fall back to global rather than return chat-A's data.
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        whenever(duckAiChatStore.getChatById("chat-A")).thenReturn(
+            DuckAiChat(chatId = "chat-A", title = "t", model = "chat-A-model", lastEdit = "now", pinned = false),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-A")
+        advanceUntilIdle()
+        assertEquals("chat-A-model", viewModel.getSelectedModelId())
+
+        // Flip to chat-B without yielding — currentChat is now null, lookup is launched but unfinished.
+        viewModel.setActiveChatId("chat-B")
+        // Intentionally no advanceUntilIdle() here.
+
+        assertEquals("global-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatIdNullThenGetSelectedModelIdReturnsGlobal() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("global-model")
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = false, isBottom = false)
+        viewModel.setActiveChatId(null)
+        advanceUntilIdle()
+
+        assertEquals("global-model", viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenChatHasReasoningModeThenGetResolvedReasoningEffortMatchesChatsMode() = runTest {
+        val modelStateFlow = MutableStateFlow(
+            ModelState(
+                models = listOf(
+                    aiModel(id = "chat-model", supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW)),
+                ),
+            ),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.REASONING.rawValue,
+            ),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        advanceUntilIdle()
+
+        assertEquals(ReasoningEffort.LOW.rawValue, viewModel.getResolvedReasoningEffort())
+    }
+
+    @Test
+    fun whenChatStoredModeIsGatedForCurrentTierThenGetResolvedReasoningEffortFallsBackToAccessible() = runTest {
+        // Chat was saved with extended_reasoning (PRO-only on this model). Current user is FREE.
+        // Submission must NOT send the gated effort; it must fall back to the first accessible mode's
+        // effort — mirroring what the picker UI shows via resolveMode's accessibility filter.
+        val gatedModel = AIChatModel(
+            id = "chat-model",
+            name = "chat-model",
+            displayName = "chat-model",
+            shortName = "chat-model",
+            accessTier = listOf("free", "plus", "pro"),
+            isAccessible = true,
+            supportedReasoningEfforts = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW, ReasoningEffort.MEDIUM),
+            reasoningEffortAccess = listOf(
+                ReasoningEffortAccess(effort = ReasoningEffort.NONE, accessTier = listOf("free", "plus", "pro"), isAccessible = true),
+                ReasoningEffortAccess(effort = ReasoningEffort.LOW, accessTier = listOf("free", "plus", "pro"), isAccessible = true),
+                ReasoningEffortAccess(effort = ReasoningEffort.MEDIUM, accessTier = listOf("pro"), isAccessible = false),
+            ),
+        )
+        val modelStateFlow = MutableStateFlow(ModelState(models = listOf(gatedModel)))
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.EXTENDED_REASONING.rawValue,
+            ),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        advanceUntilIdle()
+
+        // FAST is the first accessible mode (effort NONE). MEDIUM (extended_reasoning) is gated.
+        assertEquals(ReasoningEffort.NONE.rawValue, viewModel.getResolvedReasoningEffort())
+    }
+
+    @Test
+    fun whenChatScopedReasoningModeSetThenGetResolvedReasoningEffortOverridesChatStoredMode() = runTest {
+        val modelStateFlow = MutableStateFlow(
+            ModelState(
+                models = listOf(
+                    aiModel(id = "chat-model", supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW)),
+                ),
+            ),
+        )
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.FAST.rawValue,
+            ),
+        )
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-1")
+        advanceUntilIdle()
+        modelStateFlow.value = modelStateFlow.value.copy(chatScopedReasoningMode = ReasoningMode.REASONING)
+
+        assertEquals(ReasoningEffort.LOW.rawValue, viewModel.getResolvedReasoningEffort())
+    }
+
+    // endregion
+
+    // region tab-switch chatId clear
+
+    @Test
+    fun whenChatIdChangesThenChatScopedReasoningModeIsClearedOnManager() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-X")
+        advanceUntilIdle()
+        // Manager's setter is called every time _chatId emits (including the initial null on configure
+        // and the chat-X value). Reset verification to focus on the chatId-Y transition.
+        clearInvocations(modelManager)
+
+        viewModel.setActiveChatId("chat-Y")
+        advanceUntilIdle()
+
+        verify(modelManager).setChatScopedReasoningMode(null)
+    }
+
+    private fun aiModel(id: String, supported: List<ReasoningEffort>): AIChatModel = AIChatModel(
+        id = id,
+        name = id,
+        displayName = id,
+        shortName = id,
+        accessTier = listOf("free", "plus", "pro"),
+        isAccessible = true,
+        supportedReasoningEfforts = supported,
+    )
+
+    // endregion
+
     @Test
     fun whenNoTabIsActiveThenGetSelectedToolReturnsNull() = runTest {
         val freshViewModel = createViewModel()
@@ -840,22 +1090,6 @@ class NativeInputModeWidgetViewModelTest {
         advanceUntilIdle()
 
         assertNull(nativeInputStateProvider.stateForTab(tabId).value.chatId)
-    }
-
-    @Test
-    fun whenSetActiveChatIdBeforeConfigureThenChatIdIsBufferedAndPublishedOnConfigure() = runTest {
-        // Regression for the attach race: bindChatIdSource can fire setActiveChatId synchronously
-        // during widget attach, before configure() sets activeTabId.value. The buffered value must
-        // be replayed once a tabId becomes available.
-        val freshViewModel = createViewModel()
-
-        freshViewModel.setActiveChatId("chat-123")
-        advanceUntilIdle()
-
-        freshViewModel.configure(tabId = "tab-A", isDuckAiMode = false, isBottom = false)
-        advanceUntilIdle()
-
-        assertEquals("chat-123", nativeInputStateProvider.stateForTab("tab-A").value.chatId)
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.duckchat.impl.ui
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.AvailableReasoningMode
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
@@ -28,15 +31,25 @@ import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -46,40 +59,59 @@ class ReasoningModePickerViewModelTest {
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
-    private val state = MutableStateFlow(ModelState())
+    private val modelState = MutableStateFlow(ModelState())
     private val modelManager: DuckAiModelManager = mock<DuckAiModelManager>().also {
-        whenever(it.modelState).thenReturn(state)
+        whenever(it.modelState).thenReturn(modelState)
     }
 
-    private val testee = ReasoningModePickerViewModel(modelManager)
+    private val nativeInputState = MutableStateFlow(NativeInputState.zero())
+    private val nativeInputStateProvider: NativeInputStateProvider = mock<NativeInputStateProvider>().also {
+        whenever(it.state).thenReturn(nativeInputState)
+    }
+    private val duckAiChatStore: DuckAiChatStore = mock()
 
-    @Test
-    fun whenAvailableEmptyThenResolvedModeIsNull() {
-        state.value = ModelState(availableReasoningModes = emptyList())
-        assertNull(testee.resolvedMode(state.value))
+    private lateinit var testee: ReasoningModePickerViewModel
+
+    @Before
+    fun setUp() {
+        testee = ReasoningModePickerViewModel(
+            modelManager = modelManager,
+            nativeInputStateProvider = nativeInputStateProvider,
+            duckAiChatStore = duckAiChatStore,
+        )
     }
 
     @Test
-    fun whenPersistedNullThenResolvedModeIsFirstAvailable() {
-        state.value = ModelState(
+    fun whenAvailableEmptyThenDisplayedModeIsNullAndNotVisible() = runTest {
+        modelState.value = ModelState(availableReasoningModes = emptyList())
+        runCurrent()
+        assertNull(testee.state.value.displayedMode)
+        assertFalse(testee.state.value.visible)
+    }
+
+    @Test
+    fun whenPersistedNullThenDisplayedModeIsFirstAvailable() = runTest {
+        modelState.value = ModelState(
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
             ),
         )
-        assertEquals(ReasoningMode.FAST, testee.resolvedMode(state.value))
+        runCurrent()
+        assertEquals(ReasoningMode.FAST, testee.state.value.displayedMode)
     }
 
     @Test
-    fun whenPersistedSupportedThenResolvedModeIsPersisted() {
-        state.value = ModelState(
+    fun whenPersistedSupportedThenDisplayedModeIsPersisted() = runTest {
+        modelState.value = ModelState(
             selectedReasoningMode = ReasoningMode.REASONING,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
             ),
         )
-        assertEquals(ReasoningMode.REASONING, testee.resolvedMode(state.value))
+        runCurrent()
+        assertEquals(ReasoningMode.REASONING, testee.state.value.displayedMode)
     }
 
     @Test
@@ -99,15 +131,16 @@ class ReasoningModePickerViewModelTest {
     }
 
     @Test
-    fun whenRowsBuiltThenSelectedReflectsResolvedMode() {
-        state.value = ModelState(
+    fun whenRowsBuiltThenSelectedReflectsDisplayedMode() = runTest {
+        modelState.value = ModelState(
             selectedReasoningMode = ReasoningMode.REASONING,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
             ),
         )
-        val rows = testee.rows(state.value)
+        runCurrent()
+        val rows = testee.state.value.rows
         assertEquals(2, rows.size)
         assertEquals(ReasoningMode.FAST, rows[0].mode)
         assertEquals(ReasoningMode.REASONING, rows[1].mode)
@@ -119,9 +152,13 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenAccessibleModeTappedThenSelectModeInvokedAndNoCommandEmitted() = runTest {
-        state.value = ModelState(
-            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW)),
+        modelState.value = ModelState(
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -135,10 +172,14 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenFreeUserTapsGatedModeRequiringPlusFromAddressBarThenLaunchPurchaseEmitted() = runTest {
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.FREE,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("plus", "pro"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("plus", "pro")),
+            ),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -153,10 +194,14 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenFreeUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchPurchaseEmittedWithDuckAiOrigin() = runTest {
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.FREE,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("pro")),
+            ),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
@@ -171,10 +216,14 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenPlusUserTapsGatedModeRequiringProFromAddressBarThenLaunchUpgradeEmitted() = runTest {
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.PLUS,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("pro")),
+            ),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -189,10 +238,14 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenPlusUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchUpgradeEmittedWithDuckAiOrigin() = runTest {
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.PLUS,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("pro"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("pro")),
+            ),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
@@ -208,10 +261,11 @@ class ReasoningModePickerViewModelTest {
     @Test
     fun whenGatedModeRequiresFreeTierThenNoCommandEmitted() = runTest {
         // Pathological: a "gated" entry whose access list still includes FREE → no upsell route.
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.FREE,
             availableReasoningModes = listOf(gatedExtended(requires = listOf("free", "plus", "pro"))),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -224,10 +278,11 @@ class ReasoningModePickerViewModelTest {
     @Test
     fun whenGatedModeAccessHasNoPublicTierThenNoCommandEmitted() = runTest {
         // Only non-public tiers in the access list → requiredTier is null → no upsell route.
-        state.value = ModelState(
+        modelState.value = ModelState(
             userTier = UserTier.FREE,
             availableReasoningModes = listOf(gatedExtended(requires = listOf("internal"))),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -239,9 +294,10 @@ class ReasoningModePickerViewModelTest {
 
     @Test
     fun whenTappedModeNotInAvailableListThenNoCommandEmittedAndManagerNotCalled() = runTest {
-        state.value = ModelState(
+        modelState.value = ModelState(
             availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE)),
         )
+        runCurrent()
 
         testee.commands.test {
             testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
@@ -252,6 +308,252 @@ class ReasoningModePickerViewModelTest {
         }
     }
 
+    // ---- chat-aware behaviour ----
+
+    @Test
+    fun whenChatIdSetThenRowsAreDerivedFromChatsModel() = runTest {
+        // Globally selected model offers only FAST. Chat's model offers FAST + REASONING.
+        modelState.value = ModelState(
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE)),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        val rows = testee.state.value.rows
+        assertEquals(2, rows.size)
+        assertEquals(ReasoningMode.FAST, rows[0].mode)
+        assertEquals(ReasoningMode.REASONING, rows[1].mode)
+    }
+
+    @Test
+    fun whenChatHasReasoningModeThenDisplayedModeMatchesChat() = runTest {
+        modelState.value = ModelState(
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.REASONING.rawValue,
+            ),
+        )
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        assertEquals(ReasoningMode.REASONING, testee.state.value.displayedMode)
+    }
+
+    @Test
+    fun whenChatScopedReasoningModeSetThenItOverridesChatStoredMode() = runTest {
+        modelState.value = ModelState(
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.FAST.rawValue,
+            ),
+        )
+
+        modelState.value = modelState.value.copy(chatScopedReasoningMode = ReasoningMode.REASONING)
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        assertEquals(ReasoningMode.REASONING, testee.state.value.displayedMode)
+    }
+
+    @Test
+    fun whenChatIdSetButChatLookupInFlightThenPickerHiddenAndTapDoesNotWriteGlobal() = runTest {
+        // Global is configured with two accessible modes so the picker would be visible if the
+        // resolver fell back to global rows during the load window.
+        modelState.value = ModelState(
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+        )
+        val pending = CompletableDeferred<DuckAiChat?>()
+        duckAiChatStore.stub {
+            onBlocking { getChatById("chat-1") } doSuspendableAnswer { pending.await() }
+        }
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        assertFalse(testee.state.value.visible)
+        testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(modelManager, never()).selectReasoningMode(any())
+        verify(modelManager, never()).setChatScopedReasoningMode(any())
+
+        pending.complete(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+        runCurrent()
+        assertTrue(testee.state.value.visible)
+    }
+
+    @Test
+    fun whenChatIdFlipsDuringLoadingThenPickerHiddenAndTapsDropped() = runTest {
+        // Warm transition: currentChat is still chat-A while nativeState.chatId is "chat-B" and the
+        // getChatById("chat-B") suspend is in flight. The chatMatches guard hides the picker so a
+        // tap can't land in the global chatScopedReasoningMode slot mis-scoped to chat-B.
+        modelState.value = ModelState(
+            models = listOf(
+                aiModel(id = "model-A", supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW)),
+                aiModel(id = "model-B", supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW)),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-A")).thenReturn(
+            DuckAiChat(chatId = "chat-A", title = "t", model = "model-A", lastEdit = "now", pinned = false),
+        )
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-A")
+        runCurrent()
+        assertTrue(testee.state.value.visible)
+
+        // Flip to chat-B with the lookup suspended.
+        val pending = CompletableDeferred<DuckAiChat?>()
+        duckAiChatStore.stub {
+            onBlocking { getChatById("chat-B") } doSuspendableAnswer { pending.await() }
+        }
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-B")
+        runCurrent()
+
+        assertFalse(testee.state.value.visible)
+        testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+        runCurrent()
+        verify(modelManager, never()).setChatScopedReasoningMode(any())
+
+        // Lookup resolves to chat-B → picker becomes visible.
+        pending.complete(
+            DuckAiChat(chatId = "chat-B", title = "t", model = "model-B", lastEdit = "now", pinned = false),
+        )
+        runCurrent()
+        assertTrue(testee.state.value.visible)
+    }
+
+    @Test
+    fun whenChatLoadedButItsModelNotInModelsListThenPickerHiddenAndTapsDropped() = runTest {
+        // Chat references "missing-model" but the models list has only "other-model". Without this
+        // guard, the picker would show global rows and a tap would write chat-scoped, but submission
+        // (which gates on chatModel != null) would silently ignore it. Hide the picker instead.
+        modelState.value = ModelState(
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
+            models = listOf(
+                aiModel(id = "other-model", supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW)),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "missing-model", lastEdit = "now", pinned = false),
+        )
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        assertFalse(testee.state.value.visible)
+
+        testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(modelManager, never()).selectReasoningMode(any())
+        verify(modelManager, never()).setChatScopedReasoningMode(any())
+    }
+
+    @Test
+    fun whenInExistingChatAndAccessibleModeTappedThenWritesChatScopedAndDoesNotTouchGlobal() = runTest {
+        modelState.value = ModelState(
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(chatId = "chat-1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+
+        testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_DUCK_AI_TAB)
+        runCurrent()
+
+        verify(modelManager).setChatScopedReasoningMode(ReasoningMode.REASONING)
+        verify(modelManager, never()).selectReasoningMode(any())
+    }
+
+    @Test
+    fun whenChatIdClearedThenStateFallsBackToGlobal() = runTest {
+        modelState.value = ModelState(
+            selectedReasoningMode = ReasoningMode.FAST,
+            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE)),
+            models = listOf(
+                aiModel(
+                    id = "chat-model",
+                    supported = listOf(ReasoningEffort.NONE, ReasoningEffort.LOW),
+                ),
+            ),
+        )
+        whenever(duckAiChatStore.getChatById("chat-1")).thenReturn(
+            DuckAiChat(
+                chatId = "chat-1",
+                title = "t",
+                model = "chat-model",
+                lastEdit = "now",
+                pinned = false,
+                reasoningMode = ReasoningMode.REASONING.rawValue,
+            ),
+        )
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = "chat-1")
+        runCurrent()
+        assertEquals(ReasoningMode.REASONING, testee.state.value.displayedMode)
+
+        nativeInputState.value = NativeInputState.zero().copy(chatId = null)
+        runCurrent()
+        assertEquals(ReasoningMode.FAST, testee.state.value.displayedMode)
+        assertTrue(testee.state.value.rows.isNotEmpty())
+    }
+
     private fun gatedExtended(requires: List<String>) = AvailableReasoningMode(
         mode = ReasoningMode.EXTENDED_REASONING,
         effort = ReasoningEffort.MEDIUM,
@@ -260,5 +562,20 @@ class ReasoningModePickerViewModelTest {
             accessTier = requires,
             isAccessible = false,
         ),
+    )
+
+    private fun aiModel(
+        id: String,
+        supported: List<ReasoningEffort>,
+        access: List<ReasoningEffortAccess> = emptyList(),
+    ): AIChatModel = AIChatModel(
+        id = id,
+        name = id,
+        displayName = id,
+        shortName = id,
+        accessTier = listOf("free", "plus", "pro"),
+        isAccessible = true,
+        supportedReasoningEfforts = supported,
+        reasoningEffortAccess = access,
     )
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215057967719589?focus=true 

## Description

Tech design: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214935104654912?focus=true

PR 3/3 

When opening an existing Duck.ai chat, the input widget now restores the chat's stored model and reasoning effort instead of using the user's global defaults. Submissions in an existing chat carry the chat's values; the global "last used" model/reasoning remain untouched.

Implementation notes:
- `ReasoningModePickerViewModel` observes `nativeInputState.chatId`, looks up the chat, and derives picker rows from the chat's stored model; displayed mode prefers the session pick over the chat's stored mode.
- `NativeInputModeWidgetViewModel` submission getters return the chat's stored model and a reasoning effort routed through `ReasoningResolver.resolveMode`
- `DuckAiModelManager` adds a session-only `chatScopedReasoningMode` field with a setter; not persisted, cleared on chatId change.
- Shared helper `ReasoningResolver.forChat(chat, modelState)` centralises the chat-aware resolution.

### Steps to test this PR

_Existing chat - restoration_
- [ ] Send a message in a new chat, pick a reasoning mode (e.g. `Thinking`)
- [ ] Navigate away and reopen that chat from history
- [ ] Picker displays the chat's stored mode; submitting sends the correct selection

_New chat - global defaults_
- [ ] Open a new chat submit using any model
- [ ] Open another new chat
- [ ] Picker shows your Last used model

_Mid-chat reasoning change (session-only)_
- [ ] In an existing chat, tap the picker and change the mode
- [ ] Submit; submission uses the picked mode
- [ ] Open a new chat - your global default is unchanged

_Same-tab navigation between chats_
- [ ] In one tab, open chat A and pick a reasoning mode
- [ ] Navigate to chat B in the same tab
- [ ] Picker shows chat B's stored mode (not A's pick)

_Tab switching_
- [ ] Open chat A in tab 1 and chat B in tab 2
- [ ] Switch between tabs; each tab's picker shows its own chat's mode and submission uses that tab's chat


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how model/reasoning are resolved and submitted for existing chats, adding new session-scoped state and async chat lookups that could affect selection correctness across tab/chat switches.
> 
> **Overview**
> Existing Duck.ai chats now restore and submit their stored `model` and reasoning effort instead of always using the user’s global defaults.
> 
> This introduces a session-only `chatScopedReasoningMode` on `DuckAiModelManager`, adds `ReasoningResolver.forChat(...)` to resolve available modes/mode per chat model, and updates the input widget and reasoning picker to (a) load the active chat via `DuckAiChatStore`, (b) hide/drop interactions during in-flight chat switches or when a chat’s model is no longer available, and (c) clear chat-scoped overrides on chat changes so global preferences are not persisted/overwritten. Tests are expanded to cover chat switching, missing models, gated modes, and buffering `chatId` before `configure()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caae8f551ccdfb987c24a392ef7659a88f9d2a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->