### PR TITLE
Fix: DRM permission dialog displayed over wrong tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -6324,7 +6324,10 @@ class BrowserTabFragment :
         permissionsToRequest: SitePermissions,
         request: PermissionRequest,
     ) {
-        if (!isActiveCustomTab() && !isActiveTab) {
+        // Use liveSelectedTab.value, not isActiveTab — the latter lags the observer dispatch
+        // and the permission command can land before it updates, opening on the wrong tab.
+        val activeTabId = viewModel.liveSelectedTab.value?.tabId
+        if (!isActiveCustomTab() && tabId != activeTabId) {
             logcat(INFO) { "Will not launch a dialog for an inactive tab" }
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215140026669480?focus=true

### Description

Fixes an issue when the DRM permissions dialog can be displayed over the wrong tab.

### Steps to test this PR

- [ ] Open cnn.com and tap on a video
- [ ] Quickly change tabs
- [ ] Verify the dialog is not displayed over the wrong tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard change in permission dialog presentation with no auth, data, or API surface changes.
> 
> **Overview**
> Fixes site permission dialogs (including DRM) appearing on the wrong tab when the user switches tabs right after a page triggers a permission request.
> 
> `showSitePermissionsDialog` now treats a tab as active only if its `tabId` matches `viewModel.liveSelectedTab.value?.tabId`, instead of relying on `isActiveTab`, which is updated later in the `liveSelectedTab` observer and could still be true on the previous tab when the permission command runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4719ede3adf41252252114e0d5fc7c7c0a128d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->