### PR TITLE
enable brand design onboarding feature flags

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -27,16 +27,16 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface OnboardingBrandDesignUpdateToggles {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 
     /**
      * Gates the new fire animation work: new Inferno default in Data Clearing
      * settings + bottom-sheet Lottie swap.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun fireAnimationUpdate(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1214898434899764?focus=true

### Description
Enables the rebranded onboarding feature flags.

### Steps to test this PR

QA optional, this has already been tested and was enabled in internal for some time.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file default toggle changes for onboarding and fire-animation UX that were already validated internally; remote config can still disable.
> 
> **Overview**
> **Rolls out** the rebranded onboarding experience to production users by changing default remote-feature values from **internal-only** to **on** for `onboardingBrandDesignUpdate`.
> 
> Specifically, `@Toggle.DefaultValue` moves from `DefaultFeatureValue.INTERNAL` to `DefaultFeatureValue.TRUE` on **`self()`**, **`brandDesignUpdate()`**, and **`fireAnimationUpdate()`** (the latter gates the new Inferno default in Data Clearing and the bottom-sheet Lottie fire animation). No new UI or logic is added in this diff—only the **default on/off** when remote config does not override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1c2f9409fff7a86e8b4ca394f79df0cdbb0649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->