### PR TITLE
Preserve omnibar input and cursor when external state changes during user editing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -857,7 +857,9 @@ class OmnibarLayoutViewModel @Inject constructor(
         forceRender: Boolean,
     ) {
         logcat { "Omnibar: onExternalOmnibarStateChanged $omnibarViewState forceRender $forceRender" }
-        val state = if (shouldUpdateOmnibarTextInput(omnibarViewState, _viewState.value.omnibarText) || forceRender) {
+        val shouldUpdateText =
+            shouldUpdateOmnibarTextInput(omnibarViewState, _viewState.value.omnibarText, _viewState.value.hasFocus) || forceRender
+        val state = if (shouldUpdateText) {
             if (forceRender &&
                 !duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(omnibarViewState.queryOrFullUrl) &&
                 omnibarViewState.omnibarText != ABOUT_BLANK
@@ -898,7 +900,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                 state.copy(
                     expanded = omnibarViewState.forceExpand,
                     expandedAnimated = omnibarViewState.forceExpand,
-                    updateOmnibarText = true,
+                    updateOmnibarText = shouldUpdateText,
                     showVoiceSearch = shouldShowVoiceSearch(
                         viewMode = _viewState.value.viewMode,
                         hasFocus = omnibarViewState.isEditing,
@@ -1075,7 +1077,8 @@ class OmnibarLayoutViewModel @Inject constructor(
     private fun shouldUpdateOmnibarTextInput(
         viewState: OmnibarViewState,
         currentText: String,
-    ) = (!viewState.isEditing || viewState.omnibarText.isEmpty()) && currentText != viewState.omnibarText
+        hasFocus: Boolean,
+    ) = (!hasFocus || viewState.omnibarText.isEmpty()) && currentText != viewState.omnibarText
 
     private fun firePixelBasedOnCurrentUrl(
         emptyUrlPixel: AppPixelName,

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1131,6 +1131,29 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
+    fun whenOmnibarFocusedAndExternalOmnibarStateChangedThenUserTextAndCursorPreserved() = runTest {
+        testee.onExternalStateChange(
+            StateChange.OmnibarStateChange(
+                OmnibarViewState(omnibarText = "ducks", queryOrFullUrl = "ducks", forceExpand = false),
+            ),
+        )
+        testee.onOmnibarFocusChanged(hasFocus = true, inputFieldText = "ducks")
+        testee.onInputStateChanged(query = "newquery", hasFocus = true, clearQuery = false, deleteLastCharacter = false)
+
+        testee.onExternalStateChange(
+            StateChange.OmnibarStateChange(
+                OmnibarViewState(omnibarText = "ducks", queryOrFullUrl = "ducks", forceExpand = false),
+            ),
+        )
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertEquals("newquery", viewState.omnibarText)
+            assertFalse(viewState.updateOmnibarText)
+        }
+    }
+
+    @Test
     fun whenOmnibarFocusedAndLoadingStateChangesThenViewStateCorrect() = runTest {
         val omnibarState = OmnibarViewState(
             navigationChange = false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1114857721287938/task/1215085542809321?focus=true

### Description

Fixes a bug where typing in the address bar while a SERP page is finishing loading would have the typed text replaced by the previous search query, and the cursor reset to the beginning of the field.

**Root cause:** `OmnibarLayoutViewModel.shouldUpdateOmnibarTextInput` was guarding text overwrites by reading `viewState.isEditing` from the incoming external `OmnibarViewState`. That field is never set to `true` in production code: only ever defaulted to `false` or explicitly reset to `false` in three flows. As a result the guard collapsed to "overwrite on any text mismatch", with no real focus protection.

A secondary issue surfaced: `updateOmnibarText` was hard-coded to `true` in the non-navigation branch of `onExternalOmnibarStateChanged`, so even when the guard correctly preserved the text, `OmnibarLayout.renderOmnibarText` would still call `omnibarTextInput.setText(...)` with the unchanged text and reset the cursor to position 0.

**Fix:**
- `shouldUpdateOmnibarTextInput` now consults `_viewState.value.hasFocus` (the omnibar's live focus state) instead of the dead `viewState.isEditing` field.
- `updateOmnibarText` is now derived from the same `shouldUpdateText` decision, so the non-navigation branch no longer fires a redundant `setText` that would reset the caret.

Regression test added: `OmnibarLayoutViewModelTest.whenOmnibarFocusedAndExternalOmnibarStateChangedThenUserTextAndCursorPreserved`.

### Steps to test this PR

_Search-text replacement_
- [x] Open a new tab and search for `ducks` so the SERP loads
- [x] Kill the app from recents
- [x] Reopen the app: the tab restores and the SERP starts loading
- [x] While the SERP is still loading, tap the address bar and quickly type a different query (e.g. `cats`)
- [x] Wait for the SERP to finish loading
- [x] Confirm the typed text (`cats`) is preserved. it is **not** replaced by `ducks`

_Cursor preservation_
- [x] Repeat the above, but pay attention to the caret position
- [x] Confirm the cursor stays where you left it, it does **not** jump back to position 0 when the page finishes loading

_Regular website regression check_
- [x] Open a non-SERP page (e.g. `bbc.com`) and confirm address bar behavior is unchanged on load
- [x] Tap the address bar mid-load, type something, and confirm the typed text is preserved after load completes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to omnibar sync logic with a focused regression test; no auth, security, or data-path impact.
> 
> **Overview**
> Fixes address-bar text and caret jumping when a SERP (or other page) finishes loading while the user is still editing.
> 
> **`OmnibarLayoutViewModel`** now decides whether to overwrite the field using live **`hasFocus`** instead of the external **`OmnibarViewState.isEditing`** flag (which was effectively never true in production). The non-navigation path sets **`updateOmnibarText`** from the same **`shouldUpdateText`** guard, so the UI does not call **`setText`** when the typed query should stay put—avoiding cursor reset to position 0.
> 
> A regression test covers focused editing plus a late external omnibar state update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2001876237f66bd0a622805639c848538d56c19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->