### PR TITLE
show wing on in-context fire CTA

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -970,14 +970,16 @@ sealed class OnboardingDaxDialogCta(
                     wing.isVisible = true
                 }
                 showsWing && wing.isVisible -> {
-                    // Persist across same-wing content transitions: leave at resting state, no replay.
-                    // Abort any in-flight exit from a prior non-wing CTA — its end-listener would otherwise hide the wing.
-                    if (wing.isAnimating && wing.progress >= WING_STOP_PROGRESS) {
+                    // Persist across same-wing transitions: snap to resting and clear any in-flight
+                    // animator. Covers a settled wing from the previous wing CTA (no visible change),
+                    // an in-flight exit from a non-wing predecessor (whose end-listener would otherwise
+                    // hide the wing), and an in-flight play-in we don't want to restart.
+                    if (wing.isAnimating) {
                         wing.removeAllAnimatorListeners()
                         wing.cancelAnimation()
-                        wing.setMinAndMaxProgress(0f, WING_STOP_PROGRESS)
-                        wing.progress = WING_STOP_PROGRESS
                     }
+                    wing.setMinAndMaxProgress(0f, WING_STOP_PROGRESS)
+                    wing.progress = WING_STOP_PROGRESS
                 }
                 !showsWing && wing.isVisible -> {
                     wing.setMinAndMaxProgress(WING_STOP_PROGRESS, 1f)
@@ -1001,12 +1003,19 @@ sealed class OnboardingDaxDialogCta(
                 stripWingForPhoneLandscape(wing)
                 return
             }
-            if (!wing.isVisible || wing.isAnimating || wing.progress >= WING_STOP_PROGRESS) return
+            // Frame-based comparison instead of `progress >= WING_STOP_PROGRESS`: Lottie's
+            // [LottieDrawable.setMaxFrame] adds a fixed `+0.99f` offset after truncating the
+            // requested max frame to int, so `setMinAndMaxProgress(0f, 0.5f)` on a composition
+            // whose `endFrame` isn't an even integer (the wing's is `89.99`) leaves the animator
+            // max at `44.99` — read back as `progress ≈ 0.4999`, never quite `>= 0.5`. The int
+            // truncation of `wing.maxFrame` and `wing.frame` cancels that offset out.
+            val stopFrame = wing.maxFrame.toInt()
+            if (!wing.isVisible || wing.isAnimating || wing.frame >= stopFrame) return
             val generation = wingPlayInGeneration
             wing.postDelayed(
                 {
                     if (wingPlayInGeneration != generation) return@postDelayed
-                    if (wing.isVisible && !wing.isAnimating && wing.progress < WING_STOP_PROGRESS) {
+                    if (wing.isVisible && !wing.isAnimating && wing.frame < stopFrame) {
                         wing.playAnimation()
                     }
                 },

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCta.kt
@@ -46,7 +46,8 @@ data class DaxFireButtonBrandDesignUpdateContextualCta(
     isLightTheme = isLightTheme,
     deviceInfo = deviceInfo,
     backgroundRes = R.drawable.bg_onboarding_fire_button,
-) {
+),
+    OnboardingDaxDialogCta.ShowsWingBottom {
     override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override val showArrow: Boolean = true

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignContextualDaxDialogCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignContextualDaxDialogCtaTest.kt
@@ -349,7 +349,7 @@ class BrandDesignContextualDaxDialogCtaTest {
     }
 
     @Test
-    fun applyWingBottomState_wingMidPlayInWhenWingCtaArrives_doesNotInterrupt() {
+    fun applyWingBottomState_wingMidPlayInWhenWingCtaArrives_snapsToResting() {
         configureContainerForPhonePortrait()
         val wing: LottieAnimationView = mock()
         whenever(container.findViewById<LottieAnimationView>(R.id.wingBottom)).thenReturn(wing)
@@ -361,8 +361,29 @@ class BrandDesignContextualDaxDialogCtaTest {
 
         cta.invokeApplyWingBottomState()
 
+        verify(wing).removeAllAnimatorListeners()
+        verify(wing).cancelAnimation()
+        verify(wing).setMinAndMaxProgress(0f, 0.5f)
+        verify(wing).progress = 0.5f
+    }
+
+    @Test
+    fun applyWingBottomState_wingAtRestingWhenWingCtaArrives_snapsToRestingAndDoesNotCancel() {
+        configureContainerForPhonePortrait()
+        val wing: LottieAnimationView = mock()
+        whenever(container.findViewById<LottieAnimationView>(R.id.wingBottom)).thenReturn(wing)
+        stubWingLayoutParams(wing)
+        whenever(wing.visibility).thenReturn(View.VISIBLE)
+        whenever(wing.isAnimating).thenReturn(false)
+        whenever(wing.progress).thenReturn(0.5f)
+        val cta = WingAndArrowContextualCta(onboardingStore, appInstallStore, mockDeviceInfo)
+
+        cta.invokeApplyWingBottomState()
+
         verify(wing, never()).removeAllAnimatorListeners()
         verify(wing, never()).cancelAnimation()
+        verify(wing).setMinAndMaxProgress(0f, 0.5f)
+        verify(wing).progress = 0.5f
     }
 
     @Test
@@ -370,8 +391,11 @@ class BrandDesignContextualDaxDialogCtaTest {
         configureContainerForPhonePortrait()
         val wing: LottieAnimationView = mock()
         whenever(container.findViewById<LottieAnimationView>(R.id.wingBottom)).thenReturn(wing)
+        whenever(wing.visibility).thenReturn(View.VISIBLE)
         whenever(wing.isAnimating).thenReturn(false)
-        whenever(wing.progress).thenReturn(0f)
+        // Mid-play-in: wing has reached frame 10 of a 45-frame stop window.
+        whenever(wing.frame).thenReturn(10)
+        whenever(wing.maxFrame).thenReturn(45f)
 
         val ctaA = WingAndArrowContextualCta(onboardingStore, appInstallStore, mockDeviceInfo)
         ctaA.invokeStartWingBottomPlayIn()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215047349987939

### Description
Adds Dax wing animation to Fire CTA.

### Steps to test this PR
- [x] Apply this patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index aebae533d6..df1920652e 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -27,16 +27,16 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface OnboardingBrandDesignUpdateToggles {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun brandDesignUpdate(): Toggle
 
     /**
      * Gates the new fire animation work: new Inferno default in Data Clearing
      * settings + bottom-sheet Lottie swap.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun fireAnimationUpdate(): Toggle
 }
```
- [x] Clean install the app.
- [x] Go through onboarding until you reach the Fire CTA.
- [x] Verify that:
  - [x] Dax wing is visible.
  - [x] It didn't re-animate when transitioning from the previous CTA.
  - [x] When orientation changes to landscape, the wing is gone.
  - [x] When orientation changes back to portrait, the wing appears without any transition.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/bc2458a6-dd11-4ead-8089-a246bea851b0" />|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/17198cc7-5c33-4aa8-baff-a8ca6fa29ccb" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CTA animation state management and relies on Lottie frame/progress behavior, which can be device/composition dependent and affect visual stability across CTA transitions/orientation changes.
> 
> **Overview**
> Shows the Dax wing on the brand-design contextual Fire CTA by marking `DaxFireButtonBrandDesignUpdateContextualCta` as `ShowsWingBottom`.
> 
> Refines wing persistence logic during CTA transitions: when a wing CTA arrives and the wing is already visible, it now always snaps to the resting state and cancels any in-flight animator to prevent unwanted replays or being hidden by previous end-listeners.
> 
> Fixes wing play-in gating by switching from `progress` comparisons to frame-based checks (`wing.frame`/`maxFrame`) to avoid precision/rounding edge cases in Lottie that could prevent the play-in from triggering. Updates unit tests to cover these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7c486daa9800b8031690967074a1f769835072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->