### PR TITLE
Redirect to noai when AI is disabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
 import com.duckduckgo.app.autocomplete.impl.AutoCompletePixelNames
+import com.duckduckgo.app.browser.DuckDuckGoSerpHostProvider
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -46,7 +47,6 @@ import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.AppUrl
-import com.duckduckgo.common.utils.AppUrl.Url
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UrlScheme
 import com.duckduckgo.common.utils.baseHost
@@ -106,6 +106,7 @@ class AutoCompleteApi constructor(
     private val pixel: Pixel,
     private val deviceAppLookup: DeviceAppLookup,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val serpHostProvider: DuckDuckGoSerpHostProvider,
     private val config: AutoComplete.Config,
 ) : AutoComplete {
 
@@ -484,7 +485,7 @@ class AutoCompleteApi constructor(
                         Uri.Builder()
                             .scheme(UrlScheme.https)
                             .appendQueryParameter(AppUrl.ParamKey.QUERY, query)
-                            .authority(Url.HOST)
+                            .authority(serpHostProvider.searchHost())
                             .build()
 
                     suggestions.firstOrNull()?.let { suggestion ->

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoCompleteFactoryImpl.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.autocomplete.api
 
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
+import com.duckduckgo.app.browser.DuckDuckGoSerpHostProvider
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.DeviceAppLookup
@@ -48,6 +49,7 @@ class AutoCompleteFactoryImpl @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val pixel: Pixel,
     private val deviceAppLookup: DeviceAppLookup,
+    private val serpHostProvider: DuckDuckGoSerpHostProvider,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
 ) : AutoCompleteFactory {
 
@@ -66,6 +68,7 @@ class AutoCompleteFactoryImpl @Inject constructor(
             pixel = pixel,
             deviceAppLookup = deviceAppLookup,
             coroutineScope = coroutineScope,
+            serpHostProvider = serpHostProvider,
             config = config,
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -41,6 +41,7 @@ class DuckDuckGoRequestRewriter(
     private val duckChat: DuckChat,
     private val androidConfigFeatures: AndroidBrowserConfigFeature,
     private val serpSettingsFeature: SerpSettingsFeature,
+    private val serpHostProvider: DuckDuckGoSerpHostProvider,
 ) : RequestRewriter {
 
     private val hideDuckAiSerpKillSwitch by lazy { androidConfigFeatures.hideDuckAiInSerpKillSwitch().isEnabled() }
@@ -84,7 +85,7 @@ class DuckDuckGoRequestRewriter(
         builder.appendQueryParameter(ParamKey.HIDE_SERP, ParamValue.HIDE_SERP)
         if (!serpSettingsFeature.storeSerpSettings().isEnabled()) {
             // Once serpSettingsSync feature is permanently enabled this can be removed.
-            if (!duckChat.isEnabled() && hideDuckAiSerpKillSwitch) {
+            if (!duckChat.isEnabled() && hideDuckAiSerpKillSwitch && !serpHostProvider.shouldUseNoAiHost()) {
                 builder.appendQueryParameter(ParamKey.HIDE_DUCK_AI, ParamValue.HIDE_DUCK_AI)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoSerpHostProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoSerpHostProvider.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.utils.AppUrl
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Decides which DuckDuckGo host a search query should be sent to.
+ *
+ * When the [AndroidBrowserConfigFeature.noAiSerpHost] flag is enabled and Duck.ai is disabled,
+ * queries are routed to [AppUrl.Url.NO_AI_HOST] so the server can serve an AI-free SERP.
+ */
+interface DuckDuckGoSerpHostProvider {
+    /** `true` when the noAiSerpHost flag is enabled AND Duck.ai is disabled. */
+    fun shouldUseNoAiHost(): Boolean
+
+    /** [AppUrl.Url.NO_AI_HOST] when [shouldUseNoAiHost], else [AppUrl.Url.HOST]. */
+    fun searchHost(): String
+}
+
+@ContributesBinding(AppScope::class)
+class RealDuckDuckGoSerpHostProvider @Inject constructor(
+    private val duckChat: DuckChat,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : DuckDuckGoSerpHostProvider {
+
+    override fun shouldUseNoAiHost(): Boolean =
+        androidBrowserConfigFeature.noAiSerpHost().isEnabled() && !duckChat.isEnabled()
+
+    override fun searchHost(): String =
+        if (shouldUseNoAiHost()) AppUrl.Url.NO_AI_HOST else AppUrl.Url.HOST
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -129,6 +129,7 @@ class BrowserModule {
         duckChat: DuckChat,
         androidBrowserConfigFeature: AndroidBrowserConfigFeature,
         serpSettingsFeature: SerpSettingsFeature,
+        serpHostProvider: DuckDuckGoSerpHostProvider,
     ): RequestRewriter {
         return DuckDuckGoRequestRewriter(
             urlDetector,
@@ -138,6 +139,7 @@ class BrowserModule {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            serpHostProvider,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.app.browser.omnibar
 
 import android.net.Uri
 import android.webkit.URLUtil
+import com.duckduckgo.app.browser.DuckDuckGoSerpHostProvider
 import com.duckduckgo.app.browser.RequestRewriter
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.browser.UriString.Companion.extractUrl
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.AppUrl
-import com.duckduckgo.common.utils.AppUrl.Url
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.common.utils.withScheme
@@ -48,6 +48,7 @@ class QueryUrlConverter @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val queryUrlPredictor: QueryUrlPredictor,
+    private val serpHostProvider: DuckDuckGoSerpHostProvider,
 ) : OmnibarEntryConverter, PrivacyConfigCallbackPlugin {
 
     @Volatile
@@ -109,7 +110,7 @@ class QueryUrlConverter @Inject constructor(
         val uriBuilder = Uri.Builder()
             .scheme(https)
             .appendQueryParameter(AppUrl.ParamKey.QUERY, searchQuery)
-            .authority(Url.HOST)
+            .authority(serpHostProvider.searchHost())
 
         if (vertical != null && majorVerticals.contains(vertical)) {
             uriBuilder.appendQueryParameter(AppUrl.ParamKey.VERTICAL_REWRITE, vertical)

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -191,6 +191,13 @@ interface AndroidBrowserConfigFeature {
     fun hideDuckAiInSerpKillSwitch(): Toggle
 
     /**
+     * Controls whether search queries are routed to noai.duckduckgo.com when Duck.ai is disabled.
+     * If the remote feature is not present defaults to internal (always-on for internal builds during rollout).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun noAiSerpHost(): Toggle
+
+    /**
      * Kill switch for intent resolution validation in SpecialUrlDetector
      * @return `true` when the remote config has the global "validateIntentResolution" androidBrowserConfig
      * sub-feature flag enabled

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -17,11 +17,13 @@
 package com.duckduckgo.app.autocomplete.api
 
 import android.content.Intent
+import android.net.Uri
 import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.autocomplete.AutocompleteTabsFeature
 import com.duckduckgo.app.autocomplete.impl.AutoCompletePixelNames
+import com.duckduckgo.app.browser.DuckDuckGoSerpHostProvider
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.systemsearch.DeviceApp
@@ -67,9 +69,13 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
@@ -112,6 +118,10 @@ class AutoCompleteApiTest {
 
     @Mock
     private lateinit var mockHistory: NavigationHistory
+
+    private val mockSerpHostProvider: DuckDuckGoSerpHostProvider = mock {
+        on { searchHost() } doReturn "duckduckgo.com"
+    }
 
     @Mock
     private lateinit var mockPixel: Pixel
@@ -562,6 +572,35 @@ class AutoCompleteApiTest {
             ),
             value.suggestions,
         )
+    }
+
+    @Test
+    fun whenSerpHostProviderReturnsNoAiHostThenVisitedSerpUrlScoredWithThatHost() = runTest {
+        whenever(mockSerpHostProvider.searchHost()).thenReturn("noai.duckduckgo.com")
+        val mockScorer: AutoCompleteScorer = mock()
+        whenever(mockScorer.score(anyOrNull(), any(), any(), any(), anyOrNull())).thenReturn(100)
+        whenever(mockAutoCompleteService.autoComplete("query")).thenReturn(emptyList())
+        whenever(mockNavigationHistory.getHistory()).thenReturn(
+            flowOf(
+                listOf(
+                    VisitedSERP(
+                        "https://duckduckgo.com?q=query".toUri(),
+                        "title",
+                        "query",
+                        visits = listOf(LocalDateTime.now(), LocalDateTime.now()),
+                    ),
+                ),
+            ),
+        )
+        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(listOf()))
+        whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(flowOf(listOf()))
+
+        val testee = createTestee(scorer = mockScorer)
+        testee.autoComplete("query").first()
+
+        val urlCaptor = argumentCaptor<Uri>()
+        verify(mockScorer, times(1)).score(anyOrNull(), urlCaptor.capture(), any(), any(), anyOrNull())
+        assertEquals("noai.duckduckgo.com", urlCaptor.firstValue.host)
     }
 
     @Test
@@ -2075,12 +2114,15 @@ class AutoCompleteApiTest {
         ),
     )
 
-    private fun createTestee(config: AutoComplete.Config = AutoComplete.Config()): AutoCompleteApi {
+    private fun createTestee(
+        config: AutoComplete.Config = AutoComplete.Config(),
+        scorer: AutoCompleteScorer = RealAutoCompleteScorer(),
+    ): AutoCompleteApi {
         return AutoCompleteApi(
             mockAutoCompleteService,
             mockSavedSitesRepository,
             mockNavigationHistory,
-            RealAutoCompleteScorer(),
+            scorer,
             mockTabRepositoryProvider,
             mockBrowserModeStateHolder,
             mockAutocompleteTabsFeature,
@@ -2090,6 +2132,7 @@ class AutoCompleteApiTest {
             mockPixel,
             mockDeviceAppLookup,
             coroutineTestRule.testScope,
+            mockSerpHostProvider,
             config,
         )
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -737,6 +737,7 @@ class BrowserTabViewModelTest {
                     mockPixel,
                     mockDeviceAppLookup,
                     coroutineRule.testScope,
+                    mock<DuckDuckGoSerpHostProvider> { on { searchHost() } doReturn "duckduckgo.com" },
                     AutoComplete.Config(),
                 )
             val fireproofWebsiteRepositoryImpl =

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -60,6 +60,7 @@ class DuckDuckGoRequestRewriterTest {
         whenever(duckChat.isEnabled()).thenReturn(true)
 
         androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
 
         testee = DuckDuckGoRequestRewriter(
             DuckDuckGoUrlDetectorImpl(),
@@ -69,6 +70,7 @@ class DuckDuckGoRequestRewriterTest {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            RealDuckDuckGoSerpHostProvider(duckChat, androidBrowserConfigFeature),
         )
         builder = Uri.Builder()
     }
@@ -194,5 +196,17 @@ class DuckDuckGoRequestRewriterTest {
     fun whenShouldRewriteRequestAndUrlIsDuckDuckGoEmailThenReturnFalse() {
         val uri = "http://duckduckgo.com/email".toUri()
         assertFalse(testee.shouldRewriteRequest(uri))
+    }
+
+    @Test
+    fun whenNoAiHostActiveThenHideDuckAiParamNotAdded() {
+        whenever(duckChat.isEnabled()).thenReturn(false)
+        androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+
+        testee.addCustomQueryParams(builder)
+
+        val uri = builder.build()
+        assertFalse(uri.queryParameterNames.contains(ParamKey.HIDE_DUCK_AI))
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -491,6 +491,57 @@ class QueryUrlConverterTest {
         assertDuckDuckGoSearchQuery("Visit%20example.com%20or%20test.com%20for%20info", result)
     }
 
+    @Test
+    fun `when flag enabled and ai disabled then search query uses noai host`() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+        whenever(duckChat.isEnabled()).thenReturn(false)
+
+        val result = testee.convertQueryToUrl("foo", queryOrigin = QueryOrigin.FromUser)
+
+        assertEquals("noai.duckduckgo.com", Uri.parse(result).host)
+    }
+
+    @Test
+    fun `when flag enabled and ai enabled then search query uses default host`() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+        whenever(duckChat.isEnabled()).thenReturn(true)
+
+        val result = testee.convertQueryToUrl("foo", queryOrigin = QueryOrigin.FromUser)
+
+        assertEquals("duckduckgo.com", Uri.parse(result).host)
+    }
+
+    @Test
+    fun `when flag disabled and ai disabled then search query uses default host`() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
+        whenever(duckChat.isEnabled()).thenReturn(false)
+
+        val result = testee.convertQueryToUrl("foo", queryOrigin = QueryOrigin.FromUser)
+
+        assertEquals("duckduckgo.com", Uri.parse(result).host)
+    }
+
+    @Test
+    fun `when flag disabled and ai enabled then search query uses default host`() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
+        whenever(duckChat.isEnabled()).thenReturn(true)
+
+        val result = testee.convertQueryToUrl("foo", queryOrigin = QueryOrigin.FromUser)
+
+        assertEquals("duckduckgo.com", Uri.parse(result).host)
+    }
+
+    @Test
+    fun `when flag enabled and ai disabled and input is a url then host is not rewritten`() {
+        // Guard: the noai host applies only to generated search queries, never to a typed URL.
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+        whenever(duckChat.isEnabled()).thenReturn(false)
+
+        val result = testee.convertQueryToUrl("http://example.com", queryOrigin = QueryOrigin.FromUser)
+
+        assertEquals("http://example.com", result)
+    }
+
     private fun createTestee(useUrlPredictorEnabled: Boolean): QueryUrlConverter {
         androidBrowserConfigFeature.useUrlPredictor().setRawStoredState(State(useUrlPredictorEnabled))
         val converter = QueryUrlConverter(
@@ -499,6 +550,7 @@ class QueryUrlConverterTest {
             coroutineTestRule.testScope,
             coroutineTestRule.testDispatcherProvider,
             queryUrlPredictor,
+            RealDuckDuckGoSerpHostProvider(duckChat, androidBrowserConfigFeature),
         )
         return converter
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -70,6 +70,7 @@ class QueryUrlConverterTest {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
+            RealDuckDuckGoSerpHostProvider(duckChat, androidBrowserConfigFeature),
         )
     private val testee: QueryUrlConverter = createTestee(useUrlPredictorEnabled = false)
 
@@ -79,6 +80,7 @@ class QueryUrlConverterTest {
         whenever(duckChat.isEnabled()).thenReturn(true)
         whenever(queryUrlPredictor.isReady()).thenReturn(true)
         androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/RealDuckDuckGoSerpHostProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/RealDuckDuckGoSerpHostProviderTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.utils.AppUrl
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+@SuppressLint("DenyListedApi") // fake toggle store
+class RealDuckDuckGoSerpHostProviderTest {
+
+    private val duckChat: DuckChat = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature =
+        FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private lateinit var testee: DuckDuckGoSerpHostProvider
+
+    @Before
+    fun before() {
+        testee = RealDuckDuckGoSerpHostProvider(duckChat, androidBrowserConfigFeature)
+    }
+
+    @Test
+    fun whenFlagEnabledAndAiDisabledThenUseNoAiHost() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+        whenever(duckChat.isEnabled()).thenReturn(false)
+
+        assertTrue(testee.shouldUseNoAiHost())
+        assertEquals(AppUrl.Url.NO_AI_HOST, testee.searchHost())
+    }
+
+    @Test
+    fun whenFlagEnabledAndAiEnabledThenUseDefaultHost() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(true))
+        whenever(duckChat.isEnabled()).thenReturn(true)
+
+        assertFalse(testee.shouldUseNoAiHost())
+        assertEquals(AppUrl.Url.HOST, testee.searchHost())
+    }
+
+    @Test
+    fun whenFlagDisabledAndAiDisabledThenUseDefaultHost() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
+        whenever(duckChat.isEnabled()).thenReturn(false)
+
+        assertFalse(testee.shouldUseNoAiHost())
+        assertEquals(AppUrl.Url.HOST, testee.searchHost())
+    }
+
+    @Test
+    fun whenFlagDisabledAndAiEnabledThenUseDefaultHost() {
+        androidBrowserConfigFeature.noAiSerpHost().setRawStoredState(State(false))
+        whenever(duckChat.isEnabled()).thenReturn(true)
+
+        assertFalse(testee.shouldUseNoAiHost())
+        assertEquals(AppUrl.Url.HOST, testee.searchHost())
+    }
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -20,6 +20,7 @@ class AppUrl {
 
     object Url {
         const val HOST = "duckduckgo.com"
+        const val NO_AI_HOST = "noai.$HOST"
         const val API = "https://$HOST"
         const val HOME = "https://$HOST"
         const val COOKIES = "https://$HOST"


### PR DESCRIPTION
  Task/Issue URL: https://app.asana.com/1/137249556945/task/1215234100141222?focus=true
     
  ### Description
     
  When a user performs a search while **Duck.ai is disabled**, route the query to
  `noai.duckduckgo.com` instead of `duckduckgo.com` so the server can serve an AI-free
  SERP. Gated behind a new remote feature flag.
  
  Rather than change `AppUrl.Url.HOST` (referenced in ~20 places — cookies, URL
  classification, JS-messaging allowlists, sync, surveys), the host swap is scoped to
  **search-query URL construction only**. A new `DuckDuckGoSerpHostProvider` owns the
  decision (`noAiSerpHost` flag enabled **and** `!duckChat.isEnabled()`) and the host
  string, and is consulted at the query-building sites. Because `DuckDuckGoUrlDetector`
  matches on the registrable domain (`topPrivateDomain()`), `noai.duckduckgo.com` is
  still recognised as a DDG URL everywhere downstream, so the other `HOST` usages are
  untouched.
  
  Details:
  - New flag `androidBrowserConfig.noAiSerpHost` (default `INTERNAL` during rollout).
  - New `AppUrl.Url.NO_AI_HOST = "noai.duckduckgo.com"`.
  - `DuckDuckGoSerpHostProvider` reads the flag + Duck.ai state fresh per query (no caching),
    so it reflects the user toggling AI mid-session.
  - Wired into `QueryUrlConverter` (omnibar / navigated queries) and the `AutoComplete`
    visited-SERP suggestion URL.
  - When the noai host is used, the existing `kbg=-1` (`HIDE_DUCK_AI`) param is no longer
    appended in `DuckDuckGoRequestRewriter` — the host itself signals AI-off, so the two
    are mutually exclusive.
  
  ### Steps to test this PR
  
  Use an **internal** build (`./gradlew installInternalDebug`) — the flag defaults on there.
  
  _Queries route to noai when AI is disabled_
  - [ ] Turn Duck.ai off (Duck.ai settings).
  - [ ] Search from the address bar; confirm the SERP loads from `noai.duckduckgo.com`
        (check the loaded URL via proxy/web inspector) and that `kbg=-1` is NOT in the query.
  - [ ] Tap a previous search suggestion in autocomplete → also routes to `noai.duckduckgo.com`.
  
  _Queries stay on duckduckgo.com when AI is enabled_
  - [ ] Re-enable Duck.ai; search again → SERP loads from `duckduckgo.com`.
  
  _Flag off = unchanged behaviour_
  - [ ] Disable the `noAiSerpHost` flag (feature-flag inventory / dev settings). With Duck.ai
        off, searches go to `duckduckgo.com` and `kbg=-1` is present, exactly as before.
  
  _Typed URLs unaffected_
  - [ ] With AI off + flag on, type a full URL (e.g. `example.com`) → navigates there unchanged
        (no host rewrite).
  
  ### UI changes
  No UI changes — the AI-free SERP is rendered server-side by the `noai` host.