### PR TITLE
Bundle onboardingQuickSetup experiment in local privacy config

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupExperimentManager.kt
@@ -45,13 +45,13 @@ class OnboardingQuickSetupExperimentManagerImpl @Inject constructor(
 ) : OnboardingQuickSetupExperimentManager {
 
     override suspend fun enroll(): QuickSetupExperimentVariant? = withContext(dispatcherProvider.io()) {
-        toggles.onboardingQuickSetupExperimentMay26().enroll()
+        toggles.onboardingQuickSetupExperimentJun3().enroll()
         when {
-            toggles.onboardingQuickSetupExperimentMay26().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
+            toggles.onboardingQuickSetupExperimentJun3().isEnrolledAndEnabled(QuickSetupCohorts.TREATMENT) -> {
                 QuickSetupExperimentVariant.TREATMENT
             }
 
-            toggles.onboardingQuickSetupExperimentMay26().isEnrolledAndEnabled(QuickSetupCohorts.CONTROL) -> {
+            toggles.onboardingQuickSetupExperimentJun3().isEnrolledAndEnabled(QuickSetupCohorts.CONTROL) -> {
                 QuickSetupExperimentVariant.CONTROL
             }
 

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupSearchMetricsAtbLifecyclePlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupSearchMetricsAtbLifecyclePlugin.kt
@@ -41,7 +41,7 @@ class OnboardingQuickSetupSearchMetricsAtbLifecyclePlugin @Inject constructor(
     }
 
     private suspend fun buildMetrics(): List<MetricsPixel> {
-        val toggle = toggles.onboardingQuickSetupExperimentMay26()
+        val toggle = toggles.onboardingQuickSetupExperimentJun3()
         if (!toggle.isEnabled() || !toggle.isEnrolled()) {
             return emptyList()
         }

--- a/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupToggles.kt
@@ -43,7 +43,7 @@ interface OnboardingQuickSetupToggles {
      * cohort should be shown the quick-setup screen during onboarding.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun onboardingQuickSetupExperimentMay26(): Toggle
+    fun onboardingQuickSetupExperimentJun3(): Toggle
 
     enum class QuickSetupCohorts(override val cohortName: String) : CohortName {
         CONTROL("control"),

--- a/app/src/test/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboardingquicksetup/OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest.kt
@@ -104,7 +104,7 @@ class OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest {
 
         plugin.onSearchRetentionAtbRefreshed("", "")
 
-        val expectedName = toggles.onboardingQuickSetupExperimentMay26().featureName().name
+        val expectedName = toggles.onboardingQuickSetupExperimentJun3().featureName().name
         assertTrue(fakeMetricsPixelExtension.sentMetrics.all { it.toggle.featureName().name == expectedName })
     }
 
@@ -138,7 +138,7 @@ class OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest {
     private fun enableAndEnroll() {
         val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
         val cohort = State.Cohort(name = "treatment", weight = 1, enrollmentDateET = today)
-        toggles.onboardingQuickSetupExperimentMay26().setRawStoredState(
+        toggles.onboardingQuickSetupExperimentJun3().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -151,7 +151,7 @@ class OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest {
     private fun disabledButEnrolled() {
         val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
         val cohort = State.Cohort(name = "treatment", weight = 1, enrollmentDateET = today)
-        toggles.onboardingQuickSetupExperimentMay26().setRawStoredState(
+        toggles.onboardingQuickSetupExperimentJun3().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -164,7 +164,7 @@ class OnboardingQuickSetupSearchMetricsAtbLifecyclePluginTest {
     private fun enabledButNotEnrolled() {
         val today = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
         val cohort = State.Cohort(name = "treatment", weight = 1, enrollmentDateET = today)
-        toggles.onboardingQuickSetupExperimentMay26().setRawStoredState(
+        toggles.onboardingQuickSetupExperimentJun3().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -951,7 +951,7 @@
         "onboardingQuickSetup": {
             "state": "enabled",
             "features": {
-                "onboardingQuickSetupExperimentMay26": {
+                "onboardingQuickSetupExperimentJun3": {
                     "state": "enabled",
                     "cohorts": [
                         {

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -956,7 +956,7 @@
                     "cohorts": [
                         {
                             "name": "control",
-                            "weight": 0
+                            "weight": 1
                         },
                         {
                             "name": "treatment",

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -947,6 +947,24 @@
                     "reason": "Site breakage"
                 }
             ]
+        },
+        "onboardingQuickSetup": {
+            "state": "enabled",
+            "features": {
+                "onboardingQuickSetupExperimentMay26": {
+                    "state": "enabled",
+                    "cohorts": [
+                        {
+                            "name": "control",
+                            "weight": 0
+                        },
+                        {
+                            "name": "treatment",
+                            "weight": 1
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214770118345811

### Description
Renamed the quick setup experiment for onboarding to `onboardingQuickSetupExperimentJun3`.

The `onboardingQuickSetupExperimentJun3` experiment is normally delivered via the remote privacy config. If a reinstall user taps "I've been here before" before the remote config has been downloaded, the app falls back to the bundled `privacy_config.json`, which previously did not declare the experiment — so the user would not be enrolled and the Quick Setup screen would not be shown.

Bundle the experiment definition into the local config so first-launch enrollment works without depending on a successful remote fetch. Both cohorts (`control`, `treatment`) are weighted `1` in the bundled fallback so the actual variant assignment stays randomised, matching the remote config behaviour.

### Steps to test this PR

_Treatment variant_
- [x] In `privacy_config.json` set `control` weight to `0` and `treatment` weight to `1`.
- [x] Install the app fresh with the network disabled so no remote privacy config can be downloaded.
- [x] Launch onboarding and tap "I've been here before".
- [x] Verify the user is enrolled in the **treatment** cohort and the Quick Setup screen is shown.

_Control variant_
- [x] In `privacy_config.json` set `control` weight to `1` and `treatment` weight to `0`.
- [x] Reinstall the app fresh with the network disabled.
- [x] Launch onboarding and tap "I've been here before".
- [x] Verify the user is enrolled in the **control** cohort and the Quick Setup screen is **not** shown (existing skip-onboarding flow).

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding experiment naming and bundled privacy-config fallback only; no auth, payments, or core security paths.
> 
> **Overview**
> Renames the re-installer quick-setup A/B toggle from **`onboardingQuickSetupExperimentMay26`** to **`onboardingQuickSetupExperimentJun3`** everywhere enrollment, search metrics, and tests reference it.
> 
> Adds an **`onboardingQuickSetup`** block to the **bundled** `privacy_config.json` with **`onboardingQuickSetupExperimentJun3`** enabled and **control** / **treatment** cohorts (weight 1 each). That lets users who tap “I've been here before” before remote privacy config arrives still enroll and get the correct Quick Setup vs skip-onboarding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86225afce96157402dcd4bacde98702997a92073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->