### PR TITLE
Adapt e2e tests for rebranded onboarding

### DIFF
--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -8,26 +8,10 @@ name: "Custom Tabs navigation"
           clearState: true
           stopApp: true
 
-      - assertVisible:
-          text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
-      - tapOn: "let's get started!"
-      - assertVisible:
-          text: "Protections activated!"
-      - tapOn: "choose your browser"
       - runFlow:
-          when:
-            visible: "set as default"
-          commands:
-            - tapOn: "duckduckgo"
-            - tapOn: "set as default"
-      - assertVisible:
-          text: ".*where should I put your address bar?.*"
-      - tapOn: "next"
-      - assertVisible:
-          text: ".*want easy access to private AI chat?.*"
-      - tapOn: "next"
-      - assertVisible:
-          text: ".*Try a search!.*"
+          file: ../shared/pre_onboarding.yaml
+          env:
+            SET_AS_DEFAULT: "true"
       - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "settings"

--- a/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
@@ -10,26 +10,10 @@ tags:
           clearState: true
           stopApp: true
 
-      - assertVisible:
-          text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
-      - tapOn: "let's get started!"
-      - assertVisible:
-          text: "Protections activated!"
-      - tapOn: "choose your browser"
       - runFlow:
-          when:
-            visible: "set as default"
-          commands:
-            - tapOn: "duckduckgo"
-            - tapOn: "set as default"
-      - assertVisible:
-          text: ".*where should I put your address bar?.*"
-      - tapOn: "next"
-      - assertVisible:
-          text: ".*want easy access to private AI chat?.*"
-      - tapOn: "next"
-      - assertVisible:
-          text: ".*Try a search!.*"
+          file: ../shared/pre_onboarding.yaml
+          env:
+            SET_AS_DEFAULT: "true"
       - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "settings"

--- a/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
@@ -11,8 +11,9 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
-- assertVisible: "let's get started!"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+- assertVisible:
+    text: "(let's get started!|Let's do it!)"
 - tapOn: "I've been here before"
 - assertVisible:
     text: "Got it! I'll skip the other tips."
@@ -22,6 +23,6 @@ tags:
     text: "Start Browsing"
 - tapOn: "Show Tutorial"
 - assertVisible:
-    text: "Protections activated!"
+    text: "Protections.activated!"
 - assertVisible:
     text: "Choose Your Browser"

--- a/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
@@ -11,8 +11,9 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
-- assertVisible: "let's get started!"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+- assertVisible:
+    text: "(let's get started!|Let's do it!)"
 - tapOn: "I've been here before"
 - assertVisible:
     text: "Got it! I'll skip the other tips."

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -1,16 +1,31 @@
 appId: com.duckduckgo.mobile.android
 ---
 - assertVisible:
-    text: ".*Ready for a faster browser that protects you and lets you decide when and how to use AI?.*"
-- tapOn: "let's get started!"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+- tapOn:
+    text: "(let's get started!|Let's do it!)"
 - assertVisible:
-    text: "Protections activated!"
+    text: "Protections.activated!"
 - scrollUntilVisible:
     element:
       text: "choose your browser"
     direction: DOWN
 - tapOn: "choose your browser"
-- tapOn: "cancel"
+- runFlow:
+    when:
+      true: ${SET_AS_DEFAULT == 'true'}
+    commands:
+      - runFlow:
+          when:
+            visible: "set as default"
+          commands:
+            - tapOn: "duckduckgo"
+            - tapOn: "set as default"
+- runFlow:
+    when:
+      true: ${SET_AS_DEFAULT != 'true'}
+    commands:
+      - tapOn: "cancel"
 - assertVisible:
     text: ".*where should I put your address bar?.*"
 - tapOn: "next"

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -57,10 +57,7 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun initializePages() {
         val isBrandDesignUpdateEnabled = withContext(dispatchers.io()) {
-            // Temporary: force legacy onboarding on CI builds so existing Maestro flows keep passing.
-            // Remove once E2E tests cover the brand-design onboarding pages.
-            !appBuildConfig.isDefaultVariantForced &&
-                onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
+            onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
         }
         if (isBrandDesignUpdateEnabled) {
             pageLayoutManager.buildBrandDesignUpdatePageBlueprints()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1214638075402259

### Description

Adapts the Maestro onboarding flows so they pass against both the original copy and the rebranded onboarding (`OnboardingBrandDesignUpdate`), which can be toggled on or off via remote feature flag.

- Made `pre_onboarding.yaml` FF-tolerant: regex alternation for the first dialog title (`Ready for a faster browser that protects you...` / `...puts you in control`) and primary CTA (`let's get started!` / `Let's do it!`).
- Handled non-breaking spaces inserted by `preventWidows()` on the rebranded `Protections activated!` title via a regex wildcard.
- Added a `SET_AS_DEFAULT` env param so the shared flow can branch between tapping `cancel` and walking through the system default-browser picker.
- Refactored `custom_tabs/custom_tabs_navigation.yaml` and `custom_tabs/custom_tabs_navigation_new_tab.yaml` to delegate to the shared flow instead of duplicating ~20 lines of pre-onboarding steps.
- Applied the same FF-tolerant updates to `preonboarding/preonboarding_returning_user_show_tutorial.yaml` and `preonboarding/preonboarding_returning_user_start_browsing.yaml`.

### Steps to test this PR

QA optional.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates core onboarding initialization gating and broadens E2E test matching/branching logic, which could affect which onboarding flow runs and test stability across variants.
> 
> **Overview**
> Removes the CI-only override in `OnboardingViewModel.initializePages`, so page initialization now depends solely on the `OnboardingBrandDesignUpdate` remote toggle.
> 
> Refactors Maestro E2E onboarding steps into a shared `pre_onboarding.yaml` flow, updates assertions to match both legacy and rebranded strings (including regex handling of spacing changes), and adds a `SET_AS_DEFAULT` env-controlled branch to either complete the system default-browser picker or tap cancel; custom tabs and returning-user preonboarding flows are updated to call this shared flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b1025fccee03c5cbb529e372eb8c32429ea8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->