### PR TITLE
Hide Duck.ai toggle in chat, show back arrow with sidebar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -842,7 +842,7 @@ class OmnibarLayout @JvmOverloads constructor(
                 showChatMenu = viewState.showChatMenu,
                 showSpacer = viewState.showClearButton || viewState.showVoiceSearch,
                 showDuckSidebar = viewState.showDuckAISidebar,
-                showDuckBack = viewState.showDuckAISidebar && viewState.isDuckAiBackAvailable,
+                showDuckBack = viewState.showDuckAISidebar,
             )
 
         if (omnibarAnimationManager.isFeatureEnabled() && previousTransitionState != null &&

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -255,7 +255,6 @@ class OmnibarLayoutViewModel @Inject constructor(
         val showFindInPage: Boolean = false,
         val showDuckAIHeader: Boolean = false,
         val showDuckAISidebar: Boolean = false,
-        val isDuckAiBackAvailable: Boolean = false,
         val isNativeInputEnabled: Boolean = false,
         val isAddressBarTrackersAnimationEnabled: Boolean = false,
         val useSoftwareRenderingMode: Boolean = false,
@@ -314,12 +313,10 @@ class OmnibarLayoutViewModel @Inject constructor(
         combine(
             duckAiFeatureState.showInputScreen,
             duckChat.observeNativeInputFieldUserSettingEnabled(),
-            duckChat.observeInputScreenUserSettingEnabled(),
-        ) { inputScreenEnabled, nativeInputEnabled, aiToggleEnabled ->
+        ) { inputScreenEnabled, nativeInputEnabled ->
             _viewState.update {
                 it.copy(
                     showTextInputClickCatcher = inputScreenEnabled || nativeInputEnabled,
-                    isDuckAiBackAvailable = nativeInputEnabled && !aiToggleEnabled,
                     isNativeInputEnabled = nativeInputEnabled,
                 )
             }

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -51,7 +51,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/ic_arrow_left_24" />
+                app:srcCompat="@drawable/ic_close_24" />
 
             <ImageView
                 android:id="@+id/duckAiSidebar"

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1577,69 +1577,6 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
-    fun whenNativeInputEnabledAndAiToggleDisabledThenIsDuckAiBackAvailableTrue() = runTest {
-        nativeInputFieldSettingFlow.value = true
-        inputScreenUserSettingFlow.value = false
-
-        testee.viewState.test {
-            val viewState = expectMostRecentItem()
-            assertTrue(viewState.isDuckAiBackAvailable)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenNativeInputEnabledAndAiToggleEnabledThenIsDuckAiBackAvailableFalse() = runTest {
-        nativeInputFieldSettingFlow.value = true
-        inputScreenUserSettingFlow.value = true
-
-        testee.viewState.test {
-            val viewState = expectMostRecentItem()
-            assertFalse(viewState.isDuckAiBackAvailable)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenNativeInputDisabledAndAiToggleDisabledThenIsDuckAiBackAvailableFalse() = runTest {
-        nativeInputFieldSettingFlow.value = false
-        inputScreenUserSettingFlow.value = false
-
-        testee.viewState.test {
-            val viewState = expectMostRecentItem()
-            assertFalse(viewState.isDuckAiBackAvailable)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenNativeInputDisabledAndAiToggleEnabledThenIsDuckAiBackAvailableFalse() = runTest {
-        nativeInputFieldSettingFlow.value = false
-        inputScreenUserSettingFlow.value = true
-
-        testee.viewState.test {
-            val viewState = expectMostRecentItem()
-            assertFalse(viewState.isDuckAiBackAvailable)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAiToggleFlipsOffWhileNativeInputEnabledThenIsDuckAiBackAvailableBecomesTrue() = runTest {
-        nativeInputFieldSettingFlow.value = true
-        inputScreenUserSettingFlow.value = true
-
-        testee.viewState.test {
-            assertFalse(expectMostRecentItem().isDuckAiBackAvailable)
-
-            inputScreenUserSettingFlow.value = false
-
-            assertTrue(expectMostRecentItem().isDuckAiBackAvailable)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `when input text click catcher clicked and no URL then input screen launched with draft query`() = runTest {
         testee.onInputStateChanged(query = "draft", hasFocus = false, clearQuery = false, deleteLastCharacter = false)
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -36,7 +36,7 @@ data class NativeInputState(
 
     enum class InputPosition { TOP, BOTTOM }
 
-    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext != InputContext.DUCK_AI_CONTEXTUAL
+    val toggleVisible: Boolean get() = inputMode == InputMode.SEARCH_AND_DUCK_AI && inputContext == InputContext.BROWSER
 
     val isBottom: Boolean get() = inputPosition == InputPosition.BOTTOM
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -906,7 +906,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // fall through and reset card.radius to largeShapeCornerRadius on all four corners.
         if (isContextualWidget) return
         val state = nativeInputState ?: return
-        if (state.inputContext == NativeInputState.InputContext.DUCK_AI_CONTEXTUAL) return
+        if (state.inputContext != NativeInputState.InputContext.BROWSER) return
         if (state.isBottom) return
         if (state.toggleVisible) return
         val card = parent as? MaterialCardView ?: return

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -279,12 +279,12 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
-    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleVisible() = runTest {
+    fun whenContextIsDuckAiAndModeIsSearchAndDuckAiThenToggleNotVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true
         testee.setDuckAiMode(true)
 
-        assertTrue(testee.state.firstOrNull()!!.toggleVisible)
+        assertFalse(testee.state.firstOrNull()!!.toggleVisible)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215159003631557?focus=true

### Description

Two related navigation tweaks from the iOS Ship Review fallout that apply
to Android — both small, both in service of the broader "Duck.ai opens in
a new tab" model that the next PR delivers.

1. **Hide the Search/Duck.ai toggle inside a chat.** The toggle row only
   makes sense in the browser context now that Duck.ai will open in a new
   tab; keeping it visible inside chat would spawn a new tab on every
   toggle interaction. `NativeInputState.toggleVisible` already excluded
   the contextual sheet — this extends the rule to the fullscreen chat,
   phrased positively as `inputContext == BROWSER`. `applyOmnibarShape()`
   used `toggleVisible` to short-circuit and implicitly covered DUCK_AI;
   its guard is narrowed to `inputContext != BROWSER` so DUCK_AI fullscreen
   doesn't fall through to the minimized-pill card styling.

2. **Show the back arrow whenever the chat-history sidebar is visible.**
   The back arrow next to the sidebar only appeared when the user had the
   unified input on but the Search/Duck.ai toggle setting off — a narrow
   Search-Only case. With the toggle on (Search & Duck.ai), the arrow
   stayed hidden, leaving no consistent way back to the previous tab while
   viewing a chat. Tying the arrow to the sidebar's own visibility makes
   both appear and disappear together; focus and voice-mode gating still
   sit on `showDuckAISidebar`. `isDuckAiBackAvailable` has no other
   consumers, so it and its dedicated tests are removed.

Companion Asana task for #2:
https://app.asana.com/1/137249556945/task/1215159003631561

### Steps to test this PR

_Toggle hidden in chat_
- [x] Open the app with the unified input enabled.
- [x] Tap the input to focus it on a browser tab; the Search/Duck.ai toggle row appears.
- [x] Submit a Duck.ai query (or open a Duck.ai chat). Inside the chat, focus the input again.
- [x] Confirm the Search/Duck.ai toggle row is not shown.
- [x] Open the contextual sheet over a webpage; toggle is still hidden as before.
- [x] Open the input on a normal browser tab again; the toggle reappears.

_Back arrow alongside the sidebar_
- [x] Enable the Search/Duck.ai toggle setting (Settings → Duck.ai).
- [x] Open a Duck.ai chat from anywhere (omnibar, history, etc.).
- [x] Confirm both the chat-history sidebar icon and the back arrow are visible to the left of the address bar.
- [x] Disable the Search/Duck.ai toggle setting and repeat — both icons still visible.
- [x] Focus the input on the chat tab; both icons hide together. Defocus; both reappear.
- [x] Start voice mode; both icons hide. Exit voice; both reappear.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and visibility rules in omnibar and native input only; no auth, networking, or data-layer changes.
> 
> **Overview**
> Aligns Duck.ai omnibar and unified input behavior with **Duck.ai in its own tab**: the Search/Duck.ai toggle only appears in **browser** context, and the control beside chat history tracks the sidebar instead of a narrow “search-only + native input” case.
> 
> **Unified input:** `NativeInputState.toggleVisible` is now true only when `inputContext == BROWSER` (fullscreen chat and contextual sheet no longer show the toggle). `NativeInputModeWidget.applyOmnibarShape()` applies minimized-pill card styling only in browser context so fullscreen Duck.ai does not inherit that shape. Tests reflect toggle hidden in Duck.ai chat.
> 
> **Omnibar:** `showDuckBack` matches `showDuckAISidebar` (sidebar and back/close control show and hide together). `isDuckAiBackAvailable` and its dependency on the input-screen user setting are removed, along with related ViewModel tests. `duckAiBack` uses the **close** icon instead of the back arrow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f05dcfc017152ee306b133fe09ddeee70af704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->