### PR TITLE
Bump native-github-asana-sync to v2.4

### DIFF
--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v4
         with:
-            ref: v2.1
+            ref: v2.4
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215113750466060

### Description

Bumps the `duckduckgo/native-github-asana-sync` checkout in `.github/workflows/privacy-review.yml` from `v2.1` to `v2.4`. v2.4 brings in the privacy automation work that exposes the new triage outputs and points the classifier dispatch at `main`.

Part of [Merge Stage 1](https://app.asana.com/1/137249556945/task/1215113750466052). No app/UI changes.

### Steps to test this PR

_Privacy review automation_
- [ ] Open a draft PR against `develop` on this repo and add the `privacy review` label.
- [ ] Verify the "Create Asana task for Privacy Review" workflow runs, checks out `duckduckgo/native-github-asana-sync@v2.4`, and creates a Privacy Triage task in Asana.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single ref bump in one workflow file; no app, auth, or runtime code changes.
> 
> **Overview**
> Updates the **privacy review** GitHub workflow so `actions/checkout` pulls `duckduckgo/native-github-asana-sync` at **`v2.4`** instead of **`v2.1`**. The workflow still checks out into `native-github-asana-sync` and runs `./native-github-asana-sync/.github/actions/privacy-review/` with the same Android team and secrets.
> 
> This is CI-only automation for labeled PRs (`privacy review`); it aligns Android with the newer sync release that includes updated privacy triage outputs and classifier dispatch behavior described in the PR notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e272b795ebb8ea207bcfa326c22de281c78e62dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->