### PR TITLE
switching between chat and search tabs doesnt glitch logo

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -976,6 +976,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val previousOnChatSelected = this.onChatSelected
         this.onChatSelected = { animate ->
             previousOnChatSelected?.invoke(animate)
+            // Show the chat list adapter synchronously so async chat-history fetch doesn't leave a
+            // gap. On NTP the focusedView never covers the page (browserShowing=false), so the gap
+            // exposes the NTP logo. The list's match_parent overlay background covers it even with
+            // zero items; real chat history populates when the WebView-backed fetch returns.
+            onShowSuggestions(ensureBinding().adapter)
             showSuggestions(text)
         }
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214156122159487?focus=true

### Steps to test this PR
- Make sure you have chat history in duck.ai chats
- Open NTP
- type something in native input widget. 
- keep switching between search/duck.ai tabs.
- no duck.ai logo should be shown breifly while switching

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI timing change in native input chat-tab selection; no security, data, or API impact.
> 
> **Overview**
> Fixes a brief **Duck.ai logo flash** on the New Tab Page when toggling between Search and Duck.ai on the native input widget.
> 
> Selecting the chat tab now **mounts the chat suggestions RecyclerView adapter immediately** (before the async WebView chat-history fetch finishes). That overlay fills the area right away so the NTP logo is not visible in the gap; history still loads when the fetch completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41105ca8a33fd7e28738102773f5a09ce4c5064b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->