### PR TITLE
Promote chat-history strings for translation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -305,6 +305,10 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
                 binding.deleteAllPrimaryButton.show()
                 binding.deleteAllSecondaryButton.gone()
             }
+            if (state.isInChatSelectionMode) {
+                binding.deleteAllPrimaryButton.text =
+                    requireContext().getString(R.string.singleTabFireDialogDeleteChats)
+            }
         } else {
             binding.deleteAllPrimaryButton.gone()
             binding.deleteAllSecondaryButton.gone()

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -342,6 +342,9 @@ class SingleTabFireDialogViewModel @Inject constructor(
             val isDuckAiTabInBrowser: Boolean
                 get() = (stateData.isDuckAiTab && (origin == Browser || origin is Hatch)) || origin == DuckAiContextualChat
 
+            val isInChatSelectionMode: Boolean
+                get() = origin is FireDialogOrigin.ChatHistory
+
             val isDeleteThisTabButtonVisible: Boolean
                 get() = (stateData.isSingleTabEnabled && origin == Browser) ||
                     origin == DuckAiContextualChat ||

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Изтриване на всички</string>
     <string name="singleTabFireDialogDeleteThisTab">Изтриване на този раздел</string>
     <string name="singleTabFireDialogDeleteChat">Изтриване на чата</string>
+    <string name="singleTabFireDialogDeleteChats">Изтриване на чатовете</string>
     <string name="singleTabFireDialogTitleDuckAi">Да бъде ли изтрит този чат?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Изтриването на данни от сайта може да те отпише от акаунтите.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Това ще отмени текущите изтегляния.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1026,7 +1026,7 @@
     <string name="preOnboardingWelcomeDialogBody1">Готови ли сте за по-бърз браузър, който осигурява контрол?</string>
     <string name="preOnboardingWelcomeDialogBody2">Изкуственият интелект винаги е по избор, а защитата на поверителността винаги е включена.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d от %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва „патица“ на английски</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как се казва “патица“ на английски</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как се казва \"патица\" на испански</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Само търсене</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1065,7 +1065,7 @@
     <string name="preOnboardingWelcomeDialogTitle">Zdravíme tě.</string>
     <string name="preOnboardingWelcomeDialogBody1">Chceš rychlejší prohlížeč, se kterým budeš mít vše pod kontrolou?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umělá inteligence je vždy volitelná a ochrana soukromí je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak se anglicky řekne „kachna“</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak se španělsky řekne „kachna“</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Smazat vše</string>
     <string name="singleTabFireDialogDeleteThisTab">Vymazat tuto kartu</string>
     <string name="singleTabFireDialogDeleteChat">Smazat chat</string>
+    <string name="singleTabFireDialogDeleteChats">Smazat chaty</string>
     <string name="singleTabFireDialogTitleDuckAi">Smazat tento chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Když vymažeš data stránek, může dojít ke tvému odhlášení z účtů.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tím se zruší probíhající stahování.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Slet alle</string>
     <string name="singleTabFireDialogDeleteThisTab">Slet denne fane</string>
     <string name="singleTabFireDialogDeleteChat">Slet chat</string>
+    <string name="singleTabFireDialogDeleteChats">Slet chats</string>
     <string name="singleTabFireDialogTitleDuckAi">Slet denne chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Sletning af webstedsdata kan logge dig ud af konti.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dette annullerer igangværende downloads.</string>
@@ -1030,5 +1031,5 @@
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">sådan siger man \"and\" på spansk</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Kun søgning</string>
-    <string name="input_screen_user_pref_with_ai_updated">Skift mellem\nSøg og Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Skift mellem\nSøgning og Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Alle löschen</string>
     <string name="singleTabFireDialogDeleteThisTab">Diesen Tab löschen</string>
     <string name="singleTabFireDialogDeleteChat">Chat löschen</string>
+    <string name="singleTabFireDialogDeleteChats">Chats löschen</string>
     <string name="singleTabFireDialogTitleDuckAi">Diesen Chat löschen?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Das Löschen von Website-Daten kann dazu führen, dass du aus deinen Konten abgemeldet wirst.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dadurch werden bereits gestartete Downloads abgebrochen.</string>
@@ -917,7 +918,7 @@
     <string name="quickSetupSearchOptionsTitle">Möchtest du Such- und KI-Chatfunktionen in der Adressleiste?</string>
     <string name="quickSetupBottomSheetDone">Fertig</string>
     <string name="quickSetupInputScreenSearchOnly">Nur Suchen</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Suche und Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Suche &amp; Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">So entfernst du das Startbildschirm-Widget</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Gehe zu deinem Startbildschirm</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Halte das Widget gedrückt</string>
@@ -1023,7 +1024,7 @@
     <string name="linkTextCopyFailed">Linktext konnte nicht kopiert werden</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Hallo.</string>
-    <string name="preOnboardingWelcomeDialogBody1">Bereit für einen schnelleren Browser, der dir die Kontrolle gibt?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Bereit für einen schnelleren Browser, \nder dir die Kontrolle gibt?</string>
     <string name="preOnboardingWelcomeDialogBody2">KI ist immer optional, und der Datenschutz ist immer aktiviert.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d von %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Wie sagt man „Ente“ auf Englisch?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Διαγραφή όλων</string>
     <string name="singleTabFireDialogDeleteThisTab">Διαγραφή αυτής της καρτέλας</string>
     <string name="singleTabFireDialogDeleteChat">Διαγραφή συνομιλίας</string>
+    <string name="singleTabFireDialogDeleteChats">Διαγραφή συνομιλιών</string>
     <string name="singleTabFireDialogTitleDuckAi">Διαγραφή αυτής της συνομιλίας;</string>
     <string name="singleTabFireDialogSubtitleSiteData">Η διαγραφή δεδομένων ιστότοπου μπορεί να σας αποσυνδέσει από τους λογαριασμούς.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Αυτό θα ακυρώσει λήψεις που βρίσκονται σε εξέλιξη.</string>
@@ -1023,7 +1024,7 @@
     <string name="linkTextCopyFailed">Δεν ήταν δυνατή η αντιγραφή του κειμένου του συνδέσμου</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Γεια σας.</string>
-    <string name="preOnboardingWelcomeDialogBody1">Είστε έτοιμοι για ένα ταχύτερο πρόγραμμα περιήγησης που σας δίνει τον έλεγχο;</string>
+    <string name="preOnboardingWelcomeDialogBody1">Είσαι έτοιμος για ένα ταχύτερο πρόγραμμα περιήγησης που σου δίνει τον έλεγχο;\n\n</string>
     <string name="preOnboardingWelcomeDialogBody2">Η τεχνητή νοημοσύνη είναι πάντα προαιρετική και η προστασία προσωπικών δεδομένων είναι πάντα ενεργοποιημένη.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d από %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">πώς να πείτε «πάπια» στα αγγλικά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1026,7 +1026,7 @@
     <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que te da el control?</string>
     <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «pato» en inglés</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cómo se dice «duck» en español</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Solo buscar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Eliminar todo</string>
     <string name="singleTabFireDialogDeleteThisTab">Eliminar esta pestaña</string>
     <string name="singleTabFireDialogDeleteChat">Borrar chat</string>
+    <string name="singleTabFireDialogDeleteChats">Borrar chats</string>
     <string name="singleTabFireDialogTitleDuckAi">¿Borrar este chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Eliminar datos del sitio puede hacer que cierres sesión en tus cuentas.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Esta acción cancelará las descargas en curso.</string>
@@ -1023,7 +1024,7 @@
     <string name="linkTextCopyFailed">No se pudo copiar el texto del enlace</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Hola.</string>
-    <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que te da el control?</string>
+    <string name="preOnboardingWelcomeDialogBody1">¿Todo listo para un navegador más rápido que\nte da el control?</string>
     <string name="preOnboardingWelcomeDialogBody2">La IA es siempre opcional y la protección de privacidad está siempre activada.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d de %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cómo se dice «duck» en inglés</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Kustuta kõik</string>
     <string name="singleTabFireDialogDeleteThisTab">Kustuta see vahekaart</string>
     <string name="singleTabFireDialogDeleteChat">Kustuta vestlus</string>
+    <string name="singleTabFireDialogDeleteChats">Kustuta vestlused</string>
     <string name="singleTabFireDialogTitleDuckAi">Kustutada see vestlus?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Saidi andmete kustutamine võib sind kontodelt välja logida.</string>
     <string name="singleTabFireDialogSubtitleDownloads">See tühistab pooleliolevad allalaadimised.</string>
@@ -1030,5 +1031,5 @@
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Kuidas öelda „part“ hispaania keeles</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Ainult otsi</string>
-    <string name="input_screen_user_pref_with_ai_updated">Lülita\nOtsingu ja Duck.ai vahel</string>
+    <string name="input_screen_user_pref_with_ai_updated">Lülita \n otsingu ja Duck.ai vahel</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Poista kaikki</string>
     <string name="singleTabFireDialogDeleteThisTab">Poista tämä välilehti</string>
     <string name="singleTabFireDialogDeleteChat">Poista keskustelu</string>
+    <string name="singleTabFireDialogDeleteChats">Poista keskustelut</string>
     <string name="singleTabFireDialogTitleDuckAi">Poistetaanko tämä keskustelu?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Sivustotietojen poistaminen voi kirjata sinut ulos tileiltä.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tämä peruuttaa käynnissä olevat lataukset.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Tout supprimer</string>
     <string name="singleTabFireDialogDeleteThisTab">Supprimer cet onglet</string>
     <string name="singleTabFireDialogDeleteChat">Supprimer la discussion</string>
+    <string name="singleTabFireDialogDeleteChats">Supprimer les discussions</string>
     <string name="singleTabFireDialogTitleDuckAi">Supprimer cette discussion ?</string>
     <string name="singleTabFireDialogSubtitleSiteData">La suppression des données de site peut vous déconnecter des comptes.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Cela annulera les téléchargements en cours.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Izbriši sve</string>
     <string name="singleTabFireDialogDeleteThisTab">Izbriši ovu karticu</string>
     <string name="singleTabFireDialogDeleteChat">Izbriši čavrljanje</string>
+    <string name="singleTabFireDialogDeleteChats">Izbriši čavrljanja</string>
     <string name="singleTabFireDialogTitleDuckAi">Izbrisati ovo čavrljanje?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Brisanje podataka mrežnih lokacija može te odjaviti s računa.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Ovo će otkazati preuzimanja u tijeku.</string>
@@ -1063,7 +1064,7 @@
     <string name="linkTextCopyFailed">Nije moguće kopirati tekst poveznice</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Pozdrav!</string>
-    <string name="preOnboardingWelcomeDialogBody1">Jesi li spreman za brži preglednik koji ti daje kontrolu?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Jesi li spreman za brži preglednik koji te stavlja za upravljač?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umjetna inteligencija uvijek je neobavezna, a zaštita privatnosti uvijek aktivna.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d od %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kako se kaže \"patka\" na engleskom</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Összes törlése</string>
     <string name="singleTabFireDialogDeleteThisTab">Lap törlése</string>
     <string name="singleTabFireDialogDeleteChat">Csevegés törlése</string>
+    <string name="singleTabFireDialogDeleteChats">Csevegések törlése</string>
     <string name="singleTabFireDialogTitleDuckAi">Csevegés törlése?</string>
     <string name="singleTabFireDialogSubtitleSiteData">A webhelyadatok törlése kijelentkeztethet a fiókjaidból.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Ez megszakítja a folyamatban lévő letöltéseket.</string>
@@ -1023,8 +1024,8 @@
     <string name="linkTextCopyFailed">Nem sikerült másolni a link szövegét</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Szia!</string>
-    <string name="preOnboardingWelcomeDialogBody1">Felkészültél egy gyorsabb böngészőre, amely saját kezedbe adja az irányítást?</string>
-    <string name="preOnboardingWelcomeDialogBody2">Az AI mindig opcionális, az adatvédelem pedig állandóan be van kapcsolva.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Felkészültél egy gyorsabb böngészőre, amely a te kezedbe adja az irányítást?</string>
+    <string name="preOnboardingWelcomeDialogBody2">Az MI mindig opcionális, az adatvédelem pedig állandóan be van kapcsolva.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d/%2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hogyan mondják angolul, hogy „kacsa”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hogyan mondják spanyolul, hogy „kacsa”</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Elimina tutto</string>
     <string name="singleTabFireDialogDeleteThisTab">Elimina questa scheda</string>
     <string name="singleTabFireDialogDeleteChat">Elimina chat</string>
+    <string name="singleTabFireDialogDeleteChats">Elimina chat</string>
     <string name="singleTabFireDialogTitleDuckAi">Eliminare questa chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">L\'eliminazione dei dati del sito può comportare la disconnessione dagli account.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Questa operazione annullerà i download in corso.</string>
@@ -917,7 +918,7 @@
     <string name="quickSetupSearchOptionsTitle">Vuoi la ricerca e la chat AI nella barra degli indirizzi?</string>
     <string name="quickSetupBottomSheetDone">Operazione effettuata</string>
     <string name="quickSetupInputScreenSearchOnly">Solo ricerca</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Ricerca e Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Cerca e Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">Come rimuovere il widget della schermata iniziale</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Vai alla schermata principale</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Tocca e tieni premuto il widget</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Ištrinti viską</string>
     <string name="singleTabFireDialogDeleteThisTab">Ištrink šį skirtuką</string>
     <string name="singleTabFireDialogDeleteChat">Ištrinti pokalbį</string>
+    <string name="singleTabFireDialogDeleteChats">Ištrinti pokalbius</string>
     <string name="singleTabFireDialogTitleDuckAi">Ištrinti šį pokalbį?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Ištrynus svetainės duomenis, galite būti atjungti nuo paskyrų.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tai atšauks vykdomus atsisiuntimus.</string>
@@ -1063,12 +1064,12 @@
     <string name="linkTextCopyFailed">Nepavyko nukopijuoti nuorodos teksto</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Sveiki!</string>
-    <string name="preOnboardingWelcomeDialogBody1">Ar norite spartesnės naršyklės, kurią patys valdote?</string>
-    <string name="preOnboardingWelcomeDialogBody2">DI neprivalomas, o privatumo apsauga veikia visada.</string>
+    <string name="preOnboardingWelcomeDialogBody1">Ar nori spartesnės naršyklės, kurią valdai tu?</string>
+    <string name="preOnboardingWelcomeDialogBody2">DI neprivalomas, o privatumo apsauga – visada įjungta.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d iš %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kaip angliškai pasakyti „antis“</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kaip ispaniškai pasakyti „antis“</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Tik paieška</string>
-    <string name="input_screen_user_pref_with_ai_updated">Perjungti tarpusavyje\npaiešką ir Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Perjungti\npaiešką ir „Duck.ai“</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -269,6 +269,7 @@
     <string name="singleTabFireDialogDeleteAll">Dzēst visus</string>
     <string name="singleTabFireDialogDeleteThisTab">Dzēst šo cilni</string>
     <string name="singleTabFireDialogDeleteChat">Dzēst tērzēšanas sarunu</string>
+    <string name="singleTabFireDialogDeleteChats">Dzēst tērzēšanas</string>
     <string name="singleTabFireDialogTitleDuckAi">Dzēst šo tērzēšanas sarunu?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Dzēšot vietnes datus, tu vari tikt izrakstīts no kontiem.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tas atcels notiekošās lejupielādes.</string>
@@ -1044,7 +1045,7 @@
 
     <string name="preOnboardingWelcomeDialogTitle">Sveiki!</string>
     <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
-    <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
+    <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr darbojas.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1046,7 +1046,7 @@
     <string name="preOnboardingWelcomeDialogBody1">Vai esi gatavs ātrākai pārlūkprogrammai, kas tev sniedz kontroli?</string>
     <string name="preOnboardingWelcomeDialogBody2">Mākslīgais intelekts vienmēr ir izvēles iespēja, un privātuma aizsardzība vienmēr ir ieslēgta.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d no %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “pīle”</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">kā angliski pateikt “duck”</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">kā spāniski pateikt “pīle”</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Meklēt tikai</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Slett alt</string>
     <string name="singleTabFireDialogDeleteThisTab">Slett denne fanen</string>
     <string name="singleTabFireDialogDeleteChat">Slett chat</string>
+    <string name="singleTabFireDialogDeleteChats">Slett chatter</string>
     <string name="singleTabFireDialogTitleDuckAi">Vil du slette denne chatten?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Hvis du sletter nettstedsdata, kan du bli logget ut av kontoer.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Dette avbryter pågående nedlastinger.</string>
@@ -1023,12 +1024,12 @@
     <string name="linkTextCopyFailed">Kunne ikke kopiere lenketeksten</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Heisann.</string>
-    <string name="preOnboardingWelcomeDialogBody1">Klar for en raskere nettleser som du har kontroll over?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Er du klar for en raskere nettleser som du har kontroll over?</string>
     <string name="preOnboardingWelcomeDialogBody2">AI er alltid valgfritt, og personvern er alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «and» på engelsk</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si «and» på spansk</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hvordan si «duck» på engelsk</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hvordan si duck» på spansk</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Bare søk</string>
-    <string name="input_screen_user_pref_with_ai_updated">Bytt mellom\nSøk og Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Bytt mellom\nsøk og Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Alles verwijderen</string>
     <string name="singleTabFireDialogDeleteThisTab">Dit tabblad verwijderen</string>
     <string name="singleTabFireDialogDeleteChat">Chat verwijderen</string>
+    <string name="singleTabFireDialogDeleteChats">Chats verwijderen</string>
     <string name="singleTabFireDialogTitleDuckAi">Deze chat verwijderen?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Als je sitegegevens verwijdert, kun je uitloggen bij je accounts.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Hiermee worden lopende downloads geannuleerd.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1028,7 +1028,7 @@
     <string name="preOnboardingWelcomeDialogBody2">AI is altijd optioneel en privacybescherming staat altijd aan.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d van %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">hoe zeg je \'eend\' in het Engels?</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Spaans</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">hoe zeg je \'eend\' in het Nederlands</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Alleen zoeken</string>
     <string name="input_screen_user_pref_with_ai_updated">Schakelen tussen\nzoeken en Duck.ai</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Usuń wszystko</string>
     <string name="singleTabFireDialogDeleteThisTab">Usuń tę kartę</string>
     <string name="singleTabFireDialogDeleteChat">Usuń czat</string>
+    <string name="singleTabFireDialogDeleteChats">Usuń czaty</string>
     <string name="singleTabFireDialogTitleDuckAi">Usunąć ten czat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Usunięcie danych witryny może spowodować wylogowanie z kont.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Spowoduje to anulowanie trwającego pobierania.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1066,10 +1066,10 @@
     <string name="preOnboardingWelcomeDialogTitle">Cześć!</string>
     <string name="preOnboardingWelcomeDialogBody1">Chcesz skorzystać z szybszej przeglądarki, która daje Ci kontrolę?</string>
     <string name="preOnboardingWelcomeDialogBody2">Funkcje AI są zawsze opcjonalne, a ochrona prywatności jest zawsze aktywna.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
-    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „kaczka” po angielsku</string>
-    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"kaczka\" po hiszpańsku</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
+    <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">jak się mówi „duck” po angielsku</string>
+    <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">jak się mówi \"duck\" po hiszpańsku</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Tylko wyszukiwanie</string>
-    <string name="input_screen_user_pref_with_ai_updated">Przełączanie między\nwyszukiwaniem a Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Przełącz między\nwyszukiwaniem a Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Eliminar tudo</string>
     <string name="singleTabFireDialogDeleteThisTab">Eliminar este separador</string>
     <string name="singleTabFireDialogDeleteChat">Eliminar conversa</string>
+    <string name="singleTabFireDialogDeleteChats">Eliminar chats</string>
     <string name="singleTabFireDialogTitleDuckAi">Eliminar esta conversa?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Eliminar dados do site pode terminar a tua sessão nas contas.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Esta ação vai cancelar as transferências em curso.</string>
@@ -1030,5 +1031,5 @@
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">como dizer \"pato\" em espanhol</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Pesquisar apenas</string>
-    <string name="input_screen_user_pref_with_ai_updated">Alternar entre\npesquisa e Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Alternar entre\nPesquisa e Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -269,6 +269,7 @@
     <string name="singleTabFireDialogDeleteAll">Șterge toate</string>
     <string name="singleTabFireDialogDeleteThisTab">Șterge această filă</string>
     <string name="singleTabFireDialogDeleteChat">Șterge chatul</string>
+    <string name="singleTabFireDialogDeleteChats">Șterge chaturile</string>
     <string name="singleTabFireDialogTitleDuckAi">Ștergi acest chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Ștergerea datelor de pe site te poate deconecta de la conturi.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Aceasta va anula descărcările în desfășurare.</string>
@@ -937,7 +938,7 @@
     <string name="quickSetupSearchOptionsTitle">Dorești căutare și chat cu IA în bara de adrese?</string>
     <string name="quickSetupBottomSheetDone">Terminat</string>
     <string name="quickSetupInputScreenSearchOnly">Doar căutare</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Caută și folosește Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Caută și Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">Cum se elimină widgetul de pe ecranul de întâmpinare</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Mergi la ecranul de întâmpinare</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Atinge și menține apăsat widgetul</string>
@@ -1044,11 +1045,11 @@
 
     <string name="preOnboardingWelcomeDialogTitle">Salut!</string>
     <string name="preOnboardingWelcomeDialogBody1">Ești gata pentru un browser mai rapid, care îți oferă control deplin?</string>
-    <string name="preOnboardingWelcomeDialogBody2">Inteligența artificială este întotdeauna opțională, iar protecția confidențialității este întotdeauna activată.</string>
+    <string name="preOnboardingWelcomeDialogBody2">IA este întotdeauna opțională, iar protecția confidențialității este întotdeauna activată.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d din %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">cum se spune „rață” în engleză</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">cum se spune „rață” în spaniolă</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Doar căutare</string>
-    <string name="input_screen_user_pref_with_ai_updated">Comută între căutare și Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Comută între Căutare și Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Удалить все</string>
     <string name="singleTabFireDialogDeleteThisTab">Удалить эту вкладку</string>
     <string name="singleTabFireDialogDeleteChat">Удалить чат</string>
+    <string name="singleTabFireDialogDeleteChats">Удалить чаты</string>
     <string name="singleTabFireDialogTitleDuckAi">Удалить этот чат?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Удаление данных сайтов может сопровождаться выходом из учетных записей.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Текущие загрузки будут отменены.</string>
@@ -1063,12 +1064,12 @@
     <string name="linkTextCopyFailed">Не удалось скопировать текст ссылки</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Привет!</string>
-    <string name="preOnboardingWelcomeDialogBody1">Нужен быстрый браузер, где все контролируете вы?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Готовы перейти на быстрый браузер, где все под вашим контролем?</string>
     <string name="preOnboardingWelcomeDialogBody2">Здесь ИИ — всегда лишь дополнительная опция, а защита конфиденциальности всегда включена.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d из %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">как сказать «утка» по-английски</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">как сказать «утка» по-испански</string>
 
     <string name="input_screen_user_pref_without_ai_updated">Только поиск</string>
-    <string name="input_screen_user_pref_with_ai_updated">Переключатель между\nобычным поиском и Duck.ai</string>
+    <string name="input_screen_user_pref_with_ai_updated">Переключайтесь между\nПоиском и Duck.ai</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Odstrániť všetko</string>
     <string name="singleTabFireDialogDeleteThisTab">Vymazať túto záložku</string>
     <string name="singleTabFireDialogDeleteChat">Zmazať chat</string>
+    <string name="singleTabFireDialogDeleteChats">Zmazať čety</string>
     <string name="singleTabFireDialogTitleDuckAi">Zmazať tento chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Odstránením údajov z webových stránok sa môžeš odhlásiť z účtov.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Tým sa zrušia prebiehajúce sťahovania.</string>
@@ -957,7 +958,7 @@
     <string name="quickSetupSearchOptionsTitle">Chceš mať vyhľadávanie a AI chat v adresnom riadku?</string>
     <string name="quickSetupBottomSheetDone">Hotovo</string>
     <string name="quickSetupInputScreenSearchOnly">Len vyhľadávanie</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Vyhľadávanie a Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Vyhľadať a Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">Ako odstrániť miniaplikáciu z úvodnej obrazovky</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Prejdi na úvodnú obrazovku</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Dotkni sa a podrž miniaplikáciu</string>
@@ -1063,9 +1064,9 @@
     <string name="linkTextCopyFailed">Nepodarilo sa skopírovať text odkazu</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Dobrý deň.</string>
-    <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač, ktorý ti dáva kontrolu?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Si pripravený/-á na rýchlejší prehliadač,\nktorý ti dáva kontrolu?</string>
     <string name="preOnboardingWelcomeDialogBody2">Umelá inteligencia je vždy voliteľná a ochrana súkromia je vždy zapnutá.</string>
-    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d z %2$d</string>
+    <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">Ako povedať „kačica“ v angličtine</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">Ako povedať „kačica“ po španielsky</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -273,6 +273,7 @@
     <string name="singleTabFireDialogDeleteAll">Izbriši vse</string>
     <string name="singleTabFireDialogDeleteThisTab">Izbriši ta zavihek</string>
     <string name="singleTabFireDialogDeleteChat">Izbriši klepet</string>
+    <string name="singleTabFireDialogDeleteChats">Izbriši klepete</string>
     <string name="singleTabFireDialogTitleDuckAi">Želite izbrisati ta klepet?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Brisanje podatkov o spletnem mestu vas lahko odjavi iz računov.</string>
     <string name="singleTabFireDialogSubtitleDownloads">S tem boste preklicali prenose v teku.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Radera allt</string>
     <string name="singleTabFireDialogDeleteThisTab">Ta bort denna flik</string>
     <string name="singleTabFireDialogDeleteChat">Radera chatt</string>
+    <string name="singleTabFireDialogDeleteChats">Radera chattar</string>
     <string name="singleTabFireDialogTitleDuckAi">Radera den här chatten?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Om du tar bort webbplatsdata kan du loggas ut från konton.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Detta kommer att avbryta pågående nerladdningar.</string>
@@ -1023,7 +1024,7 @@
     <string name="linkTextCopyFailed">Kunde inte kopiera länktext</string>
 
     <string name="preOnboardingWelcomeDialogTitle">Hej!</string>
-    <string name="preOnboardingWelcomeDialogBody1">Är du redo för en snabbare webbläsare som ger dig kontroll?</string>
+    <string name="preOnboardingWelcomeDialogBody1">Är du redo för en snabbare webbläsare\nsom ger dig kontroll?</string>
     <string name="preOnboardingWelcomeDialogBody2">AI är alltid valfritt och integritetsskydd är alltid på.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d av %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">vad heter ”anka” på engelska</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -265,6 +265,7 @@
     <string name="singleTabFireDialogDeleteAll">Tümünü Sil</string>
     <string name="singleTabFireDialogDeleteThisTab">Bu Sekmeyi Sil</string>
     <string name="singleTabFireDialogDeleteChat">Sohbeti Sil</string>
+    <string name="singleTabFireDialogDeleteChats">Sohbetleri Sil</string>
     <string name="singleTabFireDialogTitleDuckAi">Bu sohbet silinsin mi?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Site verilerini silmek, hesaplarınızdan çıkış yapmanıza neden olabilir.</string>
     <string name="singleTabFireDialogSubtitleDownloads">Bu işlem devam eden indirmeleri iptal edecektir.</string>
@@ -1024,7 +1025,7 @@
 
     <string name="preOnboardingWelcomeDialogTitle">Merhaba.</string>
     <string name="preOnboardingWelcomeDialogBody1">Kontrolü size verecek daha hızlı bir tarayıcıya hazır mısınız?</string>
-    <string name="preOnboardingWelcomeDialogBody2">Yapay zeka her zaman isteğe bağlıdır ve gizlilik koruması her zaman etkindir.</string>
+    <string name="preOnboardingWelcomeDialogBody2">Yapay zekâ her zaman isteğe bağlıdır ve gizlilik koruması her zaman etkindir.</string>
     <string name="onboardingStepIndicatorText" instruction="a counter above our instructions in onboarding that tells a user what step they are on">%1$d / %2$d</string>
     <string name="onboardingSearchDaxDialogOption1Quoted" instruction="translate &apos;duck&apos; too.">ingilizcede \"ördek\" nasıl denir?</string>
     <string name="onboardingSearchDaxDialogOption1EnglishQuoted" instruction="translate &apos;duck&apos; too. Don&apos;t add question mark">ispanyolcada \"ördek\" nasıl denir?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="singleTabFireDialogDeleteAll">Delete All</string>
     <string name="singleTabFireDialogDeleteThisTab">Delete This Tab</string>
     <string name="singleTabFireDialogDeleteChat">Delete Chat</string>
+    <string name="singleTabFireDialogDeleteChats">Delete Chats</string>
     <string name="singleTabFireDialogTitleDuckAi">Delete this chat?</string>
     <string name="singleTabFireDialogSubtitleSiteData">Deleting site data can sign you out of accounts.</string>
     <string name="singleTabFireDialogSubtitleDownloads">This will cancel downloads in progress.</string>

--- a/duckchat/duckchat-impl/src/main/res/menu/menu_chat_history_default.xml
+++ b/duckchat/duckchat-impl/src/main/res/menu/menu_chat_history_default.xml
@@ -33,7 +33,7 @@
     <item
         android:id="@+id/chat_history_action_search"
         android:icon="@drawable/ic_find_search_24"
-        android:title="@string/duck_ai_chat_history_coming_soon"
+        android:title="@string/duck_ai_chat_history_action_search_content_description"
         app:showAsAction="always" />
 
     <item

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Гласов чат</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Чатове</string>
+    <string name="duck_ai_chat_history_section_pinned">Закачени</string>
+    <string name="duck_ai_chat_history_section_recent">Последни</string>
+    <string name="duck_ai_chat_history_untitled">Чат без заглавие</string>
+    <string name="duck_ai_chat_history_empty_title">Все още няма чатове</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Отваряне на Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Още опции</string>
+    <string name="duck_ai_chat_history_action_select">Избор</string>
+    <string name="duck_ai_chat_history_action_pin">Добавяне като отметка</string>
+    <string name="duck_ai_chat_history_action_unpin">Премахване на отметка</string>
+    <string name="duck_ai_chat_history_action_rename">Преименуване</string>
+    <string name="duck_ai_chat_history_action_download">Изтегляне</string>
+    <string name="duck_ai_chat_history_action_delete">Изтриване</string>
+    <string name="duck_ai_chat_history_search_hint">Търсене в чатове</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Търсене в чатове</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Затваряне на търсенето</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Изчистване на търсенето</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Изтриване на чатовете</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Отваряне на менюто с допълнителни опции</string>
+    <string name="duck_ai_chat_history_select_all">Избиране на всички</string>
+    <string name="duck_ai_chat_history_unselect_all">Отказ от избора на всички</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Избрани</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Неизбрани</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Изход от режим на избор</string>
+    <string name="duck_ai_chat_history_rename_title">Преименуване на чата</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Заглавие на чата</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Запазване</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Запазване на заглавието на чата</string>
+    <string name="duck_ai_chat_history_rename_error">Неуспешно преименуване на чата</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Закачен чат</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Незакачен чат</string>
+    <string name="duck_ai_chat_history_undo">Отмяна</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Завършено изтегляне на %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Показване</string>
+    <string name="duck_ai_chat_history_download_error">Неуспешно експортиране на чата</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Затваряне на търсенето</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Изчистване на търсенето</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Изтриване на чатовете</string>
+    <string name="duck_ai_chat_history_action_new">Нов</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Изтегляне на чатове</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Завършено изтегляне на %1$d чат</item>
+        <item quantity="other">Завършено изтегляне на %1$d чата</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Отваряне на менюто с допълнителни опции</string>
     <string name="duck_ai_chat_history_select_all">Избиране на всички</string>
     <string name="duck_ai_chat_history_unselect_all">Отказ от избора на всички</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Завършено изтегляне на %1$s</string>
     <string name="duck_ai_chat_history_download_view">Показване</string>
     <string name="duck_ai_chat_history_download_error">Неуспешно експортиране на чата</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Неуспешно експортиране на чатове</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Гласов чат</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Преглед на всички чатове</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Чатове</string>
     <string name="duck_ai_chat_history_section_pinned">Закачени</string>
@@ -146,8 +149,8 @@
     <string name="duck_ai_chat_history_rename_confirm_title">Запазване</string>
     <string name="duck_ai_chat_history_rename_confirm_content_description">Запазване на заглавието на чата</string>
     <string name="duck_ai_chat_history_rename_error">Неуспешно преименуване на чата</string>
-    <string name="duck_ai_chat_history_pin_snackbar">Закачен чат</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Незакачен чат</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Чат с отметка</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Чат без отметка</string>
     <string name="duck_ai_chat_history_undo">Отмяна</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Завършено изтегляне на %1$s</string>
     <string name="duck_ai_chat_history_download_view">Показване</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hlasový chat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Zobrazit všechny chaty</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chaty</string>
     <string name="duck_ai_chat_history_section_pinned">Připnuté</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hlasový chat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chaty</string>
+    <string name="duck_ai_chat_history_section_pinned">Připnuté</string>
+    <string name="duck_ai_chat_history_section_recent">Nedávné</string>
+    <string name="duck_ai_chat_history_untitled">Chat bez názvu</string>
+    <string name="duck_ai_chat_history_empty_title">Zatím žádné chaty</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Spustit Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Další možnosti</string>
+    <string name="duck_ai_chat_history_action_select">Zvolit</string>
+    <string name="duck_ai_chat_history_action_pin">Připnout</string>
+    <string name="duck_ai_chat_history_action_unpin">Odepnout</string>
+    <string name="duck_ai_chat_history_action_rename">Přejmenovat</string>
+    <string name="duck_ai_chat_history_action_download">Stáhnout</string>
+    <string name="duck_ai_chat_history_action_delete">Smazat</string>
+    <string name="duck_ai_chat_history_search_hint">Vyhledávání v chatech</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Vyhledávání v chatech</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zavřít vyhledávání</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Vymazat vyhledávání</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Smazat chaty</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Otevřít rozbalovací menu</string>
+    <string name="duck_ai_chat_history_select_all">Vybrat vše</string>
+    <string name="duck_ai_chat_history_unselect_all">Zrušit výběr všech</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Vybráno</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nevybráno</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Ukončit režim výběru</string>
+    <string name="duck_ai_chat_history_rename_title">Přejmenovat chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Název chatu</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Uložit</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Uložit název chatu</string>
+    <string name="duck_ai_chat_history_rename_error">Nelze přejmenovat chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat je připnutý</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat je odepnutý</string>
+    <string name="duck_ai_chat_history_undo">Vrátit</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Dokončeno stahování souboru %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Zobrazit</string>
+    <string name="duck_ai_chat_history_download_error">Nepodařilo se exportovat chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zavřít vyhledávání</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Vymazat vyhledávání</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Smazat chaty</string>
+    <string name="duck_ai_chat_history_action_new">Nová</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Stáhnout chaty</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Stahování dokončeno pro %1$d chat</item>
+        <item quantity="few">Stahování dokončeno pro %1$d chaty</item>
+        <item quantity="many">Stahování dokončeno pro %1$d chatů</item>
+        <item quantity="other">Stahování dokončeno pro %1$d chatů</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Otevřít rozbalovací menu</string>
     <string name="duck_ai_chat_history_select_all">Vybrat vše</string>
     <string name="duck_ai_chat_history_unselect_all">Zrušit výběr všech</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Dokončeno stahování souboru %1$s</string>
     <string name="duck_ai_chat_history_download_view">Zobrazit</string>
     <string name="duck_ai_chat_history_download_error">Nepodařilo se exportovat chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nepodařilo se exportovat chaty</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Stemmechat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Se alle chats</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Fastgjort</string>
@@ -135,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Luk søgning</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Ryd søgning</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Slettede chats</string>
+    <string name="duck_ai_chat_history_action_new">Ny</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Download chats</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Download fuldført for %1$d chat</item>
+        <item quantity="other">Download fuldført for %1$d chats</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Åbn overløbsmenuen</string>
     <string name="duck_ai_chat_history_select_all">Vælg alle</string>
     <string name="duck_ai_chat_history_unselect_all">Fravælg alle</string>
@@ -152,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download fuldført for %1$s</string>
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chats</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Stemmechat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Fastgjort</string>
+    <string name="duck_ai_chat_history_section_recent">Seneste</string>
+    <string name="duck_ai_chat_history_untitled">Chat uden titel</string>
+    <string name="duck_ai_chat_history_empty_title">Ingen chats endnu</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Åbn Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Flere muligheder</string>
+    <string name="duck_ai_chat_history_action_select">Vælg</string>
+    <string name="duck_ai_chat_history_action_pin">Fastgør</string>
+    <string name="duck_ai_chat_history_action_unpin">Fjern fastgørelse</string>
+    <string name="duck_ai_chat_history_action_rename">Omdøb</string>
+    <string name="duck_ai_chat_history_action_download">Download</string>
+    <string name="duck_ai_chat_history_action_delete">Slet</string>
+    <string name="duck_ai_chat_history_search_hint">Søg i chats</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Søg i chats</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Luk søgning</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Ryd søgning</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Slettede chats</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Åbn overløbsmenuen</string>
+    <string name="duck_ai_chat_history_select_all">Vælg alle</string>
+    <string name="duck_ai_chat_history_unselect_all">Fravælg alle</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Valgt</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ikke valgt</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Afslut valgtilstand</string>
+    <string name="duck_ai_chat_history_rename_title">Omdøb chatten</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chattitel</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Gem</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Gem chattitel</string>
+    <string name="duck_ai_chat_history_rename_error">Kunne ikke omdøbe chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat fastgjort</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat ikke fastgjort</string>
+    <string name="duck_ai_chat_history_undo">Fortryd</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download fuldført for %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Vis</string>
+    <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Sprachchat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Angepinnt</string>
+    <string name="duck_ai_chat_history_section_recent">Aktuell</string>
+    <string name="duck_ai_chat_history_untitled">Chat ohne Titel</string>
+    <string name="duck_ai_chat_history_empty_title">Noch keine Chats</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Duck.ai öffnen</string>
+    <string name="duck_ai_chat_history_more_options">Weitere Optionen</string>
+    <string name="duck_ai_chat_history_action_select">Auswählen</string>
+    <string name="duck_ai_chat_history_action_pin">Anpinnen</string>
+    <string name="duck_ai_chat_history_action_unpin">Pin entfernen</string>
+    <string name="duck_ai_chat_history_action_rename">Umbenennen</string>
+    <string name="duck_ai_chat_history_action_download">Download</string>
+    <string name="duck_ai_chat_history_action_delete">Löschen</string>
+    <string name="duck_ai_chat_history_search_hint">Chats durchsuchen</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Chats durchsuchen</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Suche schließen</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Suche löschen</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Chats löschen</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Überlaufmenü öffnen</string>
+    <string name="duck_ai_chat_history_select_all">Alle auswählen</string>
+    <string name="duck_ai_chat_history_unselect_all">Alle abwählen</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Ausgewählt</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nicht ausgewählt</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Auswahlmodus beenden</string>
+    <string name="duck_ai_chat_history_rename_title">Chat umbenennen</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chat-Titel</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Speichern</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Chat-Titel speichern</string>
+    <string name="duck_ai_chat_history_rename_error">Chat konnte nicht umbenannt werden</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat angepinnt</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat-Pin entfernt</string>
+    <string name="duck_ai_chat_history_undo">Rückgängig machen</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download von %1$s abgeschlossen</string>
+    <string name="duck_ai_chat_history_download_view">Anzeigen</string>
+    <string name="duck_ai_chat_history_download_error">Chat konnte nicht exportiert werden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Sprachchat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Alle Chats anzeigen</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Angepinnt</string>
@@ -135,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Suche schließen</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Suche löschen</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Chats löschen</string>
+    <string name="duck_ai_chat_history_action_new">Neu</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Chats herunterladen</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Download für %1$d Chat abgeschlossen</item>
+        <item quantity="other">Download für %1$d Chats abgeschlossen</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Überlaufmenü öffnen</string>
     <string name="duck_ai_chat_history_select_all">Alle auswählen</string>
     <string name="duck_ai_chat_history_unselect_all">Alle abwählen</string>
@@ -152,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download von %1$s abgeschlossen</string>
     <string name="duck_ai_chat_history_download_view">Anzeigen</string>
     <string name="duck_ai_chat_history_download_error">Chat konnte nicht exportiert werden</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Chats konnten nicht exportiert werden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Φωνητική συνομιλία</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Συνομιλίες</string>
+    <string name="duck_ai_chat_history_section_pinned">Καρφιτσωμένες</string>
+    <string name="duck_ai_chat_history_section_recent">Πρόσφατα</string>
+    <string name="duck_ai_chat_history_untitled">Συνομιλία χωρίς τίτλο</string>
+    <string name="duck_ai_chat_history_empty_title">Δεν υπάρχουν συνομιλίες ακόμα</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Άνοιξε το Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Περισσότερες επιλογές</string>
+    <string name="duck_ai_chat_history_action_select">Επιλογή</string>
+    <string name="duck_ai_chat_history_action_pin">Καρφίτσα</string>
+    <string name="duck_ai_chat_history_action_unpin">Αφαίρεση καρφίτσας</string>
+    <string name="duck_ai_chat_history_action_rename">Μετονομασία</string>
+    <string name="duck_ai_chat_history_action_download">Λήψη</string>
+    <string name="duck_ai_chat_history_action_delete">Διαγραφή</string>
+    <string name="duck_ai_chat_history_search_hint">Αναζήτηση συνομιλιών</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Αναζήτηση συνομιλιών</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Κλείσιμο αναζήτησης</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Εκκαθάριση αναζήτησης</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Διαγραφή συνομιλιών</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Άνοιγμα μενού υπερχείλισης</string>
+    <string name="duck_ai_chat_history_select_all">Επιλογή όλων</string>
+    <string name="duck_ai_chat_history_unselect_all">Αποεπιλογή όλων</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Επιλεγμένο</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Μη επιλεγμένο</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Έξοδος από τη λειτουργία επιλογής</string>
+    <string name="duck_ai_chat_history_rename_title">Μετονομασία συνομιλίας</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Τίτλος συνομιλίας</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Αποθήκευση</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Αποθήκευση τίτλου συνομιλίας</string>
+    <string name="duck_ai_chat_history_rename_error">Δεν ήταν δυνατή η μετονομασία της συνομιλίας</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Η συνομιλία καρφιτσώθηκε</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Η συνομιλία ξεκαρφιτσώθηκε</string>
+    <string name="duck_ai_chat_history_undo">Αναίρεση</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Ολοκληρώθηκε η λήψη για το αρχείο %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Εμφάνιση</string>
+    <string name="duck_ai_chat_history_download_error">Δεν ήταν δυνατή η εξαγωγή της συνομιλίας</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Φωνητική συνομιλία</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Προβολή όλων των συνομιλιών</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Συνομιλίες</string>
     <string name="duck_ai_chat_history_section_pinned">Καρφιτσωμένες</string>
@@ -135,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Κλείσιμο αναζήτησης</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Εκκαθάριση αναζήτησης</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Διαγραφή συνομιλιών</string>
+    <string name="duck_ai_chat_history_action_new">Νέο</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Λήψη συνομιλιών</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Ολοκληρώθηκε η λήψη για %1$d συνομιλία</item>
+        <item quantity="other">Ολοκληρώθηκε η λήψη για %1$d συνομιλίες</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Άνοιγμα μενού υπερχείλισης</string>
     <string name="duck_ai_chat_history_select_all">Επιλογή όλων</string>
     <string name="duck_ai_chat_history_unselect_all">Αποεπιλογή όλων</string>
@@ -152,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Ολοκληρώθηκε η λήψη για το αρχείο %1$s</string>
     <string name="duck_ai_chat_history_download_view">Εμφάνιση</string>
     <string name="duck_ai_chat_history_download_error">Δεν ήταν δυνατή η εξαγωγή της συνομιλίας</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Δεν ήταν δυνατή η εξαγωγή των συνομιλιών</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat de voz</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Anclados</string>
+    <string name="duck_ai_chat_history_section_recent">Reciente</string>
+    <string name="duck_ai_chat_history_untitled">Chat sin título</string>
+    <string name="duck_ai_chat_history_empty_title">Aún no hay chats</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Abrir Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Más opciones</string>
+    <string name="duck_ai_chat_history_action_select">Seleccionar</string>
+    <string name="duck_ai_chat_history_action_pin">Anclar</string>
+    <string name="duck_ai_chat_history_action_unpin">Eliminar anclaje</string>
+    <string name="duck_ai_chat_history_action_rename">Cambiar nombre</string>
+    <string name="duck_ai_chat_history_action_download">Descargar</string>
+    <string name="duck_ai_chat_history_action_delete">Eliminar</string>
+    <string name="duck_ai_chat_history_search_hint">Buscar chats</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Buscar chats</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Cerrar búsqueda</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Borrar búsqueda</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Borrar chats</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Abrir menú de desbordamiento</string>
+    <string name="duck_ai_chat_history_select_all">Seleccionar todo</string>
+    <string name="duck_ai_chat_history_unselect_all">Deseleccionar todos</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Seleccionado</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">No seleccionado</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Salir del modo de selección</string>
+    <string name="duck_ai_chat_history_rename_title">Cambiar nombre de chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Título del chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Guardar</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Guardar título del chat</string>
+    <string name="duck_ai_chat_history_rename_error">No se ha podido renombrar el chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat anclado</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat desanclado</string>
+    <string name="duck_ai_chat_history_undo">Deshacer</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Descarga de %1$s completada</string>
+    <string name="duck_ai_chat_history_download_view">Mostrar</string>
+    <string name="duck_ai_chat_history_download_error">No se pudo exportar el chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Cerrar búsqueda</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Borrar búsqueda</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Borrar chats</string>
+    <string name="duck_ai_chat_history_action_new">Nuevo</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Descargar chats</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Descarga finalizada para %1$d chat</item>
+        <item quantity="other">Descarga finalizada para %1$d chats</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Abrir menú de desbordamiento</string>
     <string name="duck_ai_chat_history_select_all">Seleccionar todo</string>
     <string name="duck_ai_chat_history_unselect_all">Deseleccionar todos</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Descarga de %1$s completada</string>
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">No se pudo exportar el chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">No se pudieron exportar los chats</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat de voz</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Ver todos los chats</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Anclados</string>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Häälvestlus</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Vestlused</string>
+    <string name="duck_ai_chat_history_section_pinned">Kinnitatud</string>
+    <string name="duck_ai_chat_history_section_recent">Hiljutised</string>
+    <string name="duck_ai_chat_history_untitled">Pealkirjata vestlus</string>
+    <string name="duck_ai_chat_history_empty_title">Ei ole veel ühtegi vestlust</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Ava Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Veel valikuid</string>
+    <string name="duck_ai_chat_history_action_select">Vali</string>
+    <string name="duck_ai_chat_history_action_pin">Kinnita</string>
+    <string name="duck_ai_chat_history_action_unpin">Eemalda kinnitamine</string>
+    <string name="duck_ai_chat_history_action_rename">Nimeta ümber</string>
+    <string name="duck_ai_chat_history_action_download">Laadi alla</string>
+    <string name="duck_ai_chat_history_action_delete">Kustuta</string>
+    <string name="duck_ai_chat_history_search_hint">Otsi vestlusi</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Otsi vestlusi</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Sulge otsing</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Tühjenda otsing</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Kustuta vestlused</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Ava ülevoolu menüü</string>
+    <string name="duck_ai_chat_history_select_all">Vali kõik</string>
+    <string name="duck_ai_chat_history_unselect_all">Tühjenda kõik valikud</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Valitud</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ei ole valitud</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Välju valikurežiimist</string>
+    <string name="duck_ai_chat_history_rename_title">Nimeta vestlus ümber</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Vestluse pealkiri</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Salvesta</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Salvesta vestluse pealkiri</string>
+    <string name="duck_ai_chat_history_rename_error">Vestlust ei õnnestunud ümber nimetada</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Vestlus kinnitatud</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Vestlus kinnitamata</string>
+    <string name="duck_ai_chat_history_undo">Võta tagasi</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Faili %1$s allalaadimine jõudis lõpule</string>
+    <string name="duck_ai_chat_history_download_view">Kuva</string>
+    <string name="duck_ai_chat_history_download_error">Vestlust ei õnnestunud eksportida</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Sulge otsing</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Tühjenda otsing</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Kustuta vestlused</string>
+    <string name="duck_ai_chat_history_action_new">Uus</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Laadi alla vestlused</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Allalaadimine lõpetatud %1$d vestluse jaoks</item>
+        <item quantity="other">Allalaadimine lõpetatud %1$d vestluse jaoks</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Ava ülevoolu menüü</string>
     <string name="duck_ai_chat_history_select_all">Vali kõik</string>
     <string name="duck_ai_chat_history_unselect_all">Tühjenda kõik valikud</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Faili %1$s allalaadimine jõudis lõpule</string>
     <string name="duck_ai_chat_history_download_view">Kuva</string>
     <string name="duck_ai_chat_history_download_error">Vestlust ei õnnestunud eksportida</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Vestlusi ei õnnestunud eksportida</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Häälvestlus</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Vaata kõiki vestlusi</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Vestlused</string>
     <string name="duck_ai_chat_history_section_pinned">Kinnitatud</string>
@@ -126,7 +129,7 @@
     <string name="duck_ai_chat_history_more_options">Veel valikuid</string>
     <string name="duck_ai_chat_history_action_select">Vali</string>
     <string name="duck_ai_chat_history_action_pin">Kinnita</string>
-    <string name="duck_ai_chat_history_action_unpin">Eemalda kinnitamine</string>
+    <string name="duck_ai_chat_history_action_unpin">Eemalda kinnitus</string>
     <string name="duck_ai_chat_history_action_rename">Nimeta ümber</string>
     <string name="duck_ai_chat_history_action_download">Laadi alla</string>
     <string name="duck_ai_chat_history_action_delete">Kustuta</string>
@@ -147,7 +150,7 @@
     <string name="duck_ai_chat_history_rename_confirm_content_description">Salvesta vestluse pealkiri</string>
     <string name="duck_ai_chat_history_rename_error">Vestlust ei õnnestunud ümber nimetada</string>
     <string name="duck_ai_chat_history_pin_snackbar">Vestlus kinnitatud</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Vestlus kinnitamata</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Vestluse kinnitus eemaldatud</string>
     <string name="duck_ai_chat_history_undo">Võta tagasi</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Faili %1$s allalaadimine jõudis lõpule</string>
     <string name="duck_ai_chat_history_download_view">Kuva</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Äänikeskustelu</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Keskustelut</string>
+    <string name="duck_ai_chat_history_section_pinned">Kiinnitetty</string>
+    <string name="duck_ai_chat_history_section_recent">Viimeaikaiset</string>
+    <string name="duck_ai_chat_history_untitled">Nimetön keskustelu</string>
+    <string name="duck_ai_chat_history_empty_title">Ei vielä yhtään keskustelua</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Avaa Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Lisää vaihtoehtoja</string>
+    <string name="duck_ai_chat_history_action_select">Valitse</string>
+    <string name="duck_ai_chat_history_action_pin">Kiinnitä</string>
+    <string name="duck_ai_chat_history_action_unpin">Poista kiinnitys</string>
+    <string name="duck_ai_chat_history_action_rename">Nimeä uudelleen</string>
+    <string name="duck_ai_chat_history_action_download">Lataa</string>
+    <string name="duck_ai_chat_history_action_delete">Poista</string>
+    <string name="duck_ai_chat_history_search_hint">Etsi keskusteluja</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Etsi keskusteluja</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Sulje haku</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Tyhjennä haku</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Poista keskustelut</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Avaa ylivuotovalikko</string>
+    <string name="duck_ai_chat_history_select_all">Valitse kaikki</string>
+    <string name="duck_ai_chat_history_unselect_all">Poista kaikki valinnat</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Valittu</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ei valittu</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Poistu valintatilasta</string>
+    <string name="duck_ai_chat_history_rename_title">Nimeä keskustelu uudelleen</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Keskustelun otsikko</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Tallenna</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Tallenna keskustelun otsikko</string>
+    <string name="duck_ai_chat_history_rename_error">Keskustelun nimeäminen uudelleen epäonnistui</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Keskustelu kiinnitetty</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Keskustelun kiinnitys poistettu</string>
+    <string name="duck_ai_chat_history_undo">Kumoa</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Kohteen %1$s lataus valmis</string>
+    <string name="duck_ai_chat_history_download_view">Näytä</string>
+    <string name="duck_ai_chat_history_download_error">Keskustelua ei voitu viedä</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Äänikeskustelu</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Näytä kaikki keskustelut</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Keskustelut</string>
     <string name="duck_ai_chat_history_section_pinned">Kiinnitetty</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Sulje haku</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Tyhjennä haku</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Poista keskustelut</string>
+    <string name="duck_ai_chat_history_action_new">Uusi</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Lataa keskustelut</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Lataus valmis %1$d keskustelulle</item>
+        <item quantity="other">Lataus valmis %1$d keskustelulle</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Avaa ylivuotovalikko</string>
     <string name="duck_ai_chat_history_select_all">Valitse kaikki</string>
     <string name="duck_ai_chat_history_unselect_all">Poista kaikki valinnat</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Kohteen %1$s lataus valmis</string>
     <string name="duck_ai_chat_history_download_view">Näytä</string>
     <string name="duck_ai_chat_history_download_error">Keskustelua ei voitu viedä</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Keskusteluja ei voitu viedä</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocal</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Voir toutes les discussions</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Discussions</string>
     <string name="duck_ai_chat_history_section_pinned">Épinglées</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocal</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Discussions</string>
+    <string name="duck_ai_chat_history_section_pinned">Épinglées</string>
+    <string name="duck_ai_chat_history_section_recent">Récentes</string>
+    <string name="duck_ai_chat_history_untitled">Chat sans titre</string>
+    <string name="duck_ai_chat_history_empty_title">Pas encore de discussions</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Ouvrir Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Plus d\'options</string>
+    <string name="duck_ai_chat_history_action_select">Sélectionner</string>
+    <string name="duck_ai_chat_history_action_pin">Épingler</string>
+    <string name="duck_ai_chat_history_action_unpin">Retirer l\'épingle</string>
+    <string name="duck_ai_chat_history_action_rename">Renommer</string>
+    <string name="duck_ai_chat_history_action_download">Télécharger</string>
+    <string name="duck_ai_chat_history_action_delete">Supprimer</string>
+    <string name="duck_ai_chat_history_search_hint">Recherche de discussions</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Rechercher des discussions</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Fermer la recherche</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Effacer la recherche</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Supprimer les discussions</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Ouvrir le menu supplémentaire</string>
+    <string name="duck_ai_chat_history_select_all">Tout sélectionner</string>
+    <string name="duck_ai_chat_history_unselect_all">Désélectionner tout</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Sélectionné</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Non sélectionné</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Sortir du mode de sélection</string>
+    <string name="duck_ai_chat_history_rename_title">Renommer la discussion</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Titre du chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Enregistrer</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Enregistrer le titre de la discussion</string>
+    <string name="duck_ai_chat_history_rename_error">Impossible de renommer la discussion</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Discussion épinglée</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Discussion détachée</string>
+    <string name="duck_ai_chat_history_undo">Annuler</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Téléchargement terminé pour %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Afficher</string>
+    <string name="duck_ai_chat_history_download_error">Impossible d\'exporter la discussion</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Fermer la recherche</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Effacer la recherche</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Supprimer les discussions</string>
+    <string name="duck_ai_chat_history_action_new">Nouvelle</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Télécharger les discussions</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Téléchargement terminé pour %1$d discussion</item>
+        <item quantity="other">Téléchargement terminé pour %1$d discussions</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Ouvrir le menu supplémentaire</string>
     <string name="duck_ai_chat_history_select_all">Tout sélectionner</string>
     <string name="duck_ai_chat_history_unselect_all">Désélectionner tout</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Téléchargement terminé pour %1$s</string>
     <string name="duck_ai_chat_history_download_view">Afficher</string>
     <string name="duck_ai_chat_history_download_error">Impossible d\'exporter la discussion</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Impossible d\'exporter les discussions</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zatvori pretragu</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Izbriši pretragu</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Izbriši čavrljanja</string>
+    <string name="duck_ai_chat_history_action_new">Novo</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Preuzmi čavrljanja</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Preuzimanje je dovršeno za %1$d čavrljanje</item>
+        <item quantity="few">Preuzimanje je dovršeno za %1$d čavrljanja</item>
+        <item quantity="many">Preuzimanje je dovršeno za %1$d čavrljanja</item>
+        <item quantity="other">Preuzimanje je dovršeno za %1$d čavrljanja</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Otvori izbornik prelijevanja</string>
     <string name="duck_ai_chat_history_select_all">Odaberi sve</string>
     <string name="duck_ai_chat_history_unselect_all">Odznači sve</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Završeno je preuzimanje datoteke %1$s</string>
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Izvoz čavrljanja nije moguć</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Izvoz čavrljanja nije uspio</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Glasovno čavrljanje</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Čavrljanja</string>
+    <string name="duck_ai_chat_history_section_pinned">Prikvačeno</string>
+    <string name="duck_ai_chat_history_section_recent">Nedavno</string>
+    <string name="duck_ai_chat_history_untitled">Neimenovano čavrljanje</string>
+    <string name="duck_ai_chat_history_empty_title">Još nema čavrljanja</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Otvori Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Dodatne mogućnosti</string>
+    <string name="duck_ai_chat_history_action_select">Odabir</string>
+    <string name="duck_ai_chat_history_action_pin">Prikvači</string>
+    <string name="duck_ai_chat_history_action_unpin">Ukloni pribadaču</string>
+    <string name="duck_ai_chat_history_action_rename">Preimenuj</string>
+    <string name="duck_ai_chat_history_action_download">Preuzmi</string>
+    <string name="duck_ai_chat_history_action_delete">Izbriši</string>
+    <string name="duck_ai_chat_history_search_hint">Pretraži čavrljanja</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Pretraži čavrljanja</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zatvori pretragu</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Izbriši pretragu</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Izbriši čavrljanja</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Otvori izbornik prelijevanja</string>
+    <string name="duck_ai_chat_history_select_all">Odaberi sve</string>
+    <string name="duck_ai_chat_history_unselect_all">Odznači sve</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Odabrano</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nije odabrano</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Izađi iz načina odabira</string>
+    <string name="duck_ai_chat_history_rename_title">Preimenuj čavrljanje</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Naziv čavrljanja</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Spremi</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Sačuvaj naziv čavrljanja</string>
+    <string name="duck_ai_chat_history_rename_error">Nije moguće preimenovati čavrljanja</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Čavrljanje je prikvačeno</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Čavrljanje je otkvačeno</string>
+    <string name="duck_ai_chat_history_undo">Poništi</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Završeno je preuzimanje datoteke %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Prikaži</string>
+    <string name="duck_ai_chat_history_download_error">Izvoz čavrljanja nije moguć</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Glasovno čavrljanje</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Prikaži sva čavrljanja</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Čavrljanja</string>
     <string name="duck_ai_chat_history_section_pinned">Prikvačeno</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hangcsevegés</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Csevegések</string>
+    <string name="duck_ai_chat_history_section_pinned">Kitűzött</string>
+    <string name="duck_ai_chat_history_section_recent">Legutóbbi</string>
+    <string name="duck_ai_chat_history_untitled">Névtelen beszélgetés</string>
+    <string name="duck_ai_chat_history_empty_title">Még nincsenek csevegések</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Duck.ai megnyitása</string>
+    <string name="duck_ai_chat_history_more_options">További lehetőségek</string>
+    <string name="duck_ai_chat_history_action_select">Kiválasztás</string>
+    <string name="duck_ai_chat_history_action_pin">Kitűzés</string>
+    <string name="duck_ai_chat_history_action_unpin">Kitűzés eltávolítása</string>
+    <string name="duck_ai_chat_history_action_rename">Átnevezés</string>
+    <string name="duck_ai_chat_history_action_download">Letöltés</string>
+    <string name="duck_ai_chat_history_action_delete">Törlés</string>
+    <string name="duck_ai_chat_history_search_hint">Csevegések keresése</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Csevegések keresése</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Keresés bezárása</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Keresés törlése</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Csevegések törlése</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Túlfolyó menü megnyitása</string>
+    <string name="duck_ai_chat_history_select_all">Összes kijelölése</string>
+    <string name="duck_ai_chat_history_unselect_all">Minden kijelölés megszüntetése</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Kiválasztva</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nincs kiválasztva</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Kilépés a kiválasztási módból</string>
+    <string name="duck_ai_chat_history_rename_title">Csevegés átnevezése</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Csevegés címe</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Mentés</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Csevegés címének mentése</string>
+    <string name="duck_ai_chat_history_rename_error">Nem sikerült átnevezni a csevegést</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Csevegés kitűzve</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Csevegés levéve</string>
+    <string name="duck_ai_chat_history_undo">Visszavonás</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s letöltése befejeződött</string>
+    <string name="duck_ai_chat_history_download_view">Megjelenítés</string>
+    <string name="duck_ai_chat_history_download_error">Nem sikerült exportálni a csevegést</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hangcsevegés</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Összes csevegés megtekintése</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Csevegések</string>
     <string name="duck_ai_chat_history_section_pinned">Kitűzött</string>
@@ -126,7 +129,7 @@
     <string name="duck_ai_chat_history_more_options">További lehetőségek</string>
     <string name="duck_ai_chat_history_action_select">Kiválasztás</string>
     <string name="duck_ai_chat_history_action_pin">Kitűzés</string>
-    <string name="duck_ai_chat_history_action_unpin">Kitűzés eltávolítása</string>
+    <string name="duck_ai_chat_history_action_unpin">Kitűzés megszüntetése</string>
     <string name="duck_ai_chat_history_action_rename">Átnevezés</string>
     <string name="duck_ai_chat_history_action_download">Letöltés</string>
     <string name="duck_ai_chat_history_action_delete">Törlés</string>
@@ -147,7 +150,7 @@
     <string name="duck_ai_chat_history_rename_confirm_content_description">Csevegés címének mentése</string>
     <string name="duck_ai_chat_history_rename_error">Nem sikerült átnevezni a csevegést</string>
     <string name="duck_ai_chat_history_pin_snackbar">Csevegés kitűzve</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Csevegés levéve</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Csevegés kitűzése megszüntetve</string>
     <string name="duck_ai_chat_history_undo">Visszavonás</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s letöltése befejeződött</string>
     <string name="duck_ai_chat_history_download_view">Megjelenítés</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Keresés bezárása</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Keresés törlése</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Csevegések törlése</string>
+    <string name="duck_ai_chat_history_action_new">Új</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Csevegések letöltése</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">%1$d csevegés letöltése befejeződött</item>
+        <item quantity="other">%1$d csevegés letöltése befejeződött</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Túlfolyó menü megnyitása</string>
     <string name="duck_ai_chat_history_select_all">Összes kijelölése</string>
     <string name="duck_ai_chat_history_unselect_all">Minden kijelölés megszüntetése</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s letöltése befejeződött</string>
     <string name="duck_ai_chat_history_download_view">Megjelenítés</string>
     <string name="duck_ai_chat_history_download_error">Nem sikerült exportálni a csevegést</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nem sikerült exportálni a csevegéseket</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Chiudi ricerca</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Cancella ricerca</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Elimina chat</string>
+    <string name="duck_ai_chat_history_action_new">Nuova</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Scarica le chat</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Download completato per %1$d chat</item>
+        <item quantity="other">Download completato per %1$d chat</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Apri il menu di overflow</string>
     <string name="duck_ai_chat_history_select_all">Seleziona tutto</string>
     <string name="duck_ai_chat_history_unselect_all">Deseleziona tutti</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download di %1$s completato</string>
     <string name="duck_ai_chat_history_download_view">Mostra</string>
     <string name="duck_ai_chat_history_download_error">Non è possibile esportare la chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Non è stato possibile esportare le chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocale</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Visualizza tutte le chat</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chat</string>
     <string name="duck_ai_chat_history_section_pinned">Fissato</string>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocale</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chat</string>
+    <string name="duck_ai_chat_history_section_pinned">Fissato</string>
+    <string name="duck_ai_chat_history_section_recent">Recente</string>
+    <string name="duck_ai_chat_history_untitled">Chat senza titolo</string>
+    <string name="duck_ai_chat_history_empty_title">Ancora nessuna chat</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Apri Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Altre opzioni</string>
+    <string name="duck_ai_chat_history_action_select">Seleziona</string>
+    <string name="duck_ai_chat_history_action_pin">Fissa</string>
+    <string name="duck_ai_chat_history_action_unpin">Rimuovi blocco</string>
+    <string name="duck_ai_chat_history_action_rename">Rinomina</string>
+    <string name="duck_ai_chat_history_action_download">Scarica</string>
+    <string name="duck_ai_chat_history_action_delete">Elimina</string>
+    <string name="duck_ai_chat_history_search_hint">Cerca chat</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Cerca chat</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Chiudi ricerca</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Cancella ricerca</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Elimina chat</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Apri il menu di overflow</string>
+    <string name="duck_ai_chat_history_select_all">Seleziona tutto</string>
+    <string name="duck_ai_chat_history_unselect_all">Deseleziona tutti</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Selezionato</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Non selezionato</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Esci dalla modalità di selezione</string>
+    <string name="duck_ai_chat_history_rename_title">Rinomina chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Titolo della chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Salva</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Salva il titolo della chat</string>
+    <string name="duck_ai_chat_history_rename_error">Impossibile rinominare la chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat fissata</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat sbloccata</string>
+    <string name="duck_ai_chat_history_undo">Annulla</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Download di %1$s completato</string>
+    <string name="duck_ai_chat_history_download_view">Mostra</string>
+    <string name="duck_ai_chat_history_download_error">Non è possibile esportare la chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Balso pokalbis</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Pokalbiai</string>
+    <string name="duck_ai_chat_history_section_pinned">Prisegti</string>
+    <string name="duck_ai_chat_history_section_recent">Naujausi</string>
+    <string name="duck_ai_chat_history_untitled">Pokalbis be pavadinimo</string>
+    <string name="duck_ai_chat_history_empty_title">Pokalbių dar nėra</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Atidaryti „Duck.ai“</string>
+    <string name="duck_ai_chat_history_more_options">Daugiau parinkčių</string>
+    <string name="duck_ai_chat_history_action_select">Pasirinkti</string>
+    <string name="duck_ai_chat_history_action_pin">Prisegti</string>
+    <string name="duck_ai_chat_history_action_unpin">Atsegti</string>
+    <string name="duck_ai_chat_history_action_rename">Pervadyti</string>
+    <string name="duck_ai_chat_history_action_download">Atsisiųsti</string>
+    <string name="duck_ai_chat_history_action_delete">Ištrinti</string>
+    <string name="duck_ai_chat_history_search_hint">Ieškoti pokalbių</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Ieškoti pokalbių</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Uždaryti paiešką</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Išvalyti paiešką</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Ištrinti pokalbius</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Atidaryti papildomą meniu</string>
+    <string name="duck_ai_chat_history_select_all">Pasirinkti viską</string>
+    <string name="duck_ai_chat_history_unselect_all">Atžymėti viską</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Pasirinkta</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nepasirinkta</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Išeiti iš pasirinkimo režimo</string>
+    <string name="duck_ai_chat_history_rename_title">Pervadyti pokalbį</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Pokalbio pavadinimas</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Išsaugoti</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Išsaugoti pokalbio pavadinimą</string>
+    <string name="duck_ai_chat_history_rename_error">Nepavyko pervadyti pokalbio</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Pokalbis prisegtas</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Pokalbis atsegtas</string>
+    <string name="duck_ai_chat_history_undo">Anuliuoti</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s atsisiuntimas baigtas</string>
+    <string name="duck_ai_chat_history_download_view">Rodyti</string>
+    <string name="duck_ai_chat_history_download_error">Nepavyko eksportuoti pokalbio</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Balso pokalbis</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Peržiūrėti visus pokalbius</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Pokalbiai</string>
     <string name="duck_ai_chat_history_section_pinned">Prisegti</string>
@@ -135,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Uždaryti paiešką</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Išvalyti paiešką</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Ištrinti pokalbius</string>
+    <string name="duck_ai_chat_history_action_new">Naujas</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Atsisiųsk pokalbius</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">%1$d pokalbio atsisiuntimas baigtas</item>
+        <item quantity="few">%1$d pokalbių atsisiuntimas baigtas</item>
+        <item quantity="many">%1$d pokalbio atsisiuntimas baigtas</item>
+        <item quantity="other">%1$d pokalbių atsisiuntimas baigtas</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Atidaryti papildomą meniu</string>
     <string name="duck_ai_chat_history_select_all">Pasirinkti viską</string>
     <string name="duck_ai_chat_history_unselect_all">Atžymėti viską</string>
@@ -152,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s atsisiuntimas baigtas</string>
     <string name="duck_ai_chat_history_download_view">Rodyti</string>
     <string name="duck_ai_chat_history_download_error">Nepavyko eksportuoti pokalbio</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nepavyko eksportuoti pokalbių</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -138,6 +138,13 @@
     <string name="duck_ai_chat_history_search_close_content_description">Aizvērt meklēšanu</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Notīrīt meklēšanu</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Dzēst tērzēšanas</string>
+    <string name="duck_ai_chat_history_action_new">Jauns</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Lejupielādēt tērzēšanas</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="zero">Pabeigta %1$d tērzēšanu lejupielāde</item>
+        <item quantity="one">Pabeigta %1$d tērzēšanas lejupielāde</item>
+        <item quantity="other">Pabeigta %1$d tērzēšanu lejupielāde</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Atvērt pārpildes izvēlni</string>
     <string name="duck_ai_chat_history_select_all">Atlasīt visus</string>
     <string name="duck_ai_chat_history_unselect_all">Noņemt visu atlasi</string>
@@ -155,4 +162,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s lejupielāde pabeigta</string>
     <string name="duck_ai_chat_history_download_view">Rādīt</string>
     <string name="duck_ai_chat_history_download_error">Nevarēja eksportēt tērzēšanu</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Neizdevās eksportēt tērzēšanas</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Balss tērzēšana</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Skatīt visas tērzēšanas sarunas</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Tērzēšanas</string>
     <string name="duck_ai_chat_history_section_pinned">Piesprausts</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Balss tērzēšana</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Tērzēšanas</string>
+    <string name="duck_ai_chat_history_section_pinned">Piesprausts</string>
+    <string name="duck_ai_chat_history_section_recent">Nesen</string>
+    <string name="duck_ai_chat_history_untitled">Tērzēšana bez nosaukuma</string>
+    <string name="duck_ai_chat_history_empty_title">Vēl nav nevienas tērzēšanas</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Atvērt Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Citas iespējas</string>
+    <string name="duck_ai_chat_history_action_select">Atlasīt</string>
+    <string name="duck_ai_chat_history_action_pin">Piespraust</string>
+    <string name="duck_ai_chat_history_action_unpin">Noņemt piespraudi</string>
+    <string name="duck_ai_chat_history_action_rename">Pārdēvēt</string>
+    <string name="duck_ai_chat_history_action_download">Lejupielādēt</string>
+    <string name="duck_ai_chat_history_action_delete">Dzēst</string>
+    <string name="duck_ai_chat_history_search_hint">Meklēt tērzēšanas</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Meklēt tērzēšanas</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Aizvērt meklēšanu</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Notīrīt meklēšanu</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Dzēst tērzēšanas</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Atvērt pārpildes izvēlni</string>
+    <string name="duck_ai_chat_history_select_all">Atlasīt visus</string>
+    <string name="duck_ai_chat_history_unselect_all">Noņemt visu atlasi</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Atlasīts</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nav atlasīts</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Iziešana no atlases režīma</string>
+    <string name="duck_ai_chat_history_rename_title">Pārdēvēt tērzēšanu</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Tērzēšanas nosaukums</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Saglabāt</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Saglabāt tērzēšanas nosaukumu</string>
+    <string name="duck_ai_chat_history_rename_error">Nevarēja pārdēvēt tērzēšanu</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Tērzēšana piesprausta</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Tērzēšanas piespraude noņemta</string>
+    <string name="duck_ai_chat_history_undo">Atsaukt</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s lejupielāde pabeigta</string>
+    <string name="duck_ai_chat_history_download_view">Rādīt</string>
+    <string name="duck_ai_chat_history_download_error">Nevarēja eksportēt tērzēšanu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Talechat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chatter</string>
+    <string name="duck_ai_chat_history_section_pinned">Festede</string>
+    <string name="duck_ai_chat_history_section_recent">Nylige</string>
+    <string name="duck_ai_chat_history_untitled">Chat uten tittel</string>
+    <string name="duck_ai_chat_history_empty_title">Ingen chatter ennå</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Åpne Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Flere alternativer</string>
+    <string name="duck_ai_chat_history_action_select">Velg</string>
+    <string name="duck_ai_chat_history_action_pin">Fest</string>
+    <string name="duck_ai_chat_history_action_unpin">Fjern festing</string>
+    <string name="duck_ai_chat_history_action_rename">Gi nytt navn</string>
+    <string name="duck_ai_chat_history_action_download">Last ned</string>
+    <string name="duck_ai_chat_history_action_delete">Slett</string>
+    <string name="duck_ai_chat_history_search_hint">Søk i chatter</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Søk i chatter</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Lukk søket</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Fjern søket</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Slett chatter</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Åpne overløpsmenyen</string>
+    <string name="duck_ai_chat_history_select_all">Velg alle</string>
+    <string name="duck_ai_chat_history_unselect_all">Fjern alle valg</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Valgt</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ikke valgt</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Gå ut av valgmodus</string>
+    <string name="duck_ai_chat_history_rename_title">Gi nytt navn til chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Tittel på chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Lagre</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Lagre chat-tittel</string>
+    <string name="duck_ai_chat_history_rename_error">Kunne ikke gi nytt navn til chatten</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chatten er festet</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chatten er ikke lenger festet</string>
+    <string name="duck_ai_chat_history_undo">Angre</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Nedlastingen av %1$s er fullført</string>
+    <string name="duck_ai_chat_history_download_view">Vis</string>
+    <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chatten</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Lukk søket</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Fjern søket</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Slett chatter</string>
+    <string name="duck_ai_chat_history_action_new">Ny</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Last ned chatter</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Nedlasting er fullført for %1$d chat</item>
+        <item quantity="other">Nedlasting er fullført for %1$d chatter</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Åpne overløpsmenyen</string>
     <string name="duck_ai_chat_history_select_all">Velg alle</string>
     <string name="duck_ai_chat_history_unselect_all">Fjern alle valg</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Nedlastingen av %1$s er fullført</string>
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chatten</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chattene</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Talechat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Vis alle chatter</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chatter</string>
     <string name="duck_ai_chat_history_section_pinned">Festede</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zoeken sluiten</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Zoeken wissen</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Chats verwijderen</string>
+    <string name="duck_ai_chat_history_action_new">Nieuw</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Chats downloaden</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Download voltooid voor %1$d chat</item>
+        <item quantity="other">Download voltooid voor %1$d chats</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Overloopmenu openen</string>
     <string name="duck_ai_chat_history_select_all">Alles selecteren</string>
     <string name="duck_ai_chat_history_unselect_all">Alles deselecteren</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Downloaden voltooid voor %1$s</string>
     <string name="duck_ai_chat_history_download_view">Tonen</string>
     <string name="duck_ai_chat_history_download_error">Kan chat niet exporteren</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Kan chats niet exporteren</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voicechat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Vastgezet</string>
+    <string name="duck_ai_chat_history_section_recent">Recent</string>
+    <string name="duck_ai_chat_history_untitled">Chat zonder titel</string>
+    <string name="duck_ai_chat_history_empty_title">Nog geen chats</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Duck.ai openen</string>
+    <string name="duck_ai_chat_history_more_options">Meer opties</string>
+    <string name="duck_ai_chat_history_action_select">Selecteren</string>
+    <string name="duck_ai_chat_history_action_pin">Pin</string>
+    <string name="duck_ai_chat_history_action_unpin">Pin verwijderen</string>
+    <string name="duck_ai_chat_history_action_rename">Naam wijzigen</string>
+    <string name="duck_ai_chat_history_action_download">Downloaden</string>
+    <string name="duck_ai_chat_history_action_delete">Verwijderen</string>
+    <string name="duck_ai_chat_history_search_hint">Chats zoeken</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Chats zoeken</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zoeken sluiten</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Zoeken wissen</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Chats verwijderen</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Overloopmenu openen</string>
+    <string name="duck_ai_chat_history_select_all">Alles selecteren</string>
+    <string name="duck_ai_chat_history_unselect_all">Alles deselecteren</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Geselecteerd</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Niet geselecteerd</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">De selectiemodus verlaten</string>
+    <string name="duck_ai_chat_history_rename_title">Naam van chat wijzigen</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chattitel</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Opslaan</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Titel van chat opslaan</string>
+    <string name="duck_ai_chat_history_rename_error">Kon naam van chat niet wijzigen</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat vastgetzet</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat losgemaakt</string>
+    <string name="duck_ai_chat_history_undo">Ongedaan maken</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Downloaden voltooid voor %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Tonen</string>
+    <string name="duck_ai_chat_history_download_error">Kan chat niet exporteren</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voicechat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Alle chats weergeven</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Vastgezet</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Czat głosowy</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Czaty</string>
+    <string name="duck_ai_chat_history_section_pinned">Przypięte</string>
+    <string name="duck_ai_chat_history_section_recent">Ostatnie</string>
+    <string name="duck_ai_chat_history_untitled">Czat bez tytułu</string>
+    <string name="duck_ai_chat_history_empty_title">Nie ma jeszcze czatów</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Otwórz Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Więcej opcji</string>
+    <string name="duck_ai_chat_history_action_select">Wybierz</string>
+    <string name="duck_ai_chat_history_action_pin">Przypnij</string>
+    <string name="duck_ai_chat_history_action_unpin">Odepnij</string>
+    <string name="duck_ai_chat_history_action_rename">Zmień nazwę</string>
+    <string name="duck_ai_chat_history_action_download">Pobierz</string>
+    <string name="duck_ai_chat_history_action_delete">Usuń</string>
+    <string name="duck_ai_chat_history_search_hint">Wyszukaj czaty</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Wyszukaj czaty</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zamknij wyszukiwanie</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Wyczyść wyszukiwanie</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Usuń czaty</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Otwórz menu przepełnienia</string>
+    <string name="duck_ai_chat_history_select_all">Wybierz wszystko</string>
+    <string name="duck_ai_chat_history_unselect_all">Anuluj wybór wszystkiego</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Wybrano</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nie wybrano</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Wyjdź z trybu wyboru</string>
+    <string name="duck_ai_chat_history_rename_title">Zmień nazwę czatu</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Tytuł czatu</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Zapisz</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Zapisz tytuł czatu</string>
+    <string name="duck_ai_chat_history_rename_error">Nie udało się zmienić nazwy czatu</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Czat przypięty</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Czat odpięty</string>
+    <string name="duck_ai_chat_history_undo">Cofnij</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Zakończono pobieranie pliku %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Pokaż</string>
+    <string name="duck_ai_chat_history_download_error">Nie udało się wyeksportować czatu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zamknij wyszukiwanie</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Wyczyść wyszukiwanie</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Usuń czaty</string>
+    <string name="duck_ai_chat_history_action_new">Nowe</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Pobierz czaty</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Pobieranie zakończone dla %1$d czatu</item>
+        <item quantity="few">Pobieranie zakończone dla %1$d czatów</item>
+        <item quantity="many">Pobieranie zakończone dla %1$d czatów</item>
+        <item quantity="other">Pobieranie zakończone dla %1$d czatów</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Otwórz menu przepełnienia</string>
     <string name="duck_ai_chat_history_select_all">Wybierz wszystko</string>
     <string name="duck_ai_chat_history_unselect_all">Anuluj wybór wszystkiego</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Zakończono pobieranie pliku %1$s</string>
     <string name="duck_ai_chat_history_download_view">Pokaż</string>
     <string name="duck_ai_chat_history_download_error">Nie udało się wyeksportować czatu</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nie udało się wyeksportować czatów</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Czat głosowy</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Zobacz wszystkie czaty</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Czaty</string>
     <string name="duck_ai_chat_history_section_pinned">Przypięte</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat de voz</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Afixado</string>
+    <string name="duck_ai_chat_history_section_recent">Recente</string>
+    <string name="duck_ai_chat_history_untitled">Chat sem título</string>
+    <string name="duck_ai_chat_history_empty_title">Ainda não há conversas</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Abrir Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Mais opções</string>
+    <string name="duck_ai_chat_history_action_select">Selecionar</string>
+    <string name="duck_ai_chat_history_action_pin">Afixar</string>
+    <string name="duck_ai_chat_history_action_unpin">Desafixar</string>
+    <string name="duck_ai_chat_history_action_rename">Renomear</string>
+    <string name="duck_ai_chat_history_action_download">Transferir</string>
+    <string name="duck_ai_chat_history_action_delete">Eliminar</string>
+    <string name="duck_ai_chat_history_search_hint">Pesquisar chats</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Pesquisar conversas</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Fechar pesquisa</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Limpar pesquisa</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Eliminar chats</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Abrir menu adicional</string>
+    <string name="duck_ai_chat_history_select_all">Selecionar tudo</string>
+    <string name="duck_ai_chat_history_unselect_all">Desmarcar tudo</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Selecionado</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Não selecionado</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Sair do modo de seleção</string>
+    <string name="duck_ai_chat_history_rename_title">Renomear chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Título do Chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Guardar</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Guardar título do chat</string>
+    <string name="duck_ai_chat_history_rename_error">Não foi possível renomear o chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat afixado</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat desafixado</string>
+    <string name="duck_ai_chat_history_undo">Anular</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Transferência de %1$s concluída</string>
+    <string name="duck_ai_chat_history_download_view">Mostrar</string>
+    <string name="duck_ai_chat_history_download_error">Não foi possível exportar a conversa</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -116,12 +116,15 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat de voz</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Ver todos os chats</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Afixado</string>
     <string name="duck_ai_chat_history_section_recent">Recente</string>
     <string name="duck_ai_chat_history_untitled">Chat sem título</string>
-    <string name="duck_ai_chat_history_empty_title">Ainda não há conversas</string>
+    <string name="duck_ai_chat_history_empty_title">Ainda não há chats</string>
     <string name="duck_ai_chat_history_empty_cta_open">Abrir Duck.ai</string>
     <string name="duck_ai_chat_history_more_options">Mais opções</string>
     <string name="duck_ai_chat_history_action_select">Selecionar</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Fechar pesquisa</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Limpar pesquisa</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Eliminar chats</string>
+    <string name="duck_ai_chat_history_action_new">Novo</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Descarregar conversas</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Transferência de %1$d chat concluída</item>
+        <item quantity="other">Transferência de %1$d chats concluída</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Abrir menu adicional</string>
     <string name="duck_ai_chat_history_select_all">Selecionar tudo</string>
     <string name="duck_ai_chat_history_unselect_all">Desmarcar tudo</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Transferência de %1$s concluída</string>
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">Não foi possível exportar a conversa</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Não foi possível exportar as conversas</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocal</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chaturi</string>
+    <string name="duck_ai_chat_history_section_pinned">Fixat</string>
+    <string name="duck_ai_chat_history_section_recent">Recent</string>
+    <string name="duck_ai_chat_history_untitled">Chat fără titlu</string>
+    <string name="duck_ai_chat_history_empty_title">Nu există încă chaturi</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Deschide Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Mai multe opțiuni</string>
+    <string name="duck_ai_chat_history_action_select">Selectează</string>
+    <string name="duck_ai_chat_history_action_pin">Fixează</string>
+    <string name="duck_ai_chat_history_action_unpin">Elimină fixarea</string>
+    <string name="duck_ai_chat_history_action_rename">Redenumește</string>
+    <string name="duck_ai_chat_history_action_download">Descarcă</string>
+    <string name="duck_ai_chat_history_action_delete">Șterge</string>
+    <string name="duck_ai_chat_history_search_hint">Caută în chaturi</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Caută în chaturi</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Închide căutarea</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Șterge căutarea</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Șterge chaturile</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Deschide meniul suplimentar</string>
+    <string name="duck_ai_chat_history_select_all">Selectează toate</string>
+    <string name="duck_ai_chat_history_unselect_all">Deselectează toate</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Selectat</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nu este selectat</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Ieși din modul de selectare</string>
+    <string name="duck_ai_chat_history_rename_title">Redenumește chatul</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Titlu chat</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Salvează</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Salvează titlul chatului</string>
+    <string name="duck_ai_chat_history_rename_error">Nu am putut redenumi chatul</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat fixat</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat deblocat</string>
+    <string name="duck_ai_chat_history_undo">Anulează</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Descărcare finalizată pentru %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Afișează</string>
+    <string name="duck_ai_chat_history_download_error">Nu s-a putut exporta chatul</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Chat vocal</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Vezi toate chaturile</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chaturi</string>
     <string name="duck_ai_chat_history_section_pinned">Fixat</string>
@@ -135,6 +138,13 @@
     <string name="duck_ai_chat_history_search_close_content_description">Închide căutarea</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Șterge căutarea</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Șterge chaturile</string>
+    <string name="duck_ai_chat_history_action_new">Nou</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Descarcă chaturile</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Descărcare finalizată pentru %1$d chat</item>
+        <item quantity="few">Descărcare completă pentru %1$d chaturi</item>
+        <item quantity="other">Descărcare completă pentru %1$d de chaturi</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Deschide meniul suplimentar</string>
     <string name="duck_ai_chat_history_select_all">Selectează toate</string>
     <string name="duck_ai_chat_history_unselect_all">Deselectează toate</string>
@@ -152,4 +162,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Descărcare finalizată pentru %1$s</string>
     <string name="duck_ai_chat_history_download_view">Afișează</string>
     <string name="duck_ai_chat_history_download_error">Nu s-a putut exporta chatul</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nu s-au putut exporta chaturile</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Голосовой чат</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Чаты</string>
+    <string name="duck_ai_chat_history_section_pinned">Закреплено</string>
+    <string name="duck_ai_chat_history_section_recent">Недавние</string>
+    <string name="duck_ai_chat_history_untitled">Чат без названия</string>
+    <string name="duck_ai_chat_history_empty_title">Пока нет чатов</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Открыть Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Другие параметры</string>
+    <string name="duck_ai_chat_history_action_select">Выбрать</string>
+    <string name="duck_ai_chat_history_action_pin">Закрепить</string>
+    <string name="duck_ai_chat_history_action_unpin">Удалить закрепленное</string>
+    <string name="duck_ai_chat_history_action_rename">Переименовать</string>
+    <string name="duck_ai_chat_history_action_download">Скачать</string>
+    <string name="duck_ai_chat_history_action_delete">Удалить</string>
+    <string name="duck_ai_chat_history_search_hint">Поиск в чатах</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Поиск в чатах</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Закрыть поиск</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Очистить поиск</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Удалить чаты</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Открыть раскрывающееся меню</string>
+    <string name="duck_ai_chat_history_select_all">Выбрать все</string>
+    <string name="duck_ai_chat_history_unselect_all">Отменить выбор всех</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Избранные</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Не выбрано</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Выйти из режима выбора</string>
+    <string name="duck_ai_chat_history_rename_title">Переименовать чат</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Заголовок чата</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Сохранить</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Сохранить заголовок чата</string>
+    <string name="duck_ai_chat_history_rename_error">Не удалось переименовать чат</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Чат закреплён</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Чат откреплен</string>
+    <string name="duck_ai_chat_history_undo">Отменить</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Загрузка файла %1$s завершена</string>
+    <string name="duck_ai_chat_history_download_view">Показать</string>
+    <string name="duck_ai_chat_history_download_error">Не удалось экспортировать чат</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Закрыть поиск</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Очистить поиск</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Удалить чаты</string>
+    <string name="duck_ai_chat_history_action_new">Создать</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Скачать чаты</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Скачивание %1$d чата завершено</item>
+        <item quantity="few">Скачивание %1$d чатов завершено</item>
+        <item quantity="many">Скачивание %1$d чатов завершено</item>
+        <item quantity="other">Скачивание %1$d чата завершено</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Открыть раскрывающееся меню</string>
     <string name="duck_ai_chat_history_select_all">Выбрать все</string>
     <string name="duck_ai_chat_history_unselect_all">Отменить выбор всех</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Загрузка файла %1$s завершена</string>
     <string name="duck_ai_chat_history_download_view">Показать</string>
     <string name="duck_ai_chat_history_download_error">Не удалось экспортировать чат</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Не удалось экспортировать чаты</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Голосовой чат</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Показать все чаты</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Чаты</string>
     <string name="duck_ai_chat_history_section_pinned">Закреплено</string>
@@ -126,7 +129,7 @@
     <string name="duck_ai_chat_history_more_options">Другие параметры</string>
     <string name="duck_ai_chat_history_action_select">Выбрать</string>
     <string name="duck_ai_chat_history_action_pin">Закрепить</string>
-    <string name="duck_ai_chat_history_action_unpin">Удалить закрепленное</string>
+    <string name="duck_ai_chat_history_action_unpin">Открепить</string>
     <string name="duck_ai_chat_history_action_rename">Переименовать</string>
     <string name="duck_ai_chat_history_action_download">Скачать</string>
     <string name="duck_ai_chat_history_action_delete">Удалить</string>
@@ -146,7 +149,7 @@
     <string name="duck_ai_chat_history_rename_confirm_title">Сохранить</string>
     <string name="duck_ai_chat_history_rename_confirm_content_description">Сохранить заголовок чата</string>
     <string name="duck_ai_chat_history_rename_error">Не удалось переименовать чат</string>
-    <string name="duck_ai_chat_history_pin_snackbar">Чат закреплён</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Чат закреплен</string>
     <string name="duck_ai_chat_history_unpin_snackbar">Чат откреплен</string>
     <string name="duck_ai_chat_history_undo">Отменить</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Загрузка файла %1$s завершена</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -116,12 +116,15 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hlasový čet</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Zobraziť všetky čety</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Čety</string>
     <string name="duck_ai_chat_history_section_pinned">Pripnuté</string>
     <string name="duck_ai_chat_history_section_recent">Nedávne</string>
     <string name="duck_ai_chat_history_untitled">Chat bez názvu</string>
-    <string name="duck_ai_chat_history_empty_title">Zatiaľ žiadne chaty</string>
+    <string name="duck_ai_chat_history_empty_title">Zatiaľ žiadne čety</string>
     <string name="duck_ai_chat_history_empty_cta_open">Otvoriť Duck.ai</string>
     <string name="duck_ai_chat_history_more_options">Ďalšie možnosti</string>
     <string name="duck_ai_chat_history_action_select">Vybrať</string>
@@ -146,8 +149,8 @@
     <string name="duck_ai_chat_history_rename_confirm_title">Uložiť</string>
     <string name="duck_ai_chat_history_rename_confirm_content_description">Uložiť názov chatu</string>
     <string name="duck_ai_chat_history_rename_error">Nepodarilo sa premenovať chat</string>
-    <string name="duck_ai_chat_history_pin_snackbar">Chat bol pripnutý</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Chat bol odopnutý</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Čet bol pripnutý</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Čet bol odopnutý</string>
     <string name="duck_ai_chat_history_undo">Zrušiť zmenu</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Sťahovanie %1$s bolo dokončené</string>
     <string name="duck_ai_chat_history_download_view">Zobraziť</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zatvoriť vyhľadávanie</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Vymazať vyhľadávanie</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Odstrániť chaty</string>
+    <string name="duck_ai_chat_history_action_new">Nové</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Stiahnutie četov</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Sťahovanie %1$d četu je dokončené</item>
+        <item quantity="few">Sťahovanie pre %1$d čety je dokončené</item>
+        <item quantity="many">Sťahovanie pre %1$d četov je dokončené</item>
+        <item quantity="other">Sťahovanie pre %1$d chatov je dokončené</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Otvoriť rozšírenú ponuku</string>
     <string name="duck_ai_chat_history_select_all">Vybrať všetko</string>
     <string name="duck_ai_chat_history_unselect_all">Zrušiť výber všetkých</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Sťahovanie %1$s bolo dokončené</string>
     <string name="duck_ai_chat_history_download_view">Zobraziť</string>
     <string name="duck_ai_chat_history_download_error">Nepodarilo sa exportovať chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Nepodarilo sa exportovať čety</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Hlasový čet</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Čety</string>
+    <string name="duck_ai_chat_history_section_pinned">Pripnuté</string>
+    <string name="duck_ai_chat_history_section_recent">Nedávne</string>
+    <string name="duck_ai_chat_history_untitled">Chat bez názvu</string>
+    <string name="duck_ai_chat_history_empty_title">Zatiaľ žiadne chaty</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Otvoriť Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Ďalšie možnosti</string>
+    <string name="duck_ai_chat_history_action_select">Vybrať</string>
+    <string name="duck_ai_chat_history_action_pin">Pripnúť</string>
+    <string name="duck_ai_chat_history_action_unpin">Odstrániť pripnutie</string>
+    <string name="duck_ai_chat_history_action_rename">Premenovať</string>
+    <string name="duck_ai_chat_history_action_download">Stiahnuť</string>
+    <string name="duck_ai_chat_history_action_delete">Odstrániť</string>
+    <string name="duck_ai_chat_history_search_hint">Vyhľadávanie v chatoch</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Vyhľadávanie v chatoch</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zatvoriť vyhľadávanie</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Vymazať vyhľadávanie</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Odstrániť chaty</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Otvoriť rozšírenú ponuku</string>
+    <string name="duck_ai_chat_history_select_all">Vybrať všetko</string>
+    <string name="duck_ai_chat_history_unselect_all">Zrušiť výber všetkých</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Vybrané</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Nevybrané</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Ukončiť režim výberu</string>
+    <string name="duck_ai_chat_history_rename_title">Premenovanie chatu</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Názov chatu</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Uložiť</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Uložiť názov chatu</string>
+    <string name="duck_ai_chat_history_rename_error">Nepodarilo sa premenovať chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat bol pripnutý</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat bol odopnutý</string>
+    <string name="duck_ai_chat_history_undo">Zrušiť zmenu</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Sťahovanie %1$s bolo dokončené</string>
+    <string name="duck_ai_chat_history_download_view">Zobraziť</string>
+    <string name="duck_ai_chat_history_download_error">Nepodarilo sa exportovať chat</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Glasovni klepet</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Oglejte si vse klepete</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Klepeti</string>
     <string name="duck_ai_chat_history_section_pinned">Pripeto</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -138,6 +138,14 @@
     <string name="duck_ai_chat_history_search_close_content_description">Zapri iskanje</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Počisti iskanje</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Izbriši klepete</string>
+    <string name="duck_ai_chat_history_action_new">Novo</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Prenesi klepete</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Prenos je končan za %1$d klepet</item>
+        <item quantity="two">Prenos je končan za %1$d klepeta</item>
+        <item quantity="few">Prenos je končan za %1$d klepete</item>
+        <item quantity="other">Prenos je končan za %1$d klepetov</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Odpri dodatni meni</string>
     <string name="duck_ai_chat_history_select_all">Izberi vse</string>
     <string name="duck_ai_chat_history_unselect_all">Odstrani vse izbire</string>
@@ -155,4 +163,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Prenos za %1$s je končan</string>
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Klepeta ni bilo mogoče izvoziti</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Klepetov ni bilo mogoče izvoziti</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Glasovni klepet</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Klepeti</string>
+    <string name="duck_ai_chat_history_section_pinned">Pripeto</string>
+    <string name="duck_ai_chat_history_section_recent">Nedavno</string>
+    <string name="duck_ai_chat_history_untitled">Nepoimenovan klepet</string>
+    <string name="duck_ai_chat_history_empty_title">Še ni pogovorov</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Odprite Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Več možnosti</string>
+    <string name="duck_ai_chat_history_action_select">Izberi</string>
+    <string name="duck_ai_chat_history_action_pin">Pripni</string>
+    <string name="duck_ai_chat_history_action_unpin">Odpni</string>
+    <string name="duck_ai_chat_history_action_rename">Preimenuj</string>
+    <string name="duck_ai_chat_history_action_download">Prenesi</string>
+    <string name="duck_ai_chat_history_action_delete">Izbriši</string>
+    <string name="duck_ai_chat_history_search_hint">Iskanje klepetov</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Iskanje klepetov</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Zapri iskanje</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Počisti iskanje</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Izbriši klepete</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Odpri dodatni meni</string>
+    <string name="duck_ai_chat_history_select_all">Izberi vse</string>
+    <string name="duck_ai_chat_history_unselect_all">Odstrani vse izbire</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Izbrano</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ni izbrano</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Izhod iz načina izbire</string>
+    <string name="duck_ai_chat_history_rename_title">Preimenuj klepet</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Naslov klepeta</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Shrani</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Shrani naslov klepeta</string>
+    <string name="duck_ai_chat_history_rename_error">Klepeta ni bilo mogoče preimenovati</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Klepet je pripet</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Klepet je odpet</string>
+    <string name="duck_ai_chat_history_undo">Razveljavi</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Prenos za %1$s je končan</string>
+    <string name="duck_ai_chat_history_download_view">Prikaži</string>
+    <string name="duck_ai_chat_history_download_error">Klepeta ni bilo mogoče izvoziti</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Röstchatt</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Visa alla chattar</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chattar</string>
     <string name="duck_ai_chat_history_section_pinned">Fäst</string>
@@ -147,7 +150,7 @@
     <string name="duck_ai_chat_history_rename_confirm_content_description">Spara chattitel</string>
     <string name="duck_ai_chat_history_rename_error">Kunde inte byta namn på chatten</string>
     <string name="duck_ai_chat_history_pin_snackbar">Chatt fäst</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Chat lossad</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chatt lossad</string>
     <string name="duck_ai_chat_history_undo">Ångra</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Nerladdning klar för %1$s</string>
     <string name="duck_ai_chat_history_download_view">Visa</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -138,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Stäng sökning</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Rensa sökning</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Raderade chattar</string>
+    <string name="duck_ai_chat_history_action_new">Ny</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Ladda ner chattar</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">Nedladdning klar för %1$d chatt</item>
+        <item quantity="other">Nedladdning klar för %1$d chattar</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Öppna överflödesmeny</string>
     <string name="duck_ai_chat_history_select_all">Välj alla</string>
     <string name="duck_ai_chat_history_unselect_all">Avmarkera alla</string>
@@ -155,4 +161,5 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Nerladdning klar för %1$s</string>
     <string name="duck_ai_chat_history_download_view">Visa</string>
     <string name="duck_ai_chat_history_download_error">Kunde inte exportera chatt</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Kunde inte exportera chattar</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Röstchatt</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chattar</string>
+    <string name="duck_ai_chat_history_section_pinned">Fäst</string>
+    <string name="duck_ai_chat_history_section_recent">Senaste</string>
+    <string name="duck_ai_chat_history_untitled">Chatt utan titel</string>
+    <string name="duck_ai_chat_history_empty_title">Inga chattar ännu</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Öppna Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">Fler alternativ</string>
+    <string name="duck_ai_chat_history_action_select">Välj</string>
+    <string name="duck_ai_chat_history_action_pin">Fäst</string>
+    <string name="duck_ai_chat_history_action_unpin">Lossa</string>
+    <string name="duck_ai_chat_history_action_rename">Byt namn</string>
+    <string name="duck_ai_chat_history_action_download">Nedladdning</string>
+    <string name="duck_ai_chat_history_action_delete">Ta bort</string>
+    <string name="duck_ai_chat_history_search_hint">Sök chattar</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Sök chattar</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Stäng sökning</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Rensa sökning</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Raderade chattar</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Öppna överflödesmeny</string>
+    <string name="duck_ai_chat_history_select_all">Välj alla</string>
+    <string name="duck_ai_chat_history_unselect_all">Avmarkera alla</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Vald</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Ej vald</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Avsluta urvalsläge</string>
+    <string name="duck_ai_chat_history_rename_title">Byt namn på chatten</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chattrubrik</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Spara</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Spara chattitel</string>
+    <string name="duck_ai_chat_history_rename_error">Kunde inte byta namn på chatten</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chatt fäst</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat lossad</string>
+    <string name="duck_ai_chat_history_undo">Ångra</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">Nerladdning klar för %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Visa</string>
+    <string name="duck_ai_chat_history_download_error">Kunde inte exportera chatt</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -116,6 +116,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Sesli Sohbet</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">Tüm Sohbetleri Görüntüle</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Sohbetler</string>
     <string name="duck_ai_chat_history_section_pinned">Sabitlenmiş</string>
@@ -126,7 +129,7 @@
     <string name="duck_ai_chat_history_more_options">Diğer seçenekler</string>
     <string name="duck_ai_chat_history_action_select">Seç</string>
     <string name="duck_ai_chat_history_action_pin">Sabitleyin</string>
-    <string name="duck_ai_chat_history_action_unpin">Sabitlemeyi Kaldırın</string>
+    <string name="duck_ai_chat_history_action_unpin">Sabitlemeyi kaldırın</string>
     <string name="duck_ai_chat_history_action_rename">Yeniden Adlandır</string>
     <string name="duck_ai_chat_history_action_download">İndir</string>
     <string name="duck_ai_chat_history_action_delete">Sil</string>
@@ -135,6 +138,12 @@
     <string name="duck_ai_chat_history_search_close_content_description">Aramayı kapat</string>
     <string name="duck_ai_chat_history_search_clear_content_description">Aramayı temizle</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Sohbetleri sil</string>
+    <string name="duck_ai_chat_history_action_new">Yeni</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Sohbetleri indir</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one">%1$d sohbet için indirme tamamlandı</item>
+        <item quantity="other">%1$d sohbet için indirme tamamlandı</item>
+    </plurals>
     <string name="duck_ai_chat_history_action_overflow_content_description">Overflow menüsünü aç</string>
     <string name="duck_ai_chat_history_select_all">Tümünü seç</string>
     <string name="duck_ai_chat_history_unselect_all">Tümünün seçimini kaldır</string>
@@ -146,10 +155,11 @@
     <string name="duck_ai_chat_history_rename_confirm_title">Kaydet</string>
     <string name="duck_ai_chat_history_rename_confirm_content_description">Sohbet başlığını kaydet</string>
     <string name="duck_ai_chat_history_rename_error">Sohbet yeniden adlandırılamadı</string>
-    <string name="duck_ai_chat_history_pin_snackbar">Sohbet Sabitlendi</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Chat Açıldı</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Sohbet sabitlendi</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Sohbet sabitlemesi kaldırıldı</string>
     <string name="duck_ai_chat_history_undo">Geri al</string>
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s için indirme tamamlandı</string>
     <string name="duck_ai_chat_history_download_view">Göster</string>
     <string name="duck_ai_chat_history_download_error">Sohbet dışa aktarılamadı</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Sohbetler dışa aktarılamadı</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -115,4 +115,41 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Sesli Sohbet</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Sohbetler</string>
+    <string name="duck_ai_chat_history_section_pinned">Sabitlenmiş</string>
+    <string name="duck_ai_chat_history_section_recent">Son</string>
+    <string name="duck_ai_chat_history_untitled">Başlıksız sohbet</string>
+    <string name="duck_ai_chat_history_empty_title">Henüz sohbet yok</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Duck.ai\'ı aç</string>
+    <string name="duck_ai_chat_history_more_options">Diğer seçenekler</string>
+    <string name="duck_ai_chat_history_action_select">Seç</string>
+    <string name="duck_ai_chat_history_action_pin">Sabitleyin</string>
+    <string name="duck_ai_chat_history_action_unpin">Sabitlemeyi Kaldırın</string>
+    <string name="duck_ai_chat_history_action_rename">Yeniden Adlandır</string>
+    <string name="duck_ai_chat_history_action_download">İndir</string>
+    <string name="duck_ai_chat_history_action_delete">Sil</string>
+    <string name="duck_ai_chat_history_search_hint">Sohbetleri ara</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Sohbetleri ara</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Aramayı kapat</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Aramayı temizle</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Sohbetleri sil</string>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Overflow menüsünü aç</string>
+    <string name="duck_ai_chat_history_select_all">Tümünü seç</string>
+    <string name="duck_ai_chat_history_unselect_all">Tümünün seçimini kaldır</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Seçili</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Seçili değil</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Seçim modundan çık</string>
+    <string name="duck_ai_chat_history_rename_title">Sohbet\'i Yeniden Adlandır</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Sohbet Başlığı</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Kaydet</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Sohbet başlığını kaydet</string>
+    <string name="duck_ai_chat_history_rename_error">Sohbet yeniden adlandırılamadı</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Sohbet Sabitlendi</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat Açıldı</string>
+    <string name="duck_ai_chat_history_undo">Geri al</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \&apos;My Chat.txt\&apos;).">%1$s için indirme tamamlandı</string>
+    <string name="duck_ai_chat_history_download_view">Göster</string>
+    <string name="duck_ai_chat_history_download_error">Sohbet dışa aktarılamadı</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -16,7 +16,6 @@
 
 <resources>
     <string name="duckAiChatSearchDuckDuckGo">Search DuckDuckGo</string>
-    <string name="duckAiChatHistoryViewAllChats">View all Chats</string>
     <string name="native_input_chat_hint">Ask anything privately…</string>
 
     <!-- Model Picker -->

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -75,48 +75,6 @@
     <string name="duckChatOptionsMenuWebSearch">Web Search</string>
     <string name="duckChatOptionsMenuWebSearchSubtitle">Source answers from the web</string>
 
-    <!-- Chat history -->
-    <string name="duck_ai_chat_history_title">Chats</string>
-    <string name="duck_ai_chat_history_section_pinned">Pinned</string>
-    <string name="duck_ai_chat_history_section_recent">Recent</string>
-    <string name="duck_ai_chat_history_untitled">Untitled chat</string>
-    <string name="duck_ai_chat_history_empty_title">No Chats yet</string>
-    <string name="duck_ai_chat_history_empty_cta_open">Open Duck.ai</string>
-    <string name="duck_ai_chat_history_coming_soon">Coming soon</string>
-    <string name="duck_ai_chat_history_more_options">More options</string>
-    <string name="duck_ai_chat_history_action_pin">Pin</string>
-    <string name="duck_ai_chat_history_action_unpin">Unpin</string>
-    <string name="duck_ai_chat_history_action_rename">Rename</string>
-    <string name="duck_ai_chat_history_action_download">Download</string>
-    <string name="duck_ai_chat_history_action_delete">Delete</string>
-    <string name="duck_ai_chat_history_search_hint">Search chats</string>
-    <string name="duck_ai_chat_history_search_close_content_description">Close search</string>
-    <string name="duck_ai_chat_history_search_clear_content_description">Clear search</string>
-    <string name="duck_ai_chat_history_action_fire_content_description">Delete chats</string>
-    <string name="duck_ai_chat_history_action_new">New</string>
-    <string name="duck_ai_chat_history_action_download_selected_content_description">Download chats</string>
-    <plurals name="duck_ai_chat_history_bulk_download_complete">
-        <item quantity="one" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chat</item>
-        <item quantity="other" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chats</item>
-    </plurals>
-    <string name="duck_ai_chat_history_select_all">Select all</string>
-    <string name="duck_ai_chat_history_unselect_all">Unselect all</string>
-    <string name="duck_ai_chat_history_row_selected_content_description">Selected</string>
-    <string name="duck_ai_chat_history_row_unselected_content_description">Not selected</string>
-    <string name="duck_ai_chat_history_exit_select_mode_content_description">Exit selection mode</string>
-    <string name="duck_ai_chat_history_rename_title">Rename Chat</string>
-    <string name="duck_ai_chat_history_rename_chat_title_hint">Chat Title</string>
-    <string name="duck_ai_chat_history_rename_confirm_title">Save</string>
-    <string name="duck_ai_chat_history_rename_confirm_content_description">Save chat title</string>
-    <string name="duck_ai_chat_history_rename_error">Couldn\'t rename chat</string>
-    <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
-    <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
-    <string name="duck_ai_chat_history_undo">Undo</string>
-    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \'My Chat.txt\').">Download complete for %1$s</string>
-    <string name="duck_ai_chat_history_download_view">Show</string>
-    <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
-    <string name="duck_ai_chat_history_bulk_download_error">Couldn\'t export chats</string>
-
     <!-- Duck.ai header -->
     <string name="duckChatPlusButtonContentDescription">Open Duck.ai menu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -115,6 +115,9 @@
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>
 
+    <!-- Duck AI Chat Suggestions -->
+    <string name="duckAiChatHistoryViewAllChats">View All Chats</string>
+
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>
     <string name="duck_ai_chat_history_section_pinned">Pinned</string>
@@ -125,7 +128,7 @@
     <string name="duck_ai_chat_history_more_options">More options</string>
     <string name="duck_ai_chat_history_action_select">Select</string>
     <string name="duck_ai_chat_history_action_pin">Pin</string>
-    <string name="duck_ai_chat_history_action_unpin">Remove Pin</string>
+    <string name="duck_ai_chat_history_action_unpin">Remove pin</string>
     <string name="duck_ai_chat_history_action_rename">Rename</string>
     <string name="duck_ai_chat_history_action_download">Download</string>
     <string name="duck_ai_chat_history_action_delete">Delete</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -114,4 +114,48 @@
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>
+
+    <!-- Native Duck.ai chat history -->
+    <string name="duck_ai_chat_history_title">Chats</string>
+    <string name="duck_ai_chat_history_section_pinned">Pinned</string>
+    <string name="duck_ai_chat_history_section_recent">Recent</string>
+    <string name="duck_ai_chat_history_untitled">Untitled chat</string>
+    <string name="duck_ai_chat_history_empty_title">No chats yet</string>
+    <string name="duck_ai_chat_history_empty_cta_open">Open Duck.ai</string>
+    <string name="duck_ai_chat_history_more_options">More options</string>
+    <string name="duck_ai_chat_history_action_select">Select</string>
+    <string name="duck_ai_chat_history_action_pin">Pin</string>
+    <string name="duck_ai_chat_history_action_unpin">Remove Pin</string>
+    <string name="duck_ai_chat_history_action_rename">Rename</string>
+    <string name="duck_ai_chat_history_action_download">Download</string>
+    <string name="duck_ai_chat_history_action_delete">Delete</string>
+    <string name="duck_ai_chat_history_search_hint">Search chats</string>
+    <string name="duck_ai_chat_history_action_search_content_description">Search chats</string>
+    <string name="duck_ai_chat_history_search_close_content_description">Close search</string>
+    <string name="duck_ai_chat_history_search_clear_content_description">Clear search</string>
+    <string name="duck_ai_chat_history_action_fire_content_description">Delete chats</string>
+    <string name="duck_ai_chat_history_action_new">New</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Download chats</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chat</item>
+        <item quantity="other" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chats</item>
+    </plurals>
+    <string name="duck_ai_chat_history_action_overflow_content_description">Open overflow menu</string>
+    <string name="duck_ai_chat_history_select_all">Select all</string>
+    <string name="duck_ai_chat_history_unselect_all">Unselect all</string>
+    <string name="duck_ai_chat_history_row_selected_content_description">Selected</string>
+    <string name="duck_ai_chat_history_row_unselected_content_description">Not selected</string>
+    <string name="duck_ai_chat_history_exit_select_mode_content_description">Exit selection mode</string>
+    <string name="duck_ai_chat_history_rename_title">Rename Chat</string>
+    <string name="duck_ai_chat_history_rename_chat_title_hint">Chat Title</string>
+    <string name="duck_ai_chat_history_rename_confirm_title">Save</string>
+    <string name="duck_ai_chat_history_rename_confirm_content_description">Save chat title</string>
+    <string name="duck_ai_chat_history_rename_error">Couldn\'t rename chat</string>
+    <string name="duck_ai_chat_history_pin_snackbar">Chat pinned</string>
+    <string name="duck_ai_chat_history_unpin_snackbar">Chat unpinned</string>
+    <string name="duck_ai_chat_history_undo">Undo</string>
+    <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \'My Chat.txt\').">Download complete for %1$s</string>
+    <string name="duck_ai_chat_history_download_view">Show</string>
+    <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Couldn\'t export chats</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1214820120386828?focus=true 

### Description

Promotes the native chat-history UI strings out of `donottranslate.xml` and into `strings-duckchat.xml` so the 35 keys enter the Smartling translation pipeline ahead of release. Also replaces the two temporary `duck_ai_chat_history_coming_soon` placeholders wired into the Search and Overflow toolbar icons with their real content descriptions, and applies the final wording revisions agreed during copy review (Unpin → Remove Pin; sentence-case "Chat Pinned" / "Chat Unpinned" snackbars).

No new resource keys for UI surfaces that don't already exist — every promoted string is already consumed by the chat-history screen shipped behind `duckAiChatHistory.historyScreen`.

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly string resource moves and label/content-description updates; the fire-dialog button text change is a small, origin-gated UI tweak with no new deletion logic in this diff.
> 
> **Overview**
> Moves native **Duck.ai chat history** strings out of `donottranslate.xml` into translatable `strings-duckchat.xml` (with locale updates), so they can go through Smartling. Copy tweaks from review include **Remove pin**, sentence-case pin/unpin snackbars, and a new **Select** action string.
> 
> The chat history toolbar **search** item no longer uses the temporary `coming_soon` title; it uses `duck_ai_chat_history_action_search_content_description` instead.
> 
> When the fire sheet is opened from **chat history selection**, the primary delete button label switches to **Delete Chats** via new `isInChatSelectionMode` / `singleTabFireDialogDeleteChats` wiring in `SingleTabFireDialog` and its ViewModel.
> 
> The diff also includes refreshed translations for `singleTabFireDialogDeleteChats` and assorted unrelated locale string edits from the translation pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9aced027027c09d6e8c81497877374a552e4e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->