### PR TITLE
migrate SYNC_RESTORE onboarding dialog to brand design

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -57,6 +57,9 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SEARCH_ONLY_SELECTED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_SHOWN_UNIQUE
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SPLIT_ADDRESS_BAR_SELECTED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -67,9 +70,13 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboardingWideEvent
+import com.duckduckgo.sync.api.SyncAutoRestore
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -77,6 +84,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import logcat.LogPriority
+import logcat.logcat
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -96,7 +106,21 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val inputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent,
     private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager,
     private val onboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager,
+    private val syncAutoRestore: SyncAutoRestore,
 ) : ViewModel() {
+
+    private val canRestoreDeferred: Deferred<Boolean> = viewModelScope.async(dispatchers.io()) {
+        try {
+            logcat { "Sync-AutoRestore: checking canRestore..." }
+            val result = syncAutoRestore.canRestore()
+            logcat(LogPriority.INFO) { "Sync-AutoRestore: canRestore=$result" }
+            result
+        } catch (t: Throwable) {
+            coroutineContext.ensureActive()
+            logcat(LogPriority.WARN) { "Sync-AutoRestore: canRestore check failed - ${t.message}" }
+            false
+        }
+    }
 
     data class ViewState(
         val hasPlayedIntroAnimation: Boolean = false,
@@ -166,7 +190,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
 
     private fun fireDialogShownPixel(dialogType: PreOnboardingDialogType) {
         when (dialogType) {
-            SYNC_RESTORE -> { } // TODO - SyncRestore: add pixel for dialog shown
+            SYNC_RESTORE -> pixel.fire(PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
             INITIAL_REINSTALL_USER -> pixel.fire(PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE, type = Unique())
             INITIAL -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
             COMPARISON_CHART -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
@@ -191,8 +215,21 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
 
     fun loadDaxDialog() {
         viewModelScope.launch {
+            val canRestore = withTimeoutOrNull(BLOCK_STORE_TIMEOUT_MS) {
+                canRestoreDeferred.await()
+            } ?: false
+
+            // Always call isAppReinstall() — it has side effects (creates DDG downloads directory, persists reinstall state)
             val isReinstall = isAppReinstall()
-            val dialogType = if (isReinstall) INITIAL_REINSTALL_USER else INITIAL
+
+            val dialogType = when {
+                canRestore -> {
+                    logcat(LogPriority.INFO) { "Sync-AutoRestore: first dialog=SYNC_RESTORE" }
+                    SYNC_RESTORE
+                }
+                isReinstall -> INITIAL_REINSTALL_USER
+                else -> INITIAL
+            }
             _viewState.update {
                 it.copy(
                     isReinstallUser = isReinstall,
@@ -208,7 +245,12 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         val currentDialog = _viewState.value.currentDialog ?: return
         when (currentDialog) {
             SYNC_RESTORE -> {
-                // TODO - SyncRestore: handle primary CTA click
+                viewModelScope.launch {
+                    logcat { "Sync-AutoRestore: user accepted restore, calling restoreSyncAccount()" }
+                    pixel.fire(PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE, type = Unique())
+                    syncAutoRestore.restoreSyncAccount()
+                    setCurrentDialog(COMPARISON_CHART)
+                }
             }
 
             INITIAL_REINSTALL_USER, INITIAL -> {
@@ -342,7 +384,15 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                 pixel.fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
             }
 
-            SYNC_RESTORE, INITIAL, COMPARISON_CHART, ADDRESS_BAR_POSITION, INPUT_SCREEN, INPUT_SCREEN_PREVIEW, QUICK_SETUP -> {
+            SYNC_RESTORE -> {
+                viewModelScope.launch {
+                    logcat { "Sync-AutoRestore: user skipped restore" }
+                    pixel.fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
+                    setCurrentDialog(SKIP_ONBOARDING_OPTION)
+                }
+            }
+
+            INITIAL, COMPARISON_CHART, ADDRESS_BAR_POSITION, INPUT_SCREEN, INPUT_SCREEN_PREVIEW, QUICK_SETUP -> {
                 // no-op
             }
         }
@@ -410,15 +460,19 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             appBuildConfig.isAppReinstall()
         }
 
+    private fun skipDialogAnimations() {
+        viewModelScope.launch {
+            _commands.send(Command.SkipDialogAnimation)
+        }
+    }
+
     private suspend fun isSplitOmnibarEnabled(): Boolean =
         withContext(dispatchers.io()) {
             androidBrowserConfigFeature.splitOmnibar().isEnabled() &&
                 androidBrowserConfigFeature.splitOmnibarWelcomePage().isEnabled()
         }
 
-    private fun skipDialogAnimations() {
-        viewModelScope.launch {
-            _commands.send(Command.SkipDialogAnimation)
-        }
+    companion object {
+        private const val BLOCK_STORE_TIMEOUT_MS = 3_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -591,8 +591,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             isAnimating = true
             viewModel.onDialogAnimationStarted()
             when (onboardingDialogType) {
-                INITIAL, INITIAL_REINSTALL_USER -> {
-                    val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER
+                INITIAL, INITIAL_REINSTALL_USER, SYNC_RESTORE -> {
+                    val isSyncRestore = onboardingDialogType == SYNC_RESTORE
+                    val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER || isSyncRestore
                     if (showSecondaryCta) {
                         // Pin the title at its current position before the secondaryCta
                         // visibility change. The CL is wrap_content in landscape, so
@@ -607,6 +608,18 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                     binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
+                    val titleRes = if (isSyncRestore) R.string.syncRestoreDialogBrandDesignTitle else R.string.preOnboardingWelcomeDialogTitle
+                    if (isSyncRestore) {
+                        // SYNC_RESTORE reuses welcomeContent with its own copy and the sync-restore CTAs.
+                        binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(titleRes)
+                        binding.daxDialogCta.welcomeContent.bodyText1.text =
+                            getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
+                        binding.daxDialogCta.welcomeContent.bodyText2.text =
+                            getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
+                        binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
+                        binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
+                    }
+
                     val showWalkingDax = applyWalkingDaxLayout()
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
 
@@ -618,7 +631,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         onAnimationEnd = {
                             fadeInDialog {
                                 binding.daxDialogCta.welcomeContent.titleText.startOnboardingTypingAnimation(
-                                    getString(R.string.preOnboardingWelcomeDialogTitle),
+                                    getString(titleRes),
                                 ) {
                                     val animators = mutableListOf<Animator>(
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
@@ -749,10 +762,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingReinstallStartBrowsing)
                     binding.daxDialogCta.primaryCta.alpha = 0f
-                }
-
-                SYNC_RESTORE -> {
-                    // TODO - SyncRestore: add dialog UI
                 }
 
                 COMPARISON_CHART -> {
@@ -1220,14 +1229,16 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         snapToIntroEndState()
 
         when (onboardingDialogType) {
-            INITIAL, INITIAL_REINSTALL_USER -> {
+            INITIAL, INITIAL_REINSTALL_USER, SYNC_RESTORE -> {
+                val isSyncRestore = onboardingDialogType == SYNC_RESTORE
+                val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER || isSyncRestore
+
                 binding.logoAnimation.alpha = 0f
                 binding.welcomeTitle.alpha = 0f
 
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.Welcome)
 
-                binding.daxDialogCta.secondaryCta.visibility =
-                    if (onboardingDialogType == INITIAL_REINSTALL_USER) View.INVISIBLE else View.GONE
+                binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
                 val showWalkingDax = applyWalkingDaxLayout()
                 if (showWalkingDax) {
@@ -1244,20 +1255,30 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.daxCtaContainer.alpha = 1f
                 binding.daxDialogCta.welcomeContent.root.alpha = 1f
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
-                binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingWelcomeDialogTitle)
+                val titleString = if (isSyncRestore) {
+                    getString(R.string.syncRestoreDialogBrandDesignTitle)
+                } else {
+                    getString(R.string.preOnboardingWelcomeDialogTitle)
+                }
+                binding.daxDialogCta.welcomeContent.titleText.text = titleString
+                if (isSyncRestore) {
+                    binding.daxDialogCta.welcomeContent.hiddenTitleText.text = titleString
+                    binding.daxDialogCta.welcomeContent.bodyText1.text =
+                        getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
+                    binding.daxDialogCta.welcomeContent.bodyText2.text =
+                        getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
+                    binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
+                    binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
+                }
                 binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
                 binding.daxDialogCta.welcomeContent.bodyText2.alpha = 1f
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
-                if (onboardingDialogType == INITIAL_REINSTALL_USER) {
+                if (showSecondaryCta) {
                     binding.daxDialogCta.secondaryCta.isVisible = true
                     binding.daxDialogCta.secondaryCta.alpha = 1f
                     binding.daxDialogCta.secondaryCta.setOnClickListener { viewModel.onSecondaryCtaClicked() }
                 }
-            }
-
-            SYNC_RESTORE -> {
-                // TODO - SyncRestore: add dialog UI
             }
 
             COMPARISON_CHART -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -989,6 +989,11 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Let\'s pick up where you left off on DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Your saved bookmarks, passwords, and more are ready.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI is always optional, and privacy protection is always on.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Download PDF</string>
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboardingWideEvent
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.api.SyncAutoRestore
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -90,6 +91,7 @@ class BrandDesignUpdatePageViewModelTest {
     private val mockInputScreenOnboardingWideEvent: InputScreenOnboardingWideEvent = mock()
     private val mockDuckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager = mock()
     private val mockOnboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager = mock()
+    private val mockSyncAutoRestore: SyncAutoRestore = mock()
 
     private fun createViewModel(): BrandDesignUpdatePageViewModel {
         return BrandDesignUpdatePageViewModel(
@@ -106,6 +108,7 @@ class BrandDesignUpdatePageViewModelTest {
             mockInputScreenOnboardingWideEvent,
             mockDuckAiOnboardingExperimentManager,
             mockOnboardingQuickSetupExperimentManager,
+            mockSyncAutoRestore,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -46,6 +46,9 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SEARCH_ONLY_SELECTED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_SHOWN_UNIQUE
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SPLIT_ADDRESS_BAR_SELECTED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -473,6 +476,117 @@ class BrandDesignUpdatePageViewModelTest {
             cancelAndConsumeRemainingEvents()
         }
         verify(mockPixel).fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
+    }
+
+    // endregion
+
+    // region Sync Restore
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreThenViewStateShowsSyncRestoreDialog() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem() // initial
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SYNC_RESTORE, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreAndReinstallThenSyncRestoreTakesPriority() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SYNC_RESTORE, state.currentDialog)
+            // isAppReinstall() side effect still runs, so the flag is captured
+            assertTrue(state.isReinstallUser)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCanRestoreThrowsThenLoadDaxDialogFallsBackToInitialDialog() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenThrow(RuntimeException("Block Store error"))
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.INITIAL, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreThenFiresSyncRestoreShownPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenPrimaryCtaFromSyncRestoreThenRestoreAccountAndShowComparisonChart() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem() // SYNC_RESTORE
+            testee.onPrimaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.COMPARISON_CHART, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(mockSyncAutoRestore).restoreSyncAccount()
+    }
+
+    @Test
+    fun whenPrimaryCtaFromSyncRestoreThenFiresSyncRestoreTappedPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onPrimaryCtaClicked()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreThenShowSkipOnboardingOption() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem() // SYNC_RESTORE
+            testee.onSecondaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SKIP_ONBOARDING_OPTION, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(mockSyncAutoRestore, never()).restoreSyncAccount()
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreThenFiresSkipRestoreTappedPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onSecondaryCtaClicked()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215116160192530?focus=true

### Description
Migrates the dialog shown to returning users that also had sync enabled to the new design.

### Steps to test this PR
- [ ] Clean install and open the app
- [ ] Verify an initial onboarding screen with "Let's do it!" action is visible
- [ ] Go to "Settings" -> "Sync & Backup"
- [ ] Click "Sync and Back Up This Device" and go through the flow
- [ ] Go to any website and add a favorite.
- [ ] Uninstall the app (**do not clear the data**)
- [ ] Reinstall and open the app
- [ ] Verify:
  - [ ] Reinstaller onbaording screen with "Restore My Stuff" primary action is visible
  - [ ] `sync-auto-restore_onboarding_prompt_shown_unique` pixel was sent
- [ ] Click "Restore My Stuff"
- [ ] Verify:
  - [ ] `sync-auto-restore_onboarding_restore_tapped_unique` pixel was sent
- [ ] Go through the rest of onboarding
- [ ] In the browser, verify that the previously added favorite is still there
- [ ] Uninstall the app (**do not clear the data**)
- [ ] Reinstall and open the app
- [ ] Verify:
  - [ ] Reinstaller onbaording screen with "Restore My Stuff" primary action is visible
  - [ ] `sync-auto-restore_onboarding_prompt_shown_unique` pixel was sent
- [ ] Click "Skip"
- [ ] Verify:
  - [ ] `sync-auto-restore_onboarding_skip_tapped_unique` pixel was sent
- [ ] Go through the rest of onboarding
- [ ] In the browser, verify that the previously added favorite **is not** there

### UI
<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/2b0d1c32-43ef-4103-b429-1d3c96f3703c" />
