### PR TITLE
Add AI-off Maestro test: open Duck.ai via icon, back to NTP

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -50,9 +50,72 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Internal Binary Upload
 
-      # TEMP: removed Release Binary upload + Omnibar / Duck Player / ADS steps to
-      # iterate quickly on the Unified Input suite. Revert this commit before
-      # merging — the dropped steps must keep running on the develop nightly.
+      - name: Upload Release Binary to Maestro
+        id: maestro-upload-release-binary
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: binary_release_upload_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
+          maestro_api_level: 30
+          maestro_include_tags: binaryUpload
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Release Binary Upload
+
+      - name: Omnibar Tests
+        id: maestro-omnibar
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: omnibar_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
+          maestro_include_tags: omnibarTest
+          maestro_api_level: 30
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Omnibar (Nightly)
+
+      - name: Run Duck Player Maestro Tests
+        id: maestro-cloud-asana
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: duckPlayerTest_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
+          maestro_include_tags: duckplayer
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Duck Player
+
+      - name: Android Design System
+        id: maestro-ads
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: ads_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
+          maestro_include_tags: androidDesignSystemTest
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          maestro_api_level: 30
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: Android Design System (Nightly)
 
       - name: Unified Input Field
         id: maestro-uif

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -50,72 +50,9 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Internal Binary Upload
 
-      - name: Upload Release Binary to Maestro
-        id: maestro-upload-release-binary
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: binary_release_upload_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 30
-          maestro_include_tags: binaryUpload
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Release Binary Upload
-
-      - name: Omnibar Tests
-        id: maestro-omnibar
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: omnibar_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_include_tags: omnibarTest
-          maestro_api_level: 30
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Omnibar (Nightly)
-
-      - name: Run Duck Player Maestro Tests
-        id: maestro-cloud-asana
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: duckPlayerTest_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_include_tags: duckplayer
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Duck Player
-
-      - name: Android Design System
-        id: maestro-ads
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: ads_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_include_tags: androidDesignSystemTest
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 30
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Android Design System (Nightly)
+      # TEMP: removed Release Binary upload + Omnibar / Duck Player / ADS steps to
+      # iterate quickly on the Unified Input suite. Revert this commit before
+      # merging — the dropped steps must keep running on the develop nightly.
 
       - name: Unified Input Field
         id: maestro-uif

--- a/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
@@ -32,7 +32,11 @@ appId: com.duckduckgo.mobile.android
     timeout: 15000
 
 # tap the back arrow — only present in this AI-off entry path — and verify
-# we land back on the NTP
+# we land back on the NTP. We avoid asserting on ddgLogo because there are
+# two views with that id (one on the NTP, one a Lottie inside the unified
+# input fragment), and after the back-pop the unified input re-opens over
+# the NTP so the NTP logo can be obscured. Instead assert the NTP container
+# is present and that the Duck.ai chat header is gone.
 - tapOn:
     id: "duckAiBack"
 - extendedWaitUntil:
@@ -41,5 +45,5 @@ appId: com.duckduckgo.mobile.android
     timeout: 15000
 - assertVisible:
     id: "newTabPage"
-- assertVisible:
-    id: "ddgLogo"
+- assertNotVisible:
+    id: "duckAIHeader"

--- a/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
@@ -1,0 +1,49 @@
+appId: com.duckduckgo.mobile.android
+---
+# unified input is open by default with nativeInputToggle="true";
+# wait for it to settle after onboarding skip
+- extendedWaitUntil:
+    visible:
+      id: "inputModeWidget"
+    timeout: 15000
+
+# focus the input field and type a question
+- tapOn:
+    id: "inputField"
+- inputText: "what is a car"
+
+# with inputWithAiToggle=false there is no Duck.ai tab — a Duck.ai icon
+# inside the input mode widget is the entry point to chat
+- assertVisible:
+    id: "aiChatIconMenu"
+- tapOn:
+    id: "aiChatIconMenu"
+
+# handle the duck.ai T&C if it appears (first run only)
+- runFlow: ../../shared/accept_duckai_agreement.yaml
+
+# duck.ai's web view sometimes fails to load — tap "Reload Duck.ai" if shown
+- runFlow: reload_duckai_if_needed.yaml
+
+# Duck.ai opened — header replaces the omnibar and the back arrow appears
+- extendedWaitUntil:
+    visible:
+      id: "duckAIHeader"
+    timeout: 15000
+- assertVisible:
+    id: "duckAIHeader"
+- assertVisible:
+    id: "inputModeUnifiedBack"
+
+# tap the back arrow — only present in this AI-off entry path — and verify
+# we land back on the NTP
+- tapOn:
+    id: "inputModeUnifiedBack"
+- extendedWaitUntil:
+    visible:
+      id: "newTabPage"
+    timeout: 15000
+- assertVisible:
+    id: "newTabPage"
+- assertVisible:
+    id: "ddgLogo"

--- a/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/shared/flow_open_duckai_back_to_ntp.yaml
@@ -28,17 +28,13 @@ appId: com.duckduckgo.mobile.android
 # Duck.ai opened — header replaces the omnibar and the back arrow appears
 - extendedWaitUntil:
     visible:
-      id: "duckAIHeader"
+      id: "duckAiBack"
     timeout: 15000
-- assertVisible:
-    id: "duckAIHeader"
-- assertVisible:
-    id: "inputModeUnifiedBack"
 
 # tap the back arrow — only present in this AI-off entry path — and verify
 # we land back on the NTP
 - tapOn:
-    id: "inputModeUnifiedBack"
+    id: "duckAiBack"
 - extendedWaitUntil:
     visible:
       id: "newTabPage"

--- a/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
+++ b/.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml
@@ -1,0 +1,52 @@
+appId: com.duckduckgo.mobile.android
+name: "UnifiedInput: open duck.ai via icon (AI off) and back to NTP × omnibar positions"
+tags:
+  - unifiedInputTest
+---
+# 1/3 — omnibar top
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "top"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/flow_open_duckai_back_to_ntp.yaml
+
+# 2/3 — omnibar bottom
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "bottom"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/flow_open_duckai_back_to_ntp.yaml
+
+# 3/3 — omnibar split
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+          arguments:
+            isMaestro: "true"
+            nativeInputToggle: "true"
+            inputWithAiToggle: "false"
+            omnibarPosition: "split"
+            addFavorites: "example.com;duckduckgo.com;privacytest.com"
+      - runFlow: shared/launch_and_skip_onboarding.yaml
+      - runFlow: shared/flow_open_duckai_back_to_ntp.yaml


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215110635982060?focus=true
Stacked on: #8676

### Description

Adds the first Maestro scenario for `inputWithAiToggle: "false"`. With AI in the input screen disabled there's no Search / Duck.ai tab switcher — instead a Duck.ai icon (`aiChatIconMenu`) is shown inside the input mode widget. Tapping it pushes Duck.ai onto the nav stack so the omnibar's back arrow (`duckAiBack`) becomes the way back to the NTP.

**Flow** (`shared/flow_open_duckai_back_to_ntp.yaml`):
1. Open the unified input, focus `inputField`, type a question.
2. Tap `aiChatIconMenu` — the AI-off entry point to Duck.ai.
3. Accept the duck.ai T&C and handle the "Reload Duck.ai" error page (shared helpers from #8676).
4. Assert `duckAIHeader` + `duckAiBack` are visible.
5. Tap `duckAiBack` and assert `newTabPage` + `ddgLogo` are shown.

Three iterations sweeping `omnibarPosition` (top / bottom / split), all pinned to `nativeInputToggle=true`, `inputWithAiToggle=false`. Each iteration wraps in `retry: maxRetries: 3` to match the rest of the `unifiedInputTest` suite.

The model / reasoning / tool pills don't exist in AI-off mode, so this PR only covers the icon → back-to-NTP scenario.

### Steps to test this PR

- [ ] Install: \`./gradlew installInternalDebug\`
- [ ] Run: \`maestro test .maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml\`
- [ ] All three iterations pass

### UI changes
| Before  | After |
| ------ | ----- |
| N/A — test-only change | N/A — test-only change |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML; no production app or security logic changes.
> 
> **Overview**
> Adds Maestro coverage for **unified input with AI in the input screen off** (`inputWithAiToggle: "false"`): open Duck.ai from `aiChatIconMenu` (no Search/Duck.ai tab), then return to the NTP via `duckAiBack`.
> 
> Introduces `shared/flow_open_duckai_back_to_ntp.yaml` (type in `inputField`, T&C/reload helpers, assert chat header/back, tap back and assert `newTabPage` while `duckAIHeader` is gone—avoiding `ddgLogo` because of duplicate ids). `unified_input_open_duckai_back_to_ntp.yaml` runs that flow three times with `omnibarPosition` top/bottom/split, each in `retry: maxRetries: 3` under `unifiedInputTest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5b6daf333a19193c0b5d7db70f5df53cffbcaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->