### PR TITLE
dismiss widget dialog when running privacy instrumentation tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/BasicJourneyTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/BasicJourneyTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.espresso
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isClickable
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -41,8 +40,7 @@ class BasicJourneyTest {
 
     @Test @UserJourney
     fun browser_openPopUp() {
-        // dismiss any first-run dialogs (e.g., widget promo)
-        dismissBlockingDialogs()
+        dismissWidgetPromoIfPresent()
 
         // since we use a fake toolbar, we want to wait until the real one is visible
         onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
@@ -52,14 +50,5 @@ class BasicJourneyTest {
 
         // check that the forward button is visible
         clickMenuItem(withId(BrowserUiR.id.forwardMenuItem))
-    }
-
-    private fun dismissBlockingDialogs() {
-        // dismiss the home screen widget promo if present
-        runCatching {
-            onView(isRoot()).inRoot(isDialog())
-                .perform(waitForView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton), timeout = 3000))
-            onView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton)).perform(click())
-        }
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/espresso/EspressoUtils.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/EspressoUtils.kt
@@ -18,7 +18,13 @@ package com.duckduckgo.espresso
 
 import android.view.*
 import androidx.test.espresso.*
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.*
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.duckduckgo.app.browser.R
 import org.hamcrest.*
 
 // used to introduce a delay not blocking main thread
@@ -29,5 +35,15 @@ fun waitFor(delay: Long): ViewAction {
         override fun perform(uiController: UiController, v: View?) {
             uiController.loopMainThreadForAtLeast(delay)
         }
+    }
+}
+
+// The Home screen widget promo bottom sheet (CtaViewModel.canShowWidgetCta) can appear on top of
+// BrowserActivity on fresh installs and obscure the activity's own root, breaking unrelated tests.
+fun dismissWidgetPromoIfPresent() {
+    runCatching {
+        onView(isRoot()).inRoot(isDialog())
+            .perform(waitForView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton), timeout = 3000))
+        onView(withId(R.id.homeScreenWidgetBottomSheetDialogGhostButton)).perform(click())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/PrivacyTestExtensions.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/PrivacyTestExtensions.kt
@@ -25,6 +25,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.espresso.dismissWidgetPromoIfPresent
 import com.duckduckgo.espresso.waitFor
 import com.duckduckgo.espresso.waitForView
 import java.util.concurrent.TimeUnit
@@ -33,6 +34,8 @@ fun preparationsForPrivacyTest() {
     val waitTime = 16000L
     IdlingPolicies.setMasterPolicyTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
     IdlingPolicies.setIdlingResourceTimeout(waitTime * 10, TimeUnit.MILLISECONDS)
+
+    dismissWidgetPromoIfPresent()
 
     onView(isRoot()).perform(waitForView(withId(R.id.browserMenu)))
     onView(isRoot()).perform(waitFor(2000))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215115320142558?focus=true

### Description
Dismiss widget pop-up when running privacy instrumentation tests.

### Steps to test this PR
QA optional, running the test on CI in https://github.com/duckduckgo/Android/actions/runs/26440610428.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Android instrumentation test utilities; no production app behavior.
> 
> **Overview**
> Centralizes Espresso handling for the **home screen widget promo** bottom sheet so instrumentation tests are less flaky on fresh installs.
> 
> The dismissal logic moves from a private helper in `BasicJourneyTest` into shared **`dismissWidgetPromoIfPresent()`** in `EspressoUtils.kt` (with a short comment tying it to `CtaViewModel.canShowWidgetCta`). **`preparationsForPrivacyTest()`** now calls that helper after the browser menu is ready, so privacy tests get the same dialog cleanup as the basic journey test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3272d284854d70e36ac41390be48b02c306c6645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->