### PR TITLE
Route sync restore skip into Quick Setup when in experiment treatment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -371,18 +371,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                 _viewState.update { it.copy(isReinstallUser = true) }
                 viewModelScope.launch {
                     if (onboardingQuickSetupExperimentManager.enroll() == QuickSetupExperimentVariant.TREATMENT) {
-                        val splitEnabled = isSplitOmnibarEnabled()
-                        val (isDefault, hasWidget) = withContext(dispatchers.io()) {
-                            defaultBrowserDetector.isDefaultBrowser() to widgetCapabilities.hasInstalledWidgets
-                        }
-                        _viewState.update {
-                            it.copy(
-                                showSplitOption = splitEnabled,
-                                hideSetDefaultBrowserRow = isDefault,
-                                hideAddWidgetRow = hasWidget,
-                            )
-                        }
-                        setCurrentDialog(QUICK_SETUP)
+                        showQuickSetupDialog()
                     } else {
                         setCurrentDialog(SKIP_ONBOARDING_OPTION)
                         pixel.fire(PREONBOARDING_SKIP_ONBOARDING_PRESSED)
@@ -399,7 +388,11 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                 viewModelScope.launch {
                     logcat { "Sync-AutoRestore: user skipped restore" }
                     pixel.fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
-                    setCurrentDialog(SKIP_ONBOARDING_OPTION)
+                    if (onboardingQuickSetupExperimentManager.enroll() == QuickSetupExperimentVariant.TREATMENT) {
+                        showQuickSetupDialog()
+                    } else {
+                        setCurrentDialog(SKIP_ONBOARDING_OPTION)
+                    }
                 }
             }
 
@@ -542,6 +535,21 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         withContext(dispatchers.io()) {
             appBuildConfig.isAppReinstall()
         }
+
+    private suspend fun showQuickSetupDialog() {
+        val splitEnabled = isSplitOmnibarEnabled()
+        val (isDefault, hasWidget) = withContext(dispatchers.io()) {
+            defaultBrowserDetector.isDefaultBrowser() to widgetCapabilities.hasInstalledWidgets
+        }
+        _viewState.update {
+            it.copy(
+                showSplitOption = splitEnabled,
+                hideSetDefaultBrowserRow = isDefault,
+                hideAddWidgetRow = hasWidget,
+            )
+        }
+        setCurrentDialog(QUICK_SETUP)
+    }
 
     private suspend fun isSplitOmnibarEnabled(): Boolean =
         withContext(dispatchers.io()) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -370,11 +370,11 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             INITIAL_REINSTALL_USER -> {
                 _viewState.update { it.copy(isReinstallUser = true) }
                 viewModelScope.launch {
+                    pixel.fire(PREONBOARDING_SKIP_ONBOARDING_PRESSED)
                     if (onboardingQuickSetupExperimentManager.enroll() == QuickSetupExperimentVariant.TREATMENT) {
                         showQuickSetupDialog()
                     } else {
                         setCurrentDialog(SKIP_ONBOARDING_OPTION)
-                        pixel.fire(PREONBOARDING_SKIP_ONBOARDING_PRESSED)
                     }
                 }
             }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -1063,13 +1063,13 @@ class BrandDesignUpdatePageViewModelTest {
     }
 
     @Test
-    fun whenSecondaryCtaFromReinstallUserAndQuickSetupTreatmentThenDoNotFireSkipOnboardingPixel() = runTest {
+    fun whenSecondaryCtaFromReinstallUserAndQuickSetupTreatmentThenFireSkipOnboardingPixel() = runTest {
         whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
         whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
         val testee = createViewModel()
         testee.loadDaxDialog()
         testee.onSecondaryCtaClicked()
-        verify(mockPixel, never()).fire(PREONBOARDING_SKIP_ONBOARDING_PRESSED)
+        verify(mockPixel).fire(PREONBOARDING_SKIP_ONBOARDING_PRESSED)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -596,6 +596,74 @@ class BrandDesignUpdatePageViewModelTest {
         verify(mockPixel).fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
     }
 
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreAndQuickSetupTreatmentThenShowQuickSetupDialog() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem() // initial
+            testee.loadDaxDialog()
+            awaitItem() // SYNC_RESTORE
+            testee.onSecondaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.QUICK_SETUP, state.currentDialog)
+            assertFalse(state.isReinstallUser)
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(mockSyncAutoRestore, never()).restoreSyncAccount()
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreAndQuickSetupTreatmentThenFiresSkipRestoreTappedPixel() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
+        val testee = createViewModel()
+        testee.loadDaxDialog()
+        testee.onSecondaryCtaClicked()
+        verify(mockPixel).fire(PREONBOARDING_SYNC_SKIP_RESTORE_TAPPED_UNIQUE, type = Unique())
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreAndQuickSetupTreatmentAndIsDefaultBrowserThenHideSetDefaultBrowserRow() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
+        whenever(mockDefaultBrowserDetector.isDefaultBrowser()).thenReturn(true)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem()
+            testee.onSecondaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.QUICK_SETUP, state.currentDialog)
+            assertTrue(state.hideSetDefaultBrowserRow)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSecondaryCtaFromSyncRestoreAndQuickSetupTreatmentAndHasInstalledWidgetsThenHideAddWidgetRow() = runTest {
+        whenever(mockSyncAutoRestore.canRestore()).thenReturn(true)
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        val testee = createViewModel()
+        testee.viewState.test {
+            awaitItem()
+            testee.loadDaxDialog()
+            awaitItem()
+            testee.onSecondaryCtaClicked()
+            val state = awaitItem()
+            assertEquals(PreOnboardingDialogType.QUICK_SETUP, state.currentDialog)
+            assertTrue(state.hideAddWidgetRow)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
     // endregion
 
     // region onDefaultBrowserSet / onDefaultBrowserNotSet


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1215102110137739?focus=true

### Description

When a user enrolled in the Quick Setup experiment treatment clicks the “Skip” button on the Sync Restore dialog in the brand-design onboarding (secondary CTA), route them into the Quick Setup screen instead of the Skip Onboarding option. Mirrors the behaviour already in place for the `INITIAL_REINSTALL_USER` secondary CTA, and extracts the shared `QUICK_SETUP` state preparation (split-omnibar flag, hide default-browser row, hide widget row) into a private helper used by both entry points.

The skip-restore pixel (`m_preonboarding_sync_skip_restore_tapped_unique`) continues to fire on both branches since the user did skip sync restore regardless of where they are routed next. `isReinstallUser` is not flipped to `true` on the sync-restore path, since a sync-restore user is not necessarily a reinstaller.

### Steps to test this PR

Setup

- [x] Create the folder privacy-config/privacy-config-internal/local-config-patches/
 Inside it, create quick-setup-patch.json:
```
[
  {
    "op": "add",
    "path": "/features/onboardingQuickSetup",
    "value": {
      "state": "enabled",
      "features": {
        "onboardingQuickSetupExperimentMay26": {
          "state": "enabled",
          "cohorts": [
            { "name": "control", "weight": 0 },
            { "name": "treatment", "weight": 1 }
          ]
        }
      }
    }
  }
]
```
- [x] Create privacy-config/privacy-config-internal/local.properties with:
config_patches=privacy-config/privacy-config-internal/local-config-patches/quick-setup-patch.json
- [x] Reinstall the app and launch onboarding as a reinstall user; tap "I've been here before”

Reinstall before each test. You need to update the control/ tretment values.

_Sync Restore secondary → Quick Setup (treatment: 1, control: 0)_
- [x] Enroll the device in the Quick Setup experiment treatment (e.g. via privacy-config patch).
- [x] Ensure the SYNC_RESTORE dialog is reachable (sync auto-restore reports `canRestore() == true`).
- [x] Launch the brand-design onboarding from a clean state and reach the Sync Restore dialog.
- [x] Tap the secondary CTA ("skip restore").
- [x] Verify the Quick Setup screen is shown next (with default-browser / widget rows hidden when those are already satisfied).
- [x] Verify `sync-auto-restore_onboarding_skip_tapped_unique` fires.
- [x] Verify `restoreSyncAccount()` is **not** invoked.

_Sync Restore secondary → Skip Onboarding (control / unenrolled -> treatment: 0, control: 1)_
- [x] Same setup but with the experiment in CONTROL or the user not enrolled.
- [x] Tap the secondary CTA from Sync Restore.
- [x] Verify the Skip Onboarding option is shown (existing behaviour).

### UI changes
https://github.com/user-attachments/assets/bdd83508-b385-4be2-8c06-29f39bbd8388


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding navigation and telemetry only; no auth, sync restore execution, or data-layer changes beyond dialog routing.
> 
> **Overview**
> **Sync Restore “skip”** now follows the same Quick Setup experiment routing as the reinstall-user secondary CTA: in **treatment**, secondary tap on `SYNC_RESTORE` opens **Quick Setup** instead of **Skip onboarding**; control/unenrolled behavior is unchanged.
> 
> Shared **Quick Setup** setup (split omnibar flag, hide default-browser / widget rows from device state) is moved into **`showQuickSetupDialog()`**, used from both entry points. **`PREONBOARDING_SKIP_ONBOARDING_PRESSED`** fires before the enroll branch on reinstall skip (including treatment); skip-restore unique pixel still fires on both paths. Sync-restore skip does **not** set **`isReinstallUser`**.
> 
> Tests cover treatment routing from sync restore, row hiding, pixels, and the updated reinstall skip-onboarding pixel expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4303a8812e8d6d009d5d69d248d325f5fbf954e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->