### PR TITLE
Fix onboarding flow background issues when native input is enabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5915,15 +5915,24 @@ class BrowserTabFragment :
                 when {
                     viewState.cta != null -> {
                         hideNewTab()
-                        showCta(viewState.cta)
+                        // Bubble lives inside newTabLayout, which is shown outside this renderer.
+                        // Hiding the parent doesn't reset the bubble's visibility, so we clear it here.
+                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
+
+                        // Non-bubble CTAs paint outside newTabLayout, so they're never at risk of leaking.
+                        // If we're on the NTP, the bubbles paint normally.
+                        if (viewState.cta !is DaxBubbleCta || !viewState.isBrowserShowing) {
+                            showCta(viewState.cta)
+                        }
                     }
 
                     viewState.isBrowserShowing -> {
+                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
                         hideNewTab()
                     }
 
                     viewState.isOnboardingCompleteInNewTabPage && !viewState.isErrorShowing -> {
-                        hideDaxBubbleCta(previousCta as? DaxBubbleCta)
+                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
                         showNewTab()
                     }
                 }
@@ -5983,7 +5992,7 @@ class BrowserTabFragment :
                         onboardingExperimentEnabled = false,
                         configuration = configuration,
                     ) { option, index ->
-                        userEnteredQuery(option.link)
+                        submitQuery(option.link)
                         viewModel.onUserSelectedOnboardingDialogOption(configuration, index)
                     }
                 }
@@ -6064,7 +6073,7 @@ class BrowserTabFragment :
                 }
             val onSuggestedOptionsSelected: ((DaxDialogIntroOption) -> Unit)? =
                 if (configuration is OnboardingDaxDialogCta.DaxSiteSuggestionsCta) {
-                    { option: DaxDialogIntroOption -> userEnteredQuery(option.link) }
+                    { option: DaxDialogIntroOption -> submitQuery(option.link) }
                 } else {
                     null
                 }
@@ -6102,7 +6111,7 @@ class BrowserTabFragment :
                 // CTA-type-specific notifications (e.g. DaxTrackersBlocked) live on the
                 // subclass override, not on the fragment.
                 onTypingAnimationFinished = { viewModel.onOnboardingDaxTypingAnimationFinished() },
-                onSuggestedOptionClicked = { option: DaxDialogIntroOption -> userEnteredQuery(option.link) },
+                onSuggestedOptionClicked = { option: DaxDialogIntroOption -> submitQuery(option.link) },
                 onDismissCtaClicked = { viewModel.onUserClickCtaDismissButton(configuration) },
                 instantShow = instantShow,
             )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4187,6 +4187,10 @@ class BrowserTabFragment :
         brandDesignDialogScrollView.gone()
     }
 
+    private fun hideIfDaxBubble(cta: Cta?) {
+        if (cta is DaxBubbleCta) hideDaxBubbleCta(cta)
+    }
+
     @SuppressLint("AddDocumentStartJavaScriptUsage")
     private fun configureWebViewForBlobDownload(webView: DuckDuckGoWebView) {
         lifecycleScope.launch(dispatchers.main()) {
@@ -5917,7 +5921,7 @@ class BrowserTabFragment :
                         hideNewTab()
                         // Bubble lives inside newTabLayout, which is shown outside this renderer.
                         // Hiding the parent doesn't reset the bubble's visibility, so we clear it here.
-                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
+                        hideIfDaxBubble(previousCta)
 
                         // Non-bubble CTAs paint outside newTabLayout, so they're never at risk of leaking.
                         // If we're on the NTP, the bubbles paint normally.
@@ -5927,12 +5931,12 @@ class BrowserTabFragment :
                     }
 
                     viewState.isBrowserShowing -> {
-                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
+                        hideIfDaxBubble(previousCta)
                         hideNewTab()
                     }
 
                     viewState.isOnboardingCompleteInNewTabPage && !viewState.isErrorShowing -> {
-                        if (previousCta is DaxBubbleCta) hideDaxBubbleCta(previousCta)
+                        hideIfDaxBubble(previousCta)
                         showNewTab()
                     }
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214882981544707?focus=true 

### Description

NOTE: To test this PR you can use the [do_not_merge/youssef/test_onboarding_native_input](https://github.com/duckduckgo/Android/tree/do_not_merge/youssef/test_onboarding_native_input) branch where I enabled the native input by default. 

Two onboarding-flow issues that surface when the native input widget is enabled:

1. **Onboarding bubble leaks behind the native input widget on a webpage.** After completing onboarding and navigating to a page, tapping the address bar opens the native input widget over the new tab layout. The previous NTP bubble reappears under the widget, most visibly when there are no autocomplete suggestions covering the gap below the input card.

2. **Tapping a dax CTA option doesn't dismiss the widget, leaving the address bar with stale text.** The widget stays open after submit, showing whatever was in its EditText, while the omnibar underneath updates to the new URL. 

#### Root cause / fix

- **Renderer fix** in `BrowserTabFragment.renderCtaViewState`: clear the previous bubble's view state when the renderer fires, and skip `showCta` for `DaxBubbleCta`s arriving while the browser is showing. The `DaxBubbleCta` family is NTP-only; the contextual `OnboardingDaxDialogCta` family (trackers blocked, fire button, SERP, etc.) paints into a different container inside `browserLayout` and continues to render normally in browser mode.
- **CTA option click fix**: route the three dax option-click sites through the existing `submitQuery` instead of `userEnteredQuery`. `submitQuery` calls `hideNativeInput` before `onUserSubmittedQuery`.

### Steps to test this PR

_Onboarding bubble doesn't leak behind the native input widget_

- [ ] Fresh install the app.
- [ ] Complete onboarding choosing **Search only** when prompted about the address bar toggle.
- [ ] On the NTP, observe the "Try a search!" bubble.
- [ ] Submit a search (or tap one of the suggestion options).
- [ ] Once the SERP loads, tap the address bar.
- [ ] Clear the URL/text in the widget (or leave it as-is).
- [ ] **Verify:** The "Try a search!" bubble is **not** visible behind the widget, neither when text is present nor when cleared.
- [ ] Dismiss the widget and confirm you return to the SERP cleanly.

_Tapping a dax bubble option closes the widget and the address bar updates_

- [ ] Fresh install the app and complete onboarding.
- [ ] On the NTP with the "Try a search!" bubble visible, tap the address bar to open the widget.
- [ ] Tap one of the bubble's suggestion options.
- [ ] **Verify:** The widget closes immediately and the address bar shows the submitted query/URL while the SERP loads.

_Contextual onboarding bubbles in the browser still work_

- [ ] Continue the onboarding.
- [ ] Contextual bubbles (`trackers blocked`, `fire button`, `visit a site` if applicable) all appear and dismiss normally.
- [ ] Finish the onboarding sequence and reach the `DaxEnd` bubble on the NTP — it appears as expected.

### UI changes

https://github.com/user-attachments/assets/c4285a84-3acd-4ccd-a73f-fdc1f20a7c0d




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/onboarding behavior in BrowserTabFragment with no security, auth, or data-handling changes.
> 
> **Overview**
> Fixes two onboarding issues when the **native address-bar input** is enabled: NTP Dax bubbles reappearing under the widget after leaving the new tab page, and the widget staying open with stale text after tapping a bubble suggestion.
> 
> **`renderCtaViewState`** now clears the previous **`DaxBubbleCta`** view state whenever the CTA renderer runs (including when switching to browser mode), and skips **`showCta`** for NTP-only bubbles while the browser is visible—contextual **`OnboardingDaxDialogCta`** flows in **`browserLayout`** are unchanged.
> 
> Onboarding suggestion taps (intro bubble, in-context, and brand-design dialogs) call **`submitQuery`** instead of **`userEnteredQuery`**, so **`hideNativeInput`** runs before navigation and the omnibar stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0caf18fc24313a8a71c039a03bc725462a59a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->