### PR TITLE
Add bulk download to chat history select mode

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -166,6 +166,8 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
             is ChatHistoryViewModel.NavigationEvent.ShowBulkDownloadComplete -> showBulkDownloadCompleteSnackbar(event.count)
             ChatHistoryViewModel.NavigationEvent.ShowExportError ->
                 Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_error, Snackbar.LENGTH_SHORT).show()
+            ChatHistoryViewModel.NavigationEvent.ShowBulkDownloadError ->
+                Snackbar.make(binding.root, R.string.duck_ai_chat_history_bulk_download_error, Snackbar.LENGTH_SHORT).show()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -236,7 +236,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
                 adapter.submitList(buildEntries(state, selectMode))
                 if (selectMode != null) {
                     applySelectModeToolbar(selectMode.selectedChatIds.size)
-                    setFireActionVisible(selectMode.selectedChatIds.isNotEmpty())
+                    setFireActionVisible(true)
                 } else {
                     applyDefaultToolbar()
                     // Fire-all wipes every chat including Pinned — show whenever any chat is present.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -163,6 +163,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         when (event) {
             is ChatHistoryViewModel.NavigationEvent.OpenRename -> openRenameScreen(event.chatId, event.currentTitle)
             is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete -> showDownloadCompleteSnackbar(event.fileName)
+            is ChatHistoryViewModel.NavigationEvent.ShowBulkDownloadComplete -> showBulkDownloadCompleteSnackbar(event.count)
             ChatHistoryViewModel.NavigationEvent.ShowExportError ->
                 Snackbar.make(binding.root, R.string.duck_ai_chat_history_download_error, Snackbar.LENGTH_SHORT).show()
         }
@@ -183,6 +184,15 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     private fun showDownloadCompleteSnackbar(fileName: String) {
         val message = getString(R.string.duck_ai_chat_history_download_complete, fileName)
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
+            .setAction(R.string.duck_ai_chat_history_download_view) {
+                globalActivityStarter.start(requireContext(), DownloadsScreens.DownloadsScreenNoParams)
+            }
+            .show()
+    }
+
+    private fun showBulkDownloadCompleteSnackbar(count: Int) {
+        val message = resources.getQuantityString(R.plurals.duck_ai_chat_history_bulk_download_complete, count, count)
         Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG)
             .setAction(R.string.duck_ai_chat_history_download_view) {
                 globalActivityStarter.start(requireContext(), DownloadsScreens.DownloadsScreenNoParams)
@@ -253,6 +263,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         binding.toolbar.setTitle(R.string.duck_ai_chat_history_title)
         binding.toolbar.menu.findItem(R.id.chat_history_action_new)?.isVisible = true
         binding.toolbar.menu.findItem(R.id.chat_history_action_search)?.isVisible = true
+        binding.toolbar.menu.findItem(R.id.chat_history_action_download_selected)?.isVisible = false
     }
 
     private fun applySelectModeToolbar(count: Int) {
@@ -263,6 +274,7 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         binding.toolbar.title = count.toString()
         binding.toolbar.menu.findItem(R.id.chat_history_action_new)?.isVisible = false
         binding.toolbar.menu.findItem(R.id.chat_history_action_search)?.isVisible = false
+        binding.toolbar.menu.findItem(R.id.chat_history_action_download_selected)?.isVisible = true
     }
 
     private fun buildEntries(
@@ -319,6 +331,10 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
         }
         R.id.chat_history_action_fire -> {
             viewModel.onFireIconClicked()
+            true
+        }
+        R.id.chat_history_action_download_selected -> {
+            viewModel.onDownloadSelectedRequested()
             true
         }
         else -> false

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryRepository.kt
@@ -35,6 +35,8 @@ import java.io.File
 import java.time.Instant
 import javax.inject.Inject
 
+data class ChatExportRequest(val chatId: String, val modelDisplay: ModelDisplay?)
+
 interface ChatHistoryRepository {
     fun observeChats(): Flow<List<ChatHistoryItem>>
 
@@ -43,6 +45,9 @@ interface ChatHistoryRepository {
     suspend fun renameChat(chatId: String, newTitle: String): Boolean
     suspend fun setPinned(chatId: String, pinned: Boolean)
     suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): File
+
+    /** Atomic: builds every payload before writing any, so a failure on any chat leaves no files behind. */
+    suspend fun exportChats(requests: List<ChatExportRequest>): List<File>
 }
 
 @ContributesBinding(AppScope::class)
@@ -87,24 +92,34 @@ class RealChatHistoryRepository @Inject constructor(
 
     override suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): File =
         withContext(dispatchers.io()) {
-            val chat = chatStore.getChatById(chatId)
-                ?: throw IllegalStateException("Chat $chatId not found")
-            val rawJson = chatStore.getChatContent(chatId)
-                ?: throw IllegalStateException("Chat $chatId content not found")
-            val result = chatExporter.export(rawJson, chat.toChatType(), chat.fileRefs, modelDisplay)
-            val payload = when (result) {
-                is ExportResult.Text -> ExportPayload.Text(result.content)
-                is ExportResult.Zip -> ExportPayload.Zip(
-                    content = result.content,
-                    images = result.imageFileRefs.mapIndexed { index, uuid ->
-                        val fileRef = chatStore.readFileRef(uuid)
-                            ?: throw IllegalStateException("File $uuid missing for chat $chatId")
-                        ExportPayload.Zip.Image(name = "image-${index + 1}.jpeg", bytes = fileRef.bytes)
-                    },
-                )
-            }
-            chatExportWriter.write(payload)
+            chatExportWriter.write(buildPayload(chatId, modelDisplay))
         }
+
+    override suspend fun exportChats(requests: List<ChatExportRequest>): List<File> =
+        withContext(dispatchers.io()) {
+            // Build every payload up front so a missing chat/content/image aborts before any file is written.
+            val payloads = requests.map { buildPayload(it.chatId, it.modelDisplay) }
+            payloads.map { chatExportWriter.write(it) }
+        }
+
+    private suspend fun buildPayload(chatId: String, modelDisplay: ModelDisplay?): ExportPayload {
+        val chat = chatStore.getChatById(chatId)
+            ?: throw IllegalStateException("Chat $chatId not found")
+        val rawJson = chatStore.getChatContent(chatId)
+            ?: throw IllegalStateException("Chat $chatId content not found")
+        val result = chatExporter.export(rawJson, chat.toChatType(), chat.fileRefs, modelDisplay)
+        return when (result) {
+            is ExportResult.Text -> ExportPayload.Text(result.content)
+            is ExportResult.Zip -> ExportPayload.Zip(
+                content = result.content,
+                images = result.imageFileRefs.mapIndexed { index, uuid ->
+                    val fileRef = chatStore.readFileRef(uuid)
+                        ?: throw IllegalStateException("File $uuid missing for chat $chatId")
+                    ExportPayload.Zip.Image(name = "image-${index + 1}.jpeg", bytes = fileRef.bytes)
+                },
+            )
+        }
+    }
 
     private fun toChatHistoryItem(chat: DuckAiChat): ChatHistoryItem = ChatHistoryItem(
         chatId = chat.chatId,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -285,7 +285,8 @@ class ChatHistoryViewModel @Inject constructor(
         if (items.isEmpty()) return ChatHistoryUiState.Empty
         val (pinned, recent) = items.partition { it.pinned }
         val effectiveMode = when (val mode = controls.mode) {
-            is Mode.Selecting -> collapseEmpty(mode.selectedChatIds intersect items.mapTo(mutableSetOf()) { it.chatId })
+            // Keep Selecting even when empty — collapsing here would make onEnterSelectMode emit no state change.
+            is Mode.Selecting -> Mode.Selecting(mode.selectedChatIds intersect items.mapTo(mutableSetOf()) { it.chatId })
             Mode.Default -> Mode.Default
         }
         return Loaded(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -96,13 +96,16 @@ class ChatHistoryViewModel @Inject constructor(
     fun onChatRowLongClicked(chatId: String): Boolean {
         controls.update { c ->
             val nextMode = when (val mode = c.mode) {
-                is Mode.Selecting -> Mode.Selecting(toggle(mode.selectedChatIds, chatId))
+                is Mode.Selecting -> collapseEmpty(toggle(mode.selectedChatIds, chatId))
                 Mode.Default -> Mode.Selecting(setOf(chatId))
             }
             c.copy(mode = nextMode)
         }
         return true
     }
+
+    private fun collapseEmpty(ids: Set<String>): Mode =
+        if (ids.isEmpty()) Mode.Default else Mode.Selecting(ids)
 
     fun onOpenDuckAiClicked() {
         duckChat.openDuckChat()
@@ -221,7 +224,7 @@ class ChatHistoryViewModel @Inject constructor(
     fun onSelectionToggled(chatId: String) {
         controls.update { c ->
             val mode = c.mode as? Mode.Selecting ?: return@update c
-            c.copy(mode = Mode.Selecting(toggle(mode.selectedChatIds, chatId)))
+            c.copy(mode = collapseEmpty(toggle(mode.selectedChatIds, chatId)))
         }
     }
 
@@ -232,7 +235,7 @@ class ChatHistoryViewModel @Inject constructor(
             // Filter to live ids — selection can lag deletes and skew the comparison.
             val effectiveSelected = mode.selectedChatIds intersect latestItems.mapTo(mutableSetOf()) { it.chatId }
             val next = if (effectiveSelected == visibleIds) emptySet() else visibleIds
-            c.copy(mode = Mode.Selecting(next))
+            c.copy(mode = collapseEmpty(next))
         }
     }
 
@@ -283,7 +286,7 @@ class ChatHistoryViewModel @Inject constructor(
         if (items.isEmpty()) return ChatHistoryUiState.Empty
         val (pinned, recent) = items.partition { it.pinned }
         val effectiveMode = when (val mode = controls.mode) {
-            is Mode.Selecting -> Mode.Selecting(mode.selectedChatIds intersect items.mapTo(mutableSetOf()) { it.chatId })
+            is Mode.Selecting -> collapseEmpty(mode.selectedChatIds intersect items.mapTo(mutableSetOf()) { it.chatId })
             Mode.Default -> Mode.Default
         }
         return Loaded(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -183,18 +183,17 @@ class ChatHistoryViewModel @Inject constructor(
         val selected = (controls.value.mode as? Mode.Selecting)?.selectedChatIds.orEmpty()
         if (selected.isEmpty()) return
         viewModelScope.launch {
-            val results = selected.map { chatId ->
+            val requests = selected.map { chatId ->
                 val modelId = latestItems.firstOrNull { it.chatId == chatId }?.model
                 val modelDisplay = modelId
                     ?.let { id -> duckAiModelManager.modelState.value.models.firstOrNull { it.id == id } }
                     ?.toModelDisplay()
-                runCatching { chatHistoryRepository.exportChat(chatId, modelDisplay) }
+                ChatExportRequest(chatId, modelDisplay)
             }
-            if (results.any { it.isFailure }) {
-                navigationChannel.trySend(NavigationEvent.ShowExportError)
-            } else {
-                navigationChannel.trySend(NavigationEvent.ShowBulkDownloadComplete(count = results.size))
-            }
+            // Atomic: any failure writes no files, so we report a single bulk error rather than a misleading success.
+            runCatching { chatHistoryRepository.exportChats(requests) }
+                .onSuccess { files -> navigationChannel.trySend(NavigationEvent.ShowBulkDownloadComplete(count = files.size)) }
+                .onFailure { navigationChannel.trySend(NavigationEvent.ShowBulkDownloadError) }
             controls.update { it.copy(mode = Mode.Default) }
         }
     }
@@ -328,6 +327,7 @@ class ChatHistoryViewModel @Inject constructor(
         data class ShowDownloadComplete(val fileName: String) : NavigationEvent
         data class ShowBulkDownloadComplete(val count: Int) : NavigationEvent
         data object ShowExportError : NavigationEvent
+        data object ShowBulkDownloadError : NavigationEvent
     }
 
     sealed interface MessageEvent {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -176,6 +176,26 @@ class ChatHistoryViewModel @Inject constructor(
         }
     }
 
+    fun onDownloadSelectedRequested() {
+        val selected = (controls.value.mode as? Mode.Selecting)?.selectedChatIds.orEmpty()
+        if (selected.isEmpty()) return
+        viewModelScope.launch {
+            val results = selected.map { chatId ->
+                val modelId = latestItems.firstOrNull { it.chatId == chatId }?.model
+                val modelDisplay = modelId
+                    ?.let { id -> duckAiModelManager.modelState.value.models.firstOrNull { it.id == id } }
+                    ?.toModelDisplay()
+                runCatching { chatHistoryRepository.exportChat(chatId, modelDisplay) }
+            }
+            if (results.any { it.isFailure }) {
+                navigationChannel.trySend(NavigationEvent.ShowExportError)
+            } else {
+                navigationChannel.trySend(NavigationEvent.ShowBulkDownloadComplete(count = results.size))
+            }
+            controls.update { it.copy(mode = Mode.Default) }
+        }
+    }
+
     private fun dispatchSelectedClear(chatIds: Set<String>) {
         if (chatIds.isEmpty()) return
         if (!duckAiFeatureState.showClearDuckAIChatHistory.value) return
@@ -303,6 +323,7 @@ class ChatHistoryViewModel @Inject constructor(
     sealed interface NavigationEvent {
         data class OpenRename(val chatId: String, val currentTitle: String) : NavigationEvent
         data class ShowDownloadComplete(val fileName: String) : NavigationEvent
+        data class ShowBulkDownloadComplete(val count: Int) : NavigationEvent
         data object ShowExportError : NavigationEvent
     }
 

--- a/duckchat/duckchat-impl/src/main/res/menu/menu_chat_history_default.xml
+++ b/duckchat/duckchat-impl/src/main/res/menu/menu_chat_history_default.xml
@@ -24,6 +24,13 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/chat_history_action_download_selected"
+        android:icon="@drawable/ic_downloads_24"
+        android:title="@string/duck_ai_chat_history_action_download_selected_content_description"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/chat_history_action_search"
         android:icon="@drawable/ic_find_search_24"
         android:title="@string/duck_ai_chat_history_coming_soon"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -115,6 +115,7 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \'My Chat.txt\').">Download complete for %1$s</string>
     <string name="duck_ai_chat_history_download_view">Show</string>
     <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
+    <string name="duck_ai_chat_history_bulk_download_error">Couldn\'t export chats</string>
 
     <!-- Duck.ai header -->
     <string name="duckChatPlusButtonContentDescription">Open Duck.ai menu</string>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -94,6 +94,11 @@
     <string name="duck_ai_chat_history_search_clear_content_description">Clear search</string>
     <string name="duck_ai_chat_history_action_fire_content_description">Delete chats</string>
     <string name="duck_ai_chat_history_action_new">New</string>
+    <string name="duck_ai_chat_history_action_download_selected_content_description">Download chats</string>
+    <plurals name="duck_ai_chat_history_bulk_download_complete">
+        <item quantity="one" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chat</item>
+        <item quantity="other" instruction="%1$d is the number of chats downloaded">Download complete for %1$d chats</item>
+    </plurals>
     <string name="duck_ai_chat_history_select_all">Select all</string>
     <string name="duck_ai_chat_history_unselect_all">Unselect all</string>
     <string name="duck_ai_chat_history_row_selected_content_description">Selected</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryRepositoryTest.kt
@@ -33,9 +33,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.File
 
 class ChatHistoryRepositoryTest {
 
@@ -225,6 +229,34 @@ class ChatHistoryRepositoryTest {
         verify(syncEngine).triggerSync(SyncEngine.SyncTrigger.DATA_CHANGE)
     }
 
+    @Test
+    fun `exportChats writes a file per chat and returns them`() = runTest {
+        whenever(chatStore.getChatById("a")).thenReturn(chat(chatId = "a"))
+        whenever(chatStore.getChatById("b")).thenReturn(chat(chatId = "b"))
+        whenever(chatStore.getChatContent("a")).thenReturn(EMPTY_CHAT_JSON)
+        whenever(chatStore.getChatContent("b")).thenReturn(EMPTY_CHAT_JSON)
+        whenever(chatExportWriter.write(any())).thenReturn(File("/tmp/export.txt"))
+
+        val files = repository.exportChats(listOf(ChatExportRequest("a", null), ChatExportRequest("b", null)))
+
+        assertEquals(2, files.size)
+        verify(chatExportWriter, times(2)).write(any())
+    }
+
+    @Test
+    fun `exportChats writes no files when any chat cannot be built`() = runTest {
+        whenever(chatStore.getChatById("a")).thenReturn(chat(chatId = "a"))
+        whenever(chatStore.getChatContent("a")).thenReturn(EMPTY_CHAT_JSON)
+        whenever(chatStore.getChatById("missing")).thenReturn(null)
+
+        val result = runCatching {
+            repository.exportChats(listOf(ChatExportRequest("a", null), ChatExportRequest("missing", null)))
+        }
+
+        assertTrue(result.isFailure)
+        verify(chatExportWriter, never()).write(any())
+    }
+
     private fun chat(
         chatId: String,
         title: String = "Title",
@@ -247,5 +279,6 @@ class ChatHistoryRepositoryTest {
 
     private companion object {
         const val FALLBACK = "Untitled chat"
+        const val EMPTY_CHAT_JSON = """{"model":"gpt-5-mini","messages":[]}"""
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -529,7 +529,7 @@ class ChatHistoryViewModelTest {
     }
 
     @Test
-    fun `onSelectionToggled adds and removes ids and empty selection stays in select mode`() = runTest {
+    fun `onSelectionToggled deselecting the last selected row exits to Default`() = runTest {
         source.value = listOf(item("a"), item("b"))
 
         viewModel.uiState.test {
@@ -543,8 +543,7 @@ class ChatHistoryViewModelTest {
 
             viewModel.onSelectionToggled("a")
             val afterRemove = awaitItem() as Loaded
-            val mode = afterRemove.mode as ChatHistoryUiState.Mode.Selecting
-            assertEquals(emptySet<String>(), mode.selectedChatIds)
+            assertEquals(ChatHistoryUiState.Mode.Default, afterRemove.mode)
         }
     }
 
@@ -566,7 +565,7 @@ class ChatHistoryViewModelTest {
     }
 
     @Test
-    fun `onSelectAllToggled with everything selected clears the selection but stays in select mode`() = runTest {
+    fun `onSelectAllToggled with everything selected exits to Default`() = runTest {
         source.value = listOf(item("a"), item("b"))
 
         viewModel.uiState.test {
@@ -579,8 +578,7 @@ class ChatHistoryViewModelTest {
             viewModel.onSelectAllToggled()
 
             val cleared = awaitItem() as Loaded
-            val mode = cleared.mode as ChatHistoryUiState.Mode.Selecting
-            assertEquals(emptySet<String>(), mode.selectedChatIds)
+            assertEquals(ChatHistoryUiState.Mode.Default, cleared.mode)
         }
     }
 
@@ -606,7 +604,7 @@ class ChatHistoryViewModelTest {
     }
 
     @Test
-    fun `onSelectAllToggled with a stale selection equal to visible still toggles off`() = runTest {
+    fun `onSelectAllToggled with a stale selection equal to visible toggles off and exits to Default`() = runTest {
         source.value = listOf(item("a"), item("b"), item("c"))
 
         viewModel.uiState.test {
@@ -622,8 +620,7 @@ class ChatHistoryViewModelTest {
             viewModel.onSelectAllToggled()
 
             val cleared = awaitItem() as Loaded
-            val mode = cleared.mode as ChatHistoryUiState.Mode.Selecting
-            assertEquals(emptySet<String>(), mode.selectedChatIds)
+            assertEquals(ChatHistoryUiState.Mode.Default, cleared.mode)
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -1017,6 +1017,78 @@ class ChatHistoryViewModelTest {
         assertEquals(listOf("a" to false, "a" to true), repository.pinnedChats)
     }
 
+    @Test
+    fun `onChatRowLongClicked in select mode toggling off the only selected row exits to Default`() = runTest {
+        source.value = listOf(item("a"), item("b"))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onChatRowLongClicked("a")
+            val entered = awaitItem() as Loaded
+            assertEquals(setOf("a"), (entered.mode as ChatHistoryUiState.Mode.Selecting).selectedChatIds)
+
+            viewModel.onChatRowLongClicked("a")
+
+            val exited = awaitItem() as Loaded
+            assertEquals(ChatHistoryUiState.Mode.Default, exited.mode)
+        }
+    }
+
+    @Test
+    fun `onDownloadSelectedRequested with no selection is a no-op`() = coroutineRule.testScope.runTest {
+        viewModel.navigationEvents.test {
+            viewModel.onDownloadSelectedRequested()
+            expectNoEvents()
+        }
+        assertTrue(repository.exportedChats.isEmpty())
+    }
+
+    @Test
+    fun `onDownloadSelectedRequested emits ShowBulkDownloadError, saves no files, and exits select mode when any export fails`() = runTest {
+        source.value = listOf(item("a"), item("b"))
+        repository.exportError = IllegalStateException("boom")
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onChatRowLongClicked("a")
+            awaitItem()
+            viewModel.onSelectionToggled("b")
+            awaitItem()
+
+            viewModel.navigationEvents.test {
+                viewModel.onDownloadSelectedRequested()
+                assertEquals(ChatHistoryViewModel.NavigationEvent.ShowBulkDownloadError, awaitItem())
+            }
+
+            val final = awaitItem() as Loaded
+            assertEquals(ChatHistoryUiState.Mode.Default, final.mode)
+        }
+        // Atomic export: a single failure leaves nothing on disk.
+        assertTrue(repository.exportedChats.isEmpty())
+    }
+
+    @Test
+    fun `onDownloadSelectedRequested exports every selection, emits ShowBulkDownloadComplete with the count, and exits select mode`() = runTest {
+        source.value = listOf(item("a"), item("b"))
+
+        viewModel.uiState.test {
+            awaitInitialLoaded()
+            viewModel.onChatRowLongClicked("a")
+            awaitItem()
+            viewModel.onSelectionToggled("b")
+            awaitItem()
+
+            viewModel.navigationEvents.test {
+                viewModel.onDownloadSelectedRequested()
+                assertEquals(ChatHistoryViewModel.NavigationEvent.ShowBulkDownloadComplete(count = 2), awaitItem())
+            }
+
+            val final = awaitItem() as Loaded
+            assertEquals(ChatHistoryUiState.Mode.Default, final.mode)
+        }
+        assertEquals(setOf("a", "b"), repository.exportedChats.toSet())
+    }
+
     /**
      * `stateIn(WhileSubscribed)` does not guarantee subscribers observe the `Loading` initial
      * value — the upstream may emit before the StateFlow can replay it. Tolerate both orderings.
@@ -1103,6 +1175,14 @@ private class FakeChatHistoryRepository(
         lastExportModelDisplay = modelDisplay
         exportError?.let { throw it }
         return exportResult
+    }
+
+    override suspend fun exportChats(requests: List<ChatExportRequest>): List<java.io.File> {
+        // Atomic: a failure writes nothing, so nothing is recorded either.
+        exportError?.let { throw it }
+        requests.forEach { exportedChats += it.chatId }
+        lastExportModelDisplay = requests.lastOrNull()?.modelDisplay
+        return requests.map { exportResult }
     }
 }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/RenameChatViewModelTest.kt
@@ -77,6 +77,7 @@ private class RecordingRenameRepository : ChatHistoryRepository {
     override suspend fun deleteChat(chatId: String) = Unit
     override suspend fun deleteAllChats() = Unit
     override suspend fun exportChat(chatId: String, modelDisplay: ModelDisplay?): java.io.File = java.io.File("/tmp/noop.txt")
+    override suspend fun exportChats(requests: List<ChatExportRequest>): List<java.io.File> = requests.map { java.io.File("/tmp/noop.txt") }
 
     override suspend fun renameChat(chatId: String, newTitle: String): Boolean {
         errorToThrow?.let { throw it }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1215237686779717?focus=true
 
### Description

Adds bulk download support to the chat history screen's select mode per ship review feedback. A new download icon appears in the select-mode toolbar alongside Fire; tapping it exports every selected chat through the existing per-row export pipeline (text/voice → `.txt`, image-generation → `.zip`). On completion, a count-driven snackbar surfaces with the same `Show` action used by per-row downloads — it opens the Downloads screen. Select mode exits automatically once the bulk action completes.

### Steps to test this PR

> [!NOTE]
> Prerequisites:
> - [x] Install Internal Debug.
> - [ ] Have at least 2 chats in Duck.ai of mixed types if possible (text discussion + image-generation, or a voice chat).

_Happy path — bulk download_

- [ ] Open the chat history screen → long-press a row to enter select mode.
- [ ] Select 2 or more chats → confirm the toolbar shows **Download · Fire** (download to the left of fire) and that the count updates.
- [ ] Tap the Download icon → confirm a "Download complete for N chats" snackbar appears with a `Show` action.
- [ ] Tap `Show` → confirm the Downloads screen opens with the new files visible (one per chat).
- [ ] Confirm the screen automatically exits select mode after the bulk download finishes.

_Mixed chat types_

- [ ] In select mode, pick at least one text discussion and one image-generation chat (if available) → tap Download.
- [ ] In the Downloads screen, confirm one `.txt` file per text/voice chat and one `.zip` per image-generation chat — matching the per-row download behaviour.

_N = 1 in select mode_

- [ ] In select mode with only one chat selected, tap Download → confirm the snackbar uses the singular form ("Download complete for 1 chat").
- [ ] Confirm the file lands in the Downloads screen and that select mode exits.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/d9309b63-13e3-44be-810d-7782e9d7ed80" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/642bfba0-0a11-446d-96a0-6f86d8464204" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses the existing local export path with atomic all-or-nothing writes; no auth or sync changes, with solid unit test coverage.
> 
> **Overview**
> Adds **bulk download** in chat history **select mode**: a toolbar download action exports all selected chats via the same pipeline as per-row download (`.txt` / `.zip`), then shows a pluralized completion snackbar with **Show** → Downloads and **always leaves select mode** when the action finishes.
> 
> **Repository** gains atomic `exportChats`: every payload is built before any file is written, so one failure produces no partial exports. Single-chat export shares a `buildPayload` helper.
> 
> **Select-mode UX** tweaks: clearing the last selection (toggle, select-all off, long-press) **exits to Default** instead of an empty Selecting state; **Fire** stays visible in select mode even with zero selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924327f81bc97a6530d62e2a7d7491c81f094db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->