### PR TITLE
Add 'View all Chats' in chat suggestions 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1405,6 +1405,10 @@ class BrowserTabFragment :
                 },
                 onChatSuggestionSelected = { query -> userEnteredQuery(query) },
                 onChatUrlSuggestionClicked = { suggestion -> viewModel.userSelectedAutocomplete(suggestion, firePixel = false) },
+                onChatHistoryShortcutClicked = {
+                    pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
+                    viewModel.openDuckChatHistory()
+                },
                 onStopTapped = {
                     contentScopeScripts.sendSubscriptionEvent(
                         SubscriptionEventData(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -68,6 +68,7 @@ class NativeInputCallbacks(
     ) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
     val onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit = {},
+    val onChatHistoryShortcutClicked: () -> Unit = {},
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
@@ -733,6 +734,10 @@ class RealNativeInputManager @Inject constructor(
             onSearchForQuerySubmitted = { query ->
                 hideNativeInput(isNavigation = true)
                 callbacks.onSearchSubmitted(query)
+            },
+            onChatHistoryShortcutClicked = {
+                hideNativeInput(isNavigation = true)
+                callbacks.onChatHistoryShortcutClicked()
             },
             onShowSuggestions = { chatAdapter ->
                 if (autoCompleteList.adapter === chatAdapter) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -61,6 +61,7 @@ import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
 import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
@@ -94,6 +95,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewMode
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelProviderFactory
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.duckduckgo.voice.api.VoiceSearchAvailability
@@ -149,6 +151,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
     @Inject
     lateinit var browserMenuHighlight: BrowserMenuHighlight
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
 
     private val viewModel: InputScreenViewModel by lazy {
         val params = requireActivity().intent.getActivityParams(InputScreenActivityParams::class.java)
@@ -470,6 +475,11 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
             is Command.ShowAppNotFoundMessage -> {
                 Toast.makeText(requireContext(), R.string.autocompleteDeviceAppNotFound, LENGTH_SHORT).show()
+            }
+
+            is Command.LaunchDuckChatHistory -> {
+                globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
+                activity?.finish()
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -479,7 +479,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
             is Command.LaunchDuckChatHistory -> {
                 globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
-                activity?.finish()
+                exitInputScreen()
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/Command.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/Command.kt
@@ -62,6 +62,8 @@ sealed class Command {
 
     data object MenuRequested : Command()
 
+    data object LaunchDuckChatHistory : Command()
+
     data class LaunchDeviceApplication(val deviceAppSuggestion: AutoComplete.AutoCompleteSuggestion.AutoCompleteDeviceAppSuggestion) : Command()
 
     data class ShowAppNotFoundMessage(val shortName: String) : Command()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatHistoryShortcutAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatHistoryShortcutAdapter.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.duckchat.impl.databinding.ItemChatHistoryShortcutBinding
+
+class ChatHistoryShortcutAdapter(
+    private val onClick: () -> Unit,
+) : RecyclerView.Adapter<ChatHistoryShortcutAdapter.ViewHolder>() {
+
+    private var visible: Boolean = false
+
+    fun setVisible(visible: Boolean) {
+        val wasVisible = this.visible
+        this.visible = visible
+        when {
+            wasVisible && !visible -> notifyItemRemoved(0)
+            !wasVisible && visible -> notifyItemInserted(0)
+        }
+    }
+
+    override fun getItemCount(): Int = if (visible) 1 else 0
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemChatHistoryShortcutBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(onClick)
+    }
+
+    class ViewHolder(
+        private val binding: ItemChatHistoryShortcutBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(onClick: () -> Unit) {
+            binding.root.setOnClickListener { onClick() }
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatHistoryShortcutAdapter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/ChatHistoryShortcutAdapter.kt
@@ -25,6 +25,10 @@ class ChatHistoryShortcutAdapter(
     private val onClick: () -> Unit,
 ) : RecyclerView.Adapter<ChatHistoryShortcutAdapter.ViewHolder>() {
 
+    companion object {
+        const val VIEW_ALL_CHATS_THRESHOLD = 8
+    }
+
     private var visible: Boolean = false
 
     fun setVisible(visible: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -31,6 +31,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.omnibar.OmnibarType
+import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.toPx
@@ -40,7 +41,9 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenFragment
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSearchSuggestionAdapter
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
@@ -51,6 +54,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import kotlin.math.roundToInt
+
+private const val VIEW_ALL_CHATS_THRESHOLD = 8
 
 @InjectWith(FragmentScope::class)
 class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
@@ -74,6 +79,8 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     private var chatSearchSuggestionAdapter: ChatSearchSuggestionAdapter? = null
     private var chatUrlDividerAdapter: SectionDividerAdapter? = null
     private var searchDividerAdapter: SectionDividerAdapter? = null
+    private var historyShortcutDividerAdapter: SectionDividerAdapter? = null
+    private var historyShortcutAdapter: ChatHistoryShortcutAdapter? = null
     private var concatAdapter: ConcatAdapter? = null
     private var bottomBlurView: BottomBlurView? = null
     private var bottomBlurLayoutListener: View.OnLayoutChangeListener? = null
@@ -133,10 +140,11 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
             viewModel.chatSuggestions,
             viewModel.chatUrlSuggestions,
             viewModel.chatInputText,
-        ) { chatSuggestions, urlSuggestions, chatInput ->
-            Triple(chatSuggestions, urlSuggestions, chatInput)
+            viewModel.isHistoryAvailable,
+        ) { chatSuggestions, urlSuggestions, chatInput, isHistoryAvailable ->
+            ObservedState(chatSuggestions, urlSuggestions, chatInput, isHistoryAvailable)
         }.flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-            .onEach { (chatSuggestions, urlSuggestions, chatInput) ->
+            .onEach { (chatSuggestions, urlSuggestions, chatInput, isHistoryAvailable) ->
                 if (viewModel.visibilityState.value.searchMode) return@onEach
                 val isTyping = chatInput.isNotEmpty()
                 val hasChatSuggestions = chatSuggestions.isNotEmpty()
@@ -156,6 +164,10 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
                 // Dividers show between non-empty adjacent sections
                 chatUrlDividerAdapter?.setVisible(hasChatSuggestions && showUrlSuggestions)
                 searchDividerAdapter?.setVisible((hasChatSuggestions || showUrlSuggestions) && isTyping)
+
+                val showShortcut = isHistoryAvailable && chatSuggestions.size > VIEW_ALL_CHATS_THRESHOLD
+                historyShortcutAdapter?.setVisible(showShortcut)
+                historyShortcutDividerAdapter?.setVisible(showShortcut)
 
                 val hasAnySuggestions = hasChatSuggestions || isTyping
                 parentFragment.updateChatSuggestionsVisibility(hasAnySuggestions)
@@ -187,12 +199,18 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         }
         chatUrlDividerAdapter = SectionDividerAdapter()
         searchDividerAdapter = SectionDividerAdapter()
+        historyShortcutDividerAdapter = SectionDividerAdapter()
+        historyShortcutAdapter = ChatHistoryShortcutAdapter {
+            viewModel.onChatHistoryShortcutClicked()
+        }
         concatAdapter = ConcatAdapter(
             chatSuggestionsAdapter,
             chatUrlDividerAdapter,
             chatUrlSuggestionsAdapter,
             searchDividerAdapter,
             chatSearchSuggestionAdapter,
+            historyShortcutDividerAdapter,
+            historyShortcutAdapter,
         )
         chatSuggestionsRecyclerView?.adapter = concatAdapter
     }
@@ -257,4 +275,11 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         chatSuggestionsRecyclerView = null
         super.onDestroyView()
     }
+
+    private data class ObservedState(
+        val chatSuggestions: List<ChatSuggestion>,
+        val urlSuggestions: AutoComplete.AutoCompleteResult,
+        val chatInput: String,
+        val isHistoryAvailable: Boolean,
+    )
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -55,8 +55,6 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
-private const val VIEW_ALL_CHATS_THRESHOLD = 8
-
 @InjectWith(FragmentScope::class)
 class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
 
@@ -165,7 +163,7 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
                 chatUrlDividerAdapter?.setVisible(hasChatSuggestions && showUrlSuggestions)
                 searchDividerAdapter?.setVisible((hasChatSuggestions || showUrlSuggestions) && isTyping)
 
-                val showShortcut = isHistoryAvailable && chatSuggestions.size > VIEW_ALL_CHATS_THRESHOLD
+                val showShortcut = isHistoryAvailable && chatSuggestions.size > ChatHistoryShortcutAdapter.VIEW_ALL_CHATS_THRESHOLD
                 historyShortcutAdapter?.setVisible(showShortcut)
                 historyShortcutDividerAdapter?.setVisible(showShortcut)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -205,12 +205,12 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
         }
         concatAdapter = ConcatAdapter(
             chatSuggestionsAdapter,
+            historyShortcutDividerAdapter,
+            historyShortcutAdapter,
             chatUrlDividerAdapter,
             chatUrlSuggestionsAdapter,
             searchDividerAdapter,
             chatSearchSuggestionAdapter,
-            historyShortcutDividerAdapter,
-            historyShortcutAdapter,
         )
         chatSuggestionsRecyclerView?.adapter = concatAdapter
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -853,6 +853,7 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun onChatHistoryShortcutClicked() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
         command.value = Command.LaunchDuckChatHistory
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -204,6 +204,9 @@ class InputScreenViewModel @AssistedInject constructor(
     val tabAttachmentState: StateFlow<TabAttachmentState> = _tabAttachmentState.asStateFlow()
     private var cachedTabs: List<TabAttachmentItem> = emptyList()
 
+    private val _isHistoryAvailable = MutableStateFlow(false)
+    val isHistoryAvailable: StateFlow<Boolean> = _isHistoryAvailable.asStateFlow()
+
     private val refreshSuggestions = MutableSharedFlow<Unit>()
 
     private val defaultTogglePosition: StateFlow<DefaultTogglePosition> =
@@ -426,6 +429,10 @@ class InputScreenViewModel @AssistedInject constructor(
                 }
             }
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            _isHistoryAvailable.value = duckChat.isChatHistoryAvailable()
+        }
     }
 
     fun onActivityResume() {
@@ -843,6 +850,10 @@ class InputScreenViewModel @AssistedInject constructor(
 
     fun onBrowserMenuTapped() {
         command.value = Command.MenuRequested
+    }
+
+    fun onChatHistoryShortcutClicked() {
+        command.value = Command.LaunchDuckChatHistory
     }
 
     fun onClearTextTapped() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -124,6 +124,9 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val _modelPickerEnabled = MutableStateFlow(true)
     val modelPickerEnabled: StateFlow<Boolean> = _modelPickerEnabled.asStateFlow()
 
+    private val _isHistoryAvailable = MutableStateFlow(false)
+    val isHistoryAvailable: StateFlow<Boolean> = _isHistoryAvailable.asStateFlow()
+
     private val currentChat = MutableStateFlow<DuckAiChat?>(null)
     private var currentChatJob: Job? = null
 
@@ -138,6 +141,9 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             _plugins.value = nativeInputPlugins.getPlugins().toList()
+        }
+        viewModelScope.launch {
+            _isHistoryAvailable.value = duckChatInternal.isChatHistoryAvailable()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
+import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.omnibar.OmnibarType
@@ -93,6 +94,12 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             historyShortcutAdapter.setVisible(false)
             historyShortcutDivider.setVisible(false)
         }
+
+        @VisibleForTesting
+        internal fun historyShortcutAdapter(): ChatHistoryShortcutAdapter = historyShortcutAdapter
+
+        @VisibleForTesting
+        internal fun historyShortcutDivider(): SectionDividerAdapter = historyShortcutDivider
     }
 
     fun create(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
-import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.omnibar.OmnibarType
@@ -94,12 +93,6 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             historyShortcutAdapter.setVisible(false)
             historyShortcutDivider.setVisible(false)
         }
-
-        @VisibleForTesting
-        internal fun historyShortcutAdapter(): ChatHistoryShortcutAdapter = historyShortcutAdapter
-
-        @VisibleForTesting
-        internal fun historyShortcutDivider(): SectionDividerAdapter = historyShortcutDivider
     }
 
     fun create(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSearchSuggestionAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsAdapter
@@ -29,7 +30,12 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAda
 import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
 import javax.inject.Inject
 
-/** Builds the chat-tab ConcatAdapter: chat history → divider → URL suggestions → divider → "Search for [query]". */
+private const val VIEW_ALL_CHATS_THRESHOLD = 8
+
+/**
+ * Builds the chat-tab ConcatAdapter:
+ * chat history → divider → URL suggestions → divider → "Search for [query]" → divider → "View all Chats".
+ */
 class NativeInputChatSuggestionsBinder @Inject constructor(
     private val inputScreenConfigResolver: InputScreenConfigResolver,
 ) {
@@ -41,6 +47,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         private val urlDivider: SectionDividerAdapter,
         private val searchDivider: SectionDividerAdapter,
         private val searchForAdapter: ChatSearchSuggestionAdapter,
+        private val historyShortcutDivider: SectionDividerAdapter,
+        private val historyShortcutAdapter: ChatHistoryShortcutAdapter,
     ) {
         /**
          * Applies content to all sub-adapters; [onCommit] fires after the async chat history
@@ -51,12 +59,14 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         fun submit(
             suggestions: ChatTabSuggestions,
             query: String,
+            isHistoryAvailable: Boolean,
             onCommit: (hasContent: Boolean) -> Unit,
         ) {
             val isTyping = query.isNotEmpty()
             val hasChat = suggestions.chatHistory.isNotEmpty()
             val hasUrl = suggestions.urlSuggestions.suggestions.isNotEmpty()
             val showUrl = isTyping && hasUrl
+            val showShortcut = isHistoryAvailable && suggestions.chatHistory.size > VIEW_ALL_CHATS_THRESHOLD
             val hasContent = hasChat || isTyping
 
             chatSuggestionsAdapter.submitList(suggestions.chatHistory) {
@@ -70,6 +80,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             searchForAdapter.update(query, visible = isTyping)
             urlDivider.setVisible(hasChat && showUrl)
             searchDivider.setVisible((hasChat || showUrl) && isTyping)
+            historyShortcutAdapter.setVisible(showShortcut)
+            historyShortcutDivider.setVisible(showShortcut)
         }
 
         fun clear() {
@@ -78,6 +90,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             searchForAdapter.update("", visible = false)
             urlDivider.setVisible(false)
             searchDivider.setVisible(false)
+            historyShortcutAdapter.setVisible(false)
+            historyShortcutDivider.setVisible(false)
         }
     }
 
@@ -85,6 +99,7 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         onChatSuggestionSelected: (ChatSuggestion) -> Unit,
         onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
         onSearchForQuerySubmitted: (String) -> Unit,
+        onChatHistoryShortcutClicked: () -> Unit,
     ): Binding {
         val chatSuggestionsAdapter = ChatSuggestionsAdapter { onChatSuggestionSelected(it) }
         val urlAdapter = BrowserAutoCompleteSuggestionsAdapter(
@@ -98,6 +113,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         val urlDivider = SectionDividerAdapter()
         val searchDivider = SectionDividerAdapter()
         val searchForAdapter = ChatSearchSuggestionAdapter { onSearchForQuerySubmitted(it) }
+        val historyShortcutDivider = SectionDividerAdapter()
+        val historyShortcutAdapter = ChatHistoryShortcutAdapter { onChatHistoryShortcutClicked() }
 
         val concat = ConcatAdapter(
             chatSuggestionsAdapter,
@@ -105,6 +122,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             urlAdapter,
             searchDivider,
             searchForAdapter,
+            historyShortcutDivider,
+            historyShortcutAdapter,
         )
 
         return Binding(
@@ -114,6 +133,8 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             urlDivider = urlDivider,
             searchDivider = searchDivider,
             searchForAdapter = searchForAdapter,
+            historyShortcutDivider = historyShortcutDivider,
+            historyShortcutAdapter = historyShortcutAdapter,
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -30,8 +30,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAda
 import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
 import javax.inject.Inject
 
-private const val VIEW_ALL_CHATS_THRESHOLD = 8
-
 /**
  * Builds the chat-tab ConcatAdapter:
  * chat history → divider → "View all Chats" → divider → URL suggestions → divider → "Search for [query]".
@@ -66,7 +64,7 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             val hasChat = suggestions.chatHistory.isNotEmpty()
             val hasUrl = suggestions.urlSuggestions.suggestions.isNotEmpty()
             val showUrl = isTyping && hasUrl
-            val showShortcut = isHistoryAvailable && suggestions.chatHistory.size > VIEW_ALL_CHATS_THRESHOLD
+            val showShortcut = isHistoryAvailable && suggestions.chatHistory.size > ChatHistoryShortcutAdapter.VIEW_ALL_CHATS_THRESHOLD
             val hasContent = hasChat || isTyping
 
             chatSuggestionsAdapter.submitList(suggestions.chatHistory) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -35,7 +35,7 @@ private const val VIEW_ALL_CHATS_THRESHOLD = 8
 
 /**
  * Builds the chat-tab ConcatAdapter:
- * chat history → divider → URL suggestions → divider → "Search for [query]" → divider → "View all Chats".
+ * chat history → divider → "View all Chats" → divider → URL suggestions → divider → "Search for [query]".
  */
 class NativeInputChatSuggestionsBinder @Inject constructor(
     private val inputScreenConfigResolver: InputScreenConfigResolver,
@@ -125,12 +125,12 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
 
         val concat = ConcatAdapter(
             chatSuggestionsAdapter,
+            historyShortcutDivider,
+            historyShortcutAdapter,
             urlDivider,
             urlAdapter,
             searchDivider,
             searchForAdapter,
-            historyShortcutDivider,
-            historyShortcutAdapter,
         )
 
         return Binding(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -161,6 +161,7 @@ interface NativeInputWidget {
         onChatSuggestionSelected: (String) -> Unit,
         onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
         onSearchForQuerySubmitted: (String) -> Unit,
+        onChatHistoryShortcutClicked: () -> Unit,
         onShowSuggestions: (RecyclerView.Adapter<*>) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     )
@@ -955,6 +956,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onChatSuggestionSelected: (String) -> Unit,
         onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit,
         onSearchForQuerySubmitted: (String) -> Unit,
+        onChatHistoryShortcutClicked: () -> Unit,
         onShowSuggestions: (RecyclerView.Adapter<*>) -> Unit,
         onClearSuggestions: (Boolean) -> Unit,
     ) {
@@ -974,6 +976,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     onChatUrlSuggestionClicked(suggestion)
                 },
                 onSearchForQuerySubmitted = onSearchForQuerySubmitted,
+                onChatHistoryShortcutClicked = onChatHistoryShortcutClicked,
             ).also { chatSuggestionsBinding = it }
         }
 
@@ -1048,13 +1051,18 @@ class NativeInputModeWidget @JvmOverloads constructor(
             val result = viewModel.fetchChatTabSuggestions(query, chatSuggestionsUserEnabled)
             // Defer the adapter swap until the chat history arrives, so the RecyclerView
             // lays out from position 0 with chat history on top and avoids repositioning.
-            binding.submit(result, query) { hasContent ->
-                if (hasContent) {
-                    onShowSuggestions?.invoke(binding.adapter)
-                } else {
-                    onClearSuggestions?.invoke(true)
-                }
-            }
+            binding.submit(
+                suggestions = result,
+                query = query,
+                isHistoryAvailable = viewModel.isHistoryAvailable.value,
+                onCommit = { hasContent ->
+                    if (hasContent) {
+                        onShowSuggestions?.invoke(binding.adapter)
+                    } else {
+                        onClearSuggestions?.invoke(true)
+                    }
+                },
+            )
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/item_chat_history_shortcut.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/item_chat_history_shortcut.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingVertical="?attr/autocompleteListItemVerticalPadding"
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding"
+    tools:ignore="Overdraw">
+
+    <ImageView
+        android:id="@+id/viewAllChatsIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_chats_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/viewAllChatsTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="?attr/autocompleteListItemIconMargin"
+        android:ellipsize="end"
+        android:gravity="center_vertical|start"
+        android:includeFontPadding="false"
+        android:maxLines="1"
+        android:text="@string/duckAiChatHistoryViewAllChats"
+        android:textAlignment="textStart"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/viewAllChatsIcon"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -20,6 +20,7 @@
     <string name="input_screen_user_pref_without_ai_updated">Search only</string>
     <string name="input_screen_user_pref_with_ai_updated">Toggle between\nSearch and Duck.ai</string>
     <string name="duckAiChatSearchDuckDuckGo">Search DuckDuckGo</string>
+    <string name="duckAiChatHistoryViewAllChats">View all Chats</string>
     <string name="native_input_chat_hint">Ask anything privately…</string>
 
     <!-- Model Picker -->

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -236,6 +236,25 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenChatHistoryAvailableThenIsHistoryAvailableEmitsTrue() = runTest {
+        whenever(duckChatInternal.isChatHistoryAvailable()).thenReturn(true)
+
+        val freshTestee = createViewModel()
+
+        assertTrue(freshTestee.isHistoryAvailable.first { it })
+    }
+
+    @Test
+    fun whenChatHistoryNotAvailableThenIsHistoryAvailableStaysFalse() = runTest {
+        whenever(duckChatInternal.isChatHistoryAvailable()).thenReturn(false)
+
+        val freshTestee = createViewModel()
+        advanceUntilIdle()
+
+        assertFalse(freshTestee.isHistoryAvailable.value)
+    }
+
+    @Test
     fun whenSearchAndDuckAiThenToggleVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -1712,12 +1712,13 @@ class InputScreenViewModelTest {
         }
 
     @Test
-    fun `when onChatHistoryShortcutClicked then emit LaunchDuckChatHistory command`() =
+    fun `when onChatHistoryShortcutClicked then emit LaunchDuckChatHistory command and fire pixel`() =
         runTest {
             val viewModel = createViewModel()
 
             viewModel.onChatHistoryShortcutClicked()
 
+            verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED)
             assertEquals(Command.LaunchDuckChatHistory, viewModel.command.value)
         }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -1690,6 +1690,38 @@ class InputScreenViewModelTest {
         }
 
     @Test
+    fun `when chat history available then isHistoryAvailable state flow emits true`() =
+        runTest {
+            whenever(duckChat.isChatHistoryAvailable()).thenReturn(true)
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.isHistoryAvailable.value)
+        }
+
+    @Test
+    fun `when chat history not available then isHistoryAvailable state flow stays false`() =
+        runTest {
+            whenever(duckChat.isChatHistoryAvailable()).thenReturn(false)
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.isHistoryAvailable.value)
+        }
+
+    @Test
+    fun `when onChatHistoryShortcutClicked then emit LaunchDuckChatHistory command`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.onChatHistoryShortcutClicked()
+
+            assertEquals(Command.LaunchDuckChatHistory, viewModel.command.value)
+        }
+
+    @Test
     fun `when any button is visible then actionButtonsContainerVisible should be true`() =
         runTest {
             data class TestCase(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/ChatHistoryShortcutAdapterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/ChatHistoryShortcutAdapterTest.kt
@@ -20,23 +20,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
-import com.duckduckgo.mobile.android.R as MobileR
 
 @RunWith(AndroidJUnit4::class)
-@Config(manifest = Config.NONE)
 class ChatHistoryShortcutAdapterTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-
-    @Before
-    fun setUp() {
-        context.setTheme(MobileR.style.Theme_DuckDuckGo_Light)
-    }
 
     @Test
     fun whenHiddenThenItemCountIsZero() {
@@ -57,20 +47,6 @@ class ChatHistoryShortcutAdapterTest {
         adapter.setVisible(true)
         adapter.setVisible(false)
         assertEquals(0, adapter.itemCount)
-    }
-
-    @Test
-    fun whenRowClickedThenCallbackInvoked() {
-        var clicked = false
-        val adapter = ChatHistoryShortcutAdapter(onClick = { clicked = true })
-        adapter.setVisible(true)
-
-        val parent = android.widget.FrameLayout(context)
-        val holder = adapter.onCreateViewHolder(parent, 0)
-        adapter.onBindViewHolder(holder, 0)
-        holder.itemView.performClick()
-
-        assertTrue(clicked)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/ChatHistoryShortcutAdapterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/suggestions/ChatHistoryShortcutAdapterTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.inputscreen.suggestions
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import com.duckduckgo.mobile.android.R as MobileR
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class ChatHistoryShortcutAdapterTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Before
+    fun setUp() {
+        context.setTheme(MobileR.style.Theme_DuckDuckGo_Light)
+    }
+
+    @Test
+    fun whenHiddenThenItemCountIsZero() {
+        val adapter = ChatHistoryShortcutAdapter(onClick = {})
+        assertEquals(0, adapter.itemCount)
+    }
+
+    @Test
+    fun whenSetVisibleTrueThenItemCountIsOne() {
+        val adapter = ChatHistoryShortcutAdapter(onClick = {})
+        adapter.setVisible(true)
+        assertEquals(1, adapter.itemCount)
+    }
+
+    @Test
+    fun whenSetVisibleTrueThenFalseItemCountReturnsToZero() {
+        val adapter = ChatHistoryShortcutAdapter(onClick = {})
+        adapter.setVisible(true)
+        adapter.setVisible(false)
+        assertEquals(0, adapter.itemCount)
+    }
+
+    @Test
+    fun whenRowClickedThenCallbackInvoked() {
+        var clicked = false
+        val adapter = ChatHistoryShortcutAdapter(onClick = { clicked = true })
+        adapter.setVisible(true)
+
+        val parent = android.widget.FrameLayout(context)
+        val holder = adapter.onCreateViewHolder(parent, 0)
+        adapter.onBindViewHolder(holder, 0)
+        holder.itemView.performClick()
+
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun whenSetVisibleSameValueTwiceThenNoCrash() {
+        val adapter = ChatHistoryShortcutAdapter(onClick = {})
+        adapter.setVisible(true)
+        adapter.setVisible(true)
+        assertEquals(1, adapter.itemCount)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.widget.FrameLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
+import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.models.ChatType
+import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import java.time.LocalDateTime
+import com.duckduckgo.mobile.android.R as MobileR
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class NativeInputChatSuggestionsBinderTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
+    private lateinit var binder: NativeInputChatSuggestionsBinder
+
+    @Before
+    fun setUp() {
+        context.setTheme(MobileR.style.Theme_DuckDuckGo_Light)
+        whenever(inputScreenConfigResolver.useTopBar()).thenReturn(false)
+        binder = NativeInputChatSuggestionsBinder(inputScreenConfigResolver)
+    }
+
+    @Test
+    fun whenChatHistoryCountGreaterThanThresholdAndHistoryAvailableThenShortcutVisible() {
+        val binding = createBinding()
+
+        binding.submit(
+            suggestions = ChatTabSuggestions(
+                chatHistory = chatSuggestions(9),
+                urlSuggestions = AutoCompleteResult(query = "", suggestions = emptyList()),
+            ),
+            query = "",
+            isHistoryAvailable = true,
+            onCommit = {},
+        )
+
+        assertEquals(1, binding.historyShortcutAdapter().itemCount)
+        assertEquals(1, binding.historyShortcutDivider().itemCount)
+    }
+
+    @Test
+    fun whenChatHistoryCountEqualsThresholdThenShortcutHidden() {
+        val binding = createBinding()
+
+        binding.submit(
+            suggestions = ChatTabSuggestions(
+                chatHistory = chatSuggestions(8),
+                urlSuggestions = AutoCompleteResult(query = "", suggestions = emptyList()),
+            ),
+            query = "",
+            isHistoryAvailable = true,
+            onCommit = {},
+        )
+
+        assertEquals(0, binding.historyShortcutAdapter().itemCount)
+        assertEquals(0, binding.historyShortcutDivider().itemCount)
+    }
+
+    @Test
+    fun whenHistoryNotAvailableThenShortcutHiddenEvenIfCountGreaterThanThreshold() {
+        val binding = createBinding()
+
+        binding.submit(
+            suggestions = ChatTabSuggestions(
+                chatHistory = chatSuggestions(9),
+                urlSuggestions = AutoCompleteResult(query = "", suggestions = emptyList()),
+            ),
+            query = "",
+            isHistoryAvailable = false,
+            onCommit = {},
+        )
+
+        assertEquals(0, binding.historyShortcutAdapter().itemCount)
+        assertEquals(0, binding.historyShortcutDivider().itemCount)
+    }
+
+    @Test
+    fun whenShortcutClickedThenCallbackInvoked() {
+        var clicked = false
+        val binding = binder.create(
+            onChatSuggestionSelected = {},
+            onChatUrlSuggestionClicked = {},
+            onSearchForQuerySubmitted = {},
+            onChatHistoryShortcutClicked = { clicked = true },
+        )
+
+        val shortcut = binding.historyShortcutAdapter()
+        shortcut.setVisible(true)
+
+        val parent = FrameLayout(context)
+        val holder = shortcut.onCreateViewHolder(parent, 0)
+        shortcut.onBindViewHolder(holder, 0)
+        holder.itemView.performClick()
+
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun whenClearThenAllAdaptersHidden() {
+        val binding = createBinding()
+
+        binding.submit(
+            suggestions = ChatTabSuggestions(
+                chatHistory = chatSuggestions(9),
+                urlSuggestions = AutoCompleteResult(query = "", suggestions = emptyList()),
+            ),
+            query = "",
+            isHistoryAvailable = true,
+            onCommit = {},
+        )
+        assertEquals(1, binding.historyShortcutAdapter().itemCount)
+
+        binding.clear()
+
+        assertEquals(0, binding.historyShortcutAdapter().itemCount)
+        assertEquals(0, binding.historyShortcutDivider().itemCount)
+    }
+
+    private fun createBinding(): NativeInputChatSuggestionsBinder.Binding =
+        binder.create(
+            onChatSuggestionSelected = {},
+            onChatUrlSuggestionClicked = {},
+            onSearchForQuerySubmitted = {},
+            onChatHistoryShortcutClicked = {},
+        )
+
+    private fun chatSuggestions(count: Int): List<ChatSuggestion> =
+        (1..count).map {
+            ChatSuggestion(
+                chatId = "id-$it",
+                title = "Chat $it",
+                lastEdit = LocalDateTime.now(),
+                pinned = false,
+                type = ChatType.Discussion,
+            )
+        }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdap
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.SectionDividerAdapter
 import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
 import org.junit.Assert.assertEquals
@@ -67,8 +68,8 @@ class NativeInputChatSuggestionsBinderTest {
             onCommit = {},
         )
 
-        assertEquals(1, binding.historyShortcutAdapter().itemCount)
-        assertEquals(1, binding.historyShortcutDivider().itemCount)
+        assertEquals(1, binding.shortcutAdapter().itemCount)
+        assertEquals(1, binding.shortcutDivider().itemCount)
     }
 
     @Test
@@ -85,8 +86,8 @@ class NativeInputChatSuggestionsBinderTest {
             onCommit = {},
         )
 
-        assertEquals(0, binding.historyShortcutAdapter().itemCount)
-        assertEquals(0, binding.historyShortcutDivider().itemCount)
+        assertEquals(0, binding.shortcutAdapter().itemCount)
+        assertEquals(0, binding.shortcutDivider().itemCount)
     }
 
     @Test
@@ -103,8 +104,8 @@ class NativeInputChatSuggestionsBinderTest {
             onCommit = {},
         )
 
-        assertEquals(0, binding.historyShortcutAdapter().itemCount)
-        assertEquals(0, binding.historyShortcutDivider().itemCount)
+        assertEquals(0, binding.shortcutAdapter().itemCount)
+        assertEquals(0, binding.shortcutDivider().itemCount)
     }
 
     @Test
@@ -117,7 +118,7 @@ class NativeInputChatSuggestionsBinderTest {
             onChatHistoryShortcutClicked = { clicked = true },
         )
 
-        val shortcut = binding.historyShortcutAdapter()
+        val shortcut = binding.shortcutAdapter()
         shortcut.setVisible(true)
 
         val parent = FrameLayout(context)
@@ -158,12 +159,12 @@ class NativeInputChatSuggestionsBinderTest {
             isHistoryAvailable = true,
             onCommit = {},
         )
-        assertEquals(1, binding.historyShortcutAdapter().itemCount)
+        assertEquals(1, binding.shortcutAdapter().itemCount)
 
         binding.clear()
 
-        assertEquals(0, binding.historyShortcutAdapter().itemCount)
-        assertEquals(0, binding.historyShortcutDivider().itemCount)
+        assertEquals(0, binding.shortcutAdapter().itemCount)
+        assertEquals(0, binding.shortcutDivider().itemCount)
     }
 
     private fun createBinding(): NativeInputChatSuggestionsBinder.Binding =
@@ -184,4 +185,17 @@ class NativeInputChatSuggestionsBinderTest {
                 type = ChatType.Discussion,
             )
         }
+
+    private fun NativeInputChatSuggestionsBinder.Binding.shortcutAdapter(): ChatHistoryShortcutAdapter {
+        val concat = adapter as ConcatAdapter
+        return concat.adapters.filterIsInstance<ChatHistoryShortcutAdapter>().single()
+    }
+
+    private fun NativeInputChatSuggestionsBinder.Binding.shortcutDivider(): SectionDividerAdapter {
+        val concat = adapter as ConcatAdapter
+        val adapters = concat.adapters
+        val shortcutIndex = adapters.indexOfFirst { it is ChatHistoryShortcutAdapter }
+        check(shortcutIndex > 0) { "ChatHistoryShortcutAdapter should not be first in the ConcatAdapter" }
+        return adapters[shortcutIndex - 1] as SectionDividerAdapter
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -17,10 +17,13 @@
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import android.widget.FrameLayout
+import androidx.recyclerview.widget.ConcatAdapter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
+import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
+import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.impl.ui.ChatTabSuggestions
@@ -123,6 +126,23 @@ class NativeInputChatSuggestionsBinderTest {
         holder.itemView.performClick()
 
         assertTrue(clicked)
+    }
+
+    @Test
+    fun whenConcatAdapterAssembledThenHistoryShortcutAppearsBeforeUrlSuggestions() {
+        val binding = binder.create(
+            onChatSuggestionSelected = {},
+            onChatUrlSuggestionClicked = {},
+            onSearchForQuerySubmitted = {},
+            onChatHistoryShortcutClicked = {},
+        )
+
+        val concat = binding.adapter as ConcatAdapter
+        val adapters = concat.adapters
+        val shortcutIndex = adapters.indexOfFirst { it is ChatHistoryShortcutAdapter }
+        val urlAdapterIndex = adapters.indexOfFirst { it is BrowserAutoCompleteSuggestionsAdapter }
+
+        assertTrue("Shortcut should be before URL suggestions in the ConcatAdapter", shortcutIndex < urlAdapterIndex)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -16,10 +16,8 @@
 
 package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
-import android.widget.FrameLayout
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
 import com.duckduckgo.browser.ui.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
@@ -35,21 +33,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.robolectric.annotation.Config
 import java.time.LocalDateTime
-import com.duckduckgo.mobile.android.R as MobileR
 
 @RunWith(AndroidJUnit4::class)
-@Config(manifest = Config.NONE)
 class NativeInputChatSuggestionsBinderTest {
-
-    private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private lateinit var binder: NativeInputChatSuggestionsBinder
 
     @Before
     fun setUp() {
-        context.setTheme(MobileR.style.Theme_DuckDuckGo_Light)
         whenever(inputScreenConfigResolver.useTopBar()).thenReturn(false)
         binder = NativeInputChatSuggestionsBinder(inputScreenConfigResolver)
     }
@@ -106,27 +98,6 @@ class NativeInputChatSuggestionsBinderTest {
 
         assertEquals(0, binding.shortcutAdapter().itemCount)
         assertEquals(0, binding.shortcutDivider().itemCount)
-    }
-
-    @Test
-    fun whenShortcutClickedThenCallbackInvoked() {
-        var clicked = false
-        val binding = binder.create(
-            onChatSuggestionSelected = {},
-            onChatUrlSuggestionClicked = {},
-            onSearchForQuerySubmitted = {},
-            onChatHistoryShortcutClicked = { clicked = true },
-        )
-
-        val shortcut = binding.shortcutAdapter()
-        shortcut.setVisible(true)
-
-        val parent = FrameLayout(context)
-        val holder = shortcut.onCreateViewHolder(parent, 0)
-        shortcut.onBindViewHolder(holder, 0)
-        holder.itemView.performClick()
-
-        assertTrue(clicked)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214566301692454 

### Description

Adds a **View all Chats** shortcut at the bottom of the chat-suggestions list — both in the omnibar chat mode and in the unified input-screen Chat tab — so users with more than 8 stored chats can jump straight to the native chat-history screen without opening the browser menu. The row uses the same icon as the browser-menu **Chats** entry and inherits the same availability gate (`historyScreen` + native storage + Duck.ai enabled).

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [x] Install Internal Debug.
> - [x] In Settings → Developer Settings → Feature Flags, confirm `duckChat → historyScreen` and `duckChat → useNativeStorageChatData` are ON, and Duck.ai itself is enabled.
> - [x] Create at least 9 chats in Duck.ai so the `> 8` threshold is exercised.

_Happy path_

- [x] Focus the omnibar and switch to chat mode → confirm the chat-suggestions list shows a divider + a **View all Chats** row directly under the chat list, using the same icon as the browser-menu **Chats** entry.
- [x] Tap **View all Chats** → confirm the native Chats screen opens.
- [x] Open the unified input screen → switch to the Chat tab → confirm the same shortcut appears in the same position with the same icon + copy.
- [x] Tap the shortcut from the input-screen Chat tab → confirm the Chats screen opens AND the input screen closes (back from the Chats screen returns to the previous browser tab, not to the input screen).

_Guards_

- [x] Delete chats one by one until 8 remain → confirm the **View all Chats** row disappears at exactly 8 (visible only when count > 8).
- [x] Re-add a chat to get back to 9 → confirm the shortcut returns on both surfaces.
- [x] Turn `historyScreen` OFF in Developer Settings → confirm the shortcut is hidden on both surfaces even with 9+ chats.

_Edge cases_

- [x] Start typing in the omnibar chat mode → confirm URL suggestions and "Search for [query]" appear **below** the **View all Chats** row (full order: chat history → View all Chats → URL suggestions → Search for).

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/73b902c1-8370-4dfe-aeeb-05c855e37b26" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/c66e22bf-f61f-4618-bae4-5b575db0c6d3" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/0de0f1bd-c11e-41fc-aa19-aae1ff27d29d" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/e6039d65-050f-4a06-a1c5-7d01ae7e9370" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation and analytics in Duck.ai suggestions, gated by existing chat-history feature flags with unit test coverage.
> 
> **Overview**
> Adds a **View all Chats** row to Duck.ai chat suggestion lists on the **omnibar native input** and the **unified input screen Chat tab**, so users with a long chat list can open the native chat-history screen without the browser menu.
> 
> The row is wired through new `onChatHistoryShortcutClicked` callbacks (`NativeInputManager`, `BrowserTabFragment`, `NativeInputModeWidget`). It only shows when `isChatHistoryAvailable()` is true **and** there are more than **8** chat suggestions (`ChatHistoryShortcutAdapter.VIEW_ALL_CHATS_THRESHOLD`). In the concat list it sits after chat history and before URL / “Search for” rows. Taps fire `DUCK_CHAT_SETTINGS_SIDEBAR_TAPPED` and navigate via `LaunchDuckChatHistory` / `openDuckChatHistory()` to `DuckChatHistoryNoParams` (input screen also exits on launch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ebfc3b75c4a34c2506ddf8bab80e16815d3d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->