### PR TITLE
fix text matcher on fire button E2E tests to work with non-breaking-spaces added in brand design

### DIFF
--- a/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
+++ b/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
@@ -17,7 +17,7 @@ tags:
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:
-          text: ".*keep browsing.*"
+          text: ".*keep.browsing.*"
       - tapOn:
           text: "got it"
       - assertVisible:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -17,7 +17,7 @@ tags:
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:
-          text: ".*keep browsing.*"
+          text: ".*keep.browsing.*"
       - tapOn:
           text: "got it"
       - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215239035977426?focus=true

### Description
Fixes text matcher on fire button E2E tests to work with non-breaking-spaces added in brand design

QA optional, tested locally with:
```
maestro test .maestro/fire_button
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only regex tweaks in two Maestro flows; no production or security impact.
> 
> **Overview**
> Updates **Maestro** fire-button onboarding E2E assertions so they still match onboarding copy after brand design introduced **non-breaking spaces** in UI text.
> 
> In `dimiss_fire_during_onboarding.yaml` and `fire_during_onboarding.yaml`, the `assertVisible` pattern for the “keep browsing” step changes from `.*keep browsing.*` to `.*keep.browsing.*`, so a single `.` matches any character (including NBSP) between “keep” and “browsing” instead of requiring a literal space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeefa2f0d367219788627ef9fbdead1576d30621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->