### PR TITLE
resolve remaining E2E tests conflicts for onboarding brand design update

### DIFF
--- a/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
+++ b/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
@@ -23,6 +23,6 @@ tags:
       - assertVisible:
           text: ".*browsing activity with the fire button.*"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - assertNotVisible:
           text: ".*browsing activity with the Fire Button.*"

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -12,9 +12,9 @@ tags:
           clearState: true
       - runFlow: ../shared/pre_onboarding.yaml
       - assertVisible:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|brandDesignDismissButton"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|brandDesignDismissButton"
       - assertVisible:
           id: ddgLogo
       - inputText: "https://www.search-company.site/#ad-id-14"
@@ -22,9 +22,9 @@ tags:
       - assertVisible:
           text: ".*As you tap and scroll, I'll block pesky trackers..*"
       - assertVisible:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - assertNotVisible:
           text: ".*As you tap and scroll, I'll block pesky trackers..*"
       - assertVisible:
@@ -34,9 +34,9 @@ tags:
       - assertVisible:
           text: ".*was trying to track you here. I blocked them!.*"
       - assertVisible:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - assertNotVisible:
           text: ".*was trying to track you here. I blocked them!.*"
       - assertVisible:
@@ -44,13 +44,13 @@ tags:
       - tapOn:
           text: "Publisher site"
       - assertVisible:
-          text: ".*Remember: every time you browse with me a creepy ad loses its wings..*"
+          text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - assertVisible:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
       - assertNotVisible:
-          text: ".*Remember: every time you browse with me a creepy ad loses its wings..*"
+          text: ".*Remember: every time you browse with me a creepy ad loses its.wings..*"
       - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
       - assertVisible:

--- a/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
@@ -12,8 +12,8 @@ tags:
           clearState: true
       - runFlow: ../shared/pre_onboarding.yaml
       - assertVisible:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|brandDesignDismissButton"
       - tapOn:
-          id: daxDialogDismissButton
+          id: "daxDialogDismissButton|brandDesignDismissButton"
       - assertVisible:
           id: ddgLogo


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215224683059972?focus=true

### Description
Resolves remaining E2E tests conflicts for onboarding brand design update.

### Steps to test this PR
QA optional, verified locally via:
```bash
maestro test .maestro/onboarding/
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes with no production code impact.
> 
> **Overview**
> Updates **Maestro** onboarding and fire-button flows so dismiss taps and visibility checks work with the new onboarding brand design.
> 
> Dismiss controls now target **`daxDialogDismissButton|brandDesignDismissButton`** on the initial dialog and **`daxDialogDismissButton|contextualBrandDesignDismissButton`** on later contextual dialogs, so tests pass whether the old or new dismiss control is shown.
> 
> The “creepy ad loses its wings” copy assertion uses a looser regex (**`its.wings`**) to match possible spacing or line-break changes in the updated UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b36af157d1b1c0f8dae93b8aa463a48e8bffea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->