### PR TITLE
Update to handle landscape (native input)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.nativeinput
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -127,6 +128,7 @@ class RealNativeInputManager @Inject constructor(
     private var isNativeInputFieldEnabled: Boolean = false
     private var isExiting: Boolean = false
     private var isPickingImage: Boolean = false
+    private var duckAiToolbarHidden: Boolean = false
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
     private var lastCallbacks: NativeInputCallbacks? = null
@@ -293,7 +295,14 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun onKeyboardShown(widgetRoot: View?) {
-        if (omnibarController.isDuckAiMode() || omnibarController.isSplitMode()) return
+        if (omnibarController.isSplitMode()) return
+        if (omnibarController.isDuckAiMode()) {
+            if (isLandscape()) {
+                omnibarController.hide()
+                duckAiToolbarHidden = true
+            }
+            return
+        }
         omnibarController.hide()
         widgetRoot?.translationZ = 0f
     }
@@ -302,9 +311,17 @@ class RealNativeInputManager @Inject constructor(
         if (widget.isModelMenuVisible) return
         if (isPickingImage) return
         if (omnibarController.isDuckAiMode()) {
+            if (duckAiToolbarHidden) {
+                omnibarController.show()
+                omnibarController.hideBackground()
+                duckAiToolbarHidden = false
+            }
             updateWidgetFocus(widget)
         }
     }
+
+    private fun isLandscape(): Boolean =
+        rootView.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 
     private fun updateWidgetFocus(widget: NativeInputWidget) {
         val focusedView = rootView.findFocus()
@@ -495,6 +512,7 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
+        duckAiToolbarHidden = false
         // Drop Fragment-scoped callback closures so they don't outlive the widget.
         lastCallbacks = null
         return removed

--- a/app/src/main/res/layout/input_mode_widget_card_view.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/inputModeTopRoot"
     android:layout_width="match_parent"
@@ -39,4 +39,4 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </com.google.android.material.card.MaterialCardView>
-</FrameLayout>
+</com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout>

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/inputModeBottomRoot"
     android:layout_width="match_parent"
@@ -45,4 +45,4 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </com.google.android.material.card.MaterialCardView>
-</FrameLayout>
+</com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout>

--- a/browser/browser-ui/src/main/res/values/styles-input-mode.xml
+++ b/browser/browser-ui/src/main/res/values/styles-input-mode.xml
@@ -34,6 +34,7 @@
     <style name="Widget.DuckDuckGo.TabLayout.Rounded.Native" parent="Widget.DuckDuckGo.TabLayout.Rounded">
         <item name="android:background">@drawable/native_tab_layout_background</item>
         <item name="tabIndicatorColor">?attr/daxColorControlRaisedFillPrimary</item>
+        <item name="tabMaxWidth">0dp</item>
     </style>
 
     <style name="Widget.DuckDuckGo.SettingsPictogram">

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -598,7 +598,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun applyTrailingButtonMargin() {
         findViewById<View?>(R.id.inputModeWidgetLayout)?.updateLayoutParams<MarginLayoutParams> {
-            marginEnd = resources.getDimensionPixelSize(R.dimen.inputScreenOmnibarCardMarginHorizontal)
+            marginEnd = resources.getDimensionPixelSize(R.dimen.nativeInputModeWidgetMarginHorizontal)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NonCollapsingFrameLayout.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NonCollapsingFrameLayout.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+
+class NonCollapsingFrameLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val heightSpec = if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST) {
+            MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+        } else {
+            heightMeasureSpec
+        }
+        super.onMeasure(widthMeasureSpec, heightSpec)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -35,7 +35,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/inputModeUnifiedBack"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginStart="@dimen/inputScreenOmnibarCardMarginHorizontal">
+        app:layout_goneMarginStart="@dimen/nativeInputModeWidgetMarginHorizontal">
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/inputModeWidgetCard"

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -19,6 +19,7 @@
     <dimen name="inputScreenOmnibarCardExtendedMarginHorizontal">@dimen/omnibarCardMarginHorizontal</dimen>
     <dimen name="inputScreenOmnibarCardMarginHorizontal">4dp</dimen>
     <dimen name="inputScreenMarginHorizontal">0dp</dimen>
+    <dimen name="nativeInputModeWidgetMarginHorizontal">4dp</dimen>
     <dimen name="inputScreenAutocompleteListBottomSpace">64dp</dimen>
     <dimen name="inputScreenContentSeparatorHeight">0.5dp</dimen>
     <dimen name="contextualBottomSheetTopOffset">80dp</dimen>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1214156122159494?focus=true

### Description

- Handles landscape mode when the native input is visible

### Steps to test this PR

_With native input enabled_
- [ ] Rotate to landscape
- [ ] Focus the input
- [ ] Verify that the native input shows correctly
- [ ] Rotate to portrait
- [ ] Verify that the input resizes correctly
- [ ] Rotate back to landscape
- [ ] Submit a chat
- [ ] Focus the input in Duck.ai
- [ ] Verify that the toolbar is hidden
- [ ] Submit a chat/unfocus the keyboard
- [ ] Verify that the toolbar is shown

### UI changes
| Browser  | Duck.ai |
| ------ | ----- |
<img width="2856" height="1280" alt="Screenshot_20260528_221658" src="https://github.com/user-attachments/assets/37dcd3a2-d997-4a88-8733-48337daa7fd3" />|<img width="2856" height="1280" alt="Screenshot_20260528_221604" src="https://github.com/user-attachments/assets/824e4b99-e852-4744-8b23-85455f657a41" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only keyboard, orientation, and layout changes in native input/Duck.ai with no auth, data, or network impact.
> 
> **Overview**
> Improves **native input / Duck.ai** behavior in **landscape**, especially when the keyboard is open.
> 
> **`NativeInputManager`** now treats Duck.ai mode differently from split/search: in landscape, showing the keyboard **hides the omnibar** and records that state so dismissal can **restore** the toolbar (with background hidden) instead of leaving it stuck hidden. Portrait Duck.ai keyboard handling is unchanged aside from that restore path. The flag resets when the widget is removed.
> 
> **Layout:** Top and bottom native input card roots use a new **`NonCollapsingFrameLayout`** that remeasures **AT_MOST** height as **UNSPECIFIED**, avoiding the widget collapsing when vertical space is tight in landscape. Native tab styling sets **`tabMaxWidth` to 0dp** so Search/Duck.ai tabs can share width evenly on narrow screens. Horizontal margins for the native switch widget use a dedicated **`nativeInputModeWidgetMarginHorizontal`** dimen (same 4dp value, clearer naming).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed97ba58056b73e2180d63c24c065bc4ecb9c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->