### PR TITLE
Improve autocomplete behaviour 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4844,6 +4844,7 @@ class BrowserTabFragment :
 
     private fun onTabHidden() {
         if (!isAdded) return
+        nativeInputManager.onTabBackgrounded()
         viewModel.onViewHidden()
         downloadMessagesJob.cancel()
         webView?.onPause()
@@ -6370,6 +6371,7 @@ class BrowserTabFragment :
     }
 
     fun onTabSwipedAway() {
+        nativeInputManager.onTabBackgrounded()
         viewModel.onTabSwipedAway()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1426,6 +1426,7 @@ class BrowserTabFragment :
                 onFilePickerRequested = { callback, mimeTypes ->
                     launchFilePicker(callback, mimeTypes)
                 },
+                restoreOmnibarAutocomplete = { forQuery -> restoreOmnibarAutocomplete(forQuery) },
             ),
         )
     }
@@ -1530,6 +1531,12 @@ class BrowserTabFragment :
         hasFocus: Boolean = true,
     ) {
         viewModel.triggerAutocomplete(text, hasFocus, true)
+    }
+
+    private fun restoreOmnibarAutocomplete(forQuery: String): Boolean {
+        val cached = viewModel.restoreOmnibarAutocomplete(forQuery) ?: return false
+        autoCompleteSuggestionsAdapter.updateData(cached.query, cached.suggestions)
+        return true
     }
 
     private fun onOmnibarCustomTabClosed() {
@@ -2044,7 +2051,10 @@ class BrowserTabFragment :
         viewModel.omnibarViewState.observe(
             viewLifecycleOwner,
             Observer {
-                it?.let { renderer.renderOmnibar(it) }
+                it?.let {
+                    renderer.renderOmnibar(it)
+                    viewModel.onOmnibarTextRendered(it.omnibarText)
+                }
             },
         )
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4844,7 +4844,6 @@ class BrowserTabFragment :
 
     private fun onTabHidden() {
         if (!isAdded) return
-        nativeInputManager.onTabBackgrounded()
         viewModel.onViewHidden()
         downloadMessagesJob.cancel()
         webView?.onPause()
@@ -6371,7 +6370,6 @@ class BrowserTabFragment :
     }
 
     fun onTabSwipedAway() {
-        nativeInputManager.onTabBackgrounded()
         viewModel.onTabSwipedAway()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -661,7 +661,13 @@ class BrowserTabViewModel @Inject constructor(
                         .debounce(300)
                         .distinctUntilChanged()
                         .flatMapLatest { query ->
-                            if (query.isBlank() || !autoCompleteSettings.autoCompleteSuggestionsEnabled) {
+                            // Skip page URLs — omnibarViewState emits on every navigation, and
+                            // running the fetch against full URLs would be both wasteful and
+                            // wrong (the autocomplete API expects user-typed queries).
+                            val isQueryLike = query.isNotBlank() &&
+                                !UriString.isWebUrl(query) &&
+                                !duckPlayer.isDuckPlayerUri(query)
+                            if (!isQueryLike || !autoCompleteSettings.autoCompleteSuggestionsEnabled) {
                                 flowOf(AutoCompleteResult(query, emptyList()))
                             } else {
                                 // Catch inside flatMapLatest so a failed fetch only drops this query's

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -649,6 +649,10 @@ class BrowserTabViewModel @Inject constructor(
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     internal val omnibarAutocompleteCache: StateFlow<AutoCompleteResult> =
         duckChat.observeNativeInputFieldUserSettingEnabled()
+            .catch { t ->
+                logcat(WARN) { "Native input setting flow failed: ${t.asLog()}" }
+                emit(false)
+            }
             .flatMapLatest { isNativeInputEnabled ->
                 if (!isNativeInputEnabled) {
                     flowOf(AutoCompleteResult("", emptyList()))
@@ -660,13 +664,20 @@ class BrowserTabViewModel @Inject constructor(
                             if (query.isBlank() || !autoCompleteSettings.autoCompleteSuggestionsEnabled) {
                                 flowOf(AutoCompleteResult(query, emptyList()))
                             } else {
+                                // Catch inside flatMapLatest so a failed fetch only drops this query's
+                                // result — without it, .catch + stateIn(Eagerly) would terminate the
+                                // pipeline for the ViewModel's lifetime (no equivalent of the existing
+                                // pipeline's ConflatedJob restart).
                                 autoComplete.autoComplete(query)
+                                    .catch { t ->
+                                        logcat(WARN) { "Failed to get omnibar autocomplete: ${t.asLog()}" }
+                                        emit(AutoCompleteResult(query, emptyList()))
+                                    }
                             }
                         }
                 }
             }
             .flowOn(dispatchers.io())
-            .catch { t: Throwable? -> logcat(WARN) { "Failed to get omnibar autocomplete: ${t?.asLog()}" } }
             .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
 
     private val fireproofWebsiteState: LiveData<List<FireproofWebsiteEntity>> = fireproofWebsiteRepository.getFireproofWebsites()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -414,6 +414,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
@@ -425,6 +426,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -634,6 +636,39 @@ class BrowserTabViewModel @Inject constructor(
 
     @VisibleForTesting
     internal val autoCompleteStateFlow = MutableStateFlow("")
+
+    /**
+     * Always-on autocomplete pipeline tied to the omnibar's text. Kept in sync with the
+     * omnibar via [onOmnibarTextRendered] so the native-input widget can restore the
+     * omnibar's autocomplete results when it closes — even if in-widget typing temporarily
+     * overwrote [autoCompleteStateFlow]. Gated on the native-input user setting so that
+     * users without the widget don't pay for a duplicate pipeline.
+     */
+    private val omnibarTextStateFlow = MutableStateFlow("")
+
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+    internal val omnibarAutocompleteCache: StateFlow<AutoCompleteResult> =
+        duckChat.observeNativeInputFieldUserSettingEnabled()
+            .flatMapLatest { isNativeInputEnabled ->
+                if (!isNativeInputEnabled) {
+                    flowOf(AutoCompleteResult("", emptyList()))
+                } else {
+                    omnibarTextStateFlow
+                        .debounce(300)
+                        .distinctUntilChanged()
+                        .flatMapLatest { query ->
+                            if (query.isBlank() || !autoCompleteSettings.autoCompleteSuggestionsEnabled) {
+                                flowOf(AutoCompleteResult(query, emptyList()))
+                            } else {
+                                autoComplete.autoComplete(query)
+                            }
+                        }
+                }
+            }
+            .flowOn(dispatchers.io())
+            .catch { t: Throwable? -> logcat(WARN) { "Failed to get omnibar autocomplete: ${t?.asLog()}" } }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
+
     private val fireproofWebsiteState: LiveData<List<FireproofWebsiteEntity>> = fireproofWebsiteRepository.getFireproofWebsites()
 
     @ExperimentalCoroutinesApi
@@ -2783,6 +2818,39 @@ class BrowserTabViewModel @Inject constructor(
         if (hasFocus && autoCompleteSuggestionsEnabled) {
             autoCompleteStateFlow.value = query.trim()
         }
+    }
+
+    /**
+     * Notify the viewmodel that the omnibar finished rendering [text]. Feeds the
+     * [omnibarAutocompleteCache] so the native-input widget can restore the omnibar's
+     * autocomplete state on close. Distinct from [Omnibar.OmnibarTextListener.onOmnibarTextChanged],
+     * which is the user-typing callback.
+     */
+    fun onOmnibarTextRendered(text: String) {
+        omnibarTextStateFlow.value = text
+    }
+
+    /**
+     * Restore the autocomplete view state from [omnibarAutocompleteCache] for [forQuery].
+     * Returns the cached result when it matched and was applied (null otherwise); callers
+     * should also refresh any adapter holding the suggestions since the renderer's
+     * `renderIfChanged` may skip a re-render for an equal view state.
+     *
+     * `showSuggestions` and `showFocusedView` are forced to false — the caller decides
+     * whether to surface the list.
+     */
+    fun restoreOmnibarAutocomplete(forQuery: String): AutoCompleteResult? {
+        val cached = omnibarAutocompleteCache.value
+        if (cached.query != forQuery || cached.suggestions.isEmpty()) return null
+        val current = autoCompleteViewState.value ?: return null
+        val restored = current.copy(
+            searchResults = cached,
+            showSuggestions = false,
+            showFocusedView = false,
+        )
+        autoCompleteViewState.value = restored
+        lastAutoCompleteState = restored
+        return cached
     }
 
     fun onBookmarkMenuClicked() {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -72,6 +72,12 @@ class NativeInputCallbacks(
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
     val onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit = {},
     val onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit = { _, _ -> },
+    /**
+     * Restore the autocomplete view state from the always-on cache the viewmodel keeps for
+     * the omnibar's text. Returns true when the cache matched [forQuery] and was applied;
+     * the caller uses the return value to decide whether to re-show the suggestions list.
+     */
+    val restoreOmnibarAutocomplete: (forQuery: String) -> Boolean = { _ -> false },
 )
 
 interface NativeInputManager {
@@ -120,6 +126,7 @@ class RealNativeInputManager @Inject constructor(
     private var isPickingImage: Boolean = false
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
+    private var lastCallbacks: NativeInputCallbacks? = null
 
     private fun widgetFrom(widgetView: View): NativeInputWidget? {
         return widgetView.findViewById<View?>(R.id.inputModeWidget) as? NativeInputWidget
@@ -188,15 +195,25 @@ class RealNativeInputManager @Inject constructor(
         rootView.findViewById<View?>(R.id.autoCompleteSuggestionsList)?.gone()
         rootView.findViewById<View?>(R.id.focusedView)?.gone()
 
+        // Reveal the browser behind the closing widget so the exit animation plays over the
+        // live page instead of the NTP background that showNtp swapped in.
+        if (omnibarController.isBrowserMode()) {
+            hideNtp()
+        }
+
+        // Roll the autocomplete cache back to the omnibar's text so in-widget typing is
+        // dismissed. Skip on navigation paths: submit/voice-result/etc. leave the cache to
+        // follow the destination, not the pre-submit omnibar state.
+        if (!isNavigation) {
+            lastCallbacks?.restoreOmnibarAutocomplete?.invoke(omnibarController.getText())
+        }
+
         if (!animate) {
             animator.cancelAnimation()
             isExiting = false
             omnibarController.restore()
             omnibarController.show()
             removeWidget()
-            if (omnibarController.isBrowserMode()) {
-                hideNtp()
-            }
             return !omnibarController.isDuckAiMode()
         }
 
@@ -247,16 +264,10 @@ class RealNativeInputManager @Inject constructor(
                 .withEndAction {
                     widgetCard.alpha = 1f
                     removeWidget()
-                    if (omnibarController.isBrowserMode()) {
-                        hideNtp()
-                    }
                 }
                 .start()
         } else {
             removeWidget()
-            if (omnibarController.isBrowserMode()) {
-                hideNtp()
-            }
         }
     }
 
@@ -333,6 +344,9 @@ class RealNativeInputManager @Inject constructor(
             omnibarController.forceToTop()
         }
         removeWidget()
+        // Assign after removeWidget — removeWidget clears lastCallbacks to drop references
+        // to the previous widget's closures.
+        lastCallbacks = callbacks
         if (omnibarController.isDuckAiMode()) {
             omnibarController.show()
             omnibarController.hideBackground()
@@ -342,10 +356,24 @@ class RealNativeInputManager @Inject constructor(
         val prefillText = query.ifEmpty { omnibarController.getText() }
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
-            callbacks.onClearAutocomplete()
+            // Restore the cache before setting text — triggerAutocomplete preserves the
+            // current searchResults, so a stale cache (post-submit reset, or overwritten by
+            // a previous in-widget query) would otherwise flash the list empty.
+            val cacheRestored = callbacks.restoreOmnibarAutocomplete(prefillText)
             widgetFrom(widgetView)?.apply {
                 text = prefillText
                 selectAllText()
+            }
+            // hideNativeInput hid the list directly without touching autoCompleteViewState,
+            // so renderIfChanged skips re-showing on reopen. Surface it manually when the
+            // cache is for the current prefill; otherwise leave it hidden so a different
+            // query's stale items don't flash.
+            if (cacheRestored) {
+                rootView.findViewById<RecyclerView?>(R.id.autoCompleteSuggestionsList)?.let { list ->
+                    if ((list.adapter?.itemCount ?: 0) > 0) {
+                        list.show()
+                    }
+                }
             }
         }
         attachWidget(widgetView, isBottom, tabId)
@@ -456,6 +484,8 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
+        // Drop Fragment-scoped callback closures so they don't outlive the widget.
+        lastCallbacks = null
         return removed
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -107,6 +107,9 @@ interface NativeInputManager {
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
     fun setPickingImage(picking: Boolean)
     fun setText(text: String)
+
+    /** Dismisses the IME and clears widget focus so the keyboard doesn't leak onto the next tab. */
+    fun onTabBackgrounded()
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -165,6 +168,13 @@ class RealNativeInputManager @Inject constructor(
         if (!::rootView.isInitialized) return
         val widget = widgetFrom(rootView) ?: return
         widget.text = text
+    }
+
+    override fun onTabBackgrounded() {
+        if (!::rootView.isInitialized) return
+        val widget = widgetFrom(rootView) ?: return
+        if (widget.hasInputFocus()) widget.clearInputFocus()
+        widget.hideKeyboard()
     }
 
     override fun handleDuckAiVoiceResult(query: String) {
@@ -627,6 +637,18 @@ class RealNativeInputManager @Inject constructor(
             configure(tabId = tabId, isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
+        // Cancel any in-flight enter animation if the widget detaches before it completes —
+        // otherwise onComplete fires post-detach and focusInput raises the IME on the next tab.
+        widgetView.addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) = Unit
+                override fun onViewDetachedFromWindow(v: View) {
+                    animator.cancelAnimation()
+                    v.removeOnAttachStateChangeListener(this)
+                }
+            },
+        )
+
         applyWindowChrome(widgetView, isBottom)
 
         if (!startEnterAnimation(widgetView, isBottom)) {
@@ -654,7 +676,7 @@ class RealNativeInputManager @Inject constructor(
         val omnibarCard = omnibarController.getCardView() ?: return false
         // Apply focused-state layout so the widget is measured at its final size; otherwise
         // padding/bottom-row/toggle-row visibility land after the 200ms enter as a second step.
-        widgetFrom(widgetView)?.beginEnterAnimationPreview()
+        widgetFrom(widgetView)?.beginEnterAnimationPreview(isBottom)
         val margins = animator.init(widgetCard, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom)
             ?: return false
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -107,9 +107,6 @@ interface NativeInputManager {
     fun onKeyboardVisibilityChanged(isVisible: Boolean)
     fun setPickingImage(picking: Boolean)
     fun setText(text: String)
-
-    /** Dismisses the IME and clears widget focus so the keyboard doesn't leak onto the next tab. */
-    fun onTabBackgrounded()
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -168,13 +165,6 @@ class RealNativeInputManager @Inject constructor(
         if (!::rootView.isInitialized) return
         val widget = widgetFrom(rootView) ?: return
         widget.text = text
-    }
-
-    override fun onTabBackgrounded() {
-        if (!::rootView.isInitialized) return
-        val widget = widgetFrom(rootView) ?: return
-        if (widget.hasInputFocus()) widget.clearInputFocus()
-        widget.hideKeyboard()
     }
 
     override fun handleDuckAiVoiceResult(query: String) {
@@ -637,18 +627,6 @@ class RealNativeInputManager @Inject constructor(
             configure(tabId = tabId, isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
-        // Cancel any in-flight enter animation if the widget detaches before it completes —
-        // otherwise onComplete fires post-detach and focusInput raises the IME on the next tab.
-        widgetView.addOnAttachStateChangeListener(
-            object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(v: View) = Unit
-                override fun onViewDetachedFromWindow(v: View) {
-                    animator.cancelAnimation()
-                    v.removeOnAttachStateChangeListener(this)
-                }
-            },
-        )
-
         applyWindowChrome(widgetView, isBottom)
 
         if (!startEnterAnimation(widgetView, isBottom)) {
@@ -713,6 +691,10 @@ class RealNativeInputManager @Inject constructor(
     private fun onEnterComplete(widgetView: View) {
         layoutCoordinator.enableContentLayoutTransition()
         if (omnibarController.isDuckAiMode()) return
+        // Skip the IME-raising work if the widget has been detached before the animation
+        // finished (e.g. fragment-manager transient detach during a tab switch). Otherwise
+        // focusInput would raise the keyboard on whatever tab is now in front.
+        if (!widgetView.isAttachedToWindow) return
         omnibarController.hide()
         widgetFrom(widgetView)?.apply {
             focusInput(rootView.context as? Activity)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -240,6 +240,7 @@ import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteDefaultSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
@@ -605,6 +606,7 @@ class BrowserTabViewModelTest {
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
     private val voiceSessionEndTriggerFlow = MutableSharedFlow<String>(extraBufferCapacity = 8)
+    private val nativeInputUserSettingFlow = MutableStateFlow(false)
     private val mockDuckChat: DuckChat = mock {
         on { observeTriggerVoiceChatSessionEnd() } doReturn voiceSessionEndTriggerFlow
     }
@@ -831,6 +833,7 @@ class BrowserTabViewModelTest {
 
             whenever(mockDuckChat.getDuckChatUrl(any(), any(), any())).thenReturn(duckChatURL)
             whenever(mockDuckChat.isChatHistoryAvailable()).thenReturn(false)
+            whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputUserSettingFlow)
             whenever(mockQueryUrlPredictor.isReady()).thenReturn(true)
             whenever(mockSyncStatusChangedObserver.syncStatusChangedEvents).thenReturn(syncStatusChangedEventsFlow)
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(subscriptionStatusFlow)
@@ -2091,6 +2094,123 @@ class BrowserTabViewModelTest {
             encodedParameters = any(),
             type = any(),
         )
+    }
+
+    @Test
+    fun whenRestoreOmnibarAutocompleteAndCacheEmptyThenReturnsNull() = runTest {
+        // Default state: native input flag is false, cache initial value is empty.
+        assertNull(testee.restoreOmnibarAutocomplete("foo"))
+    }
+
+    @Test
+    fun whenRestoreOmnibarAutocompleteAndQueryDoesNotMatchCacheThenReturnsNull() = runTest {
+        primeOmnibarAutocompleteCacheForQuery()
+        delay(500)
+        // Cache populated for "query"; ask for a different query.
+        assertNull(testee.restoreOmnibarAutocomplete("different"))
+    }
+
+    @Test
+    fun whenRestoreOmnibarAutocompleteAndCacheMatchesThenRestoresAndUpdatesViewState() = runTest {
+        primeOmnibarAutocompleteCacheForQuery()
+        delay(500)
+
+        // Pretend the in-widget query changed the view state so we can prove the restore overwrote it.
+        testee.autoCompleteViewState.value =
+            autoCompleteViewState().copy(
+                searchResults = AutoCompleteResult("widget-query", emptyList()),
+                showSuggestions = true,
+                showFocusedView = true,
+            )
+
+        val result = testee.restoreOmnibarAutocomplete("query")
+
+        assertNotNull(result)
+        assertEquals("query", result!!.query)
+        assertTrue(result.suggestions.isNotEmpty())
+        assertEquals("query", autoCompleteViewState().searchResults.query)
+        assertFalse(autoCompleteViewState().showSuggestions)
+        assertFalse(autoCompleteViewState().showFocusedView)
+    }
+
+    @Test
+    fun whenRestoreOmnibarAutocompleteThenLastAutoCompleteStateUpdatedSoSubsequentGonePixelReflectsRestoredSuggestions() = runTest {
+        primeOmnibarAutocompleteCacheForQuery()
+        delay(500)
+
+        // Overwrite lastAutoCompleteState with empty suggestions (simulating in-widget typing that
+        // produced no results) so we can prove the restore re-populates it.
+        testee.autoCompleteViewState.value =
+            autoCompleteViewState().copy(searchResults = AutoCompleteResult("widget-query", emptyList()))
+        assertNotNull(testee.restoreOmnibarAutocomplete("query"))
+
+        testee.autoCompleteSuggestionsGone()
+
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED)
+        verify(mockPixel).fire(DuckChatPixelName.PRODUCT_TELEMETRY_SURFACE_AUTOCOMPLETE_DISPLAYED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenNativeInputDisabledThenOmnibarAutocompleteCacheStaysEmpty() = runTest {
+        nativeInputUserSettingFlow.value = false
+        doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
+        whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(
+            flowOf(listOf(Bookmark("abc", "query", "https://example.com", lastModified = null))),
+        )
+
+        testee.onOmnibarTextRendered("query")
+        delay(500)
+
+        assertTrue(testee.omnibarAutocompleteCache.value.suggestions.isEmpty())
+    }
+
+    @Test
+    fun whenAutoCompleteSettingDisabledThenOmnibarAutocompleteCacheStaysEmpty() = runTest {
+        nativeInputUserSettingFlow.value = true
+        doReturn(false).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
+
+        testee.onOmnibarTextRendered("query")
+        delay(500)
+
+        assertTrue(testee.omnibarAutocompleteCache.value.suggestions.isEmpty())
+    }
+
+    @Test
+    fun whenOmnibarTextRenderedWithBlankThenOmnibarAutocompleteCacheStaysEmpty() = runTest {
+        nativeInputUserSettingFlow.value = true
+        doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
+
+        testee.onOmnibarTextRendered("   ")
+        delay(500)
+
+        assertTrue(testee.omnibarAutocompleteCache.value.suggestions.isEmpty())
+    }
+
+    /**
+     * Common setup mirroring [wheneverAutoCompleteIsGoneAndSuggestionsIsNotEmptyFireAutocompleteDisplayed]'s
+     * sources so the AutoCompleteApi produces a non-empty result for "query", then triggers the cache pipeline.
+     * Caller still needs to wait for the debounce.
+     */
+    private fun primeOmnibarAutocompleteCacheForQuery() {
+        nativeInputUserSettingFlow.value = true
+        doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
+        whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())
+        whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(
+            flowOf(listOf(Bookmark("abc", "query", "https://example.com", lastModified = null))),
+        )
+        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(
+            flowOf(listOf(Favorite("abc", "query", "https://example.com", position = 1, lastModified = null))),
+        )
+        whenever(mockNavigationHistory.getHistory()).thenReturn(
+            flowOf(listOf(VisitedPage("https://foo.com".toUri(), "query", listOf(LocalDateTime.now())))),
+        )
+        whenever(mockTabRepository.flowTabs).thenReturn(
+            flowOf(listOf(TabEntity(tabId = "1", position = 1, url = "https://example.com", title = "query"))),
+        )
+        whenever(mockAutoCompleteScorer.score("query", "https://foo.com".toUri(), 1, "query")).thenReturn(1)
+        whenever(mockUserStageStore.getUserAppStage()).thenReturn(ESTABLISHED)
+
+        testee.onOmnibarTextRendered("query")
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2191,7 +2191,7 @@ class BrowserTabViewModelTest {
      * sources so the AutoCompleteApi produces a non-empty result for "query", then triggers the cache pipeline.
      * Caller still needs to wait for the debounce.
      */
-    private fun primeOmnibarAutocompleteCacheForQuery() {
+    private suspend fun primeOmnibarAutocompleteCacheForQuery() {
         nativeInputUserSettingFlow.value = true
         doReturn(true).whenever(mockAutoCompleteSettings).autoCompleteSuggestionsEnabled
         whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -51,7 +51,6 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
-import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -97,7 +96,7 @@ interface NativeInputWidget {
     fun hasInputFocus(): Boolean
     fun clearInputFocus()
     fun requestInputFocus()
-    fun beginEnterAnimationPreview()
+    fun beginEnterAnimationPreview(isBottom: Boolean)
     fun endEnterAnimationPreview()
     fun selectAllText()
     fun hideKeyboard()
@@ -184,9 +183,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     @Inject
     lateinit var chatSuggestionsBinder: NativeInputChatSuggestionsBinder
-
-    @Inject
-    lateinit var nativeInputStateProvider: NativeInputStateProvider
 
     private var activeTabId: String? = null
 
@@ -681,13 +677,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
-    override fun beginEnterAnimationPreview() {
+    override fun beginEnterAnimationPreview(isBottom: Boolean) {
         doOnAttach {
             if (inputField.hasFocus()) return@doOnAttach
-            // State observation is async; apply it synchronously so toggle-row visibility etc. are
-            // in their final positions before the enter animation measures the widget.
             if (nativeInputState == null) {
-                activeTabId?.let { nativeInputStateProvider.stateForTab(it).value }?.let(::applyState)
+                applyState(
+                    NativeInputState.zero().copy(
+                        inputPosition = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP,
+                    ),
+                )
             }
             previewEnterFocus = true
             updateBottomRowVisibility()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
@@ -183,6 +184,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     @Inject
     lateinit var chatSuggestionsBinder: NativeInputChatSuggestionsBinder
+
+    @Inject
+    lateinit var nativeInputStateProvider: NativeInputStateProvider
 
     private var activeTabId: String? = null
 
@@ -681,8 +685,17 @@ class NativeInputModeWidget @JvmOverloads constructor(
         doOnAttach {
             if (inputField.hasFocus()) return@doOnAttach
             if (nativeInputState == null) {
+                // Apply the synchronously-readable per-tab state so toggle-row visibility etc.
+                // are in their final positions before the enter animation measures the widget.
+                // Falling back to NativeInputState.zero() defaults toggle visible, which causes
+                // a measure-then-snap jump on tabs whose real state hides the toggle (e.g.
+                // SEARCH_ONLY or DUCK_AI_CONTEXTUAL). Fall back to a position-only seed only
+                // if the state provider hasn't been injected yet.
+                val publishedState = activeTabId
+                    ?.takeIf { ::nativeInputStateProvider.isInitialized }
+                    ?.let { nativeInputStateProvider.stateForTab(it).value }
                 applyState(
-                    NativeInputState.zero().copy(
+                    publishedState ?: NativeInputState.zero().copy(
                         inputPosition = if (isBottom) NativeInputState.InputPosition.BOTTOM else NativeInputState.InputPosition.TOP,
                     ),
                 )


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1214157224317277/task/1214964760144656?focus=true

### Description
Three related fixes around the native-input widget's autocomplete:

1. Avoid spurious "loading from scratch" on widget re-open with same text. showNativeInput dropped the onClearAutocomplete call that emptied searchResults and re-triggered a fetch; restores the suggestions list visibility from the adapter when the cache matches the prefill.

2. Reveal the browser behind the closing widget earlier. hideNtp now runs at the start of hideNativeInput so the webpage is visible during the exit animation, instead of after the 200ms exit + 150ms fade leaves the NTP background filling the screen.

3. Always keep an autocomplete cache for the omnibar's text so in-widget typing never permanently displaces the omnibar's results. Adds an always-on parallel pipeline in BrowserTabViewModel (omnibarAutocompleteCache) fed by onOmnibarTextChanged; the widget restores from it on close (non-navigation) and on open if the cache matches the prefill.

### Steps to test this PR
- enable native input widget
- start a search by typing on the keyboard
- observe autocomplete 
- going back should immediately display the web page.
- lauching the keyboard again should immediately display the autocomplete list.


### UI changes
| Before  | After |
| ------ | ----- |
<img width="280" height="607" alt="before" src="https://github.com/user-attachments/assets/c5b87564-591b-4b28-b20d-44241497a555" />|<img width="280" height="607" alt="after" src="https://github.com/user-attachments/assets/64849d7b-2386-4199-a890-86fd35e61176" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a second autocomplete pipeline and changes native-input open/close timing; behavior is gated on the native-input setting and covered by new ViewModel tests, but autocomplete and tab lifecycle edge cases warrant manual QA.
> 
> **Overview**
> Improves native-input omnibar autocomplete so reopening the keyboard can show prior suggestions without refetching, and closing the widget feels more like returning to the page you were on.
> 
> **Browser tab / ViewModel:** Adds an `omnibarAutocompleteCache` pipeline (debounced, IO-backed) driven by `onOmnibarTextRendered` when omnibar text is rendered—not user typing. It runs only when the native-input setting is on, skips full URLs and Duck Player URIs, and mirrors autocomplete settings. `restoreOmnibarAutocomplete` reapplies cached results into view state; the fragment also refreshes the suggestions adapter when the cache matches.
> 
> **Native input manager:** Wires `restoreOmnibarAutocomplete` on widget close (non-navigation) and before prefill on open; removes `onClearAutocomplete` on open and manually shows the list when cache restore succeeds. Calls `hideNtp()` at the start of hide in browser mode so the exit animation plays over the live page. Guards `onEnterComplete` with `isAttachedToWindow` to avoid raising the IME after detach.
> 
> **Widget enter animation:** `beginEnterAnimationPreview(isBottom)` applies per-tab `NativeInputState` (or a position-only fallback) before measure so toggle/layout does not snap mid-animation.
> 
> **Tests:** Coverage for restore/no-match, cache gating (setting off, autocomplete off, blank query), and telemetry state after restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cffed1957c14c17c5c1885f2eb2b9e944e07a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->