### PR TITLE
Custom Duck.ai Onboarding - update bubble CTA copy and subscription page for custom AI onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -275,6 +275,7 @@ import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.model.domainMatchesUrl
 import com.duckduckgo.app.global.model.orderedTrackerBlockedEntities
 import com.duckduckgo.app.location.data.LocationPermissionType
+import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RESULT_DELETED
@@ -557,6 +558,7 @@ class BrowserTabViewModel @Inject constructor(
     private val downloadMenuStateProvider: DownloadMenuStateProvider,
     private val downloadsRepository: DownloadsRepository,
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
+    private val onboardingStore: OnboardingStore,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -5071,8 +5073,15 @@ class BrowserTabViewModel @Inject constructor(
             is DaxSubscriptionBrandDesignUpdateBubbleCta,
             -> {
                 viewModelScope.launch {
-                    val origin = "funnel_onboarding_android"
-                    command.value = LaunchSubscription("https://duckduckgo.com/pro?origin=$origin".toUri())
+                    val uri = "https://duckduckgo.com/pro".toUri().buildUpon()
+                        .appendQueryParameter("origin", "funnel_onboarding_android")
+                        .apply {
+                            if (onboardingStore.isCustomAiOnboardingFlow()) {
+                                appendQueryParameter("featurePage", "duckai")
+                            }
+                        }
+                        .build()
+                    command.value = LaunchSubscription(uri)
                 }
             }
             is DaxBubbleCta.DaxEndCta,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1620,6 +1620,8 @@ sealed class DaxBubbleCta(
 
         abstract fun configureContentViews(view: View)
 
+        protected open fun decorateDescription(context: Context, text: CharSequence): CharSequence = text
+
         private var cardContainer: TouchInterceptingLinearLayout? = null
 
         private var isAnimating: Boolean = false
@@ -1701,6 +1703,7 @@ sealed class DaxBubbleCta(
 
             val daxTitle = container.context.getString(title)
             val daxDescription = container.context.getString(description).preventWidows()
+            val descriptionText = decorateDescription(container.context, daxDescription.html(container.context))
 
             val titleView = container.findViewById<DaxTypeAnimationTextView>(R.id.brandDesignTitle)
             val hiddenTitle = container.findViewById<DaxTextView>(R.id.brandDesignHiddenTitle)
@@ -1732,7 +1735,7 @@ sealed class DaxBubbleCta(
             // Helper: type title then fade in content
             val typeAndFadeIn = {
                 hiddenTitle.text = daxTitle.html(container.context)
-                descriptionView.text = daxDescription.html(container.context)
+                descriptionView.text = descriptionText
 
                 val startTyping = {
                     titleView.alpha = 1f
@@ -1793,7 +1796,7 @@ sealed class DaxBubbleCta(
 
             val applySettledState = {
                 hiddenTitle.text = daxTitle.html(container.context)
-                descriptionView.text = daxDescription.html(container.context)
+                descriptionView.text = descriptionText
                 if (!titleView.hasAnimationStarted()) {
                     titleView.text = daxTitle.html(container.context)
                 }
@@ -1856,7 +1859,7 @@ sealed class DaxBubbleCta(
                 clearDialog()
                 resetAllIncludesExcept(container, activeInclude)
                 hiddenTitle.text = daxTitle.html(container.context)
-                descriptionView.text = daxDescription.html(container.context)
+                descriptionView.text = descriptionText
                 resetHeaderState()
                 resetTextAlignment()
                 configureContentViews(container)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -16,16 +16,18 @@
 
 package com.duckduckgo.app.cta.ui
 
+import android.content.Context
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
-import com.duckduckgo.app.cta.ui.DaxBubbleCta.WavingDaxSpec
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.appendIconToText
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.google.android.material.button.MaterialButton
+import com.duckduckgo.mobile.android.R as CommonR
 
 data class DaxEndBrandDesignUpdateBubbleCta(
     override val onboardingStore: OnboardingStore,
@@ -35,7 +37,11 @@ data class DaxEndBrandDesignUpdateBubbleCta(
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = R.string.onboardingEndDaxDialogTitle,
-    description = R.string.onboardingEndDaxDialogDescription,
+    description = if (onboardingStore.isCustomAiOnboardingFlow()) {
+        R.string.onboardingEndCustomAiFlowDaxDialogDescription
+    } else {
+        R.string.onboardingEndDaxDialogDescription
+    },
     backgroundRes = R.drawable.bg_onboarding_end,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
     okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
@@ -59,4 +65,11 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override fun configureContentViews(view: View) {
         view.findViewById<MaterialButton>(R.id.primaryCta)?.setText(R.string.onboardingEndDaxDialogButton)
     }
+
+    override fun decorateDescription(context: Context, text: CharSequence): CharSequence =
+        if (onboardingStore.isCustomAiOnboardingFlow()) {
+            context.appendIconToText(text, CommonR.drawable.ic_ai_chat_16)
+        } else {
+            text
+        }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -40,7 +40,11 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_INTRO_PRIVACY_PRO,
     title = R.string.onboardingPrivacyProDaxDialogTitle,
-    description = R.string.onboardingPrivacyProDaxDialogDescription,
+    description = if (onboardingStore.isCustomAiOnboardingFlow()) {
+        R.string.onboardingPrivacyProCustomAiFlowDaxDialogDescription
+    } else {
+        R.string.onboardingPrivacyProDaxDialogDescription
+    },
     backgroundRes = R.drawable.bg_onboarding_subscription,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
     okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -30,4 +30,11 @@ interface OnboardingStore {
     fun setInputScreenSelectionOverriddenByUser()
     fun setDuckAiOnboardingFlow()
     fun isDuckAiOnboardingFlow(): Boolean
+
+    /**
+     * `true` if the user installs through AI referral link
+     *
+     * **Note: this feature is WIP, details to follow during the rest of integration**
+     */
+    fun isCustomAiOnboardingFlow(): Boolean
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -221,6 +221,10 @@ class OnboardingStoreImpl @Inject constructor(
         return preferences.getBoolean(KEY_DUCK_AI_ONBOARDING_FLOW, false)
     }
 
+    override fun isCustomAiOnboardingFlow(): Boolean {
+        return false
+    }
+
     companion object {
         const val FILENAME = "com.duckduckgo.app.onboarding.settings"
         const val ONBOARDING_JOURNEY = "onboardingJourney"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -132,7 +132,8 @@
     <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
     <string name="browserModeToggleTabCountInfinite">∞</string>
 
-    <!-- Pre-onboarding: AI comparison chart screen. Move to strings.xml when localized. -->
+    <!-- Custom AI onboarding flow -->
+    <!-- Pre-onboarding: AI comparison chart screen. -->
     <string name="preOnboardingDaxDialogAiTitle">AI protections activated!</string>
     <string name="preOnboardingAiComparisonChartPopularAis">Popular AIs</string>
     <string name="preOnboardingAiComparisonChartItem1">All chats are anonymized</string>
@@ -140,4 +141,8 @@
     <string name="preOnboardingAiComparisonChartItem3">Never uses your chats to train AI</string>
     <string name="preOnboardingAiComparisonChartItem4">Access ChatGPT, Claude, and more, all in one place.</string>
     <string name="preOnboardingAiComparisonChartButton">Give Duck.ai a try!</string>
+    <!-- In-context onboarding. -->
+    <string name="onboardingEndCustomAiFlowDaxDialogDescription"><![CDATA[Start a private AI chat with Duck.ai or toggle to Search for protected browsing.<br/><br/>You can use Duck.ai from anywhere you see the chat icon]]></string>
+    <string name="onboardingPrivacyProCustomAiFlowDaxDialogDescription">We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT, Claude, and Llama, a secure VPN, and more.</string>
+
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -994,6 +994,7 @@ class BrowserTabViewModelTest {
                 downloadMenuStateProvider = mockDownloadMenuStateProvider,
                 downloadsRepository = mockDownloadsRepository,
                 onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
+                onboardingStore = mockOnboardingStore,
             )
 
         testee.loadData("abc", null, false, false)
@@ -3534,6 +3535,23 @@ class BrowserTabViewModelTest {
         testee.onUserClickCtaOkButton(cta)
         assertCommandIssued<LaunchSubscription> {
             assertEquals("funnel_onboarding_android", uri.getQueryParameter("origin"))
+            assertNull(uri.getQueryParameter("featurePage"))
+        }
+    }
+
+    @Test
+    fun whenUserClickedDaxSubscriptionCtaInCustomAiOnboardingFlowThenLaunchSubscriptionWithFeaturePageDuckAi() {
+        whenever(mockOnboardingStore.isCustomAiOnboardingFlow()).thenReturn(true)
+        val cta = DaxBubbleCta.DaxSubscriptionCta(
+            mockOnboardingStore,
+            mockAppInstallStore,
+            isFreeTrialCopy = false,
+        )
+        setCta(cta)
+        testee.onUserClickCtaOkButton(cta)
+        assertCommandIssued<LaunchSubscription> {
+            assertEquals("funnel_onboarding_android", uri.getQueryParameter("origin"))
+            assertEquals("duckai", uri.getQueryParameter("featurePage"))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1214496769534854?focus=true

### Description
Adds alternative copy and link variants for onboarding bubble CTAs when custom AI onboarding flow is engaged.

### Steps to test this PR
- [x] Apply this diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index f3fdf90c42..485e6704af 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -113,7 +113,7 @@ class CtaViewModel @Inject constructor(
             }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true//subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
```
- [x] Clean install the app.
- [x] Go through onboarding until reaching the End dialog.
- [x] Verify the copy matches the existing production variant.
- [x] Click the primary button.
- [x] Verify the copy on the Subscription dialog matches the existing production variant.
- [x] Click the primary button.
- [x] Verify the default subscription page loads.

- [x] Apply this patch on top of the last:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
index 19f4e74c11..ad958e68ce 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -222,7 +222,7 @@ class OnboardingStoreImpl @Inject constructor(
     }
 
     override fun isCustomAiOnboardingFlow(): Boolean {
-        return false
+        return true
     }
```
- [x] Clean install the app.
- [x] Go through onboarding until reaching the End dialog.
- [x] Verify the copy matches the alternative variant.
- [x] Click the primary button.
- [x] Verify the copy on the Subscription dialog matches the alternative variant.
- [x] Click the primary button.
- [x] Verify the alternative, Duck.ai-focused subscription page loads.

### UI changes

| Default  | Custom AI flow |
| ------ | ----- |
|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/5fc74d9f-0169-4df6-a423-32a0ad9de13e" /><img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/a4940412-c55b-4620-816c-6353c896c444" /><img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/b93e702c-4e86-44e8-9e76-c8c8d841074f" />|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/e70c374a-50f3-4ebe-bd46-faa966268171" /><img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/0b8efd44-5598-489c-adf7-3fb7b1949466" /><img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/4581be73-74c9-42fe-9728-c3f8c0aaaff3" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and subscription URL query params only; flow is gated behind a stub that returns false until referral wiring ships.
> 
> **Overview**
> Introduces a **custom AI onboarding** branch (via `OnboardingStore.isCustomAiOnboardingFlow()`, still stubbed to `false` until referral integration lands) that swaps Dax **end** and **Privacy Pro subscription** bubble copy and tweaks presentation for that path.
> 
> When the flag is on, the end bubble uses new strings and can **inline a chat icon** in the description through a new `decorateDescription` hook on brand-design bubble CTAs. Tapping subscription from onboarding still opens `duckduckgo.com/pro` with `origin=funnel_onboarding_android`, and additionally appends **`featurePage=duckai`** so the web subscription experience can land on Duck.ai-focused content.
> 
> Unit tests cover the subscription URI with and without the custom-AI query parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a6478db237967b623545982a0e7a098b8edd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->