### PR TITLE
Stop Glide from upscaling favicons during decode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloader.kt
@@ -23,6 +23,7 @@ import android.net.Uri
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
@@ -50,11 +51,28 @@ class GlideFaviconDownloader @Inject constructor(
     private val context: Context,
     private val dispatcherProvider: DispatcherProvider,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val downsamplingStrategyFixFeature: FaviconDownloaderGlideDownsamplingStrategyFixFeature,
 ) : FaviconDownloader {
 
     companion object {
         private const val MAX_FAVICON_SIZE_PX = 512
     }
+
+    // Single point of policy for every Glide favicon load. When the kill-switch flag is on
+    // (default), apply DownsampleStrategy.CENTER_INSIDE: Glide's default (CENTER_OUTSIDE)
+    // would upscale a sub-target source (e.g. a 32×32 favicon → 512×512) and that upscaled
+    // bitmap is what we then encode to disk, destroying the size signal FaviconPersister's
+    // "keep higher-res" guard relies on. CENTER_INSIDE keeps the MAX_FAVICON_SIZE_PX ceiling
+    // but never scales up.
+    //
+    // Callers are already inside withContext(dispatcherProvider.io()) via the public overrides,
+    // so the synchronous isEnabled() check below runs on IO without an extra dispatch.
+    private fun faviconRequest(): RequestBuilder<Bitmap> =
+        Glide.with(context)
+            .asBitmap()
+            .let { if (downsamplingStrategyFixFeature.self().isEnabled()) it.downsample(DownsampleStrategy.CENTER_INSIDE) else it }
+            .diskCacheStrategy(DiskCacheStrategy.NONE)
+            .skipMemoryCache(true)
 
     override suspend fun getFaviconFromDisk(file: File): Bitmap? = withContext(dispatcherProvider.io()) {
         if (androidBrowserConfigFeature.glideSuspend().isEnabled()) {
@@ -86,7 +104,7 @@ class GlideFaviconDownloader @Inject constructor(
     }
 
     private suspend fun getFaviconFromDiskAsync(file: File): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(file).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).awaitBitmap(context)
+        faviconRequest().load(file).awaitBitmap(context)
     }.getOrNull()
 
     private suspend fun getFaviconFromDiskAsync(
@@ -94,18 +112,15 @@ class GlideFaviconDownloader @Inject constructor(
         cornerRadius: Int,
         width: Int,
         height: Int,
-    ): Bitmap? = kotlin.runCatching {
-        Glide.with(context)
-            .asBitmap()
+    ): Bitmap? = runCatching {
+        faviconRequest()
             .load(file)
             .transform(RoundedCorners(cornerRadius))
-            .diskCacheStrategy(DiskCacheStrategy.NONE)
-            .skipMemoryCache(true)
             .awaitBitmap(context, width, height)
     }.getOrNull()
 
     private suspend fun getFaviconFromUrlAsync(uri: Uri): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(uri).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).awaitBitmap(context)
+        faviconRequest().load(uri).awaitBitmap(context)
     }.getOrNull()
 
     private suspend fun RequestBuilder<Bitmap>.awaitBitmap(
@@ -113,7 +128,7 @@ class GlideFaviconDownloader @Inject constructor(
         width: Int,
         height: Int,
     ): Bitmap? = suspendCancellableCoroutine { continuation ->
-        kotlin.runCatching {
+        runCatching {
             val target = object : CustomTarget<Bitmap>(width, height) {
                 override fun onResourceReady(
                     resource: Bitmap,
@@ -139,7 +154,7 @@ class GlideFaviconDownloader @Inject constructor(
     }
 
     private suspend fun RequestBuilder<Bitmap>.awaitBitmap(context: Context): Bitmap? = suspendCancellableCoroutine { continuation ->
-        kotlin.runCatching {
+        runCatching {
             val target = object : CustomTarget<Bitmap>(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX) {
                 override fun onResourceReady(
                     resource: Bitmap,
@@ -174,8 +189,7 @@ class GlideFaviconDownloader @Inject constructor(
     }
 
     private fun getFaviconFromDiskSync(file: File): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(file).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true)
-            .submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
+        faviconRequest().load(file).submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
     }.getOrNull()
 
     private fun getFaviconFromDiskSync(
@@ -184,18 +198,14 @@ class GlideFaviconDownloader @Inject constructor(
         width: Int,
         height: Int,
     ): Bitmap? = runCatching {
-        Glide.with(context)
-            .asBitmap()
+        faviconRequest()
             .load(file)
             .transform(RoundedCorners(cornerRadius))
-            .diskCacheStrategy(DiskCacheStrategy.NONE)
-            .skipMemoryCache(true)
             .submit(width, height)
             .get()
     }.getOrNull()
 
     private fun getFaviconFromUrlSync(uri: Uri): Bitmap? = runCatching {
-        Glide.with(context).asBitmap().load(uri).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true)
-            .submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
+        faviconRequest().load(uri).submit(MAX_FAVICON_SIZE_PX, MAX_FAVICON_SIZE_PX).get()
     }.getOrNull()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloaderGlideDownsamplingStrategyFixFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconDownloaderGlideDownsamplingStrategyFixFeature.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.favicon
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Kill switch for the favicon-decode downsampling fix. When enabled (default), Glide loads in
+ * [GlideFaviconDownloader] use [com.bumptech.glide.load.resource.bitmap.DownsampleStrategy.CENTER_INSIDE]
+ * so sub-target favicons (e.g. 32×32) are not upscaled to 512×512 and then written to disk.
+ * Toggle off to fall back to Glide's default behaviour.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "faviconDownloaderGlideDownsamplingStrategyFix",
+)
+interface FaviconDownloaderGlideDownsamplingStrategyFixFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/favicon/FaviconModule.kt
@@ -66,7 +66,8 @@ class FaviconModule {
         context: Context,
         dispatcherProvider: DispatcherProvider,
         androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+        downsamplingStrategyFixFeature: FaviconDownloaderGlideDownsamplingStrategyFixFeature,
     ): FaviconDownloader {
-        return GlideFaviconDownloader(context, dispatcherProvider, androidBrowserConfigFeature)
+        return GlideFaviconDownloader(context, dispatcherProvider, androidBrowserConfigFeature, downsamplingStrategyFixFeature)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1214789916598888?focus=true

### Description
Glide's default `CENTER_OUTSIDE` downsample strategy was inflating small favicons (e.g. 32x32) up to `MAX_FAVICON_SIZE_PX` (512x512) before they got encoded to disk, breaking `FaviconPersister`'s size-based dedup (`width > existing` skips, but every URL-fetched favicon now had width=512 regardless of source) and the `iconReceived` pre-check added in #8156 (which rejected real higher-res bitmaps because the on-disk file was reported as 512). Regression from #7710, which added the 512 target without specifying a downsample strategy.

Switch to `CENTER_INSIDE` on the Glide loads in `GlideFaviconDownloader`: keeps the 512 px memory ceiling that #7710 wanted (large OOM-class favicons still get downsampled), but never scales smaller sources up.

### Steps to test this PR
- [ ] Grab [blurry-favicons-repro-server.py](https://github.com/user-attachments/files/28360548/blurry-favicons-repro-server.py) and run it:
```bash
python3 blurry-favicons-repro-server.py
```
- [ ] Checkout a commit before the fix.
- [ ] Install the app on an emulator and point a tab to http://10.0.2.2:8088/.
- [ ] Wait a couple of seconds (until the blue icon loads on the page).
- [ ] Open the tab switcher.
- [ ] Verify that the tab used the 32x32 icon (red) and its text is blurry.
- [ ] (optional) Use fire button.
- [ ] Checkout the fix branch.
- [ ] Install the app on an emulator and point a tab to http://10.0.2.2:8088/.
- [ ] Wait a couple of seconds (until the blue icon loads on the page).
- [ ] Open the tab switcher.
- [ ] Verify that the tab used the 192x192 icon (blue) and its text is sharp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped favicon decode/persist behavior with a remote kill switch; no auth or sensitive data paths.
> 
> **Overview**
> Fixes favicons being decoded at a fake 512×512 size by routing all `GlideFaviconDownloader` loads through a shared `faviconRequest()` that applies **`DownsampleStrategy.CENTER_INSIDE`** when the new remote flag is on (default). That keeps the existing 512px cap for large icons but stops Glide from upscaling small sources before they are written to disk, so `FaviconPersister` can again compare real dimensions and higher-res icons can win in the tab switcher.
> 
> Adds **`FaviconDownloaderGlideDownsamplingStrategyFixFeature`** as a kill switch (toggle off restores Glide’s prior downsampling) and wires it through **`FaviconModule`** into `GlideFaviconDownloader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220bdd356518e8ef84a34ab8157f377e5de46b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->