### PR TITLE
Android 16 compatibility: Fix FireActivity nested intent relaunch

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
@@ -42,15 +43,18 @@ class FireActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val intent = intent.getParcelableExtra<Intent>(KEY_RESTART_INTENTS)
-        startActivity(intent, fadeTransitionConfig())
+        // Reconstruct the restart Intent in this process from the primitive extras passed by triggerRestart.
+        val notifyDataCleared = intent.getBooleanExtra(KEY_NOTIFY_DATA_CLEARED, false)
+        val deletedTabCount = intent.getIntExtra(KEY_DELETED_TAB_COUNT, 0)
+        startActivity(getRestartIntent(this, notifyDataCleared, deletedTabCount), fadeTransitionConfig())
         overridePendingTransition(0, 0)
         finish()
         killProcess()
     }
 
     companion object {
-        private const val KEY_RESTART_INTENTS = "KEY_RESTART_INTENTS"
+        private const val KEY_NOTIFY_DATA_CLEARED = "KEY_NOTIFY_DATA_CLEARED"
+        private const val KEY_DELETED_TAB_COUNT = "KEY_DELETED_TAB_COUNT"
 
         fun triggerRestart(
             context: Context,
@@ -58,11 +62,7 @@ class FireActivity : AppCompatActivity() {
             enableTransitionAnimation: Boolean = true,
             deletedTabCount: Int = 0,
         ) {
-            val intent = Intent(context, FireActivity::class.java)
-            val nextIntent = getRestartIntent(context, notifyDataCleared, deletedTabCount)
-
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            intent.putExtra(KEY_RESTART_INTENTS, nextIntent)
+            val intent = fireActivityIntent(context, notifyDataCleared, deletedTabCount)
 
             val transitionAnimationConfig = if (enableTransitionAnimation) {
                 context.fadeTransitionConfig()
@@ -76,6 +76,25 @@ class FireActivity : AppCompatActivity() {
                 context.finish()
             }
             killProcess()
+        }
+
+        /**
+         * Builds the Intent that launches [FireActivity], carrying only primitive extras and never a
+         * nested Intent. [FireActivity] reconstructs the restart Intent itself, because forwarding a
+         * nested Intent unparceled from another Intent's extras trips Android 16's intent-redirection
+         * hardening (UnsafeIntentLaunchViolation).
+         */
+        @VisibleForTesting
+        internal fun fireActivityIntent(
+            context: Context,
+            notifyDataCleared: Boolean,
+            deletedTabCount: Int,
+        ): Intent {
+            return Intent(context, FireActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtra(KEY_NOTIFY_DATA_CLEARED, notifyDataCleared)
+                putExtra(KEY_DELETED_TAB_COUNT, deletedTabCount)
+            }
         }
 
         private fun getRestartIntent(

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.global
 
+import android.os.Build
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -176,6 +177,15 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
                     .penaltyDropBox()
                     .build(),
             )
+            if (Build.VERSION.SDK_INT >= 31) {
+                StrictMode.setVmPolicy(
+                    StrictMode.VmPolicy.Builder()
+                        .detectUnsafeIntentLaunch()
+                        .penaltyLog()
+                        .penaltyDeath()
+                        .build(),
+                )
+            }
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/fire/FireActivityTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/FireActivityTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FireActivityTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun whenFireActivityIntentBuiltThenNoExtraIsANestedIntent() {
+        // Android 16 intent-redirection hardening: FireActivity must never receive a nested Parcelable
+        // Intent in its extras, otherwise launching it trips UnsafeIntentLaunchViolation. Guard against
+        // a regression that re-introduces a forwarded Intent.
+        val intent = FireActivity.fireActivityIntent(context, notifyDataCleared = true, deletedTabCount = 3)
+
+        val extras = intent.extras
+        assertTrue("Expected primitive extras to be present", extras != null && !extras.isEmpty)
+        extras!!.keySet().forEach { key ->
+            @Suppress("DEPRECATION")
+            assertFalse("Extra '$key' must not be a nested Intent", extras.get(key) is Intent)
+        }
+    }
+
+    @Test
+    fun whenFireActivityIntentBuiltThenTargetsFireActivity() {
+        val intent = FireActivity.fireActivityIntent(context, notifyDataCleared = false, deletedTabCount = 0)
+
+        assertTrue(intent.component?.className == FireActivity::class.java.name)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215234376231845?focus=true

### Description
- Adds unsafe intent launch `StrictMode` policy to debug variant.
- Adapts the `FireActivity` to avoid using nested intents to reopen the `BrowserActivity` after process restart.

### Steps to test this PR
- [x] Open the app.
- [x] Use the Fire Button.
- [x] Verify there's no `UnsafeIntentLaunchViolation` in logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Fire Button process-kill/relaunch path; behavior should match prior flow but any mistake could break app restart after clear data.
> 
> **Overview**
> Fixes **Fire Button / clear-data** process restart on Android 16 by stopping **nested `Intent` extras** on the path into `FireActivity`, which otherwise triggers **`UnsafeIntentLaunchViolation`**.
> 
> `triggerRestart` now launches `FireActivity` with **primitive extras only** (`notifyDataCleared`, `deletedTabCount`) via a new **`fireActivityIntent`** helper; **`onCreate`** rebuilds the **`BrowserActivity`** restart intent locally instead of unparceling a forwarded intent. **Debug** builds also enable **`StrictMode` `detectUnsafeIntentLaunch`** (API 31+) to catch regressions. **`FireActivityTest`** asserts extras are never nested intents and that the launcher targets `FireActivity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ac7381d66fae004e319a63be6f2ae0c5d4056f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->