### PR TITLE
Add the translations for the texts used on the quick setup flow of the onboarding

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Следващ</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Функциите на изкуствения интелект са поверителни и незадължителни. Можеш да направиш промени в <b>Настройки > ИИ функции</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Добре дошли отново!&lt;br/&gt;Искате ли да персонализирате нещо?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Задайте DuckDuckGo по подразбиране</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Добавяне на приспособление на началния екран</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Позиция на адресната лента</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Опции за търсене в адресната лента</string>
+    <string name="preOnboardingReinstallStartBrowsing">Стартиране на сърфирането</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Къде искате да бъде адресната лента?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Можете да направите промени в <b>Настройки > Оформление</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Искате в адресната лента да има търсене и чат с AI?</string>
+    <string name="quickSetupBottomSheetDone">Готово</string>
+    <string name="quickSetupInputScreenSearchOnly">Само търсене</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Търсене и Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Как да премахнете приспособлението от началния екран</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Отидете на началния екран</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Докоснете и задръжте приспособлението</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Докоснете или плъзнете, за да го премахнете</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Адресна лента</string>
     <string name="settingsAddressBarPositionHeaderTitle">Позиция на адресната лента</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Další</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Funkce AI jsou soukromé a volitelné. Změny můžeš provádět v <b>Nastavení > Funkce AI</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Vítej zpět!&lt;br/&gt;Chcete si něco přizpůsobit?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Nastavit DuckDuckGo jako výchozí</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Přidat widget na domovskou obrazovku</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Pozice adresního řádku</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Možnosti vyhledávání v adresním řádku</string>
+    <string name="preOnboardingReinstallStartBrowsing">Spustit procházení</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kde chceš mít adresní řádek?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Změny můžeš provést v <b>Nastavení > Vzhled</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Chceš Vyhledávání a chat s AI v adresním řádku?</string>
+    <string name="quickSetupBottomSheetDone">Hotovo</string>
+    <string name="quickSetupInputScreenSearchOnly">Jen vyhledávání</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Vyhledávání a Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Jak odstranit widget z domovské obrazovky</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Přejdi na domovskou obrazovku</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Dotkni se widgetu a podrž ho</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Odstraníš ho klepnutím nebo přetažením</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adresní řádek</string>
     <string name="settingsAddressBarPositionHeaderTitle">Pozice adresního řádku</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Næste</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI-funktioner er private og valgfrie. Du kan foretage ændringer i <b>Indstillinger > AI-funktioner</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Velkommen tilbage!&lt;br/&gt;Vil du tilpasse noget?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Indstil DuckDuckGo som standard</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Tilføj widget til startskærmen</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Placering af adresselinje</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Søgemuligheder i adresselinjen</string>
+    <string name="preOnboardingReinstallStartBrowsing">Start søgning</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Hvor vil du have din adresselinje?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Du kan foretage ændringer i <b>Indstillinger > Udseende</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vil du have søgning og AI-chat i adresselinjen?</string>
+    <string name="quickSetupBottomSheetDone">Færdig</string>
+    <string name="quickSetupInputScreenSearchOnly">Kun søgning</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Søgning og Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Sådan fjerner du widgeten på startskærmen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Gå til startskærmen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Tryk og hold widgetten nede</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tryk eller træk for at fjerne den</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adresselinje</string>
     <string name="settingsAddressBarPositionHeaderTitle">Placering af adresselinje</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -917,7 +917,7 @@
     <string name="quickSetupSearchOptionsTitle">Möchtest du Such- und KI-Chatfunktionen in der Adressleiste?</string>
     <string name="quickSetupBottomSheetDone">Fertig</string>
     <string name="quickSetupInputScreenSearchOnly">Nur Suchen</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Suche &amp; Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Suche und Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">So entfernst du das Startbildschirm-Widget</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Gehe zu deinem Startbildschirm</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Halte das Widget gedrückt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Weiter</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Die KI-Funktionen sind privat und optional. Unter <b>Einstellungen > KI-Funktionen</b> kannst du Änderungen vornehmen.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Willkommen zurück!&lt;br/&gt;Möchtest du etwas individuell anpassen?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">DuckDuckGo als Standard festlegen</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Startbildschirm-Widget hinzufügen</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Position der Adressleiste</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Suchoptionen für die Adressleiste</string>
+    <string name="preOnboardingReinstallStartBrowsing">Mit dem Browsen beginnen</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Wo möchtest du deine Adressleiste haben?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Du kannst Änderungen unter <b>Einstellungen > Erscheinungsbild</b> vornehmen.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Möchtest du Such- und KI-Chatfunktionen in der Adressleiste?</string>
+    <string name="quickSetupBottomSheetDone">Fertig</string>
+    <string name="quickSetupInputScreenSearchOnly">Nur Suchen</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Suche &amp; Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">So entfernst du das Startbildschirm-Widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Gehe zu deinem Startbildschirm</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Halte das Widget gedrückt</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Zum Entfernen antippen oder ziehen</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adresszeile</string>
     <string name="settingsAddressBarPositionHeaderTitle">Position der Adressleiste</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Επόμενο</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Οι λειτουργίες τεχνητής νοημοσύνης είναι ιδιωτικές και προαιρετικές. Μπορείτε να κάνετε αλλαγές στις <b>Ρυθμίσεις > Λειτουργίες τεχνητής νοημοσύνης</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Καλώς ήρθες ξανά!&lt;br/&gt;Θέλεις να προσαρμόσεις κάτι;</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Ορισμός DuckDuckGo ως προεπιλογή</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Προσθήκη μικροεφαρμογής Αρχικής οθόνης</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Θέση γραμμής διευθύνσεων</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Επιλογές αναζήτησης στη γραμμή διευθύνσεων</string>
+    <string name="preOnboardingReinstallStartBrowsing">Έναρξη περιήγησης</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Πού θέλεις να τοποθετήσεις τη γραμμή διευθύνσεων;</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Μπορείς να κάνεις αλλαγές στις <b>Ρυθμίσεις > Εμφάνιση</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Θέλεις αναζήτηση και συνομιλία με τεχνητή νοημοσύνη στη γραμμή διευθύνσεων;</string>
+    <string name="quickSetupBottomSheetDone">Ολοκληρώθηκε</string>
+    <string name="quickSetupInputScreenSearchOnly">Αναζήτηση μόνο</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Αναζήτηση και Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Οδηγίες για να καταργήσεις τη μικροεφαρμογή Αρχικής Οθόνης</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Πήγαινε στην Αρχική Οθόνη σου</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Πάτα και κράτα πατημένη τη μικροεφαρμογή</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Πάτα ή σύρε για να την αφαιρέσεις</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Γραμμή διευθύνσεων</string>
     <string name="settingsAddressBarPositionHeaderTitle">Θέση γραμμής διευθύνσεων</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Siguiente</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Las funciones de IA son privadas y opcionales. Puedes realizar cambios en <b>Ajustes > Funciones de</b> IA.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">¡Te damos de nuevo la bienvenida!&lt;br/&gt;¿Quieres personalizar algo?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Establecer DuckDuckGo como predeterminado</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Añadir widget a la pantalla de inicio</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Posición de la barra de direcciones</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opciones de búsqueda en la barra de direcciones</string>
+    <string name="preOnboardingReinstallStartBrowsing">Empezar a navegar</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">¿Dónde quieres tu barra de direcciones?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Puedes realizar cambios en <b>Ajustes > Apariencia</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">¿Quieres la búsqueda y chat de IA en la barra de direcciones? </string>
+    <string name="quickSetupBottomSheetDone">Hecho</string>
+    <string name="quickSetupInputScreenSearchOnly">Solo buscar</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Búsqueda y Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Cómo eliminar el widget de la pantalla de inicio</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Ve a tu pantalla de inicio</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Toca y mantén pulsado el widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Toca o arrastra para eliminarlo</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Barra de direcciones</string>
     <string name="settingsAddressBarPositionHeaderTitle">Posición de la barra de direcciones</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Järgmine</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Tehisintellekti funktsioonid on privaatsed ja valikulised. Saate muudatusi teha suvandis <b>Seaded > Tehisintellekti funktsioonid</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Tere tulemast tagasi!&lt;br/&gt;Kas soovid midagi kohandada?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Määra DuckDuckGo vaikeotsinguks</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Lisa avalehe vidin</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Aadressiriba asukoht</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Aadressiriba otsinguvõimalused</string>
+    <string name="preOnboardingReinstallStartBrowsing">Alusta sirvimist</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kuhu sa oma aadressiriba paigutada soovid?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Muudatusi saad teha <b>menüüs Seaded > Välimus</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Kas soovid otsingut ja tehisintellektiga vestlust aadressiribale?</string>
+    <string name="quickSetupBottomSheetDone">Valmis</string>
+    <string name="quickSetupInputScreenSearchOnly">Ainult otsing</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Otsing ja Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Kuidas avalehe vidinat eemaldada</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Mine oma avalehele</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Puuduta ja hoia vidinat</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Eemalda see puudutades või lohistades</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Aadressiriba</string>
     <string name="settingsAddressBarPositionHeaderTitle">Aadressiriba asukoht</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Seuraava</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Tekoälyominaisuudet ovat yksityisiä ja valinnaisia. Voit tehdä muutoksia kohdassa <b>Asetukset > Tekoälyominaisuudet</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Tervetuloa takaisin!&lt;br/&gt;Haluatko muokata jotain?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Aseta DuckDuckGo oletukseksi</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Lisää kotinäytön widget</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Osoitepalkin sijainti</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Osoitepalkin hakuvaihtoehdot</string>
+    <string name="preOnboardingReinstallStartBrowsing">Aloita selailu</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Mihin haluat osoitepalkin?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Voit tehdä muutoksia kohdassa <b>Asetukset > Ulkoasu</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Haluatko haun ja tekoälychatin osoiteriville?</string>
+    <string name="quickSetupBottomSheetDone">Valmis</string>
+    <string name="quickSetupInputScreenSearchOnly">Vain haku</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Haku ja Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Aloitusnäytön widgetin poistaminen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Siirry aloitusnäyttöön</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Kosketa ja pidä widget painettuna</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Poista se napauttamalla tai vetämällä</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Osoitekenttä</string>
     <string name="settingsAddressBarPositionHeaderTitle">Osoitepalkin sijainti</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Suivant</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Les fonctionnalités d\'IA sont privées et facultatives. Vous pouvez apporter des modifications dans <b>Paramètres > Fonctionnalités d\'IA</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Bon retour parmi nous !&lt;br/&gt;Vous voulez personnaliser quelque chose ?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Définir DuckDuckGo par défaut</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Ajouter un widget à l\'écran d\'accueil</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Position de la barre d\'adresse</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Options de recherche dans la barre d’adresses</string>
+    <string name="preOnboardingReinstallStartBrowsing">Commencer la navigation</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Où voulez-vous placer votre barre d\'adresse ?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Vous pouvez apporter des modifications dans <b>Paramètres > Apparence</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vous souhaiter avoir la recherche et le chat IA dans la barre d\'adresse ?</string>
+    <string name="quickSetupBottomSheetDone">Terminé</string>
+    <string name="quickSetupInputScreenSearchOnly">Recherche uniquement</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Recherche et Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Comment supprimer le widget de l\'écran d\'accueil</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Allez à votre écran d\'accueil</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Touchez longuement le widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Appuyez ou faites glisser pour le supprimer</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Barre d\'adresse</string>
     <string name="settingsAddressBarPositionHeaderTitle">Position de la barre d\'adresse</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Dalje</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Značajke umjetne inteligencije privatne su i neobavezne. Izmjene možeš napraviti u izborniku <b>Postavke > AI značajke</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Dobrodošao natrag!&lt;br/&gt;Želiš li nešto prilagoditi?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Postavi DuckDuckGo kao zadanu tražilicu</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Dodaj widget na početni zaslon</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Položaj adresne trake</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opcije pretraživanja adresne trake</string>
+    <string name="preOnboardingReinstallStartBrowsing">Započni pretraživanje</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Gdje želiš svoju adresnu traku?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Promjene možeš napraviti u <b>Postavke > Izgled</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Želiš pretraživanje i AI čavrljanje u adresnoj traci?</string>
+    <string name="quickSetupBottomSheetDone">Gotovo</string>
+    <string name="quickSetupInputScreenSearchOnly">Samo pretraživanje</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Pretraživanje i Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Kako ukloniti widget s početnog zaslona</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Idi na početni zaslon</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Dodirni i drži widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Dodirni ili povuci da ga ukloniš</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adresna traka</string>
     <string name="settingsAddressBarPositionHeaderTitle">Položaj adresne trake</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Következő</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Az AI-funkciók privátak és opcionálisak. Módosításokat a <b>Beállítások > AI-funkciók</b> menüpontban végezhetsz.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Üdv újra!&lt;br/&gt;Testre szeretnél szabni valamit?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">DuckDuckGo beállítása alapértelmezettként</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Kezdőképernyő minialkalmazás hozzáadása</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Címsor elhelyezkedése</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Címsor keresési lehetőségei</string>
+    <string name="preOnboardingReinstallStartBrowsing">Böngészés indítása</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Hová szeretnéd tenni a címsort?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Módosításokat a <b>Beállítások > Megjelenés</b> menüpontban végezhetsz.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Szeretnéd, ha lenne keresés és AI csevegés a címsorban?</string>
+    <string name="quickSetupBottomSheetDone">Kész</string>
+    <string name="quickSetupInputScreenSearchOnly">Csak keresés</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Keresés és Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Hogyan távolíthatom el a Kezdőképernyő minialkalmazást?</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Lépj a kezdőképernyőre</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Érintsd meg és tartsd megérintve a minialkalmazást</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Koppints rá vagy húzd el az eltávolításhoz</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Címsor</string>
     <string name="settingsAddressBarPositionHeaderTitle">Címsor elhelyezkedése</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Successivo</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Le funzionalità AI sono private e opzionali. Puoi effettuare modifiche in <b>Impostazioni > Funzionalità AI</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Bentornato!&lt;br/&gt;Vuoi personalizzare qualcosa?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Imposta DuckDuckGo come predefinito</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Aggiungi widget alla schermata iniziale</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Posizione della barra degli indirizzi</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opzioni di ricerca nella barra degli indirizzi</string>
+    <string name="preOnboardingReinstallStartBrowsing">Inizia a navigare</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Dove vuoi la barra degli indirizzi?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Puoi effettuare modifiche in <b>Impostazioni > Aspetto</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vuoi la ricerca e la chat AI nella barra degli indirizzi?</string>
+    <string name="quickSetupBottomSheetDone">Operazione effettuata</string>
+    <string name="quickSetupInputScreenSearchOnly">Solo ricerca</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Ricerca e Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Come rimuovere il widget della schermata iniziale</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Vai alla schermata principale</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Tocca e tieni premuto il widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tocca o trascina per rimuoverlo</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Barra degli indirizzi</string>
     <string name="settingsAddressBarPositionHeaderTitle">Posizione Barra degli indirizzi</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Kitas</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[DI funkcijos yra privačios ir neprivalomos. Galite atlikti pakeitimus <b>Nustatymai > DI funkcijos</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Smagu, kad grįžai!&lt;br/&gt;Nori ką nors tinkinti?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Nustatyti „DuckDuckGo“ kaip numatytąją</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Pridėti pradžios ekrano valdiklį</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Adreso juostos vieta</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Adreso juostos paieškos parinktys</string>
+    <string name="preOnboardingReinstallStartBrowsing">Pradėti naršyti</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kur nori matyti adreso juostą?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Jei nori tai pakeisti, pasirink <b>Nuostatos > Išvaizda</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Nori adreso juostoje matyti paiešką ir DI pokalbius?</string>
+    <string name="quickSetupBottomSheetDone">Atlikta</string>
+    <string name="quickSetupInputScreenSearchOnly">Tik paieška</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Paieška ir „Duck.ai“</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Kaip pašalinti pradžios ekrano valdiklį</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Eik į pradžios ekraną</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Paliesk ir palaikyk valdiklį</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Paliesk arba nuvilk, kad pašalintum</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adreso juosta</string>
     <string name="settingsAddressBarPositionHeaderTitle">Adreso juostos padėtis</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -923,6 +923,26 @@
     <string name="preOnboardingInputScreenButton">Nākamais</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[MI funkcijas ir privātas un nav obligātas. Tu vari veikt izmaiņas sadaļā <b>Iestatījumi > MI funkcijas</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Laipni lūdzam atpakaļ!&lt;br/&gt;Vai gribi kaut ko pielāgot?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Iestatī DuckDuckGo kā noklusējumu</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Pievienot sākuma ekrāna logrīku</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Adreses joslas pozīcija</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Adreses joslas meklēšanas opcijas</string>
+    <string name="preOnboardingReinstallStartBrowsing">Sākt pārlūkošanu</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kur attēlot adreses joslu?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Tu vari veikt izmaiņas sadaļā <b>Iestatījumi > Izskats</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vēlies meklēšanu un MI tērzēšanu adreses joslā?</string>
+    <string name="quickSetupBottomSheetDone">Gatavs</string>
+    <string name="quickSetupInputScreenSearchOnly">Tikai meklēšana</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Meklēšana un Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Kā noņemt sākuma ekrāna logrīku</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Dodies uz sākuma ekrānu</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Pieskarieties logrīkam un turi to</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Pieskaries vai velc, lai to noņemtu</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adreses josla</string>
     <string name="settingsAddressBarPositionHeaderTitle">Adreses joslas pozīcija</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Neste</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI-funksjoner er private og valgfrie. Du kan gjøre endringer i <b>Innstillinger > AI-funksjoner</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Velkommen tilbake!&lt;br/&gt;Vil du tilpasse noe?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Angi DuckDuckGo som standard</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Legg til en widget på startskjermen</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Plassering av adressefelt</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Søkealternativer i adressefeltet</string>
+    <string name="preOnboardingReinstallStartBrowsing">Begynn å surfe</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Hvor vil du ha adressefeltet?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Du kan gjøre endringer i <b>Innstillinger > Utseende</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vil du ha søk og AI-chat i adressefeltet?</string>
+    <string name="quickSetupBottomSheetDone">Ferdig</string>
+    <string name="quickSetupInputScreenSearchOnly">Bare søk</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Søk og Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Slik fjerner du startskjerm-widgeten</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Gå til startskjermen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Trykk og hold på widgeten</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Trykk eller dra for å fjerne den</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adressefelt</string>
     <string name="settingsAddressBarPositionHeaderTitle">Plassering av adressefelt</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Volgende</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI-functies zijn privé en optioneel. Je kunt wijzigingen aanbrengen in <b>Instellingen > AI-functies</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Welkom terug!&lt;br/&gt;Wil je iets aanpassen?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">DuckDuckGo instellen als standaard</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Widget toevoegen aan het startscherm</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Positie van adresbalk</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opties voor zoeken in de adresbalk</string>
+    <string name="preOnboardingReinstallStartBrowsing">Beginnen met browsen</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Waar wil je je adresbalk hebben?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Je kunt wijzigingen aanbrengen in <b>Instellingen > Uiterlijk</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Wil je de zoek- en AI-chatfunctie in de adresbalk?</string>
+    <string name="quickSetupBottomSheetDone">Klaar</string>
+    <string name="quickSetupInputScreenSearchOnly">Alleen zoeken</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Zoeken en Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Zo verwijder je de widget van het startscherm</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Ga naar je beginscherm</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Raak de widget aan en houd hem vast</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tik of sleep om hem te verwijderen</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adresbalk</string>
     <string name="settingsAddressBarPositionHeaderTitle">Positie van adresbalk</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Dalej</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Funkcje sztucznej inteligencji są prywatne i opcjonalne. Możesz dokonać zmian w obszarze <b>Ustawienia > Funkcje AI</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Witamy z powrotem!&lt;br/&gt;Chcesz coś spersonalizować?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Ustaw DuckDuckGo jako domyślną przeglądarkę</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Dodaj widżet do ekranu głównego</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Pozycja paska adresu</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opcje wyszukiwania na pasku adresowym</string>
+    <string name="preOnboardingReinstallStartBrowsing">Rozpocznij przeglądanie</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Gdzie chcesz mieć pasek adresu?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Możesz dokonać zmian w obszarze <b>Ustawienia > Wygląd</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Chcesz mieć dostęp do wyszukiwania i czatu AI na pasku adresu?</string>
+    <string name="quickSetupBottomSheetDone">Gotowe</string>
+    <string name="quickSetupInputScreenSearchOnly">Tylko wyszukiwanie</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Wyszukiwanie i Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Jak usunąć widżet na ekranie głównym</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Przejdź do ekranu głównego</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Dotknij i przytrzymaj widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Stuknij lub przeciągnij, aby go usunąć</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Pasek adresu</string>
     <string name="settingsAddressBarPositionHeaderTitle">Pozycja paska adresu</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Seguinte</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[As funcionalidades de IA são privadas e opcionais. Podes fazer alterações em <b>Definições > Funcionalidades de IA</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Bem-vindo de volta!&lt;br/&gt;Queres personalizar alguma coisa?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Definir o DuckDuckGo como predefinido</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Adicionar widget Ecrã inicial</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Posição da barra de endereços</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opções de pesquisa na barra de endereços</string>
+    <string name="preOnboardingReinstallStartBrowsing">Iniciar a navegação</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Onde queres a tua barra de endereços?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Podes fazer alterações em <b>Definições > Aparência</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Queres a pesquisa e o chat com IA na barra de endereços?</string>
+    <string name="quickSetupBottomSheetDone">Feito</string>
+    <string name="quickSetupInputScreenSearchOnly">Pesquisar apenas</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Pesquisa e Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Como remover o widget Ecrã inicial</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Vai ao teu Ecrã inicial</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Toca no widget e segura</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Toca ou arrasta para o remover</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Barra de endereço</string>
     <string name="settingsAddressBarPositionHeaderTitle">Posição da barra de endereços</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -923,6 +923,26 @@
     <string name="preOnboardingInputScreenButton">Următorul</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Funcțiile IA sunt private și opționale. Poți face modificări în <b>Setări > Funcții IA</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Bine ai revenit!&lt;br/&gt;Dorești să personalizezi ceva?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Setează DuckDuckGo ca implicit</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Adaugă widgetul pentru ecranul de întâmpinare</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Poziția barei de adrese</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Opțiuni de căutare în bara de adrese</string>
+    <string name="preOnboardingReinstallStartBrowsing">Începe navigarea</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Unde vrei să se afle bara de adrese?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Poți face modificări în <b>Setări > Aspect</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Dorești căutare și chat cu IA în bara de adrese?</string>
+    <string name="quickSetupBottomSheetDone">Terminat</string>
+    <string name="quickSetupInputScreenSearchOnly">Doar căutare</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Caută și folosește Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Cum se elimină widgetul de pe ecranul de întâmpinare</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Mergi la ecranul de întâmpinare</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Atinge și menține apăsat widgetul</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Atinge sau trage pentru a-l elimina</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Bara de adrese</string>
     <string name="settingsAddressBarPositionHeaderTitle">Poziția barei de adrese</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Далее</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Функции на базе ИИ работают конфиденциально и предлагаются дополнительно. Их можно изменить в разделе <b>Настройки > Функции ИИ</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">С возвращением!&lt;br/&gt;Хочешь что-нибудь настроить?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Сделать DuckDuckGo браузером по умолчанию</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Добавить виджет на главный экран</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Положение адресной строки</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Параметры поиска в адресной строке</string>
+    <string name="preOnboardingReinstallStartBrowsing">Начать работу</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Где вы хотите разместить адресную строку?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Изменения можно внести в разделе <b>«Настройки» > «Внешний вид»</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Нужен доступ к поиску и чатам с ИИ прямо из адресной строки?</string>
+    <string name="quickSetupBottomSheetDone">Готово</string>
+    <string name="quickSetupInputScreenSearchOnly">Только поиск</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Поиск и Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Как удалить виджет с главного экрана</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Перейти на главный экран</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Нажмите и удерживайте виджет</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Нажми или перетащи, чтобы удалить его</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Адресная строка</string>
     <string name="settingsAddressBarPositionHeaderTitle">Положение адресной строки</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Ďalšie</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Funkcie AI sú súkromné a voliteľné. Môžeš urobiť zmeny v&nbsp;<b>Nastaveniach >&nbsp;Funkcie AI</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Vitaj späť!&lt;br/&gt;Chceš si niečo prispôsobiť?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Nastaviť DuckDuckGo ako predvolený</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Pridať miniaplikáciu na úvodnú obrazovku</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Poloha riadku s adresou</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Možnosti vyhľadávania v adresnom paneli</string>
+    <string name="preOnboardingReinstallStartBrowsing">Začni prehliadať</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kam chceš umiestniť riadok adresy?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Zmeny môžeš vykonať v časti <b>Nastavenia > Vzhľad</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Chceš mať vyhľadávanie a AI chat v adresnom riadku?</string>
+    <string name="quickSetupBottomSheetDone">Hotovo</string>
+    <string name="quickSetupInputScreenSearchOnly">Len vyhľadávanie</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Vyhľadávanie a Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Ako odstrániť miniaplikáciu z úvodnej obrazovky</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Prejdi na úvodnú obrazovku</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Dotkni sa a podrž miniaplikáciu</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Klepni alebo potiahni, aby si to odstránil/-a</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Riadok adresy</string>
     <string name="settingsAddressBarPositionHeaderTitle">Poloha riadku s adresou</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -943,6 +943,26 @@
     <string name="preOnboardingInputScreenButton">Naslednji</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[Funkcije umetne inteligence so zasebne in izbirne. Spremembe lahko opravite v meniju <b>Nastavitve > Funkcije UI</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Dobrodošli nazaj!&lt;br/&gt;Želite kaj prilagoditi?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Nastavi DuckDuckGo kot privzeto</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Dodaj pripomoček za začetni zaslon</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Položaj naslovne vrstice</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Možnosti iskanja v naslovni vrstici</string>
+    <string name="preOnboardingReinstallStartBrowsing">Začni brskanje</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Kje želite imeti naslovno vrstico?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Spremembe lahko opravite v <b>Nastavitve > Videz</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Želite iskanje in klepet z umetno inteligenco v naslovni vrstici?</string>
+    <string name="quickSetupBottomSheetDone">Končano</string>
+    <string name="quickSetupInputScreenSearchOnly">Samo iskanje</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Iskanje in Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Kako odstraniti pripomoček z začetnega zaslona</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Pojdite na svoj začetni zaslon</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Pripomočka se dotaknite in ga pridržite</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tapnite ali povlecite, da ga odstranite</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Naslovna vrstica</string>
     <string name="settingsAddressBarPositionHeaderTitle">Položaj naslovne vrstice</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -917,7 +917,7 @@
     <string name="quickSetupSearchOptionsTitle">Vill du ha sökning och AI-chatt i adressfältet?</string>
     <string name="quickSetupBottomSheetDone">Klart</string>
     <string name="quickSetupInputScreenSearchOnly">Sök endast</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Sök &amp; Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Sök och Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">Så här tar du bort widgeten för startskärmen</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Gå till din startskärm</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Tryck och håll kvar på widgeten</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Nästa</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI-funktioner är privata och valfria. Du kan göra ändringar i <b>Inställningar > AI-funktioner</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Välkommen tillbaka!&lt;br/&gt;Vill du anpassa något?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Ställ in DuckDuckGo som standard</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Lägg till widget på startskärmen</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Adressfältsläge</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Sökalternativ för adressfält</string>
+    <string name="preOnboardingReinstallStartBrowsing">Börja surfa</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Var vill du ha adressfältet?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Du kan göra ändringar i <b>Inställningar > Utseende</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Vill du ha sökning och AI-chatt i adressfältet?</string>
+    <string name="quickSetupBottomSheetDone">Klart</string>
+    <string name="quickSetupInputScreenSearchOnly">Sök endast</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Sök &amp; Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Så här tar du bort widgeten för startskärmen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Gå till din startskärm</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Tryck och håll kvar på widgeten</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tryck eller dra för att ta bort den</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adressfält</string>
     <string name="settingsAddressBarPositionHeaderTitle">Adressfältsläge</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -903,6 +903,26 @@
     <string name="preOnboardingInputScreenButton">Sonraki</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI özellikleri gizli ve isteğe bağlıdır. Değişiklikleri <b>Ayarlar > AI Özellikleri</b> bölümünden yapabilirsiniz.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Tekrar hoşgeldiniz!&lt;br/&gt;Özelleştirmek istediğiniz bir var mı?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">DuckDuckGo\'yu varsayılan olarak ayarla</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Ana ekran widget\'ını ekle</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Adres çubuğu konumu</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Adres çubuğu arama seçenekleri</string>
+    <string name="preOnboardingReinstallStartBrowsing">Gezinmeye Başla</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Adres çubuğu nerede olsun?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[Değişiklikleri <b>Ayarlar > Görünüm</b> bölümünden yapabilirsiniz.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Adres çubuğunda Arama ve Yapay Zeka sohbeti olsun mu?</string>
+    <string name="quickSetupBottomSheetDone">Bitti</string>
+    <string name="quickSetupInputScreenSearchOnly">Yalnızca Arama</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Arama ve Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">Ana ekran widget\'ı nasıl kaldırılır?</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Ana ekranınıza gidin</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Widget\'a dokunun ve basılı tutun</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Kaldırmak için dokunun veya sürükleyin</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Adres Çubuğu</string>
     <string name="settingsAddressBarPositionHeaderTitle">Adres Çubuğu Konumu</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -79,6 +79,11 @@
       }]
     </string>
 
+    <!-- Quick Setup Onboarding Steps Count -->
+    <string name="quickSetupRemoveHomeScreenWidgetStep1Number" translatable="false">1</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2Number" translatable="false">2</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3Number" translatable="false">3</string>
+
     <!-- Input Mode Demo Onboarding step -->
     <string name="preOnboardingInputModeDemoTitle">Ready to get started?&lt;br/&gt;Try a search or AI chat!</string>
     <string name="preOnboardingInputModeDemoSearchHint">Search privately</string>
@@ -95,30 +100,6 @@
     <!-- Default browser changed survey -->
     <string name="defaultBrowserChangedSurveyNotificationTitle">We noticed a change</string>
     <string name="defaultBrowserChangedSurveyNotificationDescription">DuckDuckGo is no longer your default browser. Mind telling us why?</string>
-
-    <!--Onboarding Reinstall Quick Setup-->
-    <string name="preOnboardingReinstallQuickSetupTitle">Welcome back!&lt;br/&gt;Want to customize anything?</string>
-    <string name="preOnboardingReinstallSetDefaultLabel">Set DuckDuckGo as default</string>
-    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Add Home screen widget</string>
-    <string name="preOnboardingReinstallAddressBarLabel">Address bar position</string>
-    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Address bar search options</string>
-    <string name="preOnboardingReinstallStartBrowsing">Start Browsing</string>
-
-    <!-- Quick setup bottom sheets -->
-    <string name="quickSetupAddressBarPositionTitle">Where do you want your address bar?</string>
-    <string name="quickSetupAddressBarPositionCaption"><![CDATA[You can make changes in <b>Settings > Appearance</b>.]]></string>
-    <string name="quickSetupSearchOptionsTitle">Want Search &amp; AI chat in the address bar?</string>
-    <string name="quickSetupBottomSheetDone">Done</string>
-    <string name="quickSetupInputScreenSearchOnly">Search Only</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Search &amp; Duck.ai</string>
-    <string name="quickSetupRemoveHomeScreenWidgetTitle">How to remove the Home screen widget</string>
-    <string name="quickSetupRemoveHomeScreenWidgetStep1">Go to your Home screen</string>
-    <string name="quickSetupRemoveHomeScreenWidgetStep2">Touch and hold the widget</string>
-    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tap or drag to remove it</string>
-
-    <string name="quickSetupRemoveHomeScreenWidgetStep1Number" translatable="false">1</string>
-    <string name="quickSetupRemoveHomeScreenWidgetStep2Number" translatable="false">2</string>
-    <string name="quickSetupRemoveHomeScreenWidgetStep3Number" translatable="false">3</string>
 
     <!-- Fire animation rollout: relabel HeroFire to "Inferno Classic" when fireAnimationUpdate is on — pending translation -->
     <plurals name="fireDialogDeleteCountTitle">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -916,7 +916,7 @@
     <string name="quickSetupSearchOptionsTitle">Want Search &amp; AI chat in the address bar?</string>
     <string name="quickSetupBottomSheetDone">Done</string>
     <string name="quickSetupInputScreenSearchOnly">Search Only</string>
-    <string name="quickSetupInputScreenSearchAndDuckAi">Search &amp; Duck.ai</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Search and Duck.ai</string>
     <string name="quickSetupRemoveHomeScreenWidgetTitle">How to remove the Home screen widget</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep1">Go to your Home screen</string>
     <string name="quickSetupRemoveHomeScreenWidgetStep2">Touch and hold the widget</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -902,6 +902,26 @@
     <string name="preOnboardingInputScreenButton">Next</string>
     <string name="preOnboardingInputScreenDescription"><![CDATA[AI features are private and optional. You can make changes in <b>Settings > AI Features</b>.]]></string>
 
+    <!--Onboarding Reinstall Quick Setup-->
+    <string name="preOnboardingReinstallQuickSetupTitle">Welcome back!&lt;br/&gt;Want to customize anything?</string>
+    <string name="preOnboardingReinstallSetDefaultLabel">Set DuckDuckGo as default</string>
+    <string name="preOnboardingReinstallAddHomeScreenWidgetLabel">Add Home screen widget</string>
+    <string name="preOnboardingReinstallAddressBarLabel">Address bar position</string>
+    <string name="preOnboardingReinstallAddressBarSearchOptionsLabel">Address bar search options</string>
+    <string name="preOnboardingReinstallStartBrowsing">Start Browsing</string>
+
+    <!-- Quick setup bottom sheets -->
+    <string name="quickSetupAddressBarPositionTitle">Where do you want your address bar?</string>
+    <string name="quickSetupAddressBarPositionCaption"><![CDATA[You can make changes in <b>Settings > Appearance</b>.]]></string>
+    <string name="quickSetupSearchOptionsTitle">Want Search &amp; AI chat in the address bar?</string>
+    <string name="quickSetupBottomSheetDone">Done</string>
+    <string name="quickSetupInputScreenSearchOnly">Search Only</string>
+    <string name="quickSetupInputScreenSearchAndDuckAi">Search &amp; Duck.ai</string>
+    <string name="quickSetupRemoveHomeScreenWidgetTitle">How to remove the Home screen widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep1">Go to your Home screen</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep2">Touch and hold the widget</string>
+    <string name="quickSetupRemoveHomeScreenWidgetStep3">Tap or drag to remove it</string>
+
     <!-- Appearance settings -->
     <string name="settingsAddressBarPositionTitle">Address Bar</string>
     <string name="settingsAddressBarPositionHeaderTitle">Address Bar Position</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1215176725605504?focus=true

### Description
Translations for the quick setup texts from the onboarding flow. 

### Steps to test this PR

QA-Optional.

**No UI changes**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization-only string resource changes with no app logic or security impact.
> 
> **Overview**
> This PR **localizes** the reinstall onboarding **quick setup** copy so returning users see translated UI instead of English-only strings from `donottranslate.xml`.
> 
> **English defaults** move into `values/strings.xml` (welcome-back screen, default browser/widget/address bar options, bottom sheets for address bar position, search vs Duck.ai, and home-screen widget removal steps). **~25 locale** `strings.xml` files gain matching entries. **Step numbers** (`1`–`3`) stay in `donottranslate.xml` as non-translatable. Default English tweaks **Search & Duck.ai** to **Search and Duck.ai**.
> 
> No Kotlin or behavior changes—string resources only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97d0a18b4c2e5f39bdbecf32f2bdc381c49a5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->