### PR TITLE
fix text matcher on pre-onboarding E2E tests to work with non-breaking-spaces added in initial screen

### DIFF
--- a/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
@@ -11,7 +11,7 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use.AI|Ready for a faster browser that puts you in.control).*"
 - assertVisible:
     text: "(let's get started!|Let's do it!)"
 - tapOn: "I've been here before"

--- a/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_start_browsing.yaml
@@ -11,7 +11,7 @@ tags:
       - launchApp:
           clearState: true
 - assertVisible:
-    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use.AI|Ready for a faster browser that puts you in.control).*"
 - assertVisible:
     text: "(let's get started!|Let's do it!)"
 - tapOn: "I've been here before"

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 ---
 - assertVisible:
-    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use AI|Ready for a faster browser that puts you in control).*"
+    text: ".*(Ready for a faster browser that protects you and lets you decide when and how to use.AI|Ready for a faster browser that puts you in.control).*"
 - tapOn:
     text: "(let's get started!|Let's do it!)"
 - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215245267209382?focus=true

### Description
Fixes text matcher on pre-onboarding E2E tests to work with non-breaking-spaces added in initial screen


### Steps to test this PR

QA optional, tested locally with:
```
maestro test .maestro/custom_tabs/custom_tabs_navigation.yaml
```
or any other test that runs `pre_onboarding.yaml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only regex updates for E2E flows; no app or production logic changes.
> 
> **Overview**
> Updates Maestro pre-onboarding **`assertVisible`** regexes in **`pre_onboarding.yaml`** and two returning-user flows so they match the first onboarding headline when the UI uses **non-breaking spaces** (e.g. between “use” and “AI”, and “in” and “control”).
> 
> The patterns now use `.` as a single-character wildcard instead of literal spaces in those spots, keeping the same two copy variants without requiring exact space characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d8b6269b7f2c051a834104ae84b15eb3ebed23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->