### PR TITLE
[TEST - DO NOT MERGE] decouple dispatch_pat for privacy-review

### DIFF
--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v4
         with:
-            ref: v2.1
+            ref: la/decouple-dispatch-pat
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync
@@ -23,3 +23,4 @@ jobs:
           team_name: 'Android'
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           github_pat: ${{ secrets.DAXMOBILE_ANDROID_AUTOMATION }}
+          dispatch_pat: ${{ secrets.GT_DAXMOBILE }}

--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -22,5 +22,4 @@ jobs:
         with:
           team_name: 'Android'
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          github_pat: ${{ secrets.DAXMOBILE_ANDROID_AUTOMATION }}
-          dispatch_pat: ${{ secrets.GT_DAXMOBILE }}
+          github_pat: ${{ secrets.GH_AW_GITHUB_TOKEN }}


### PR DESCRIPTION
Task/Issue URL: N/A (test PR)

### Description

**DO NOT MERGE.** Throwaway test PR to validate a proposed change to `duckduckgo/native-github-asana-sync`.

Background: PR #8684 bumped the privacy-review checkout from v2.1 to v2.4. v2.4 added a cross-repo dispatch step against `duckduckgo/privacy-review-automation`, and `DAXMOBILE_ANDROID_AUTOMATION` lacks access to that repo (404).

The proposed action change ([branch la/decouple-dispatch-pat](https://github.com/duckduckgo/native-github-asana-sync/tree/la/decouple-dispatch-pat)) adds an optional `dispatch_pat` input. This PR pins to that branch and passes `GT_DAXMOBILE` as `dispatch_pat`, while keeping `DAXMOBILE_ANDROID_AUTOMATION` as `github_pat` (which already passes the user_map lookup).

### Steps to test this PR

_Privacy review workflow_
- [ ] Once this PR is open, label it with `privacy review`.
- [ ] Watch the `Create Asana task for Privacy Review` run and verify:
  - `Get PR author Asana ID` succeeds (validates `DAXMOBILE_ANDROID_AUTOMATION` for user_map).
  - `Dispatch AI Privacy Review classifier` succeeds (validates `GT_DAXMOBILE` for cross-repo dispatch).
- [ ] If both pass: action change is good; we'll tag v2.5. Close this PR after testing.
- [ ] If dispatch step still fails: `GT_DAXMOBILE` lacks the needed scope; need to escalate.

**Do not approve, do not merge.** Close after testing.

Made with [Cursor](https://cursor.com)