### PR TITLE
Per-chat reasoning effort in contextual sheet

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.json.JSONArray
@@ -43,6 +44,7 @@ interface ContextualNativeInputManager {
         widget: NativeInputModeWidget,
         jsMessaging: JsMessaging,
         lifecycleOwner: LifecycleOwner,
+        chatIdFlow: Flow<String?>,
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit = {},
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit = { _, _ -> },
@@ -68,6 +70,7 @@ class RealContextualNativeInputManager @Inject constructor(
         widget: NativeInputModeWidget,
         jsMessaging: JsMessaging,
         lifecycleOwner: LifecycleOwner,
+        chatIdFlow: Flow<String?>,
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
@@ -77,7 +80,7 @@ class RealContextualNativeInputManager @Inject constructor(
         this.widget = widget
 
         applyCardShape(card)
-        setupWidget(tabId, widget, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
+        setupWidget(tabId, widget, chatIdFlow, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
         observeNativeInputSetting(lifecycleOwner)
     }
 
@@ -113,11 +116,13 @@ class RealContextualNativeInputManager @Inject constructor(
     private fun setupWidget(
         tabId: String,
         widget: NativeInputModeWidget,
+        chatIdFlow: Flow<String?>,
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
     ) {
         widget.configureContextual(tabId)
+        widget.bindChatIdSource(chatIdFlow)
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.bindAttachmentCallbacks(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -433,6 +433,7 @@ class DuckChatContextualFragment :
             widget = binding.contextualNativeInputWidget,
             jsMessaging = contentScopeScripts,
             lifecycleOwner = viewLifecycleOwner,
+            chatIdFlow = viewModel.chatId,
             onSearchSubmitted = { query ->
                 viewModel.onContextualClose()
                 startActivity(browserNav.openInNewTab(requireContext(), query))

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -80,6 +80,11 @@ class DuckChatContextualViewModel @Inject constructor(
     var updatedPageContext: String = ""
     var sheetTabId: String = ""
 
+    // Chat id currently shown in the contextual webview, derived from the URL query param.
+    // Null when in INPUT mode (composing a new chat) or when the URL has no chatID yet.
+    private val _chatId = MutableStateFlow<String?>(null)
+    val chatId: StateFlow<String?> = _chatId.asStateFlow()
+
     @VisibleForTesting
     internal var isPageContextRequested: Boolean = false
 
@@ -172,6 +177,7 @@ class DuckChatContextualViewModel @Inject constructor(
         if (existingChatUrl == null) {
             val urlToLoad = duckChat.getDuckChatUrl("", false, sidebar = true)
             withContext(dispatchers.main()) {
+                setSheetUrl(urlToLoad)
                 commandChannel.trySend(Command.LoadUrl(urlToLoad))
                 _viewState.update { state ->
                     state.copy(
@@ -182,6 +188,7 @@ class DuckChatContextualViewModel @Inject constructor(
             }
         } else {
             withContext(dispatchers.main()) {
+                setSheetUrl(existingChatUrl)
                 _viewState.update { state ->
                     state.copy(
                         sheetMode = SheetMode.WEBVIEW,
@@ -233,6 +240,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 val hasChatHistory = hasChatId(existingChatUrl)
 
                 withContext(dispatchers.main()) {
+                    setSheetUrl(existingChatUrl)
                     _viewState.update { current ->
                         current.copy(
                             sheetMode = SheetMode.WEBVIEW,
@@ -277,9 +285,9 @@ class DuckChatContextualViewModel @Inject constructor(
         if (url == null) {
             return
         } else {
-            fullModeUrl = url
             val sheetMode = _viewState.value.sheetMode
             if (sheetMode == SheetMode.WEBVIEW) {
+                setSheetUrl(url)
                 val hasChatId = hasChatId(url)
 
                 viewModelScope.launch {
@@ -636,6 +644,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 contextualDataStore.clearTabChatUrl(currentTabId)
 
                 withContext(dispatchers.main()) {
+                    clearSheetUrl()
                     _viewState.update {
                         it.copy(
                             sheetMode = SheetMode.INPUT,
@@ -655,10 +664,20 @@ class DuckChatContextualViewModel @Inject constructor(
         }
     }
 
-    private fun hasChatId(url: String?): Boolean {
-        return url?.toUri()?.getQueryParameter(CHAT_ID_PARAM)
-            .orEmpty()
-            .isNotBlank()
+    private fun hasChatId(url: String?): Boolean = !extractChatId(url).isNullOrBlank()
+
+    private fun extractChatId(url: String?): String? =
+        url?.toUri()?.getQueryParameter(CHAT_ID_PARAM)?.takeIf { it.isNotBlank() }
+
+    // Owns the coupled (fullModeUrl, _chatId) invariant: _chatId is always extractChatId(fullModeUrl).
+    private fun setSheetUrl(url: String) {
+        fullModeUrl = url
+        _chatId.value = extractChatId(url)
+    }
+
+    private fun clearSheetUrl() {
+        fullModeUrl = ""
+        _chatId.value = null
     }
 
     private suspend fun shouldReuseStoredChatUrl(tabId: String): Boolean {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -121,9 +121,10 @@ class ReasoningModePickerViewModel @Inject constructor(
     fun onModeTapped(mode: ReasoningMode, surface: PickerSurface) {
         // Drop taps that race past the picker hiding (loading, mismatch, no accessible rows).
         if (!state.value.visible) return
+        val modelState = modelManager.modelState.value
         val chat = currentChat.value
-        val chatResolution = chat?.let { ReasoningResolver.forChat(it, modelManager.modelState.value) }
-        val available = chatResolution?.available ?: modelManager.modelState.value.availableReasoningModes
+        val chatResolution = chat?.let { ReasoningResolver.forChat(it, modelState) }
+        val available = chatResolution?.available ?: modelState.availableReasoningModes
 
         val match = available.firstOrNull { it.mode == mode }
         if (match == null) {
@@ -138,7 +139,7 @@ class ReasoningModePickerViewModel @Inject constructor(
             }
             return
         }
-        val userTier = modelManager.modelState.value.userTier
+        val userTier = modelState.userTier
         val requiredTier = match.access?.requiredTier ?: run {
             logcat { "Duck.ai reasoning picker: gated mode $mode has no public required tier, ignoring." }
             return

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1202,6 +1202,67 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `chatId starts null`() {
+        assertNull(testee.chatId.value)
+    }
+
+    @Test
+    fun `when sheet opened with stored chat url then chatId set before page load`() = runTest {
+        val tabId = "tab-1"
+        val storedUrl = "https://duck.ai/chat?chatID=abc-123"
+        contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+
+        testee.onSheetOpened(tabId)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("abc-123", testee.chatId.value)
+    }
+
+    @Test
+    fun `onChatPageLoaded in WEBVIEW mode then chatId set from url`() = runTest {
+        val tabId = "tab-1"
+        val storedUrl = "https://duck.ai/chat?chatID=abc-123"
+        contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        testee.onSheetOpened(tabId)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val newUrl = "https://duck.ai/chat?chatID=xyz-789"
+        testee.onChatPageLoaded(newUrl)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("xyz-789", testee.chatId.value)
+    }
+
+    @Test
+    fun `onChatPageLoaded in INPUT mode then chatId not set`() = runTest {
+        val tabId = "tab-1"
+        testee.onSheetOpened(tabId)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(testee.chatId.value)
+
+        val staleUrl = "https://duck.ai/chat?chatID=stale-123"
+        testee.onChatPageLoaded(staleUrl)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(testee.chatId.value)
+    }
+
+    @Test
+    fun `onNewChatRequested clears chatId`() = runTest {
+        val tabId = "tab-1"
+        val storedUrl = "https://duck.ai/chat?chatID=abc-123"
+        contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        testee.onSheetOpened(tabId)
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("abc-123", testee.chatId.value)
+
+        testee.onNewChatRequested()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(testee.chatId.value)
+    }
+
+    @Test
     fun `onNewChatRequested clears stored url for current tab`() = runTest {
         val tabId = "tab-1"
         val url = "https://duck.ai/chat?chatID=123"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -263,7 +263,10 @@ class ReasoningModePickerViewModelTest {
         // Pathological: a "gated" entry whose access list still includes FREE → no upsell route.
         modelState.value = ModelState(
             userTier = UserTier.FREE,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("free", "plus", "pro"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("free", "plus", "pro")),
+            ),
         )
         runCurrent()
 
@@ -280,7 +283,10 @@ class ReasoningModePickerViewModelTest {
         // Only non-public tiers in the access list → requiredTier is null → no upsell route.
         modelState.value = ModelState(
             userTier = UserTier.FREE,
-            availableReasoningModes = listOf(gatedExtended(requires = listOf("internal"))),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("internal")),
+            ),
         )
         runCurrent()
 
@@ -295,7 +301,10 @@ class ReasoningModePickerViewModelTest {
     @Test
     fun whenTappedModeNotInAvailableListThenNoCommandEmittedAndManagerNotCalled() = runTest {
         modelState.value = ModelState(
-            availableReasoningModes = listOf(AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE)),
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
         )
         runCurrent()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215062229903137?focus=true

### Description

Wires the contextual Duck.ai sheet into the per-chat reasoning flow introduced by #8666 and fixes two correctness bugs

+ Minor cleanup in `ReasoningModePickerViewModel`

### Steps to test this PR

_Per-chat scope restored on reopen_
- [ ] Start a chat in the contextual sheet on tab A; pick a non-default model and reasoning effort; submit a prompt.
- [ ] Close the contextual sheet.
- [ ] Open new duck ai on another tab or submit a prompt via the native input field using a new model (global default changes)
- [ ] Reopen the contextual sheet on tab A (within the session window). Verify the picker reflects the reasoning effort, not the global default)
- [ ] Submit another prompt; confirm that the submission carries the chat's modelId and reasoningEffort.
- [ ] Open another tab and start a new chat in the contextual sheet on tab B
- [ ] Switching between tabs properly restore the reasoning effort of the corresponding chat. 

_Globals untouched_
- [ ] After any per-chat submission above, dismiss the sheet and open Duck.ai from the address bar (or a fresh tab). Verify your global defaults are unchanged.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes contextual sheet state management and URL/chat-id tracking, which can affect session restore behavior and what model/reasoning settings get applied to submissions.
> 
> **Overview**
> Wires the contextual Duck.ai sheet to a **per-chat** identifier by extracting `chatID` from the webview URL and exposing it as a `StateFlow` on `DuckChatContextualViewModel`.
> 
> The contextual native input widget now receives this `chatIdFlow` (via `ContextualNativeInputManager.init`) and binds it into the native-input state, enabling chat-scoped reasoning/model selection to follow the active chat across sheet reopen/tab switches. The view model centralizes URL/chat-id updates via `setSheetUrl`/`clearSheetUrl` and adds tests to ensure `chatId` is set/cleared correctly; `ReasoningModePickerViewModel` is lightly refactored to use a single snapshot of `modelState`, with tests adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666691bf3290412dadcfc15fb1d8368f61e2c433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->