### PR TITLE
Move voice chat into bottom-row buttons

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -563,22 +563,15 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun updateVoiceButtons(widget: NativeInputWidget) {
-        val isOnActiveDuckChat = omnibarController.isDuckAiMode()
-        val voiceSearchAvailable = voiceSearchAvailability.isVoiceSearchAvailable
-        val voiceSearchDuckAiAvailable = duckAiFeatureState.showVoiceSearchToggle.value
-        val voiceChatEntryAvailable = duckAiFeatureState.showVoiceChatEntry.value
-
-        if (isOnActiveDuckChat) {
-            widget.setVoiceSearchAvailable(voiceSearchAvailable && voiceSearchDuckAiAvailable)
-            widget.setVoiceChatAvailable(false)
-            return
-        }
-
-        val isDuckAiTabSelected = widget.isChatTabSelected()
-        // Voice search and voice chat now occupy separate slots (in-field vs. bottom-row), so they
-        // can coexist on the Duck.ai tab. Voice search there is gated only by its own feature flag.
-        widget.setVoiceSearchAvailable(voiceSearchAvailable && (!isDuckAiTabSelected || voiceSearchDuckAiAvailable))
-        widget.setVoiceChatAvailable(isDuckAiTabSelected && voiceChatEntryAvailable)
+        val state = computeVoiceButtonAvailability(
+            isOnActiveDuckChat = omnibarController.isDuckAiMode(),
+            isVoiceSearchDeviceAvailable = voiceSearchAvailability.isVoiceSearchAvailable,
+            isVoiceSearchDuckAiEnabled = duckAiFeatureState.showVoiceSearchToggle.value,
+            isVoiceChatEntryEnabled = duckAiFeatureState.showVoiceChatEntry.value,
+            isDuckAiTabSelected = widget.isChatTabSelected(),
+        )
+        widget.setVoiceSearchAvailable(state.voiceSearchAvailable)
+        widget.setVoiceChatAvailable(state.voiceChatAvailable)
     }
 
     private fun bindSearchTabAutocompleteClearing(
@@ -797,4 +790,40 @@ class RealNativeInputManager @Inject constructor(
         private const val FADE_OUT_DURATION_MS = 150L
         private const val DUCK_AI_FEATURE_PAGE = "duckai"
     }
+}
+
+internal data class VoiceButtonAvailability(
+    val voiceSearchAvailable: Boolean,
+    val voiceChatAvailable: Boolean,
+)
+
+/**
+ * Pure decision logic for which voice entry points the unified input should expose.
+ *
+ * Rules:
+ * - On an active Duck.ai chat page, voice chat is suppressed (you're already in the chat). Voice
+ *   search is offered only if both the device supports it and the Duck.ai voice-search flag is on.
+ * - Otherwise (NTP / search omnibar with the Search↔Duck.ai toggle):
+ *   - Search tab: voice search if device-available.
+ *   - Duck.ai tab: voice search if device-available AND [isVoiceSearchDuckAiEnabled]; voice chat
+ *     if [isVoiceChatEntryEnabled]. The two are independent now that they occupy separate slots
+ *     (in-field microphone vs. bottom-row chip).
+ */
+internal fun computeVoiceButtonAvailability(
+    isOnActiveDuckChat: Boolean,
+    isVoiceSearchDeviceAvailable: Boolean,
+    isVoiceSearchDuckAiEnabled: Boolean,
+    isVoiceChatEntryEnabled: Boolean,
+    isDuckAiTabSelected: Boolean,
+): VoiceButtonAvailability {
+    if (isOnActiveDuckChat) {
+        return VoiceButtonAvailability(
+            voiceSearchAvailable = isVoiceSearchDeviceAvailable && isVoiceSearchDuckAiEnabled,
+            voiceChatAvailable = false,
+        )
+    }
+    return VoiceButtonAvailability(
+        voiceSearchAvailable = isVoiceSearchDeviceAvailable && (!isDuckAiTabSelected || isVoiceSearchDuckAiEnabled),
+        voiceChatAvailable = isDuckAiTabSelected && isVoiceChatEntryEnabled,
+    )
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -575,8 +575,9 @@ class RealNativeInputManager @Inject constructor(
         }
 
         val isDuckAiTabSelected = widget.isChatTabSelected()
-        val shouldShowVoiceSearchForDuckAi = !voiceChatEntryAvailable && voiceSearchDuckAiAvailable
-        widget.setVoiceSearchAvailable(voiceSearchAvailable && (!isDuckAiTabSelected || shouldShowVoiceSearchForDuckAi))
+        // Voice search and voice chat now occupy separate slots (in-field vs. bottom-row), so they
+        // can coexist on the Duck.ai tab. Voice search there is gated only by its own feature flag.
+        widget.setVoiceSearchAvailable(voiceSearchAvailable && (!isDuckAiTabSelected || voiceSearchDuckAiAvailable))
         widget.setVoiceChatAvailable(isDuckAiTabSelected && voiceChatEntryAvailable)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/VoiceButtonAvailabilityTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/VoiceButtonAvailabilityTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoiceButtonAvailabilityTest {
+
+    @Test
+    fun whenDeviceVoiceSearchUnavailableThenVoiceSearchUnavailableEverywhere() {
+        val searchTab = compute(deviceAvailable = false, isDuckAiTabSelected = false)
+        val chatTab = compute(deviceAvailable = false, isDuckAiTabSelected = true)
+        val activeDuckChat = compute(deviceAvailable = false, isOnActiveDuckChat = true)
+
+        assertEquals(false, searchTab.voiceSearchAvailable)
+        assertEquals(false, chatTab.voiceSearchAvailable)
+        assertEquals(false, activeDuckChat.voiceSearchAvailable)
+    }
+
+    @Test
+    fun whenOnSearchTabThenVoiceSearchGatedByDeviceOnlyAndVoiceChatUnavailable() {
+        val withFlags = compute(isDuckAiTabSelected = false, duckAiVoiceSearch = true, voiceChatEntry = true)
+        val withoutFlags = compute(isDuckAiTabSelected = false, duckAiVoiceSearch = false, voiceChatEntry = false)
+
+        assertEquals(true, withFlags.voiceSearchAvailable)
+        assertEquals(false, withFlags.voiceChatAvailable)
+        assertEquals(true, withoutFlags.voiceSearchAvailable)
+        assertEquals(false, withoutFlags.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnDuckAiTabAndBothFlagsEnabledThenBothControlsAvailable() {
+        val state = compute(isDuckAiTabSelected = true, duckAiVoiceSearch = true, voiceChatEntry = true)
+
+        assertEquals(true, state.voiceSearchAvailable)
+        assertEquals(true, state.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnDuckAiTabAndOnlyVoiceChatFlagEnabledThenOnlyVoiceChatAvailable() {
+        val state = compute(isDuckAiTabSelected = true, duckAiVoiceSearch = false, voiceChatEntry = true)
+
+        assertEquals(false, state.voiceSearchAvailable)
+        assertEquals(true, state.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnDuckAiTabAndOnlyVoiceSearchFlagEnabledThenOnlyVoiceSearchAvailable() {
+        val state = compute(isDuckAiTabSelected = true, duckAiVoiceSearch = true, voiceChatEntry = false)
+
+        assertEquals(true, state.voiceSearchAvailable)
+        assertEquals(false, state.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnDuckAiTabAndBothFlagsDisabledThenNeitherAvailable() {
+        val state = compute(isDuckAiTabSelected = true, duckAiVoiceSearch = false, voiceChatEntry = false)
+
+        assertEquals(false, state.voiceSearchAvailable)
+        assertEquals(false, state.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnActiveDuckChatThenVoiceChatSuppressedRegardlessOfFlag() {
+        val withFlag = compute(isOnActiveDuckChat = true, voiceChatEntry = true)
+        val withoutFlag = compute(isOnActiveDuckChat = true, voiceChatEntry = false)
+
+        assertEquals(false, withFlag.voiceChatAvailable)
+        assertEquals(false, withoutFlag.voiceChatAvailable)
+    }
+
+    @Test
+    fun whenOnActiveDuckChatThenVoiceSearchGatedByDuckAiFlag() {
+        val enabled = compute(isOnActiveDuckChat = true, duckAiVoiceSearch = true)
+        val disabled = compute(isOnActiveDuckChat = true, duckAiVoiceSearch = false)
+
+        assertEquals(true, enabled.voiceSearchAvailable)
+        assertEquals(false, disabled.voiceSearchAvailable)
+    }
+
+    @Test
+    fun whenOnActiveDuckChatThenTabSelectionIsIgnored() {
+        val searchTabSelected = compute(isOnActiveDuckChat = true, isDuckAiTabSelected = false, duckAiVoiceSearch = true)
+        val chatTabSelected = compute(isOnActiveDuckChat = true, isDuckAiTabSelected = true, duckAiVoiceSearch = true)
+
+        assertEquals(searchTabSelected, chatTabSelected)
+    }
+
+    private fun compute(
+        isOnActiveDuckChat: Boolean = false,
+        deviceAvailable: Boolean = true,
+        duckAiVoiceSearch: Boolean = true,
+        voiceChatEntry: Boolean = true,
+        isDuckAiTabSelected: Boolean = false,
+    ): VoiceButtonAvailability = computeVoiceButtonAvailability(
+        isOnActiveDuckChat = isOnActiveDuckChat,
+        isVoiceSearchDeviceAvailable = deviceAvailable,
+        isVoiceSearchDuckAiEnabled = duckAiVoiceSearch,
+        isVoiceChatEntryEnabled = voiceChatEntry,
+        isDuckAiTabSelected = isDuckAiTabSelected,
+    )
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -42,7 +42,7 @@ class InputScreenButtons @JvmOverloads constructor(
     private val actionSend: ImageView by lazy { findViewById(R.id.actionSend) }
     private val actionNewLine: ImageView by lazy { findViewById(R.id.actionNewLine) }
     private val actionVoiceSearch: ImageView by lazy { findViewById(R.id.actionVoiceSearch) }
-    private val actionVoiceChat: ImageView by lazy { findViewById(R.id.actionVoiceChat) }
+    private val actionVoiceChat: ImageView? by lazy { findViewById(R.id.actionVoiceChat) }
 
     var onSendClick: (() -> Unit)? = null
         set(value) {
@@ -67,7 +67,7 @@ class InputScreenButtons @JvmOverloads constructor(
     var onVoiceChatClick: (() -> Unit)? = null
         set(value) {
             field = value
-            actionVoiceChat.setOnClickListener { value?.invoke() }
+            actionVoiceChat?.setOnClickListener { value?.invoke() }
         }
 
     init {
@@ -131,7 +131,7 @@ class InputScreenButtons @JvmOverloads constructor(
     }
 
     fun setVoiceChatVisible(visible: Boolean) {
-        actionVoiceChat.isVisible = visible
+        actionVoiceChat?.isVisible = visible
     }
 
     private fun transformButtonsToFloating() {
@@ -149,7 +149,7 @@ class InputScreenButtons @JvmOverloads constructor(
             width = buttonSizePx
             height = buttonSizePx
         }
-        actionVoiceChat.updateLayoutParams {
+        actionVoiceChat?.updateLayoutParams {
             width = buttonSizePx
             height = buttonSizePx
         }
@@ -164,11 +164,11 @@ class InputScreenButtons @JvmOverloads constructor(
         // three buttons only need it when floating, so we apply it here.
         val backgroundRes = R.drawable.background_input_screen_button
         actionNewLine.setBackgroundResource(backgroundRes)
-        actionVoiceChat.setBackgroundResource(backgroundRes)
+        actionVoiceChat?.setBackgroundResource(backgroundRes)
         actionVoiceSearch.setBackgroundResource(backgroundRes)
         val circularRippleDrawable = ContextCompat.getDrawable(context, CommonR.drawable.selectable_circular_ripple)
         actionNewLine.foreground = circularRippleDrawable
         actionVoiceSearch.foreground = circularRippleDrawable
-        actionVoiceChat.foreground = circularRippleDrawable
+        actionVoiceChat?.foreground = circularRippleDrawable
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -41,7 +41,7 @@ class InputScreenButtons @JvmOverloads constructor(
 
     private val actionSend: ImageView by lazy { findViewById(R.id.actionSend) }
     private val actionNewLine: ImageView by lazy { findViewById(R.id.actionNewLine) }
-    private val actionVoiceSearch: ImageView by lazy { findViewById(R.id.actionVoiceSearch) }
+    private val actionVoiceSearch: ImageView? by lazy { findViewById(R.id.actionVoiceSearch) }
     private val actionVoiceChat: ImageView? by lazy { findViewById(R.id.actionVoiceChat) }
 
     var onSendClick: (() -> Unit)? = null
@@ -61,7 +61,7 @@ class InputScreenButtons @JvmOverloads constructor(
     var onVoiceSearchClick: (() -> Unit)? = null
         set(value) {
             field = value
-            actionVoiceSearch.setOnClickListener { value?.invoke() }
+            actionVoiceSearch?.setOnClickListener { value?.invoke() }
         }
 
     var onVoiceChatClick: (() -> Unit)? = null
@@ -77,7 +77,7 @@ class InputScreenButtons @JvmOverloads constructor(
             transformButtonsToFloating()
         } else {
             // when in bottom bar mode, the voice search icon is shown in the input field
-            actionVoiceSearch.gone()
+            actionVoiceSearch?.gone()
         }
     }
 
@@ -127,7 +127,7 @@ class InputScreenButtons @JvmOverloads constructor(
     }
 
     fun setVoiceSearchVisible(visible: Boolean) {
-        actionVoiceSearch.isVisible = visible
+        actionVoiceSearch?.isVisible = visible
     }
 
     fun setVoiceChatVisible(visible: Boolean) {
@@ -145,7 +145,7 @@ class InputScreenButtons @JvmOverloads constructor(
             width = buttonSizePx
             height = buttonSizePx
         }
-        actionVoiceSearch.updateLayoutParams {
+        actionVoiceSearch?.updateLayoutParams {
             width = buttonSizePx
             height = buttonSizePx
         }
@@ -165,10 +165,10 @@ class InputScreenButtons @JvmOverloads constructor(
         val backgroundRes = R.drawable.background_input_screen_button
         actionNewLine.setBackgroundResource(backgroundRes)
         actionVoiceChat?.setBackgroundResource(backgroundRes)
-        actionVoiceSearch.setBackgroundResource(backgroundRes)
+        actionVoiceSearch?.setBackgroundResource(backgroundRes)
         val circularRippleDrawable = ContextCompat.getDrawable(context, CommonR.drawable.selectable_circular_ripple)
         actionNewLine.foreground = circularRippleDrawable
-        actionVoiceSearch.foreground = circularRippleDrawable
+        actionVoiceSearch?.foreground = circularRippleDrawable
         actionVoiceChat?.foreground = circularRippleDrawable
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -523,9 +523,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val isBrowserContext = nativeInputState?.inputContext == NativeInputState.InputContext.BROWSER
         val hasText = inputField.text.isNotBlank()
         val visible = isBrowserContext && isChatTabSelected() && hasText && !isStreaming
-        // Top-bar uses the floating row; bottom-bar has no floating row, so the new-line button
-        // in `submitButtons` (card's bottom row) is the only host available there.
-        (floatingButtons ?: submitButtons)?.setNewLineButtonVisible(visible)
+        // Only the top-bar floating row hosts the new-line button. Bottom-bar mode has no
+        // on-screen new-line; carriage return there is the IME enter key while on a Duck.ai
+        // page (see `applyChatInputType`: IME_ACTION_NONE + TYPE_TEXT_FLAG_MULTI_LINE).
+        floatingButtons?.setNewLineButtonVisible(visible)
     }
 
     private fun applyState(state: NativeInputState) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -626,15 +626,26 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     applyTabUi()
                     pushToggleSelectionIfUserDriven()
                     viewModel.updatePluginContainerVisibility(isChatTabSelected())
+                    refreshTabDependentButtons()
                 }
                 override fun onTabUnselected(tab: TabLayout.Tab) {}
                 override fun onTabReselected(tab: TabLayout.Tab) {
                     applyTabUi()
                     pushToggleSelectionIfUserDriven()
                     viewModel.updatePluginContainerVisibility(isChatTabSelected())
+                    refreshTabDependentButtons()
                 }
             },
         )
+    }
+
+    // send and new-line both gate on `isChatTabSelected()`. Voice buttons re-evaluate on tab
+    // change via NativeInputManager's `onSearchSelected`/`onChatSelected` hooks (which call
+    // `setVoice*Available`), but send and new-line have no such external trigger, so without
+    // this their visibility stays stale across tab switches.
+    private fun refreshTabDependentButtons() {
+        updateSendButtonVisibility()
+        updateNewLineButtonVisibility()
     }
 
     // Only propagate the TabLayout selection into NativeInputState when the toggle row is actually

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1165,7 +1165,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 layoutResId = R.layout.view_native_input_screen_floating_buttons,
             ).apply {
                 onNewLineClick = { printNewLine() }
-                onVoiceSearchClick = this@NativeInputModeWidget.onVoiceSearchClick
                 setSendButtonVisible(false)
                 setNewLineButtonVisible(false)
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -530,7 +530,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun applyState(state: NativeInputState) {
-        val contextChanged = nativeInputState?.inputContext != state.inputContext
+        val previousState = nativeInputState
+        val firstStateEmission = previousState == null
+        val contextChanged = previousState?.inputContext != state.inputContext
+        val positionChanged = previousState?.isBottom != state.isBottom
         nativeInputState = state
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
@@ -541,7 +544,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyVerticalPaddingForFocus()
         updateNewLineButtonVisibility()
         applyOmnibarShape()
-        if (contextChanged && isChatTabSelected()) {
+        // Re-apply chat input type whenever the inputs to `applyChatInputType` (context, position)
+        // change, or on the first emission. This corrects stale IME setup from a tab listener
+        // that fired before the state-flow caught up.
+        if ((firstStateEmission || contextChanged || positionChanged) && isChatTabSelected()) {
             inputField.applyChatInputType()
             (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(inputField)
         }
@@ -669,7 +675,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // Enter inserts a newline when we're on a Duck.ai chat page (existing behavior) or when
         // the widget sits in bottom-bar position with the Duck.ai toggle selected. Bottom-bar
         // mode has no on-screen new-line button, so the IME enter key is the only carriage-
-        // return affordance there.
+        // return affordance there. We read position from `isWidgetBottom()` (state-driven), and
+        // `applyState` re-fires this on the first state emission / position change so a stale
+        // value at tab-selection time gets corrected via `restartInput`.
         val newLineOnEnter = isDuckAiPageContext() || isWidgetBottom()
         val actionFlag = if (newLineOnEnter) EditorInfo.IME_ACTION_NONE else EditorInfo.IME_ACTION_GO
         imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or actionFlag

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -523,7 +523,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val isBrowserContext = nativeInputState?.inputContext == NativeInputState.InputContext.BROWSER
         val hasText = inputField.text.isNotBlank()
         val visible = isBrowserContext && isChatTabSelected() && hasText && !isStreaming
-        floatingButtons?.setNewLineButtonVisible(visible)
+        // Top-bar uses the floating row; bottom-bar has no floating row, so the new-line button
+        // in `submitButtons` (card's bottom row) is the only host available there.
+        (floatingButtons ?: submitButtons)?.setNewLineButtonVisible(visible)
     }
 
     private fun applyState(state: NativeInputState) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -666,19 +666,23 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun EditText.applyChatInputType() {
         hint = context.getString(R.string.native_input_chat_hint)
-        val isDuckAiChat = isDuckAiPageContext()
-        val actionFlag = if (isDuckAiChat) EditorInfo.IME_ACTION_NONE else EditorInfo.IME_ACTION_GO
+        // Enter inserts a newline when we're on a Duck.ai chat page (existing behavior) or when
+        // the widget sits in bottom-bar position with the Duck.ai toggle selected. Bottom-bar
+        // mode has no on-screen new-line button, so the IME enter key is the only carriage-
+        // return affordance there.
+        val newLineOnEnter = isDuckAiPageContext() || isWidgetBottom()
+        val actionFlag = if (newLineOnEnter) EditorInfo.IME_ACTION_NONE else EditorInfo.IME_ACTION_GO
         imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or actionFlag
         val baseInputType = InputType.TYPE_CLASS_TEXT or
             InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
         setRawInputType(
-            if (isDuckAiChat) baseInputType or InputType.TYPE_TEXT_FLAG_MULTI_LINE else baseInputType,
+            if (newLineOnEnter) baseInputType or InputType.TYPE_TEXT_FLAG_MULTI_LINE else baseInputType,
         )
         setHorizontallyScrolling(false)
     }
 
     override fun shouldSubmitOnHardwareEnter(): Boolean =
-        !(isDuckAiPageContext() && isChatTabSelected())
+        !(isChatTabSelected() && (isDuckAiPageContext() || isWidgetBottom()))
 
     override fun submitMessage(message: String?) {
         if (message == null && isChatTabSelected() && attachmentLimitExceeded) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1149,6 +1149,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             ).apply {
                 onSendClick = { submitMessage() }
                 onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
+                onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
                 setSendButtonVisible(false)
                 setNewLineButtonVisible(false)
             }
@@ -1161,11 +1162,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
             val buttons = InputScreenButtons(
                 context = context,
                 useTopBar = true,
-                layoutResId = R.layout.view_native_input_screen_buttons,
+                layoutResId = R.layout.view_native_input_screen_floating_buttons,
             ).apply {
                 onNewLineClick = { printNewLine() }
                 onVoiceSearchClick = this@NativeInputModeWidget.onVoiceSearchClick
-                onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
                 setSendButtonVisible(false)
                 setNewLineButtonVisible(false)
             }
@@ -1175,7 +1175,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateVoiceButtonVisibility()
     }
 
-    private fun voiceHostButtons(): InputScreenButtons? = floatingButtons ?: submitButtons
+    private fun voiceHostButtons(): InputScreenButtons? = submitButtons
 
     companion object {
         private const val MAX_LINES = 5

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
@@ -38,7 +38,7 @@
         android:layout_height="36dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/background_input_screen_button"
-        android:backgroundTint="?attr/daxColorControlFillSecondary"
+        android:backgroundTint="?attr/daxColorControlFillPrimary"
         android:foreground="@drawable/selectable_circular_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
@@ -38,13 +38,13 @@
         android:layout_height="36dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/background_input_screen_button"
-        android:backgroundTint="?attr/daxColorAccentAltPrimary"
+        android:backgroundTint="?attr/daxColorControlFillSecondary"
         android:foreground="@drawable/selectable_circular_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
         android:src="@drawable/ic_ai_chat_voice_24"
         android:visibility="gone"
-        app:tint="?attr/daxColorAccentAltContentPrimary" />
+        app:tint="?attr/daxColorPrimaryIcon" />
 
     <ImageView
         android:id="@+id/actionNewLine"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
@@ -22,17 +22,6 @@
     android:orientation="horizontal">
 
     <ImageView
-        android:id="@+id/actionVoiceSearch"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginStart="8dp"
-        android:background="@drawable/selectable_item_rounded_corner_background"
-        android:importantForAccessibility="no"
-        android:scaleType="centerInside"
-        android:src="@drawable/ic_microphone_24"
-        android:visibility="gone" />
-
-    <ImageView
         android:id="@+id/actionNewLine"
         android:layout_width="36dp"
         android:layout_height="36dp"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:clipToPadding="false"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/actionVoiceSearch"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_microphone_24"
+        android:visibility="gone" />
+
+    <ImageView
+        android:id="@+id/actionNewLine"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_enter_24"
+        android:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/actionSend"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/background_input_screen_button"
+        android:backgroundTint="?attr/daxColorButtonPrimaryContainer"
+        android:foreground="@drawable/selectable_circular_ripple"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_arrow_right_24_inverted"
+        android:visibility="gone"
+        app:tint="?attr/daxColorWhite" />
+
+</LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214927873875120

### Description

Fixes the position and styling of the voice chat control in the unified input, and unblocks voice search on the Duck.ai tab now that the two controls no longer share a slot.

What changed:

- **Voice chat moves to the card's bottom row.** `voiceHostButtons()` returns `submitButtons` unconditionally, so voice chat lives in the input card's bottom row (`inputScreenButtonsContainer`) in both top-bar and bottom-bar modes. The floating bottom-right row inflates a new dedicated layout (`view_native_input_screen_floating_buttons.xml`) that omits `actionVoiceChat` entirely — the button is physically removed from the floating container, not just hidden. `actionVoiceChat` in `InputScreenButtons` is now `ImageView?` so layouts that omit it run without an NPE.
- **Voice-chat click works in bottom-bar mode.** `submitButtons` re-reads `this@NativeInputModeWidget.onVoiceChatClick` at construction. Previously the widget setter forwarded the handler before `submitButtons` was created (during attach), leaving the click silently dead in bottom-bar mode. `floatingButtons` was already wired this way, which is why top-bar voice chat worked.
- **Voice-chat chip uses the neutral grey background.** `daxColorControlFillPrimary` instead of `daxColorAccentAltPrimary`, with `daxColorPrimaryIcon` for the icon tint.
- **Voice search now visible on the Duck.ai tab.** Voice search used to be suppressed whenever voice-chat-entry was enabled, because both lived in the same floating row. With voice search in the input field and voice chat in the bottom row, they can coexist. Voice search on Duck.ai is now gated only by its own `showVoiceSearchToggle` flag.

Out of scope (deferred from the Asana task):

- _AV5 / voice mode in chat on Android_: open design question, not a code-only change.

### Steps to test this PR

_Voice chat — top-bar (NTP / standard omnibar)_
- [x] Open a new tab and tap the omnibar to focus the unified input
- [x] Switch to the Duck.ai tab with the prompt empty — voice chat icon appears in the input card's bottom row (next to model picker, etc.), NOT as a floating button bottom-right
- [x] Tap the voice chat icon — voice chat launches
- [x] Carriage return: type something in chat mode (browser context) — newline button still floats bottom-right; voice chat is hidden
- [x] Clear the text — voice chat reappears in the bottom row

_Voice chat — bottom-bar_
- [x] Switch the address bar position to bottom in Settings
- [x] Focus the input, switch to Duck.ai tab with empty prompt — voice chat icon still appears in the bottom row (no visual regression)
- [x] Tap the voice chat icon — voice chat launches (previously this click was a no-op due to the wiring bug fixed in this PR)

_Voice chat — color_
- [x] On the Duck.ai tab with an empty prompt, the voice chat chip renders with the neutral grey `daxColorControlFillPrimary` background — not the previous blue
- [x] Switch between light and dark theme — the chip remains a subtle neutral fill in both modes (light: faint dark overlay; dark: faint light overlay)

_Voice search visibility — Duck.ai tab_
- [ ] On the Duck.ai tab with an empty prompt and the `showVoiceSearchToggle` flag enabled — the microphone (voice search) icon appears inside the input field, alongside the voice chat chip in the bottom row
- [ ] Disable `showVoiceSearchToggle` — microphone is hidden on Duck.ai tab (voice chat still shown)
- [ ] Confirm Search tab is unchanged — microphone still shown when blank

_Regression_
- [ ] Voice search (microphone) still appears inside the input field in Search mode, unchanged
- [x] Send / stop button behavior in chat mode unchanged
- [ ] On an active Duck.ai page (chat URL), only the voice search microphone is offered (voice chat suppressed, as before)

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unified omnibar/Duck.ai input UX, IME behavior, and click wiring across top/bottom layouts; logic is covered by new tests but manual QA on tab/position combos matters.
> 
> **Overview**
> Relocates **voice chat** to the unified input card’s **bottom row** in both top- and bottom-omnibar modes, while the floating corner row now only hosts **newline** and **send** via a dedicated layout—voice controls are no longer competing for the same slot.
> 
> **Voice search** can show on the Duck.ai tab alongside voice chat: availability is centralized in `computeVoiceButtonAvailability` (with unit tests), dropping the old rule that hid voice search when voice-chat entry was enabled. The voice-chat chip uses neutral fill/icon tokens; bottom-bar voice-chat clicks are wired when `submitButtons` is built.
> 
> Tab switches refresh send/newline visibility; bottom-bar Duck.ai chat mode gets multiline IME enter behavior and corrected hardware-enter submit rules when position/state updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c25839b20973c0908fbd7688edd5d70332158a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->