### PR TITLE
Restore NTP when backing out of Duck.ai from a chat submit

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -438,7 +438,12 @@ class RealNativeInputManager @Inject constructor(
                     omnibarController.restore()
                     omnibarController.show()
                     removeWidget()
-                    hideNtp()
+                    // Only tear down the NTP layer if we were over the browser — the submitted
+                    // Duck.ai URL is intercepted by SpecialUrlDetector and opens an overlay
+                    // fragment without webview navigation, so the underlying view must stay.
+                    if (omnibarController.isBrowserMode()) {
+                        hideNtp()
+                    }
                     isExiting = false
                     callbacks.onSearchSubmitted(duckChat.getDuckChatUrl(query, true))
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215110089153716?focus=true

### Description

With the native input toggle enabled and the AI-mode toggle off, opening Duck.ai from a focused NTP and pressing the in-omnibar back arrow left the user on a blank screen — no NTP logo, no NTP modules.

The native-input chat-submit-from-search branch in `NativeInputManager.bindSearchCallbacks` unconditionally called `hideNtp()` before submitting via `onSearchSubmitted(duckChat.getDuckChatUrl(query, true))`. That Duck.ai URL is intercepted by `SpecialUrlDetector` → `ShouldLaunchDuckChatLink` → `openDuckChatWithPrefill`, which opens Duck.ai as a fragment overlay without driving a webview navigation. When the overlay closes the renderer never re-runs `showHome()` (no `browserShowing` change), so the directly-hidden NTP stays hidden and the user sees the empty `browserLayout` underneath.

The companion `hideNativeInput()` already guards its `hideNtp()` with `if (omnibarController.isBrowserMode())` (added in #8669). This inline branch was missed, so on `NewTab` it tore down the NTP it should have preserved. Guarding the call the same way leaves browser-mode behaviour unchanged and preserves the NTP backdrop on submit from the focused NTP.

### Steps to test this PR

_Restore from focused NTP_
- [x] Internal build, complete onboarding choosing "Search only" (AI toggle off).
- [x] Enable Native Input Field in Settings / AI Features
- [x] On the NTP, tap the omnibar to focus and type a query (e.g. `what is a car`).
- [x] Tap the Duck.ai (chevron-down) start-chat icon — Duck.ai opens.
- [x] Tap the back arrow in the Duck.ai header.
- [x] Expected: NTP is visible (logo, modules) — no blank screen.
- [x] Repeat with omnibar position set to top, bottom and split.

_Regressions check — browser path unchanged_
- [x] Open any page (e.g. `https://example.com`), focus the omnibar, clear the URL, and type a query.
- [x] Tap the Duck.ai icon, then tap the back arrow.
- [x] Expected: the loaded page is restored (not the NTP).

_E2E_
- [x] Run `.maestro/unified_input_screen/unified_input_open_duckai_back_to_ntp.yaml` — `newTabPage` should be visible after the back-pop in all three iterations.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional around existing NTP teardown in one submit branch; browser-mode behavior unchanged.
> 
> **Overview**
> Fixes a **blank screen after backing out of Duck.ai** when chat is started from a focused **new tab page** with native input.
> 
> The native-input **chat submit** path (non–Duck.ai-mode, non-URL query) used to always call `hideNtp()` before submitting the Duck.ai URL. That URL opens Duck.ai as an **overlay** without webview navigation, so the NTP layer was removed with nothing to restore it on back. **`hideNtp()` is now gated with `omnibarController.isBrowserMode()`**, matching `hideNativeInput()`: on NTP the backdrop stays; over a loaded page the browser layer is still revealed as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eba724e1e4691572b2aff06d7abff58d71ad46e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->