### PR TITLE
resize and reposition waving Dax on NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1535,23 +1535,33 @@ sealed class DaxBubbleCta(
 
     interface ShowsWavingDax {
         val restartWavingDax: Boolean get() = false
+        val wavingDaxSpec: WavingDaxSpec
+
         fun configureWavingDax(dax: LottieAnimationView, deviceInfo: DeviceInfo) {
+            val spec = wavingDaxSpec
             val density = dax.resources.displayMetrics.density
-            dax.rotation = 0f
-            dax.translationX = DEFAULT_WAVING_DAX_TRANSLATION_X_DP * density
-            dax.translationY = DEFAULT_WAVING_DAX_TRANSLATION_Y_DP * density
+            dax.rotation = spec.rotationDegrees
+            dax.translationX = spec.translationXDp * density
+            dax.translationY = spec.translationYDp * density
             (dax.layoutParams as? ConstraintLayout.LayoutParams)?.let { lp ->
-                lp.startToStart =
-                    if (deviceInfo.isTablet()) R.id.brandDesignCardView else ConstraintLayout.LayoutParams.PARENT_ID
+                lp.startToStart = if (spec.anchorToCardOnTablet && deviceInfo.isTablet()) {
+                    R.id.brandDesignCardView
+                } else {
+                    ConstraintLayout.LayoutParams.PARENT_ID
+                }
+                lp.height = (spec.heightDp * density).toInt()
                 dax.layoutParams = lp
             }
         }
-
-        companion object {
-            private const val DEFAULT_WAVING_DAX_TRANSLATION_X_DP = -54f
-            private const val DEFAULT_WAVING_DAX_TRANSLATION_Y_DP = -110f
-        }
     }
+
+    data class WavingDaxSpec(
+        val rotationDegrees: Float,
+        val translationXDp: Float,
+        val translationYDp: Float,
+        val heightDp: Float,
+        val anchorToCardOnTablet: Boolean,
+    )
 
     abstract class BrandDesignUpdateBubbleCta(
         ctaId: CtaId,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.cta.ui
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.WavingDaxSpec
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
@@ -47,6 +48,13 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     DaxBubbleCta.ShowsWavingDax {
     override val activeIncludeId: Int = R.id.primaryCta
     override val showArrow: Boolean = true
+    override val wavingDaxSpec = WavingDaxSpec(
+        rotationDegrees = 0f,
+        translationXDp = -40f,
+        translationYDp = -150f,
+        heightDp = 178f,
+        anchorToCardOnTablet = true,
+    )
 
     override fun configureContentViews(view: View) {
         view.findViewById<MaterialButton>(R.id.primaryCta)?.setText(R.string.onboardingEndDaxDialogButton)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -20,11 +20,10 @@ import android.view.Gravity
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
-import com.airbnb.lottie.LottieAnimationView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.WavingDaxSpec
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
@@ -56,6 +55,14 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     override val showArrow: Boolean = true
     override val restartWavingDax: Boolean = true
 
+    override val wavingDaxSpec = WavingDaxSpec(
+        rotationDegrees = 22.62f,
+        translationXDp = -114f,
+        translationYDp = -288f,
+        heightDp = 267f,
+        anchorToCardOnTablet = false,
+    )
+
     override fun configureContentViews(view: View) {
         view.findViewById<ImageView>(R.id.brandDesignHeaderImage)?.isVisible = true
 
@@ -71,22 +78,5 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
         view.findViewById<TextView>(R.id.brandDesignDescription)?.gravity = Gravity.CENTER
 
         view.findViewById<MaterialButton>(R.id.primaryCta)?.setText(buttonTextRes)
-    }
-
-    override fun configureWavingDax(dax: LottieAnimationView, deviceInfo: DeviceInfo) {
-        val density = dax.resources.displayMetrics.density
-        dax.rotation = SUBSCRIPTION_DAX_ROTATION_DEGREES
-        dax.translationX = SUBSCRIPTION_DAX_TRANSLATION_X_DP * density
-        dax.translationY = SUBSCRIPTION_DAX_TRANSLATION_Y_DP * density
-        (dax.layoutParams as? ConstraintLayout.LayoutParams)?.let { lp ->
-            lp.startToStart = ConstraintLayout.LayoutParams.PARENT_ID
-            dax.layoutParams = lp
-        }
-    }
-
-    private companion object {
-        private const val SUBSCRIPTION_DAX_ROTATION_DEGREES = 22.62f
-        private const val SUBSCRIPTION_DAX_TRANSLATION_X_DP = -76f
-        private const val SUBSCRIPTION_DAX_TRANSLATION_Y_DP = -192f
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.cta.ui
 
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.ui.DaxBubbleCta.WavingDaxSpec
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -41,4 +42,13 @@ data class DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
     deviceInfo = deviceInfo,
     showArrow = true,
 ),
-    DaxBubbleCta.ShowsWavingDax
+    DaxBubbleCta.ShowsWavingDax {
+
+    override val wavingDaxSpec = WavingDaxSpec(
+        rotationDegrees = 0f,
+        translationXDp = -54f,
+        translationYDp = -110f,
+        heightDp = 178f,
+        anchorToCardOnTablet = true,
+    )
+}

--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog_brand_design_update.xml
@@ -136,8 +136,6 @@
         android:layout_width="wrap_content"
         android:layout_height="178dp"
         android:adjustViewBounds="true"
-        android:translationX="-54dp"
-        android:translationY="-110dp"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="parent"

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -152,6 +152,22 @@ class BrandDesignUpdateBubbleCtaTest {
     }
 
     @Test
+    fun visitSiteConfigureWavingDax_resetsRotationToZero() {
+        val dax: LottieAnimationView = mock()
+        stubDaxForFormFactor(dax, FormFactor.PHONE)
+        val cta = DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
+            onboardingStore = onboardingStore,
+            appInstallStore = appInstallStore,
+            isLightTheme = true,
+            deviceInfo = mockDeviceInfo,
+        )
+
+        cta.configureWavingDax(dax, mockDeviceInfo)
+
+        verify(dax).rotation = 0f
+    }
+
+    @Test
     fun subscriptionConfigureWavingDax_phone_anchorsStartToParent() {
         val dax: LottieAnimationView = mock()
         val lp = stubDaxForFormFactor(dax, FormFactor.PHONE)
@@ -219,6 +235,13 @@ class BrandDesignUpdateBubbleCtaTest {
         DaxBubbleCta.ShowsWavingDax {
         override val activeIncludeId: Int = R.id.primaryCta
         override val showArrow: Boolean = false
+        override val wavingDaxSpec = DaxBubbleCta.WavingDaxSpec(
+            rotationDegrees = 0f,
+            translationXDp = -40f,
+            translationYDp = -150f,
+            heightDp = 178f,
+            anchorToCardOnTablet = true,
+        )
 
         override fun configureContentViews(view: View) {}
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1215060119809247?focus=true

### Description
Sets different sizes/offsets for waving Dax CTAs on NTP.

### Steps to test this PR

- [x] Apply this diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index d23642060b..aed162eba1 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -113,7 +113,7 @@ class CtaViewModel @Inject constructor(
             }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
```

- [x] Clean install the app.
- [x] Go through linear onboarding.
- [x] Once you reach try-a-search context dialog
- [x] Go to tab switcher and re-open NTP.
- [x] Verify that try-a-site dialog is visible and waving Dax is in the bottom left corner.
  - [x] On a tablet - verify that dax is aligned with the left edge of the dialog.
- [x] Close the dialog.
- [x] Go to tab switcher and re-open NTP.
- [x] Verify that high-five dialog is visible and waving Dax is in the bottom left corner, larger than previously.
  - [x] On a tablet - verify that dax is aligned with the left edge of the dialog.
- [x] Click the primary button.
- [x] Verify that subscription dialog is visible and waving Dax is peeking from the left edge, even larger than previously.

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/b65a1957-de8c-42aa-ac80-fa5d8c403669" />|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/696acb39-d7f7-40b9-af53-0b9b0b83435c" />|
|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/226f4919-8794-41c8-952f-5b77a0c88fe3" />|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/3a3c3f02-9e5f-4b59-a38c-8e66bd546f87" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust Lottie positioning/sizing for onboarding CTAs; primary risk is visual regressions across phone/tablet form factors.
> 
> **Overview**
> Standardizes waving Dax configuration for brand-design bubble CTAs by introducing a `WavingDaxSpec` (rotation, x/y offsets, height, and tablet anchoring) and updating `configureWavingDax` to apply those values.
> 
> Updates the visit-site, end, and subscription brand-design CTAs to supply their own specs (including a larger/offset subscription Dax) and removes hardcoded translation values from the shared layout XML. Adds/updates unit tests to cover rotation reset and tablet/parent anchoring behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50af91d970c13f7daee87f6d9f2d9eb94ac3670b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->