### PR TITLE
Update content scope scripts to version 14.13.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -5454,6 +5454,20 @@
       return deviceInfo;
     }
     /**
+     * Fallback device list when the deviceEnumeration messaging request fails.
+     * Mimics pre-permission enumerateDevices (unlabeled devices) without calling native.
+     * Includes audiooutput so sites can still detect speaker/output capability.
+     * @param {'syntheticPrototype' | 'instanceOwn'} shimMode
+     * @returns {MediaDeviceInfo[]}
+     */
+    createEnumerateDevicesFallback(shimMode) {
+      return [
+        this.createMediaDeviceInfo("videoinput", shimMode),
+        this.createMediaDeviceInfo("audioinput", shimMode),
+        this.createMediaDeviceInfo("audiooutput", shimMode)
+      ];
+    }
+    /**
      * Helper to wrap a promise with timeout
      * @param {Promise} promise - Promise to wrap
      * @param {number} timeoutMs - Timeout in milliseconds
@@ -5500,8 +5514,8 @@
             } else {
               return DDGReflect.apply(target, thisArg, args);
             }
-          } catch (err) {
-            return DDGReflect.apply(target, thisArg, args);
+          } catch (_err) {
+            return Promise.resolve(this.createEnumerateDevicesFallback(shimMode));
           }
         }
       });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8283,6 +8283,20 @@
       return deviceInfo;
     }
     /**
+     * Fallback device list when the deviceEnumeration messaging request fails.
+     * Mimics pre-permission enumerateDevices (unlabeled devices) without calling native.
+     * Includes audiooutput so sites can still detect speaker/output capability.
+     * @param {'syntheticPrototype' | 'instanceOwn'} shimMode
+     * @returns {MediaDeviceInfo[]}
+     */
+    createEnumerateDevicesFallback(shimMode) {
+      return [
+        this.createMediaDeviceInfo("videoinput", shimMode),
+        this.createMediaDeviceInfo("audioinput", shimMode),
+        this.createMediaDeviceInfo("audiooutput", shimMode)
+      ];
+    }
+    /**
      * Helper to wrap a promise with timeout
      * @param {Promise} promise - Promise to wrap
      * @param {number} timeoutMs - Timeout in milliseconds
@@ -8329,8 +8343,8 @@
             } else {
               return DDGReflect.apply(target, thisArg, args);
             }
-          } catch (err) {
-            return DDGReflect.apply(target, thisArg, args);
+          } catch (_err) {
+            return Promise.resolve(this.createEnumerateDevicesFallback(shimMode));
           }
         }
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.77.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -22,13 +22,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.84.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.84.1.tgz",
-      "integrity": "sha512-0XASSabqGAcsBetIWQ2hD6GjdSVa0NdYZByMnKjwOzuLaZ/ffGDzYQ3Pd+wdVQdxQKiTRX4Gp745iz98TQazTg==",
+      "version": "14.84.2",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.84.2.tgz",
+      "integrity": "sha512-Pkx+kvNeXDCHId2fLZIM2/q4jVHEaTtM/TPHVLEEmS2wO5daf4YfosIQQoskwr8usffWcjdP3nREqA70zsLtMQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d3d2daabba2846b667184bf6896f1e51dc9b9aa1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9154d509a51501cecf541b66e2c932023996fbe5",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
+      "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.30.tgz",
-      "integrity": "sha512-r5Y5PHuJg96xNfYJd71fxFT4EJvSs2gsZ1iilGR+xH1vwJpUWQ5CwT2ZwAZ0q8Lo9sdiijX2/zSQ6X+2YojGFg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.0.tgz",
+      "integrity": "sha512-F/xMOEOBEadHoaap73sz2utvE0vAvKv3h/a5vZYt3zLrJY51sGYIifbV2x8KNhENaU6xrTevydtVZjEr1iAfKQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.30"
+        "tldts-core": "^7.4.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.77.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1215115093236160/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes injected WebView fingerprinting/media enumeration behavior on failure paths, which can affect site compatibility and privacy-related API surface without touching Kotlin app code directly.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **14.12.0** to **14.13.0** and refreshes the Android vendored bundles (`contentScope.js`, `adsjsContentScope.js`) plus **`package-lock.json`**.
> 
> The meaningful behavior change is in the **`enumerateDevices`** web-compat shim: when the native **device enumeration** messaging call fails or times out, the proxy now returns a **synthetic pre-permission-style device list** (video input, audio input, and audio output) via **`createEnumerateDevicesFallback`**, instead of falling through to the real **`enumerateDevices`** API. That keeps sites from hitting native enumeration on error paths while still exposing basic media capability signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec8d2c304e9ef33e4e22aecf48ffb0585ca46d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->