### PR TITLE
Fix native input regressions in search-only mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1427,6 +1427,9 @@ class BrowserTabFragment :
                     launchFilePicker(callback, mimeTypes)
                 },
                 restoreOmnibarAutocomplete = { forQuery -> restoreOmnibarAutocomplete(forQuery) },
+                onContextualSheetRequested = {
+                    viewModel.openDuckAIContextualMode()
+                },
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5330,6 +5330,10 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
+    fun openDuckAIContextualMode() {
+        command.value = Command.ShowDuckAIContextualMode(tabId)
+    }
+
     fun onDuckChatOmnibarButtonClicked(
         query: String?,
         hasFocus: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -78,6 +78,7 @@ class NativeInputCallbacks(
      * the caller uses the return value to decide whether to re-show the suggestions list.
      */
     val restoreOmnibarAutocomplete: (forQuery: String) -> Boolean = { _ -> false },
+    val onContextualSheetRequested: () -> Unit = {},
 )
 
 interface NativeInputManager {
@@ -407,7 +408,7 @@ class RealNativeInputManager @Inject constructor(
             onChatSubmitted = { query ->
                 if (queryUrlPredictor.isUrl(query)) {
                     hideNativeInput(isNavigation = true)
-                    callbacks.onSearchSubmitted(query)
+                    callbacks.onContextualSheetRequested()
                 } else if (omnibarController.isDuckAiMode()) {
                     widget.saveLastUsedTogglePosition(isChat = true)
                     val imagesJson = widget.getImageAttachmentsJson()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -406,10 +406,10 @@ class RealNativeInputManager @Inject constructor(
                 callbacks.onSearchSubmitted(query)
             },
             onChatSubmitted = { query ->
-                if (queryUrlPredictor.isUrl(query)) {
-                    hideNativeInput(isNavigation = true)
-                    callbacks.onContextualSheetRequested()
-                } else if (omnibarController.isDuckAiMode()) {
+                if (omnibarController.isDuckAiMode()) {
+                    // In Duck.ai context the user is actively chatting — a pasted URL is a chat
+                    // message, never a contextual-sheet trigger or a navigation. Fall through to
+                    // the standard chat-submit path so the message reaches the Duck.ai webview.
                     widget.saveLastUsedTogglePosition(isChat = true)
                     val imagesJson = widget.getImageAttachmentsJson()
                     val filesJson = widget.getFileAttachmentsJson()
@@ -425,6 +425,9 @@ class RealNativeInputManager @Inject constructor(
                         filesJson,
                     )
                     widget.clearSelectedTool()
+                } else if (queryUrlPredictor.isUrl(query)) {
+                    hideNativeInput(isNavigation = true)
+                    callbacks.onContextualSheetRequested()
                 } else {
                     widget.saveLastUsedTogglePosition(isChat = true)
                     widget.storePendingPrompt(query)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10081,6 +10081,14 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOpenDuckAIContextualModeThenShowDuckAIContextualModeCommandSent() = runTest {
+        testee.openDuckAIContextualMode()
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertTrue(commandCaptor.lastValue is Command.ShowDuckAIContextualMode)
+    }
+
+    @Test
     fun whenOnDuckChatOmnibarButtonClickedAndContextualModeEnabledAndNTPThenContextualNotCalled() = runTest {
         val duckAIUrl = "https://duckduckgo.com/?q=test"
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -52,11 +54,20 @@ interface ContextualNativeInputManager {
 
     fun onWebViewMode()
     fun onInputMode()
+
+    /**
+     * Called when the contextual sheet is closed (e.g. STATE_HIDDEN). Reverts the per-tab
+     * [NativeInputState] back to a browser-context default so other observers (like StartChatView
+     * in the main widget) don't keep reading the DUCK_AI_CONTEXTUAL/DUCK_AI values the contextual
+     * widget wrote during its lifetime.
+     */
+    fun onContextualClosed(tabId: String)
 }
 
 @ContributesBinding(FragmentScope::class)
 class RealContextualNativeInputManager @Inject constructor(
     private val duckChat: DuckChat,
+    private val nativeInputStatePublisher: NativeInputStatePublisher,
 ) : ContextualNativeInputManager {
 
     private var isNativeInputEnabled = false
@@ -82,6 +93,17 @@ class RealContextualNativeInputManager @Inject constructor(
         applyCardShape(card)
         setupWidget(tabId, widget, chatIdFlow, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested)
         observeNativeInputSetting(lifecycleOwner)
+    }
+
+    override fun onContextualClosed(tabId: String) {
+        if (tabId.isBlank()) return
+        val browser = NativeInputState.InputContext.BROWSER
+        nativeInputStatePublisher.update(tabId) {
+            it.copy(
+                inputContext = browser,
+                toggleSelection = NativeInputState.defaultToggleFor(browser),
+            )
+        }
     }
 
     override fun onWebViewMode() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -63,6 +63,7 @@ class DuckChatContextualViewModel @Inject constructor(
     private val duckChatFeature: DuckChatFeature,
     private val featureTogglesInventory: FeatureTogglesInventory,
     private val modelManager: DuckAiModelManager,
+    private val contextualNativeInputManager: ContextualNativeInputManager,
 ) : ViewModel() {
 
     private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
@@ -412,6 +413,7 @@ class DuckChatContextualViewModel @Inject constructor(
         isPageContextRequested = false
         persistTabClosed()
         duckChatPixels.reportContextualSheetDismissed()
+        contextualNativeInputManager.onContextualClosed(sheetTabId)
     }
 
     private fun persistTabClosed() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -454,7 +454,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateBottomRowVisibility() {
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
-        val visible = isChatTabSelected() && (inputField.hasFocus() || previewEnterFocus || isStreaming)
+        val suppress = nativeInputState?.shouldSuppressBottomRow() == true
+        val visible = isChatTabSelected() &&
+            (inputField.hasFocus() || previewEnterFocus || isStreaming) &&
+            !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
     }
 
@@ -1188,3 +1191,12 @@ internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
+
+/**
+ * The bottom row hosts chat-mode tools (attachments, options, reasoning, model picker).
+ * In search-only mode opened from the browser address bar, those tools should never appear —
+ * even if a stale `toggleSelection=DUCK_AI` from a prior interaction makes `isChatTabSelected()` true.
+ */
+internal fun NativeInputState.shouldSuppressBottomRow(): Boolean =
+    inputMode == NativeInputState.InputMode.SEARCH_ONLY &&
+        inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -71,6 +71,7 @@ class DuckChatContextualViewModelTest {
     private val contextualFireButtonToggle: Toggle = mock()
     private val featureTogglesInventory: FeatureTogglesInventory = mock()
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
+    private val contextualNativeInputManager: ContextualNativeInputManager = mock()
     private val singleTabFireDialogToggle: Toggle = mock()
     private val singleTabFireDialogFeatureName: Toggle.FeatureName = Toggle.FeatureName(
         parentName = "androidBrowserConfig",
@@ -107,6 +108,7 @@ class DuckChatContextualViewModelTest {
             duckChatFeature = duckChatFeature,
             featureTogglesInventory = featureTogglesInventory,
             modelManager = modelManager,
+            contextualNativeInputManager = contextualNativeInputManager,
         )
     }
 
@@ -388,6 +390,7 @@ class DuckChatContextualViewModelTest {
                     duckChatFeature = duckChatFeature,
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
+                    contextualNativeInputManager = contextualNativeInputManager,
                 )
 
             val tabId = "tab-1"
@@ -796,6 +799,7 @@ class DuckChatContextualViewModelTest {
                     duckChatFeature = duckChatFeature,
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
+                    contextualNativeInputManager = contextualNativeInputManager,
                 )
 
             val serializedPageData =
@@ -833,6 +837,7 @@ class DuckChatContextualViewModelTest {
                     duckChatFeature = duckChatFeature,
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
+                    contextualNativeInputManager = contextualNativeInputManager,
                 )
 
             val serializedPageData =
@@ -1305,6 +1310,16 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when sheet closed then contextual native input manager is notified with active tabId`() = runTest {
+        val tabId = "tab-1"
+        testee.onSheetOpened(tabId)
+
+        testee.onSheetClosed()
+
+        verify(contextualNativeInputManager).onContextualClosed(tabId)
+    }
+
+    @Test
     fun `reopenSheet in webview mode starts new chat when session expired`() = runTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=123"
@@ -1560,6 +1575,7 @@ class DuckChatContextualViewModelTest {
         duckChatFeature = duckChatFeature,
         featureTogglesInventory = featureTogglesInventory,
         modelManager = modelManager,
+        contextualNativeInputManager = contextualNativeInputManager,
     )
 
     private class FakeDuckChat : com.duckduckgo.duckchat.api.DuckChat {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.contextual
+
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class RealContextualNativeInputManagerTest {
+
+    private val duckChat: DuckChat = mock()
+    private val publisher: NativeInputStatePublisher = mock()
+    private val testee = RealContextualNativeInputManager(duckChat, publisher)
+
+    @Test
+    fun `when onContextualClosed called with blank tabId then publisher is not touched`() {
+        testee.onContextualClosed("")
+
+        verify(publisher, never()).update(any(), any())
+    }
+
+    @Test
+    fun `when onContextualClosed called then publisher resets inputContext to browser`() {
+        val tabId = "tab-1"
+        val previous = NativeInputState(
+            inputMode = NativeInputState.InputMode.SEARCH_ONLY,
+            inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL,
+            toggleSelection = NativeInputState.ToggleSelection.DUCK_AI,
+        )
+
+        testee.onContextualClosed(tabId)
+
+        val captor = argumentCaptor<(NativeInputState) -> NativeInputState>()
+        verify(publisher).update(eq(tabId), captor.capture())
+        val updated = captor.firstValue.invoke(previous)
+
+        assertEquals(NativeInputState.InputContext.BROWSER, updated.inputContext)
+        assertEquals(NativeInputState.ToggleSelection.SEARCH, updated.toggleSelection)
+    }
+
+    @Test
+    fun `when onContextualClosed called then inputMode is preserved`() {
+        val tabId = "tab-1"
+        val previous = NativeInputState(
+            inputMode = NativeInputState.InputMode.SEARCH_ONLY,
+            inputContext = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL,
+            toggleSelection = NativeInputState.ToggleSelection.DUCK_AI,
+        )
+
+        testee.onContextualClosed(tabId)
+
+        val captor = argumentCaptor<(NativeInputState) -> NativeInputState>()
+        verify(publisher).update(eq(tabId), captor.capture())
+        val updated = captor.firstValue.invoke(previous)
+
+        // inputMode is owned by the main widget VM; the reset must leave it alone.
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, updated.inputMode)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowCardRowBack
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowToggleRowBack
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldSuppressBottomRow
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -87,6 +88,34 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `card row back is hidden in duck ai contextual context`() {
         assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowCardRowBack())
         assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowCardRowBack())
+    }
+
+    @Test
+    fun `bottom row is suppressed in search only from browser`() {
+        val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
+
+        assertTrue(state.shouldSuppressBottomRow())
+    }
+
+    @Test
+    fun `bottom row is not suppressed in search only from duck ai`() {
+        val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI)
+
+        assertFalse(state.shouldSuppressBottomRow())
+    }
+
+    @Test
+    fun `bottom row is not suppressed in search and duck ai mode regardless of context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER).shouldSuppressBottomRow())
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI).shouldSuppressBottomRow())
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldSuppressBottomRow())
+    }
+
+    @Test
+    fun `bottom row is not suppressed in search only from duck ai contextual`() {
+        val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL)
+
+        assertFalse(state.shouldSuppressBottomRow())
     }
 
     private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214970032476125?focus=true

### Description

Two regressions reported under "Android: Ship Review Feedback" (AV3, AV4) in the toggle-disabled (search-only) configuration with the native input widget.

**AV3 — Duck.ai icon tap reloads the page.**
On a loaded page (e.g. bbc.com), focusing the address bar opens the native input widget with the page URL pre-filled. Tapping the duck.ai start-chat icon submitted that URL as a navigation, reloading the page. The URL branch of `NativeInputManager.onChatSubmitted` now opens the contextual sheet instead, via a new `onContextualSheetRequested` callback wired to `BrowserTabViewModel.openDuckAIContextualMode()` (sends `Command.ShowDuckAIContextualMode(tabId)`).

**AV4 — Tool buttons visible in search-only mode.**
`NativeInputModeWidget.updateBottomRowVisibility()` only gated on `isChatTabSelected()`, which can remain true in `BROWSER` context if a previous interaction set `toggleSelection=DUCK_AI` (the widget config doesn't reset it on every activation). The chat tools (attach, options, reasoning mode, model picker) were therefore shown despite the AI toggle being off. A new `NativeInputState.shouldSuppressBottomRow()` extension hides the row when `inputMode=SEARCH_ONLY && inputContext=BROWSER`, mirroring the existing `shouldShowToggleRowBack` / `shouldShowCardRowBack` pattern. `DUCK_AI` and `DUCK_AI_CONTEXTUAL` contexts are unchanged.

Unit tests added for both fixes.

### Steps to test this PR

_AV3 — duck.ai icon should not reload the page_
- [x] Internal build, complete onboarding choosing "Search only" (AI toggle off).
- [x] Open a tab and load https://bbc.com.
- [ ] Tap the duck.ai (chevron-down) start-chat icon.
- [ ] Expected: the Duck.ai contextual sheet appears. Page is NOT reloaded.

_AV4 — tool buttons should be hidden in search-only mode from the browser_
- [x] Same config (Search only).
- [ ] If the screenshot scenario can be reached on your build (toggle row hidden but chat tab implicitly selected from a prior session), open the address bar from a regular page.
- [x] Expected: bottom row (paperclip / options / reasoning / model picker / submit container) is NOT visible. Back arrow, input field, and start-chat icon remain.
- [x] On a Duck.ai page (`DUCK_AI` context), bottom row behavior is unchanged.

_Regressions check_
- [x] Switch the AI toggle back on. Confirm the bottom row tools appear normally on the chat tab.
- [x] On a Duck.ai page with toggle off, confirm the existing behavior is unchanged (out of scope for this PR).

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI/input routing and per-tab state reset with unit tests; no auth, security, or data-layer changes.
> 
> **Overview**
> Fixes **search-only** native input regressions: URL-like chat submits from the browser no longer navigate away, chat tool chrome stays hidden when it should, and per-tab state is cleaned up when the contextual sheet closes.
> 
> **Duck.ai / URL submit (AV3):** `NativeInputManager` reorders `onChatSubmitted` so **Duck.ai mode** always treats input as chat (including pasted URLs). Outside Duck.ai, a URL now triggers **`onContextualSheetRequested`** → `openDuckAIContextualMode()` / `ShowDuckAIContextualMode` instead of reloading the page.
> 
> **Bottom row tools (AV4):** `NativeInputModeWidget` uses **`shouldSuppressBottomRow()`** when `SEARCH_ONLY` + `BROWSER` so attach/options/model UI does not show from stale `toggleSelection=DUCK_AI`.
> 
> **Contextual sheet cleanup:** On sheet close, **`ContextualNativeInputManager.onContextualClosed`** resets per-tab `NativeInputState` to browser defaults via `NativeInputStatePublisher` (preserving `inputMode`).
> 
> Unit tests cover the new command, bottom-row suppression, and publisher reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23299d43a0433e46ceed1e526188a5838c27d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->