### PR TITLE
migrate SYNC_RESTORE onboarding dialog to brand design

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -58,6 +58,9 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SEARCH_ONLY_SELECTED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_SHOWN_UNIQUE
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SPLIT_ADDRESS_BAR_SELECTED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -69,9 +72,13 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboardingWideEvent
+import com.duckduckgo.sync.api.SyncAutoRestore
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -79,6 +86,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import logcat.LogPriority
+import logcat.logcat
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
@@ -100,7 +110,21 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
     private val onboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager,
     private val defaultBrowserDetector: DefaultBrowserDetector,
     private val widgetCapabilities: WidgetCapabilities,
+    private val syncAutoRestore: SyncAutoRestore,
 ) : ViewModel() {
+
+    private val canRestoreDeferred: Deferred<Boolean> = viewModelScope.async(dispatchers.io()) {
+        try {
+            logcat { "Sync-AutoRestore: checking canRestore..." }
+            val result = syncAutoRestore.canRestore()
+            logcat(LogPriority.INFO) { "Sync-AutoRestore: canRestore=$result" }
+            result
+        } catch (t: Throwable) {
+            coroutineContext.ensureActive()
+            logcat(LogPriority.WARN) { "Sync-AutoRestore: canRestore check failed - ${t.message}" }
+            false
+        }
+    }
 
     data class ViewState(
         val hasPlayedIntroAnimation: Boolean = false,
@@ -183,7 +207,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
 
     private fun fireDialogShownPixel(dialogType: PreOnboardingDialogType) {
         when (dialogType) {
-            SYNC_RESTORE -> { } // TODO - SyncRestore: add pixel for dialog shown
+            SYNC_RESTORE -> pixel.fire(PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
             INITIAL_REINSTALL_USER -> pixel.fire(PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE, type = Unique())
             INITIAL -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
             COMPARISON_CHART -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
@@ -208,8 +232,21 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
 
     fun loadDaxDialog() {
         viewModelScope.launch {
+            val canRestore = withTimeoutOrNull(BLOCK_STORE_TIMEOUT_MS) {
+                canRestoreDeferred.await()
+            } ?: false
+
+            // Always call isAppReinstall() — it has side effects (creates DDG downloads directory, persists reinstall state)
             val isReinstall = isAppReinstall()
-            val dialogType = if (isReinstall) INITIAL_REINSTALL_USER else INITIAL
+
+            val dialogType = when {
+                canRestore -> {
+                    logcat(LogPriority.INFO) { "Sync-AutoRestore: first dialog=SYNC_RESTORE" }
+                    SYNC_RESTORE
+                }
+                isReinstall -> INITIAL_REINSTALL_USER
+                else -> INITIAL
+            }
             _viewState.update {
                 it.copy(
                     isReinstallUser = isReinstall,
@@ -225,7 +262,12 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         val currentDialog = _viewState.value.currentDialog ?: return
         when (currentDialog) {
             SYNC_RESTORE -> {
-                // TODO - SyncRestore: handle primary CTA click
+                viewModelScope.launch {
+                    logcat { "Sync-AutoRestore: user accepted restore, calling restoreSyncAccount()" }
+                    pixel.fire(PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE, type = Unique())
+                    syncAutoRestore.restoreSyncAccount()
+                    setCurrentDialog(COMPARISON_CHART)
+                }
             }
 
             INITIAL_REINSTALL_USER, INITIAL -> {
@@ -345,7 +387,15 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                 pixel.fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
             }
 
-            SYNC_RESTORE, INITIAL, COMPARISON_CHART, ADDRESS_BAR_POSITION, INPUT_SCREEN, INPUT_SCREEN_PREVIEW, QUICK_SETUP -> {
+            SYNC_RESTORE -> {
+                viewModelScope.launch {
+                    logcat { "Sync-AutoRestore: user skipped restore" }
+                    pixel.fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
+                    setCurrentDialog(SKIP_ONBOARDING_OPTION)
+                }
+            }
+
+            INITIAL, COMPARISON_CHART, ADDRESS_BAR_POSITION, INPUT_SCREEN, INPUT_SCREEN_PREVIEW, QUICK_SETUP -> {
                 // no-op
             }
         }
@@ -533,5 +583,9 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         viewModelScope.launch {
             _commands.send(Command.SkipDialogAnimation)
         }
+    }
+
+    companion object {
+        private const val BLOCK_STORE_TIMEOUT_MS = 3_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -661,11 +661,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(titleRes)
                         binding.daxDialogCta.welcomeContent.bodyText1.text =
                             getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
-                        binding.daxDialogCta.welcomeContent.bodyText2.text =
-                            getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
                         binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
                         binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
                     }
+                    // SYNC_RESTORE shows no second body line; INITIAL/INITIAL_REINSTALL_USER do.
+                    // Set isVisible explicitly so a prior dialog that hid bodyText2 doesn't leak into this one.
+                    binding.daxDialogCta.welcomeContent.bodyText2.isVisible = !isSyncRestore
 
                     val showWalkingDax = applyWalkingDaxLayout()
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
@@ -683,11 +684,13 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                                     val animators = mutableListOf<Animator>(
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
                                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
-                                        ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText2, View.ALPHA, 1f)
-                                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.primaryCta, View.ALPHA, 1f)
                                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                                     )
+                                    if (!isSyncRestore) {
+                                        animators += ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText2, View.ALPHA, 1f)
+                                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION)
+                                    }
                                     if (showSecondaryCta) {
                                         binding.daxDialogCta.secondaryCta.isVisible = true
                                         animators += ObjectAnimator.ofFloat(binding.daxDialogCta.secondaryCta, View.ALPHA, 1f)
@@ -1313,11 +1316,12 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     binding.daxDialogCta.welcomeContent.hiddenTitleText.text = titleString
                     binding.daxDialogCta.welcomeContent.bodyText1.text =
                         getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
-                    binding.daxDialogCta.welcomeContent.bodyText2.text =
-                        getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
                     binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
                     binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
                 }
+                // SYNC_RESTORE shows no second body line; INITIAL/INITIAL_REINSTALL_USER do.
+                // Set isVisible explicitly so a prior dialog that hid bodyText2 doesn't leak into this one.
+                binding.daxDialogCta.welcomeContent.bodyText2.isVisible = !isSyncRestore
                 binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
                 binding.daxDialogCta.welcomeContent.bodyText2.alpha = 1f
                 binding.daxDialogCta.primaryCta.alpha = 1f

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -638,8 +638,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             isAnimating = true
             viewModel.onDialogAnimationStarted()
             when (onboardingDialogType) {
-                INITIAL, INITIAL_REINSTALL_USER -> {
-                    val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER
+                INITIAL, INITIAL_REINSTALL_USER, SYNC_RESTORE -> {
+                    val isSyncRestore = onboardingDialogType == SYNC_RESTORE
+                    val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER || isSyncRestore
                     if (showSecondaryCta) {
                         // Pin the title at its current position before the secondaryCta
                         // visibility change. The CL is wrap_content in landscape, so
@@ -654,6 +655,18 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     }
                     binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
+                    val titleRes = if (isSyncRestore) R.string.syncRestoreDialogBrandDesignTitle else R.string.preOnboardingWelcomeDialogTitle
+                    if (isSyncRestore) {
+                        // SYNC_RESTORE reuses welcomeContent with its own copy and the sync-restore CTAs.
+                        binding.daxDialogCta.welcomeContent.hiddenTitleText.text = getString(titleRes)
+                        binding.daxDialogCta.welcomeContent.bodyText1.text =
+                            getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
+                        binding.daxDialogCta.welcomeContent.bodyText2.text =
+                            getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
+                        binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
+                        binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
+                    }
+
                     val showWalkingDax = applyWalkingDaxLayout()
                     binding.daxDialogCta.cardView.setArrowDepthFraction(if (showWalkingDax) 1f else 0f)
 
@@ -665,7 +678,7 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                         onAnimationEnd = {
                             fadeInDialog {
                                 binding.daxDialogCta.welcomeContent.titleText.startOnboardingTypingAnimation(
-                                    getString(R.string.preOnboardingWelcomeDialogTitle),
+                                    getString(titleRes),
                                 ) {
                                     val animators = mutableListOf<Animator>(
                                         ObjectAnimator.ofFloat(binding.daxDialogCta.welcomeContent.bodyText1, View.ALPHA, 1f)
@@ -797,10 +810,6 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
 
                     binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingReinstallStartBrowsing)
                     binding.daxDialogCta.primaryCta.alpha = 0f
-                }
-
-                SYNC_RESTORE -> {
-                    // TODO - SyncRestore: add dialog UI
                 }
 
                 COMPARISON_CHART -> {
@@ -1268,14 +1277,16 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
         snapToIntroEndState()
 
         when (onboardingDialogType) {
-            INITIAL, INITIAL_REINSTALL_USER -> {
+            INITIAL, INITIAL_REINSTALL_USER, SYNC_RESTORE -> {
+                val isSyncRestore = onboardingDialogType == SYNC_RESTORE
+                val showSecondaryCta = onboardingDialogType == INITIAL_REINSTALL_USER || isSyncRestore
+
                 binding.logoAnimation.alpha = 0f
                 binding.welcomeTitle.alpha = 0f
 
                 backgroundAnimator?.snapTo(OnboardingBackgroundStep.Welcome)
 
-                binding.daxDialogCta.secondaryCta.visibility =
-                    if (onboardingDialogType == INITIAL_REINSTALL_USER) View.INVISIBLE else View.GONE
+                binding.daxDialogCta.secondaryCta.visibility = if (showSecondaryCta) View.INVISIBLE else View.GONE
 
                 val showWalkingDax = applyWalkingDaxLayout()
                 if (showWalkingDax) {
@@ -1292,20 +1303,30 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 binding.daxDialogCta.daxCtaContainer.alpha = 1f
                 binding.daxDialogCta.welcomeContent.root.alpha = 1f
                 binding.daxDialogCta.welcomeContent.titleText.cancelAnimation()
-                binding.daxDialogCta.welcomeContent.titleText.text = getString(R.string.preOnboardingWelcomeDialogTitle)
+                val titleString = if (isSyncRestore) {
+                    getString(R.string.syncRestoreDialogBrandDesignTitle)
+                } else {
+                    getString(R.string.preOnboardingWelcomeDialogTitle)
+                }
+                binding.daxDialogCta.welcomeContent.titleText.text = titleString
+                if (isSyncRestore) {
+                    binding.daxDialogCta.welcomeContent.hiddenTitleText.text = titleString
+                    binding.daxDialogCta.welcomeContent.bodyText1.text =
+                        getString(R.string.syncRestoreDialogBrandDesignBody1).preventWidows().html(requireContext())
+                    binding.daxDialogCta.welcomeContent.bodyText2.text =
+                        getString(R.string.syncRestoreDialogBrandDesignBody2).preventWidows().html(requireContext())
+                    binding.daxDialogCta.primaryCta.text = getString(R.string.syncRestoreDialogPrimaryCta)
+                    binding.daxDialogCta.secondaryCta.text = getString(R.string.syncRestoreDialogSecondaryCta)
+                }
                 binding.daxDialogCta.welcomeContent.bodyText1.alpha = 1f
                 binding.daxDialogCta.welcomeContent.bodyText2.alpha = 1f
                 binding.daxDialogCta.primaryCta.alpha = 1f
                 binding.daxDialogCta.primaryCta.setOnClickListener { viewModel.onPrimaryCtaClicked() }
-                if (onboardingDialogType == INITIAL_REINSTALL_USER) {
+                if (showSecondaryCta) {
                     binding.daxDialogCta.secondaryCta.isVisible = true
                     binding.daxDialogCta.secondaryCta.alpha = 1f
                     binding.daxDialogCta.secondaryCta.setOnClickListener { viewModel.onSecondaryCtaClicked() }
                 }
-            }
-
-            SYNC_RESTORE -> {
-                // TODO - SyncRestore: add dialog UI
             }
 
             COMPARISON_CHART -> {

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Възстановяване на моите неща</string>
     <string name="syncRestoreDialogSecondaryCta">Пропускане</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Нека продължим оттам, откъдето спряхте в DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Запазените отметки, пароли и други са готови.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Изтегляне на PDF</string>
 
@@ -1002,6 +1007,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Готови ли сте за по-бърз браузър,\nкойто осигурява контрол?</string>
     <string name="preOnboardingWelcomeDialogBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d от %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва „патица“ на английски</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва “патица“ на английски</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как се казва \"патица\" на испански</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Нека продължим оттам, откъдето спряхте в DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Запазените отметки, пароли и други са готови.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Изтегляне на PDF</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1006,6 +1006,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Готови ли сте за по-бърз браузър,\nкойто осигурява контрол?</string>
     <string name="preOnboardingWelcomeDialogBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d от %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва “патица“ на английски</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва „патица“ на английски</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как се казва \"патица\" на испански</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Pojďme navázat tam, kde jsi na DuckDuckGo skončil.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tvé uložené záložky, hesla a další položky jsou připraveny.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Stáhnout PDF</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1045,7 +1045,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Zdravíme tě.</string>
     <string name="preOnboardingWelcomeDialogBody1">Chceš rychlejší prohlížeč, se kterým budeš mít vše pod kontrolou?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak se anglicky řekne „kachna“</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak se španělsky řekne „kachna“</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Obnovit moje věci</string>
     <string name="syncRestoreDialogSecondaryCta">Přeskočit</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Pojďme navázat tam, kde jsi na DuckDuckGo skončil.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tvé uložené záložky, hesla a další položky jsou připraveny.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Stáhnout PDF</string>
 
@@ -1041,7 +1046,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Zdravíme tě.</string>
     <string name="preOnboardingWelcomeDialogBody1">Chceš rychlejší prohlížeč, se kterým budeš mít vše pod kontrolou?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak se anglicky řekne „kachna“</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak se španělsky řekne „kachna“</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Gendan mine data</string>
     <string name="syncRestoreDialogSecondaryCta">Spring over</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Lad os fortsætte, hvor du slap på DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Dine gemte bogmærker, adgangskoder og mere er klar.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI er altid valgfrit, og beskyttelse af privatlivet er altid aktiveret.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Download PDF-fil</string>
 

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Lad os fortsætte, hvor du slap på DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Dine gemte bogmærker, adgangskoder og mere er klar.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">AI er altid valgfrit, og beskyttelse af privatlivet er altid aktiveret.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Download PDF-fil</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Lass uns dort weitermachen, wo du bei DuckDuckGo aufgehört hast.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Deine gespeicherten Lesezeichen, Passwörter und mehr sind bereit.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">KI ist immer optional, und der Datenschutz ist immer aktiviert.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF herunterladen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Meine Sachen wiederherstellen</string>
     <string name="syncRestoreDialogSecondaryCta">Überspringen</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Lass uns dort weitermachen, wo du bei DuckDuckGo aufgehört hast.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Deine gespeicherten Lesezeichen, Passwörter und mehr sind bereit.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">KI ist immer optional, und der Datenschutz ist immer aktiviert.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF herunterladen</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Ας συνεχίσουμε από εκεί που μείνατε στο DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Οι αποθηκευμένοι σελιδοδείκτες, οι κωδικοί πρόσβασης και πολλά άλλα είναι έτοιμα.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Η τεχνητή νοημοσύνη είναι πάντα προαιρετική και η προστασία προσωπικών δεδομένων είναι πάντα ενεργοποιημένη.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Λήψη PDF</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Επαναφορά των στοιχείων μου</string>
     <string name="syncRestoreDialogSecondaryCta">Παράλειψη</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Ας συνεχίσουμε από εκεί που μείνατε στο DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Οι αποθηκευμένοι σελιδοδείκτες, οι κωδικοί πρόσβασης και πολλά άλλα είναι έτοιμα.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Η τεχνητή νοημοσύνη είναι πάντα προαιρετική και η προστασία προσωπικών δεδομένων είναι πάντα ενεργοποιημένη.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Λήψη PDF</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Restaura mis cosas</string>
     <string name="syncRestoreDialogSecondaryCta">Omitir</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Vamos a continuar donde lo dejaste en DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tus marcadores, contraseñas y más están listos.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descargar PDF</string>
 
@@ -1002,6 +1007,6 @@
     <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que\nte da el control?</string>
     <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «pato» en inglés</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cómo se dice «duck» en español</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Vamos a continuar donde lo dejaste en DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tus marcadores, contraseñas y más están listos.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descargar PDF</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1006,6 +1006,6 @@
     <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que\nte da el control?</string>
     <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «pato» en inglés</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cómo se dice «duck» en español</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Jätkame DuckDuckGo-ga sealt, kus pooleli jäid.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Sinu salvestatud järjehoidjad, paroolid ja muu on valmis.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Tehisintellekt on alati valikuline ja privaatsuskaitse on alati sisse lülitatud.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Laadi alla PDF</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Taasta minu andmed</string>
     <string name="syncRestoreDialogSecondaryCta">Jäta vahele</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Jätkame DuckDuckGo-ga sealt, kus pooleli jäid.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Sinu salvestatud järjehoidjad, paroolid ja muu on valmis.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Tehisintellekt on alati valikuline ja privaatsuskaitse on alati sisse lülitatud.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Laadi alla PDF</string>
 

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Jatketaan DuckDuckGossa siitä, mihin jäit.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tallennetut kirjanmerkkisi, salasanasi ja muut ovat valmiina.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Tekoäly on aina valinnainen, ja yksityisyyden suoja on aina päällä.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Lataa PDF</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Palauta tiedot</string>
     <string name="syncRestoreDialogSecondaryCta">Ohita</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Jatketaan DuckDuckGossa siitä, mihin jäit.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tallennetut kirjanmerkkisi, salasanasi ja muut ovat valmiina.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Tekoäly on aina valinnainen, ja yksityisyyden suoja on aina päällä.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Lataa PDF</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Reprenons là où vous en étiez sur DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Vos favoris, mots de passe et autres informations enregistrées sont prêts.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">L\'IA reste une option et la protection de la confidentialité reste activée.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Télécharger le PDF</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Rétablir mes données</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorer</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Reprenons là où vous en étiez sur DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Vos favoris, mots de passe et autres informations enregistrées sont prêts.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">L\'IA reste une option et la protection de la confidentialité reste activée.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Télécharger le PDF</string>
 

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Nastavimo tamo gdje si stao na DuckDuckGou.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tvoje spremljene oznake, lozinke (i još mnogo toga) su spremne.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Umjetna inteligencija uvijek je neobavezna, a zaštita privatnosti uvijek aktivna.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Preuzmi PDF</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Vrati mi stvari</string>
     <string name="syncRestoreDialogSecondaryCta">Preskoči</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Nastavimo tamo gdje si stao na DuckDuckGou.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tvoje spremljene oznake, lozinke (i još mnogo toga) su spremne.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Umjetna inteligencija uvijek je neobavezna, a zaštita privatnosti uvijek aktivna.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Preuzmi PDF</string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Folytassuk ott, ahol abbahagytad a DuckDuckGo használatát.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Mentett könyvjelzőid, jelszavaid és a további elemek készen állnak.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Az AI mindig opcionális, az adatvédelem pedig állandóan be van kapcsolva.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF letöltése</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Saját adataim visszaállítása</string>
     <string name="syncRestoreDialogSecondaryCta">Kihagyás</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Folytassuk ott, ahol abbahagytad a DuckDuckGo használatát.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Mentett könyvjelzőid, jelszavaid és a további elemek készen állnak.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Az AI mindig opcionális, az adatvédelem pedig állandóan be van kapcsolva.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF letöltése</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Riprendiamo da dove avevi lasciato su DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">I segnalibri salvati, le password e altro ancora sono pronti.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">L\'AI è sempre opzionale e la protezione della privacy è sempre attiva.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Scarica PDF</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Ripristina i miei contenuti</string>
     <string name="syncRestoreDialogSecondaryCta">Salta</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Riprendiamo da dove avevi lasciato su DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">I segnalibri salvati, le password e altro ancora sono pronti.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">L\'AI è sempre opzionale e la protezione della privacy è sempre attiva.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Scarica PDF</string>
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Pratęskime nuo ten, kur baigėte naudotis „DuckDuckGo“.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Jau paruoštos jūsų išsaugotos žymės, slaptažodžiai ir kita.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">DI neprivalomas, o privatumo apsauga yra visada įjungta.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Atsisiųsti PDF</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Atkurti mano duomenis</string>
     <string name="syncRestoreDialogSecondaryCta">Praleisti</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Pratęskime nuo ten, kur baigėte naudotis „DuckDuckGo“.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Jau paruoštos jūsų išsaugotos žymės, slaptažodžiai ir kita.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">DI neprivalomas, o privatumo apsauga yra visada įjungta.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Atsisiųsti PDF</string>
 

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1013,7 +1013,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Turpināsim darbu ar DuckDuckGo no vietas, kur beidzāt.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tavas saglabātās grāmatzīmes, paroles un citi dati ir gatavi.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Lejupielādēt PDF</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="syncRestoreDialogPrimaryCta">Manas lietas atjaunošana</string>
     <string name="syncRestoreDialogSecondaryCta">Izlaist</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Turpināsim darbu ar DuckDuckGo no vietas, kur beidzāt.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tavas saglabātās grāmatzīmes, paroles un citi dati ir gatavi.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Lejupielādēt PDF</string>
 
@@ -1022,6 +1027,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
     <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “pīle”</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1026,6 +1026,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
     <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “pīle”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">La oss fortsette der du slapp på DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Dine lagrede bokmerker, passord osv. er klare.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Last ned PDF</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1006,6 +1006,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Klar for en raskere nettleser som du har kontroll over?</string>
     <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si duck» på spansk</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «and» på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «and» på spansk</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Gjenopprett innholdet mitt</string>
     <string name="syncRestoreDialogSecondaryCta">Hopp over</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">La oss fortsette der du slapp på DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Dine lagrede bokmerker, passord osv. er klare.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Last ned PDF</string>
 
@@ -1002,6 +1007,6 @@
     <string name="preOnboardingWelcomeDialogBody1">Klar for en raskere nettleser som du har kontroll over?</string>
     <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «and» på engelsk</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «and» på spansk</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si duck» på spansk</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Laten we verdergaan waar je gebleven was op DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Je opgeslagen bladwijzers, wachtwoorden en meer staan klaar.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF downloaden</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Herstel mijn gegevens</string>
     <string name="syncRestoreDialogSecondaryCta">Overslaan</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Laten we verdergaan waar je gebleven was op DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Je opgeslagen bladwijzers, wachtwoorden en meer staan klaar.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF downloaden</string>
 
@@ -1003,5 +1008,5 @@
     <string name="preOnboardingWelcomeDialogBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d van %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hoe zeg je \'eend\' in het Engels?</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Spaans</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Nederlands</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1007,5 +1007,5 @@
     <string name="preOnboardingWelcomeDialogBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d van %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hoe zeg je \'eend\' in het Engels?</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Nederlands</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Spaans</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Przywróć moje dane</string>
     <string name="syncRestoreDialogSecondaryCta">Pomiń</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Kontynuujmy tam, gdzie przerwałeś na DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Twoje zapisane zakładki, hasła i inne są gotowe.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Pobierz PDF</string>
 
@@ -1041,7 +1046,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Cześć!</string>
     <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
     <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „kaczka” po angielsku</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"kaczka\" po hiszpańsku</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1045,7 +1045,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Cześć!</string>
     <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
     <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „kaczka” po angielsku</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"kaczka\" po hiszpańsku</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Kontynuujmy tam, gdzie przerwałeś na DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Twoje zapisane zakładki, hasła i inne są gotowe.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Pobierz PDF</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Vamos continuar onde paraste no DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Os teus marcadores, palavras-passe e mais estão prontos.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">A IA é sempre opcional, e a proteção de privacidade está sempre ativa.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descarregar PDF</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Restaurar as minhas coisas</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorar</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Vamos continuar onde paraste no DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Os teus marcadores, palavras-passe e mais estão prontos.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">A IA é sempre opcional, e a proteção de privacidade está sempre ativa.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descarregar PDF</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1010,6 +1010,11 @@
     <string name="syncRestoreDialogPrimaryCta">Restaurează lucrurile mele</string>
     <string name="syncRestoreDialogSecondaryCta">Ignorare</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Hai să reluăm de unde ai rămas cu DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Marcajele salvate, parolele și multe altele sunt gata.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">IA este întotdeauna opțională, iar protecția confidențialității este întotdeauna activată.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descarcă PDF</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1013,7 +1013,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Hai să reluăm de unde ai rămas cu DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Marcajele salvate, parolele și multe altele sunt gata.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">IA este întotdeauna opțională, iar protecția confidențialității este întotdeauna activată.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Descarcă PDF</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Восстановить мои данные</string>
     <string name="syncRestoreDialogSecondaryCta">Пропустить</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Давайте продолжим с того места, где вы остановились в DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Ваши сохраненные закладки, пароли и т. д. готовы.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Здесь ИИ — всегда лишь дополнительная опция, а защита конфиденциальности всегда включена.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Скачать PDF</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Давайте продолжим с того места, где вы остановились в DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Ваши сохраненные закладки, пароли и т. д. готовы.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Здесь ИИ — всегда лишь дополнительная опция, а защита конфиденциальности всегда включена.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Скачать PDF</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1045,7 +1045,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Dobrý deň.</string>
     <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač,\nktorý ti dáva kontrolu?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umelá inteligencia je vždy voliteľná\na ochrana súkromia je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Ako povedať „kačica“ v angličtine</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Ako povedať „kačica“ po španielsky</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Obnoviť moje veci</string>
     <string name="syncRestoreDialogSecondaryCta">Preskočiť</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Poďme pokračovať tam, kde si na DuckDuckGo skončil.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Tvoje uložené záložky, heslá a ďalšie údaje sú pripravené.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Umelá inteligencia je vždy voliteľná a ochrana súkromia je vždy zapnutá.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Stiahnuť PDF</string>
 
@@ -1041,7 +1046,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Dobrý deň.</string>
     <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač,\nktorý ti dáva kontrolu?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umelá inteligencia je vždy voliteľná\na ochrana súkromia je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Ako povedať „kačica“ v angličtine</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Ako povedať „kačica“ po španielsky</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Poďme pokračovať tam, kde si na DuckDuckGo skončil.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Tvoje uložené záložky, heslá a ďalšie údaje sú pripravené.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Umelá inteligencia je vždy voliteľná a ochrana súkromia je vždy zapnutá.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Stiahnuť PDF</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1030,6 +1030,11 @@
     <string name="syncRestoreDialogPrimaryCta">Obnovi moje stvari</string>
     <string name="syncRestoreDialogSecondaryCta">Preskoči</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Nadaljujte tam, kjer ste končali na DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Shranjeni zaznamki, gesla in drugo so pripravljeni.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Umetna inteligenca je vedno neobvezna, zaščita zasebnosti pa je vedno vklopljena.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Prenesi PDF</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1033,7 +1033,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Nadaljujte tam, kjer ste končali na DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Shranjeni zaznamki, gesla in drugo so pripravljeni.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Umetna inteligenca je vedno neobvezna, zaščita zasebnosti pa je vedno vklopljena.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Prenesi PDF</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Återställ mitt innehåll</string>
     <string name="syncRestoreDialogSecondaryCta">Hoppa över</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Nu fortsätter vi där du slutade på DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Dina sparade bokmärken, lösenord och mer är redo.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI är alltid valfritt och integritetsskydd är alltid på.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Ladda ner PDF</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Nu fortsätter vi där du slutade på DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Dina sparade bokmärken, lösenord och mer är redo.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">AI är alltid valfritt och integritetsskydd är alltid på.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Ladda ner PDF</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -993,7 +993,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">DuckDuckGo\'da kaldığınız yerden devam edelim.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Kaydedilmiş yer işaretleriniz, şifreleriniz ve daha fazlası hazır.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">Yapay zeka her zaman isteğe bağlıdır ve gizlilik koruması her zaman etkindir.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF indir</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -990,6 +990,11 @@
     <string name="syncRestoreDialogPrimaryCta">Geri Yükle</string>
     <string name="syncRestoreDialogSecondaryCta">Atla</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">DuckDuckGo\'da kaldığınız yerden devam edelim.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Kaydedilmiş yer işaretleriniz, şifreleriniz ve daha fazlası hazır.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">Yapay zeka her zaman isteğe bağlıdır ve gizlilik koruması her zaman etkindir.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">PDF indir</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -989,6 +989,11 @@
     <string name="syncRestoreDialogPrimaryCta">Restore My Stuff</string>
     <string name="syncRestoreDialogSecondaryCta">Skip</string>
 
+    <!-- Sync Restore (brand-design onboarding) -->
+    <string name="syncRestoreDialogBrandDesignTitle">Let\'s pick up where you left off on DuckDuckGo.</string>
+    <string name="syncRestoreDialogBrandDesignBody1">Your saved bookmarks, passwords, and more are ready.</string>
+    <string name="syncRestoreDialogBrandDesignBody2">AI is always optional, and privacy protection is always on.</string>
+
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Download PDF</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -992,7 +992,6 @@
     <!-- Sync Restore (brand-design onboarding) -->
     <string name="syncRestoreDialogBrandDesignTitle">Let\'s pick up where you left off on DuckDuckGo.</string>
     <string name="syncRestoreDialogBrandDesignBody1">Your saved bookmarks, passwords, and more are ready.</string>
-    <string name="syncRestoreDialogBrandDesignBody2">AI is always optional, and privacy protection is always on.</string>
 
     <!-- PDF download tooltip -->
     <string name="pdfDownloadTooltipText">Download PDF</string>

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -47,6 +47,9 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SEARCH_ONLY_SELECTED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SKIP_ONBOARDING_SHOWN_UNIQUE
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SPLIT_ADDRESS_BAR_SELECTED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE
+import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -59,6 +62,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboardingWideEvent
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.api.SyncAutoRestore
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -95,6 +99,7 @@ class BrandDesignUpdatePageViewModelTest {
     private val mockOnboardingQuickSetupExperimentManager: OnboardingQuickSetupExperimentManager = mock()
     private val mockDefaultBrowserDetector: DefaultBrowserDetector = mock()
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
+    private val mockSyncAutoRestore: SyncAutoRestore = mock()
 
     private fun createViewModel(): BrandDesignUpdatePageViewModel {
         return BrandDesignUpdatePageViewModel(
@@ -113,6 +118,7 @@ class BrandDesignUpdatePageViewModelTest {
             mockOnboardingQuickSetupExperimentManager,
             mockDefaultBrowserDetector,
             mockWidgetCapabilities,
+            mockSyncAutoRestore,
         )
     }
 
@@ -477,6 +483,117 @@ class BrandDesignUpdatePageViewModelTest {
             cancelAndConsumeRemainingEvents()
         }
         verify(mockPixel).fire(PREONBOARDING_RESUME_ONBOARDING_PRESSED)
+    }
+
+    // endregion
+
+    // region Sync Restore
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreThenViewStateShowsSyncRestoreDialog() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem() // initial
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SYNC_RESTORE, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreAndReinstallThenSyncRestoreTakesPriority() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SYNC_RESTORE, state.currentDialog)
+            // isAppReinstall() side effect still runs, so the flag is captured
+            assertTrue(state.isReinstallUser)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCanRestoreThrowsThenLoadDaxDialogFallsBackToInitialDialog() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenThrow(RuntimeException("Block Store error"))
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.INITIAL, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLoadDaxDialogAndCanRestoreThenFiresSyncRestoreShownPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_RESTORE_SHOWN_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenPrimaryCtaFromSyncRestoreThenRestoreAccountAndShowComparisonChart() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem() // SYNC_RESTORE
+            testee.onPrimaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.COMPARISON_CHART, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(mockSyncAutoRestore).restoreSyncAccount()
+    }
+
+    @Test
+    fun whenPrimaryCtaFromSyncRestoreThenFiresSyncRestoreTappedPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onPrimaryCtaClicked()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_RESTORE_TAPPED_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreThenShowSkipOnboardingOption() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem() // SYNC_RESTORE
+            testee.onSecondaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.SKIP_ONBOARDING_OPTION, state.currentDialog)
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(mockSyncAutoRestore, never()).restoreSyncAccount()
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreThenFiresSkipRestoreTappedPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onSecondaryCtaClicked()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215116160192530?focus=true

### Description
Migrates the dialog shown to returning Sync users to the new design.

### Steps to test this PR
- [ ] Clean install and open the app
- [ ] Verify an initial onboarding screen with "Let's do it!" action is visible
- [ ] Go to "Settings" -> "Sync & Backup"
- [ ] Click "Sync and Back Up This Device" and go through the flow
- [ ] Go to any website and add a favorite.
- [ ] Uninstall the app (**do not clear the data**)
- [ ] Reinstall and open the app
- [ ] Verify:
  - [ ] Reinstaller onbaording screen with "Restore My Stuff" primary action is visible
  - [ ] `sync-auto-restore_onboarding_prompt_shown_unique` pixel was sent
- [ ] Click "Restore My Stuff"
- [ ] Verify:
  - [ ] `sync-auto-restore_onboarding_restore_tapped_unique` pixel was sent
- [ ] Go through the rest of onboarding
- [ ] In the browser, verify that the previously added favorite is still there
- [ ] Uninstall the app (**do not clear the data**)
- [ ] Reinstall and open the app
- [ ] Verify:
  - [ ] Reinstaller onbaording screen with "Restore My Stuff" primary action is visible
  - [ ] `sync-auto-restore_onboarding_prompt_shown_unique` pixel was sent
- [ ] Click "Skip"
- [ ] Verify:
  - [ ] `sync-auto-restore_onboarding_skip_tapped_unique` pixel was sent
- [ ] Go through the rest of onboarding
- [ ] In the browser, verify that the previously added favorite **is not** there

### UI
<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/2b0d1c32-43ef-4103-b429-1d3c96f3703c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run onboarding and sync account restore via Block Store; failures are guarded by timeout/fallback, but restore/skip paths affect user data on reinstall.
> 
> **Overview**
> **Brand-design pre-onboarding** now offers returning Sync users a **restore prompt** when `SyncAutoRestore.canRestore()` succeeds (checked in the background with a **3s timeout**; failures/timeouts fall back to the normal welcome/reinstall flow). That dialog **outranks** the reinstall welcome screen.
> 
> The **welcome card** reuses the brand welcome layout for `SYNC_RESTORE`: dedicated title/body/CTAs, **no second body line**, and **Restore** / **Skip** wired in both animated and skip-animation paths.
> 
> **Restore** fires unique pixels, calls `restoreSyncAccount()`, then continues to the comparison chart; **Skip** fires skip pixels and goes to skip-onboarding. New **`syncRestoreDialogBrandDesign*`** strings are added across locales, with **ViewModel tests** for priority, errors, pixels, and navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb6a9e0ad8d5759f427e4248a454f36b11af76e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->