### PR TITLE
Add hatch menu pixels for return/close/burn/inactivity taps

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -261,14 +261,14 @@
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_ntp_after_escape_hatch_after_inactivity_tapped": {
+    "m_ntp_after_idle_escape_hatch_after_inactivity_tapped": {
         "description": "User tapped After inactivity from the new tab return hatch menu",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_ntp_after_escape_hatch_after_inactivity_tapped_daily": {
+    "m_ntp_after_idle_escape_hatch_after_inactivity_tapped_daily": {
         "description": "(Daily Pixel) User tapped After inactivity from the new tab return hatch menu",
         "owners": ["malmstein"],
         "triggers": ["other"],

--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -216,5 +216,63 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+
+    // Escape hatch menu action pixels
+    "m_ntp_after_idle_escape_hatch_return_tapped": {
+        "description": "User tapped Return to tab from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_return_tapped_daily": {
+        "description": "(Daily Pixel) User tapped Return to tab from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_close_tab_tapped": {
+        "description": "User tapped Close tab from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_close_tab_tapped_daily": {
+        "description": "(Daily Pixel) User tapped Close tab from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped": {
+        "description": "User tapped Burn tab from the new tab return hatch menu (the confirmation FireDialog is shown next)",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped_daily": {
+        "description": "(Daily Pixel) User tapped Burn tab from the new tab return hatch menu (the confirmation FireDialog is shown next)",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_escape_hatch_after_inactivity_tapped": {
+        "description": "User tapped After inactivity from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_escape_hatch_after_inactivity_tapped_daily": {
+        "description": "(Daily Pixel) User tapped After inactivity from the new tab return hatch menu",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/browser/browser-ui/build.gradle
+++ b/browser/browser-ui/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation project(':navigation-api')
     implementation project(':duckchat-api')
     implementation project(':new-tab-page-api')
+    implementation project(':statistics-api')
     implementation project(':design-system')
     implementation "androidx.datastore:datastore-preferences:_"
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.ui.newtab.hatch
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class NewTabReturnHatchPixelName(override val pixelName: String) : Pixel.PixelName {
+    OPTION_SELECTED_BURN_TAB("m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped"),
+    OPTION_SELECTED_BURN_TAB_DAILY("m_ntp_after_idle_escape_hatch_burn_with_confirmation_tapped_daily"),
+    OPTION_SELECTED_CLOSE_TAB("m_ntp_after_idle_escape_hatch_close_tab_tapped"),
+    OPTION_SELECTED_CLOSE_TAB_DAILY("m_ntp_after_idle_escape_hatch_close_tab_tapped_daily"),
+    OPTION_SELECTED_RETURN_TAB("m_ntp_after_idle_escape_hatch_return_tapped"),
+    OPTION_SELECTED_RETURN_TAB_DAILY("m_ntp_after_idle_escape_hatch_return_tapped_daily"),
+    OPTION_SELECTED_AFTER_INACTIVITY("m_ntp_after_escape_hatch_after_inactivity_tapped"),
+    OPTION_SELECTED_AFTER_INACTIVITY_DAILY("m_ntp_after_escape_hatch_after_inactivity_tapped_daily"),
+}

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
@@ -25,6 +25,6 @@ enum class NewTabReturnHatchPixelName(override val pixelName: String) : Pixel.Pi
     OPTION_SELECTED_CLOSE_TAB_DAILY("m_ntp_after_idle_escape_hatch_close_tab_tapped_daily"),
     OPTION_SELECTED_RETURN_TAB("m_ntp_after_idle_escape_hatch_return_tapped"),
     OPTION_SELECTED_RETURN_TAB_DAILY("m_ntp_after_idle_escape_hatch_return_tapped_daily"),
-    OPTION_SELECTED_AFTER_INACTIVITY("m_ntp_after_escape_hatch_after_inactivity_tapped"),
-    OPTION_SELECTED_AFTER_INACTIVITY_DAILY("m_ntp_after_escape_hatch_after_inactivity_tapped_daily"),
+    OPTION_SELECTED_AFTER_INACTIVITY("m_ntp_after_idle_escape_hatch_after_inactivity_tapped"),
+    OPTION_SELECTED_AFTER_INACTIVITY_DAILY("m_ntp_after_idle_escape_hatch_after_inactivity_tapped_daily"),
 }

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelParamRemovalPlugin.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelParamRemovalPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.ui.newtab.hatch
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class NewTabReturnHatchPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return NewTabReturnHatchPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
+    }
+}

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -159,6 +159,7 @@ class NewTabReturnHatchView @JvmOverloads constructor(
 
     private fun initPopupMenu() {
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuReturnToTab)) {
+            viewModel.onHatchPressed()
             hatchHatchListener?.onHatchPressed()
         }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuCloseTab)) {
@@ -169,6 +170,7 @@ class NewTabReturnHatchView @JvmOverloads constructor(
             hatchHatchListener?.onBurnTabPressed()
         }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuAfterInactivity)) {
+            viewModel.onAfterInactivityPressed()
             hatchHatchListener?.onAfterInactivityPressed()
         }
     }

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -23,6 +23,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
@@ -51,6 +54,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
     private val duckChat: DuckChat,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val pixel: Pixel,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -128,12 +132,13 @@ class NewTabReturnHatchViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ViewState())
 
     fun onHatchPressed() {
-        viewModelScope.launch(dispatchers.io()) {
-            tabRepository.select(viewState.value.currentTabId)
-        }
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB, type = Count)
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB_DAILY, type = Daily())
     }
 
     fun closeTab() {
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
         val tabId = viewState.value.currentTabId
         if (tabId.isEmpty()) return
         pendingClose.value = true
@@ -141,6 +146,8 @@ class NewTabReturnHatchViewModel @Inject constructor(
     }
 
     fun onBurnTabPressed() {
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB, type = Count)
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB_DAILY, type = Daily())
         burnTargetTabId.value = viewState.value.currentTabId.takeIf { it.isNotEmpty() }
     }
 
@@ -158,5 +165,10 @@ class NewTabReturnHatchViewModel @Inject constructor(
 
     fun onTabManagerPressed() {
         commandChannel.trySend(Command.LaunchTabSwitcher)
+    }
+
+    fun onAfterInactivityPressed() {
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY, type = Count)
+        pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY_DAILY, type = Daily())
     }
 }

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -20,6 +20,9 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -50,6 +53,7 @@ class NewTabReturnHatchViewModelTest {
     private val mockDuckChat: DuckChat = mock()
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val mockPixel: Pixel = mock()
     private val lastAccessedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
     private val afterIdleReturnFlow = MutableStateFlow(true)
@@ -70,6 +74,7 @@ class NewTabReturnHatchViewModelTest {
             duckChat = mockDuckChat,
             duckDuckGoUrlDetector = mockDuckDuckGoUrlDetector,
             ntpAfterIdleManager = mockNtpAfterIdleManager,
+            pixel = mockPixel,
         )
     }
 
@@ -116,31 +121,11 @@ class NewTabReturnHatchViewModelTest {
     }
 
     @Test
-    fun whenOnHatchPressedThenSelectsCurrentTab() = runTest {
-        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            awaitItem() // wait for state to settle
-        }
-
+    fun whenOnHatchPressedThenFiresReturnTabCountAndDailyPixels() = runTest {
         testee.onHatchPressed()
 
-        verify(mockTabRepository).select("tab1")
-    }
-
-    @Test
-    fun whenOnHatchPressedWithNoTabThenSelectsEmptyTabId() = runTest {
-        lastAccessedTabFlow.emit(null)
-
-        testee.viewState.test {
-            awaitItem()
-        }
-
-        testee.onHatchPressed()
-
-        verify(mockTabRepository).select("")
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB_DAILY, type = Daily())
     }
 
     @Test
@@ -515,5 +500,44 @@ class NewTabReturnHatchViewModelTest {
 
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun whenCloseTabThenFiresCloseTabCountAndDailyPixels() = runTest {
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+        lastAccessedTabFlow.emit(tab)
+
+        testee.viewState.test {
+            awaitItem() // wait for state to settle so currentTabId is populated
+        }
+
+        testee.closeTab()
+
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenCloseTabWithEmptyCurrentTabIdThenStillFiresCloseTabPixels() = runTest {
+        testee.closeTab()
+
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenOnBurnTabPressedThenFiresBurnTabCountAndDailyPixels() = runTest {
+        testee.onBurnTabPressed()
+
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenOnAfterInactivityPressedThenFiresAfterInactivityCountAndDailyPixels() = runTest {
+        testee.onAfterInactivityPressed()
+
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY_DAILY, type = Daily())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215074552678133?focus=true

### Description

Fires count + daily pixels when the user taps any of the four hatch menu options on the new tab return hatch: Return to tab, Close tab, Burn tab, After inactivity.

The pixel names are defined locally in `browser-ui` (`NewTabReturnHatchPixelName`) and fired via `Pixel` from `:statistics-api` directly. This keeps `browser-ui` off the `:new-tab-page-impl` module per the project's architecture rules (only `:app` depends on `-impl` modules). Added `:statistics-api` to `browser-ui`'s dependencies.

### Steps to test this PR

_Hatch menu pixels_
- [x] Trigger the new tab return hatch (after-idle return on NTP).
- [x] Tap each of the four menu options in turn (Return to tab, Close tab, Burn tab, After inactivity).
- [x] Confirm the corresponding `m_ntp_after_idle_escape_hatch_*` count pixels fire on each tap, and the matching `_daily` pixel fires once per day.

### UI changes
| Before  | After |
| ------ | ----- |
| n/a    | n/a   |

No UI changes — pixel instrumentation only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk instrumentation-only change: adds pixel firing and parameter stripping for hatch menu taps, with minimal impact on navigation/close logic aside from removing the old tab-selection side effect from `onHatchPressed`.
> 
> **Overview**
> Adds new `m_ntp_after_idle_escape_hatch_*` pixel definitions and wires **count + daily** pixel firing for the New Tab Return Hatch menu actions (Return to tab, Close tab, Burn tab, After inactivity).
> 
> `browser-ui` now depends on `:statistics-api`, introduces `NewTabReturnHatchPixelName`, and registers a `PixelParamRemovalPlugin` to strip ATB from these pixels; tests were updated/added to verify the new pixel firing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d8f5db0717e89e185cc43f7f6aac3f0701b661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->