### PR TITLE
JS messages and notification schedule for subscription experiment

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -291,6 +291,18 @@ interface SubscriptionsFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun subscriptionExpirationReminderNotification(): Toggle
 
+    /**
+     * Kill switch for `getUserSettings` JS message
+     */
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    fun userSettingsMessaging(): Toggle
+
+    /**
+     * Kill switch for the `requestNotificationsPermission` JS message
+     */
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    fun notificationsPermissionMessaging(): Toggle
+
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun handleExpiredStateWhenSubscriptionChangeSelected(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -284,6 +284,13 @@ interface SubscriptionsFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun vpnReminderNotification(): Toggle
 
+    /**
+     * When enabled, a local reminder notification can be scheduled by the subscription page
+     * to fire ahead of the subscription's expiry/renewal date.
+     */
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    fun subscriptionExpirationReminderNotification(): Toggle
+
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun handleExpiredStateWhenSubscriptionChangeSelected(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -156,6 +156,8 @@ class SubscriptionMessagingInterface @Inject constructor(
             "activateSubscription",
             "featureSelected",
             "backToSettingsActivateSuccess",
+            "getUserSettings",
+            "requestNotificationsPermission",
         )
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
-import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.notification.model.Channel
 import com.duckduckgo.app.notification.model.NotificationSpec
 import com.duckduckgo.app.notification.model.SchedulableNotification
@@ -35,8 +34,6 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.R
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -99,8 +96,6 @@ class SubscriptionExpirationReminderNotificationPlugin @Inject constructor(
     private val schedulableNotification: SubscriptionExpirationReminderNotification,
     private val globalActivityStarter: GlobalActivityStarter,
     private val pixel: Pixel,
-    @AppCoroutineScope private val coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
 ) : SchedulableNotificationPlugin {
 
     override fun getSchedulableNotification(): SchedulableNotification = schedulableNotification
@@ -116,10 +111,7 @@ class SubscriptionExpirationReminderNotificationPlugin @Inject constructor(
     private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
 
     override fun getSpecification(): NotificationSpec {
-        val deferred = coroutineScope.async(dispatcherProvider.io()) {
-            schedulableNotification.buildSpecification()
-        }
-        return runBlocking { deferred.await() }
+        return runBlocking { schedulableNotification.buildSpecification() }
     }
 
     override suspend fun getLaunchIntent(): Intent? {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.NotificationManagerCompat
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.notification.model.Channel
+import com.duckduckgo.app.notification.model.NotificationSpec
+import com.duckduckgo.app.notification.model.SchedulableNotification
+import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.impl.R
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class SubscriptionExpirationReminderNotification @Inject constructor(
+    private val context: Context,
+    private val subscriptions: Subscriptions,
+    private val dispatcherProvider: DispatcherProvider,
+) : SchedulableNotification {
+
+    override val id = "com.duckduckgo.subscriptions.expiration.reminder"
+
+    override suspend fun canShow(): Boolean {
+        return withContext(dispatcherProvider.io()) {
+            subscriptions.getSubscriptionStatus().isActive()
+        }
+    }
+
+    private fun SubscriptionStatus.isActive(): Boolean = when (this) {
+        SubscriptionStatus.AUTO_RENEWABLE,
+        SubscriptionStatus.NOT_AUTO_RENEWABLE,
+        SubscriptionStatus.GRACE_PERIOD,
+        -> true
+        else -> false
+    }
+
+    override suspend fun buildSpecification(): NotificationSpec {
+        return SubscriptionExpirationReminderNotificationSpecification(context)
+    }
+}
+
+class SubscriptionExpirationReminderNotificationSpecification(context: Context) : NotificationSpec {
+
+    override val channel = Channel(
+        id = "com.duckduckgo.subscriptions.expiration.reminder",
+        name = R.string.subscriptionExpirationReminderNotificationChannelName,
+        priority = NotificationManagerCompat.IMPORTANCE_DEFAULT,
+    )
+    override val systemId = NOTIFICATION_SYSTEM_ID
+    override val name = "Subscription Expiration Reminder"
+    override val icon = com.duckduckgo.mobile.android.R.drawable.notification_logo
+    override val title: String = context.getString(R.string.subscriptionExpirationReminderNotificationTitle)
+    override val description: String = context.getString(R.string.subscriptionExpirationReminderNotificationDescription)
+    override val launchButton: String? = null
+    override val closeButton: String? = null
+    override val pixelSuffix = PIXEL_SUFFIX
+    override val autoCancel = true
+    override val bundle: Bundle = Bundle()
+    override val color: Int = context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorAccentBlue)
+
+    companion object {
+        private const val NOTIFICATION_SYSTEM_ID = 112
+        private const val PIXEL_SUFFIX = "subscription_expiration_reminder"
+    }
+}
+
+@ContributesMultibinding(AppScope::class)
+class SubscriptionExpirationReminderNotificationPlugin @Inject constructor(
+    private val context: Context,
+    private val schedulableNotification: SubscriptionExpirationReminderNotification,
+    private val globalActivityStarter: GlobalActivityStarter,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : SchedulableNotificationPlugin {
+
+    override fun getSchedulableNotification(): SchedulableNotification = schedulableNotification
+
+    override fun onNotificationCancelled() {
+        pixel.fire(pixelName(NOTIFICATION_CANCELLED_PIXEL))
+    }
+
+    override fun onNotificationShown() {
+        pixel.fire(pixelName(NOTIFICATION_SHOWN_PIXEL))
+    }
+
+    private fun pixelName(notificationType: String) = "${notificationType}_${getSpecification().pixelSuffix}"
+
+    override fun getSpecification(): NotificationSpec {
+        val deferred = coroutineScope.async(dispatcherProvider.io()) {
+            schedulableNotification.buildSpecification()
+        }
+        return runBlocking { deferred.await() }
+    }
+
+    override suspend fun getLaunchIntent(): Intent? {
+        return globalActivityStarter.startIntent(context, SubscriptionsSettingsScreenWithEmptyParams)
+    }
+
+    companion object {
+        private const val NOTIFICATION_SHOWN_PIXEL = "mnot_s"
+        private const val NOTIFICATION_CANCELLED_PIXEL = "mnot_c"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderScheduler.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderScheduler.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+/**
+ * Schedules a local reminder that fires [daysBeforeCancel] days before the active subscription's
+ * expiration. The reminder is only enqueued if the user has an active subscription whose expiry
+ * leaves a positive delay.
+ */
+interface SubscriptionExpirationReminderScheduler {
+    suspend fun scheduleReminderNotification(daysBeforeCancel: Int)
+    fun cancelScheduledNotification()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class SubscriptionExpirationReminderSchedulerImpl @Inject constructor(
+    private val workManager: WorkManager,
+    private val notificationManager: NotificationManagerCompat,
+    private val subscriptionsManager: SubscriptionsManager,
+) : SubscriptionExpirationReminderScheduler {
+
+    override suspend fun scheduleReminderNotification(daysBeforeCancel: Int) {
+        cancelScheduledNotification()
+
+        if (daysBeforeCancel <= 0) return
+        if (!notificationManager.areNotificationsEnabled()) return
+
+        val expiresOrRenewsAt = subscriptionsManager.getSubscription()?.expiresOrRenewsAt ?: return
+        val delayMillis = expiresOrRenewsAt - TimeUnit.DAYS.toMillis(daysBeforeCancel.toLong()) - System.currentTimeMillis()
+        if (delayMillis <= 0) return
+
+        val request = OneTimeWorkRequestBuilder<SubscriptionExpirationReminderWorker>()
+            .addTag(EXPIRATION_REMINDER_WORK_TAG)
+            .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+            .build()
+
+        workManager.enqueue(request)
+    }
+
+    override fun cancelScheduledNotification() {
+        workManager.cancelAllWorkByTag(EXPIRATION_REMINDER_WORK_TAG)
+    }
+
+    companion object {
+        const val EXPIRATION_REMINDER_WORK_TAG = "com.duckduckgo.subscriptions.expiration.reminder.schedule"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderWorker.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderWorker.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.notification.NotificationSender
+import com.duckduckgo.di.scopes.AppScope
+import javax.inject.Inject
+
+@ContributesWorker(AppScope::class)
+class SubscriptionExpirationReminderWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    @Inject
+    lateinit var notificationSender: NotificationSender
+
+    @Inject
+    lateinit var subscriptionExpirationReminderNotification: SubscriptionExpirationReminderNotification
+
+    override suspend fun doWork(): Result {
+        notificationSender.sendNotification(subscriptionExpirationReminderNotification)
+        return Result.success()
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -191,7 +191,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
     }
 
     private fun getUserSettings(id: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            if (!subscriptionsFeature.userSettingsMessaging().isEnabled()) return@launch
             command.send(ComputeUserSettings(id))
         }
     }
@@ -222,7 +223,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
     }
 
     private fun requestNotificationsPermission(id: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            if (!subscriptionsFeature.notificationsPermissionMessaging().isEnabled()) return@launch
             command.send(RequestNotificationsPermission(id))
         }
     }
@@ -319,9 +321,13 @@ class SubscriptionWebViewViewModel @Inject constructor(
             val offerId = runCatching { data?.getString("offerId") }.getOrNull()
             val experimentName = runCatching { data?.getJSONObject("experiment")?.getString("name") }.getOrNull()
             val experimentCohort = runCatching { data?.getJSONObject("experiment")?.getString("cohort") }.getOrNull()
-            pendingScheduleNotificationDaysBeforeCancel = runCatching {
-                data?.getJSONObject("scheduleNotification")?.getInt("daysBeforeCancel")
-            }.getOrNull()
+            pendingScheduleNotificationDaysBeforeCancel = if (subscriptionsFeature.userSettingsMessaging().isEnabled()) {
+                runCatching {
+                    data?.getJSONObject("scheduleNotification")?.getInt("daysBeforeCancel")
+                }.getOrNull()
+            } else {
+                null
+            }
             if (id.isNullOrBlank()) {
                 pixelSender.reportPurchaseFailureOther(SubscriptionFailureErrorType.INVALID_PRODUCT_ID.name)
                 _currentPurchaseViewState.emit(currentPurchaseViewState.value.copy(purchaseState = Failure))

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -313,7 +313,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
             val experimentCohort = runCatching { data?.getJSONObject("experiment")?.getString("cohort") }.getOrNull()
             pendingScheduleNotificationDaysBeforeCancel = runCatching {
                 data?.getJSONObject("scheduleNotification")?.getInt("daysBeforeCancel")
-            }.getOrNull()?.takeIf { it in 1..3 }
+            }.getOrNull()
             if (id.isNullOrBlank()) {
                 pixelSender.reportPurchaseFailureOther(SubscriptionFailureErrorType.INVALID_PRODUCT_ID.name)
                 _currentPurchaseViewState.emit(currentPurchaseViewState.value.copy(purchaseState = Failure))

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -140,7 +140,9 @@ class SubscriptionWebViewViewModel @Inject constructor(
                 is CurrentPurchase.Success -> {
                     subscriptionsChecker.runChecker()
                     pendingScheduleNotificationDaysBeforeCancel?.let { days ->
-                        subscriptionExpirationReminderScheduler.scheduleReminderNotification(days)
+                        if (subscriptionsFeature.subscriptionExpirationReminderNotification().isEnabled()) {
+                            subscriptionExpirationReminderScheduler.scheduleReminderNotification(days)
+                        }
                         pendingScheduleNotificationDaysBeforeCancel = null
                     }
                     Success(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -199,13 +199,13 @@ class SubscriptionWebViewViewModel @Inject constructor(
     fun onUserSettingsComputed(
         id: String,
         notificationsEnabled: Boolean,
-        sdkAtLeastTiramisu: Boolean,
+        isAtLeastApi33: Boolean,
         runtimePermissionGranted: Boolean,
         shouldShowRationale: Boolean,
     ) {
         val status = when {
             notificationsEnabled -> NOTIFICATIONS_PERMISSION_GRANTED
-            !sdkAtLeastTiramisu -> NOTIFICATIONS_PERMISSION_DENIED
+            !isAtLeastApi33 -> NOTIFICATIONS_PERMISSION_DENIED
             runtimePermissionGranted -> NOTIFICATIONS_PERMISSION_DENIED
             shouldShowRationale -> NOTIFICATIONS_PERMISSION_NOT_DETERMINED
             else -> NOTIFICATIONS_PERMISSION_DENIED

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -118,6 +118,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
 
     private lateinit var subscriptionStatus: SubscriptionStatus
 
+    private var pendingScheduleNotificationDaysBeforeCancel: Int? = null
+
     fun start() {
         subscriptionsManager.currentPurchaseState.onEach {
             val state = when (it) {
@@ -172,9 +174,60 @@ class SubscriptionWebViewViewModel @Inject constructor(
             "featureSelected" -> data?.let { featureSelected(data) }
             "subscriptionsWelcomeFaqClicked" -> subscriptionsWelcomeFaqClicked()
             "subscriptionsWelcomeAddEmailClicked" -> subscriptionsWelcomeAddEmailClicked()
+            "getUserSettings" -> id?.let { getUserSettings(it) }
+            "requestNotificationsPermission" -> id?.let { requestNotificationsPermission(it) }
             else -> {
                 // NOOP
             }
+        }
+    }
+
+    private fun getUserSettings(id: String) {
+        viewModelScope.launch {
+            command.send(ComputeUserSettings(id))
+        }
+    }
+
+    fun onUserSettingsComputed(
+        id: String,
+        notificationsEnabled: Boolean,
+        sdkAtLeastTiramisu: Boolean,
+        runtimePermissionGranted: Boolean,
+        shouldShowRationale: Boolean,
+    ) {
+        val status = when {
+            notificationsEnabled -> NOTIFICATIONS_PERMISSION_GRANTED
+            !sdkAtLeastTiramisu -> NOTIFICATIONS_PERMISSION_DENIED
+            runtimePermissionGranted -> NOTIFICATIONS_PERMISSION_DENIED
+            shouldShowRationale -> NOTIFICATIONS_PERMISSION_NOT_DETERMINED
+            else -> NOTIFICATIONS_PERMISSION_DENIED
+        }
+        viewModelScope.launch {
+            val response = JsCallbackData(
+                featureName = "useSubscription",
+                method = "getUserSettings",
+                id = id,
+                params = JSONObject().apply { put("notificationsPermission", status) },
+            )
+            command.send(SendResponseToJs(response))
+        }
+    }
+
+    private fun requestNotificationsPermission(id: String) {
+        viewModelScope.launch {
+            command.send(RequestNotificationsPermission(id))
+        }
+    }
+
+    fun onNotificationsPermissionResult(id: String, granted: Boolean) {
+        viewModelScope.launch {
+            val response = JsCallbackData(
+                featureName = "useSubscription",
+                method = "requestNotificationsPermission",
+                id = id,
+                params = JSONObject().apply { put("granted", granted) },
+            )
+            command.send(SendResponseToJs(response))
         }
     }
 
@@ -258,6 +311,9 @@ class SubscriptionWebViewViewModel @Inject constructor(
             val offerId = runCatching { data?.getString("offerId") }.getOrNull()
             val experimentName = runCatching { data?.getJSONObject("experiment")?.getString("name") }.getOrNull()
             val experimentCohort = runCatching { data?.getJSONObject("experiment")?.getString("cohort") }.getOrNull()
+            pendingScheduleNotificationDaysBeforeCancel = runCatching {
+                data?.getJSONObject("scheduleNotification")?.getInt("daysBeforeCancel")
+            }.getOrNull()?.takeIf { it in 1..3 }
             if (id.isNullOrBlank()) {
                 pixelSender.reportPurchaseFailureOther(SubscriptionFailureErrorType.INVALID_PRODUCT_ID.name)
                 _currentPurchaseViewState.emit(currentPurchaseViewState.value.copy(purchaseState = Failure))
@@ -730,6 +786,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
             val replacementMode: SubscriptionReplacementMode,
         ) : Command()
         data object RestoreSubscription : Command()
+        data class ComputeUserSettings(val id: String) : Command()
+        data class RequestNotificationsPermission(val id: String) : Command()
         data object GoToITR : Command()
         data object GoToPIR : Command()
         data object GoToPIRDashboard : Command()
@@ -743,5 +801,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
         const val PURCHASE_COMPLETED_SUBSCRIPTION_NAME = "onPurchaseUpdate"
         const val PURCHASE_COMPLETED_JSON = """{ type: "completed" }"""
         const val PURCHASE_CANCELED_JSON = """{ type: "canceled" }"""
+        private const val NOTIFICATIONS_PERMISSION_GRANTED = "granted"
+        private const val NOTIFICATIONS_PERMISSION_DENIED = "denied"
+        private const val NOTIFICATIONS_PERMISSION_NOT_DETERMINED = "notDetermined"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -66,6 +66,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.billing.SubscriptionReplacementMode
+import com.duckduckgo.subscriptions.impl.notification.SubscriptionExpirationReminderScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionFailureErrorType
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.isActive
@@ -102,6 +103,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     private val pixelSender: SubscriptionPixelSender,
     private val subscriptionsFeature: SubscriptionsFeature,
     private val pirFeature: PirFeature,
+    private val subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduler,
 ) : ViewModel() {
 
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
@@ -137,6 +139,10 @@ class SubscriptionWebViewViewModel @Inject constructor(
                 }
                 is CurrentPurchase.Success -> {
                     subscriptionsChecker.runChecker()
+                    pendingScheduleNotificationDaysBeforeCancel?.let { days ->
+                        subscriptionExpirationReminderScheduler.scheduleReminderNotification(days)
+                        pendingScheduleNotificationDaysBeforeCancel = null
+                    }
                     Success(
                         SubscriptionEventData(
                             PURCHASE_COMPLETED_FEATURE_NAME,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -20,6 +20,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
@@ -30,9 +31,12 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.AnyThread
 import androidx.appcompat.widget.Toolbar
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.DialogFragment
@@ -85,12 +89,14 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettings
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettingsActivateSuccess
+import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.ComputeUserSettings
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToDuckAI
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToITR
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToNetP
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIR
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIRDashboard
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.Reload
+import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RequestNotificationsPermission
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.RestoreSubscription
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.SendJsEvent
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.SendResponseToJs
@@ -197,7 +203,15 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     // Used to represent a file to download, but may first require permission
     private var pendingFileDownload: PendingFileDownload? = null
+    private var pendingNotificationsPermissionRequestId: String? = null
     private val downloadMessagesJob = ConflatedJob()
+
+    private val notificationsPermissionLauncher = registerForActivityResult(RequestPermission()) { granted ->
+        pendingNotificationsPermissionRequestId?.let { id ->
+            viewModel.onNotificationsPermissionResult(id, granted)
+        }
+        pendingNotificationsPermissionRequestId = null
+    }
     private val toolbar
         get() = binding.includeToolbar.toolbar
 
@@ -511,6 +525,8 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             is GoToPIRDashboard -> goToPIRDashboard()
             is GoToNetP -> goToNetP(command.activityParams)
             is GoToDuckAI -> goToDuckAI()
+            is ComputeUserSettings -> computeUserSettings(command.id)
+            is RequestNotificationsPermission -> launchNotificationsPermission(command.id)
             Reload -> binding.webview.reload()
         }
     }
@@ -542,6 +558,30 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun goToDuckAI() {
         duckChat.openDuckChat()
+    }
+
+    private fun computeUserSettings(id: String) {
+        val sdkAtLeastTiramisu = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        viewModel.onUserSettingsComputed(
+            id = id,
+            notificationsEnabled = NotificationManagerCompat.from(this).areNotificationsEnabled(),
+            sdkAtLeastTiramisu = sdkAtLeastTiramisu,
+            runtimePermissionGranted = sdkAtLeastTiramisu &&
+                ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PERMISSION_GRANTED,
+            shouldShowRationale = sdkAtLeastTiramisu &&
+                ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.POST_NOTIFICATIONS),
+        )
+    }
+
+    private fun launchNotificationsPermission(id: String) {
+        pendingNotificationsPermissionRequestId = id
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            val granted = NotificationManagerCompat.from(this).areNotificationsEnabled()
+            viewModel.onNotificationsPermissionResult(id, granted)
+            pendingNotificationsPermissionRequestId = null
+        }
     }
 
     private fun renderPurchaseState(purchaseState: PurchaseStateView) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -561,7 +561,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     }
 
     private fun computeUserSettings(id: String) {
-        val sdkAtLeastTiramisu = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        val sdkAtLeastTiramisu = Build.VERSION.SDK_INT >= 33
         viewModel.onUserSettingsComputed(
             id = id,
             notificationsEnabled = NotificationManagerCompat.from(this).areNotificationsEnabled(),
@@ -575,7 +575,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun launchNotificationsPermission(id: String) {
         pendingNotificationsPermissionRequestId = id
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= 33) {
             notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         } else {
             val granted = NotificationManagerCompat.from(this).areNotificationsEnabled()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -561,14 +561,14 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     }
 
     private fun computeUserSettings(id: String) {
-        val sdkAtLeastTiramisu = Build.VERSION.SDK_INT >= 33
+        val isAtLeastApi33 = Build.VERSION.SDK_INT >= 33
         viewModel.onUserSettingsComputed(
             id = id,
             notificationsEnabled = NotificationManagerCompat.from(this).areNotificationsEnabled(),
-            sdkAtLeastTiramisu = sdkAtLeastTiramisu,
-            runtimePermissionGranted = sdkAtLeastTiramisu &&
+            isAtLeastApi33 = isAtLeastApi33,
+            runtimePermissionGranted = isAtLeastApi33 &&
                 ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PERMISSION_GRANTED,
-            shouldShowRationale = sdkAtLeastTiramisu &&
+            shouldShowRationale = isAtLeastApi33 &&
                 ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.POST_NOTIFICATIONS),
         )
     }

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -31,4 +31,9 @@
     <string name="vpnReminderNotificationTitle">Don\'t forget to set up your VPN</string>
     <string name="vpnReminderNotificationDescription">Block harmful sites and scams, hide your location, and shield your online activity now.</string>
 
+    <!-- Subscription Expiration Reminder Notification -->
+    <string name="subscriptionExpirationReminderNotificationChannelName">Subscription Reminders</string>
+    <string name="subscriptionExpirationReminderNotificationTitle">Your Privacy Pro subscription is ending soon</string>
+    <string name="subscriptionExpirationReminderNotificationDescription">Tap to review your subscription and stay protected.</string>
+
 </resources>

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderSchedulerImplTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderSchedulerImplTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.repository.Subscription
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+class SubscriptionExpirationReminderSchedulerImplTest {
+
+    private val workManager: WorkManager = mock()
+    private val notificationManager: NotificationManagerCompat = mock()
+    private val subscriptionsManager: SubscriptionsManager = mock()
+
+    private lateinit var testee: SubscriptionExpirationReminderSchedulerImpl
+
+    @Before
+    fun before() {
+        testee = SubscriptionExpirationReminderSchedulerImpl(
+            workManager,
+            notificationManager,
+            subscriptionsManager,
+        )
+    }
+
+    @Test
+    fun whenDaysBeforeCancelIsZeroThenNotificationNotScheduled() = runTest {
+        whenever(notificationManager.areNotificationsEnabled()).thenReturn(true)
+
+        testee.scheduleReminderNotification(0)
+
+        verify(workManager, never()).enqueue(any<WorkRequest>())
+    }
+
+    @Test
+    fun whenNotificationsDisabledThenNotificationNotScheduled() = runTest {
+        whenever(notificationManager.areNotificationsEnabled()).thenReturn(false)
+
+        testee.scheduleReminderNotification(1)
+
+        verify(workManager, never()).enqueue(any<WorkRequest>())
+    }
+
+    @Test
+    fun whenAllConditionsMetThenNotificationScheduled() = runTest {
+        whenever(notificationManager.areNotificationsEnabled()).thenReturn(true)
+        whenever(subscriptionsManager.getSubscription()).thenReturn(activeSubscriptionExpiringIn(days = 30))
+
+        testee.scheduleReminderNotification(7)
+
+        verify(workManager).enqueue(any<WorkRequest>())
+    }
+
+    @Test
+    fun whenCancelScheduledNotificationThenWorkCancelled() {
+        testee.cancelScheduledNotification()
+
+        verify(workManager).cancelAllWorkByTag(SubscriptionExpirationReminderSchedulerImpl.EXPIRATION_REMINDER_WORK_TAG)
+    }
+
+    private fun activeSubscriptionExpiringIn(days: Int): Subscription = Subscription(
+        productId = "test-product",
+        billingPeriod = "monthly",
+        startedAt = 0L,
+        expiresOrRenewsAt = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(days.toLong()),
+        status = SubscriptionStatus.AUTO_RENEWABLE,
+        platform = "google",
+        activeOffers = emptyList(),
+    )
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PRO_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.notification.SubscriptionExpirationReminderScheduler
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.Subscription
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
@@ -81,6 +82,7 @@ class SubscriptionWebViewViewModelTest {
     private val pixelSender: SubscriptionPixelSender = mock()
     private val subscriptionsFeature = FakeFeatureToggleFactory.create(SubscriptionsFeature::class.java, FakeToggleStore())
     private val pirFeature: PirFeature = mock()
+    private val subscriptionExpirationReminderScheduler: SubscriptionExpirationReminderScheduler = mock()
 
     private lateinit var viewModel: SubscriptionWebViewViewModel
 
@@ -96,6 +98,7 @@ class SubscriptionWebViewViewModelTest {
             pixelSender,
             subscriptionsFeature,
             pirFeature,
+            subscriptionExpirationReminderScheduler,
         )
         givenSubscriptionStatus(UNKNOWN)
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -60,7 +60,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -205,6 +207,55 @@ class SubscriptionWebViewViewModelTest {
             assertTrue(result is Command.SubscriptionSelected)
             assertEquals("myId", (result as Command.SubscriptionSelected).id)
         }
+    }
+
+    @Test
+    fun whenPurchaseSucceedsWithScheduleNotificationAndFlagEnabledThenSchedulerCalled() = runTest {
+        subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
+        val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)
+        viewModel.start()
+        viewModel.processJsCallbackMessage(
+            "test",
+            "subscriptionSelected",
+            "id",
+            JSONObject("""{"id":"myId","scheduleNotification":{"daysBeforeCancel":7}}"""),
+        )
+
+        flowTest.emit(CurrentPurchase.Success(isFreeTrial = false))
+
+        verify(subscriptionExpirationReminderScheduler).scheduleReminderNotification(7)
+    }
+
+    @Test
+    fun whenPurchaseSucceedsWithScheduleNotificationAndFlagDisabledThenSchedulerNotCalled() = runTest {
+        subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = false))
+        val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)
+        viewModel.start()
+        viewModel.processJsCallbackMessage(
+            "test",
+            "subscriptionSelected",
+            "id",
+            JSONObject("""{"id":"myId","scheduleNotification":{"daysBeforeCancel":7}}"""),
+        )
+
+        flowTest.emit(CurrentPurchase.Success(isFreeTrial = false))
+
+        verify(subscriptionExpirationReminderScheduler, never()).scheduleReminderNotification(any())
+    }
+
+    @Test
+    fun whenPurchaseSucceedsWithoutScheduleNotificationThenSchedulerNotCalled() = runTest {
+        subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
+        val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)
+        viewModel.start()
+        viewModel.processJsCallbackMessage("test", "subscriptionSelected", "id", JSONObject("""{"id":"myId"}"""))
+
+        flowTest.emit(CurrentPurchase.Success(isFreeTrial = false))
+
+        verify(subscriptionExpirationReminderScheduler, never()).scheduleReminderNotification(any())
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -262,6 +262,45 @@ class SubscriptionWebViewViewModelTest {
     }
 
     @Test
+    fun whenMessagingFlagDisabledAndGetUserSettingsThenNoCommandEmitted() = runTest {
+        subscriptionsFeature.userSettingsMessaging().setRawStoredState(Toggle.State(enable = false))
+
+        viewModel.commands().test {
+            viewModel.processJsCallbackMessage("test", "getUserSettings", "msgId", JSONObject("{}"))
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenMessagingFlagDisabledAndRequestNotificationsPermissionThenNoCommandEmitted() = runTest {
+        subscriptionsFeature.notificationsPermissionMessaging().setRawStoredState(Toggle.State(enable = false))
+
+        viewModel.commands().test {
+            viewModel.processJsCallbackMessage("test", "requestNotificationsPermission", "msgId", JSONObject("{}"))
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenMessagingFlagDisabledAndSubscriptionSelectedHasScheduleNotificationThenSchedulerNotCalled() = runTest {
+        subscriptionsFeature.userSettingsMessaging().setRawStoredState(Toggle.State(enable = false))
+        subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
+        val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
+        whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)
+        viewModel.start()
+        viewModel.processJsCallbackMessage(
+            "test",
+            "subscriptionSelected",
+            "id",
+            JSONObject("""{"id":"myId","scheduleNotification":{"daysBeforeCancel":7}}"""),
+        )
+
+        flowTest.emit(CurrentPurchase.Success(isFreeTrial = false))
+
+        verify(subscriptionExpirationReminderScheduler, never()).scheduleReminderNotification(any())
+    }
+
+    @Test
     fun whenPurchaseSucceedsWithScheduleNotificationAndFlagEnabledThenSchedulerCalled() = runTest {
         subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
         val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -210,6 +210,58 @@ class SubscriptionWebViewViewModelTest {
     }
 
     @Test
+    fun whenGetUserSettingsThenComputeUserSettingsCommandSent() = runTest {
+        viewModel.commands().test {
+            viewModel.processJsCallbackMessage("test", "getUserSettings", "msgId", JSONObject("{}"))
+            val result = awaitItem()
+            assertTrue(result is Command.ComputeUserSettings)
+            assertEquals("msgId", (result as Command.ComputeUserSettings).id)
+        }
+    }
+
+    @Test
+    fun whenOnUserSettingsComputedThenSendResponseToJsWithNotificationsPermission() = runTest {
+        viewModel.commands().test {
+            viewModel.onUserSettingsComputed(
+                id = "msgId",
+                notificationsEnabled = true,
+                isAtLeastApi33 = true,
+                runtimePermissionGranted = true,
+                shouldShowRationale = false,
+            )
+            val result = awaitItem()
+            assertTrue(result is Command.SendResponseToJs)
+            val response = (result as Command.SendResponseToJs).data
+            assertEquals("msgId", response.id)
+            assertEquals("getUserSettings", response.method)
+            assertEquals("granted", response.params.getString("notificationsPermission"))
+        }
+    }
+
+    @Test
+    fun whenRequestNotificationsPermissionThenRequestNotificationsPermissionCommandSent() = runTest {
+        viewModel.commands().test {
+            viewModel.processJsCallbackMessage("test", "requestNotificationsPermission", "msgId", JSONObject("{}"))
+            val result = awaitItem()
+            assertTrue(result is Command.RequestNotificationsPermission)
+            assertEquals("msgId", (result as Command.RequestNotificationsPermission).id)
+        }
+    }
+
+    @Test
+    fun whenOnNotificationsPermissionResultThenSendResponseToJsWithGranted() = runTest {
+        viewModel.commands().test {
+            viewModel.onNotificationsPermissionResult(id = "msgId", granted = true)
+            val result = awaitItem()
+            assertTrue(result is Command.SendResponseToJs)
+            val response = (result as Command.SendResponseToJs).data
+            assertEquals("msgId", response.id)
+            assertEquals("requestNotificationsPermission", response.method)
+            assertTrue(response.params.getBoolean("granted"))
+        }
+    }
+
+    @Test
     fun whenPurchaseSucceedsWithScheduleNotificationAndFlagEnabledThenSchedulerCalled() = runTest {
         subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
         val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207260194172075/task/1215239602418252?focus=true

### Description
Add JS messages to bridge the notification permission prompt and subscription cancellation notification scheduling for an FE experiment.

### Steps to test this PR

_Pre steps_
- [x] Host index.html attached to https://app.asana.com/1/137249556945/project/488551667048375/task/1215239602418252?focus=true (instructions in the next step)
- [x] Apply patch on https://app.asana.com/1/137249556945/project/488551667048375/task/1215239602418252?focus=true. 
      - This will apply the staging environment for subscriptions
      - The subscription paywall will be redirected to a local test site that serves custom JS messages for testing notifications
      - To host the test site locally, put the provided `index.html` file in a folder on your laptop and run this command from that folder: `python3 -m http.server 8080`
      - Then replace the local URL (http://YOUR_IP:8080) in SubscriptionsWebViewActivity.kt line 300 so when subscription paywall is selected, the test site is loaded.
      - Make sure your laptop and Android device are connected to the same Wi-Fi network

_Notification not determined_
- [x] Fresh install
- [x] Reject notification permissions in the first prompt
- [x] Skip onboarding
- [x] Go to Subcriptions landing page -> will redirect to the custom site
- [x] Verify notification permissions will appear as not determined
- [x] In section 2. Tap on "Request notifications permissions"
- [x] Verify notification permissions prompt appear
- [x] Tap on 'Allow'
- [x] Verify notification permission is changed to 'Notifications granted'

_Notification schedule_
- [x] In section 3 tap on 'Fire subscriptionSelected'
- [x] Verify that notification is scheduled and fired in 10 seconds (or whatever you selected in section 2)

_Notification granted_
- [x] Fresh install
- [x] Grant notification permissions in the first prompt
- [x] Skip onboarding
- [x] Go to Susbcriptions landing page -> will redirect to the custom site
- [x] Verify notification permissions will appear as granted
- [x] In section 2. Verify "Request notifications permissions" is disabled
- [x] In section 3 tap on 'Fire subscriptionSelected'
- [x] Verify that notification is scheduled and fired in 10 seconds (or whatever you selected in section 2)

_Notification rejected_
- [x] Fresh install
- [x] Reject notification permissions in the first prompt
- [x] Skip onbaording
- [x] Open Settings > AppTP
- [x] Tap on notify me button and select 'Don't allow'
- [x] Go to Subcriptions landing page -> will redirect to the custom site
- [x] Verify notification permissions will appear as rejected
- [x] In section 2. Verify "Request notifications permissions" is disabled
- [x] In section 3 tap on 'Fire subscriptionSelected'
- [x] Verify that notification is neither scheduled nor shown in 10 seconds (or whatever you selected in section 2)

### No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches purchase-success side effects, notification permission UX, and timed WorkManager jobs tied to subscription expiry; mitigated by feature flags and guards when notifications are disabled or delay is invalid.
> 
> **Overview**
> Adds **subscription WebView JS messaging** so the paywall can read notification state, prompt for `POST_NOTIFICATIONS`, and schedule a **local expiration reminder** after purchase.
> 
> **`getUserSettings`** returns `notificationsPermission` as `granted`, `denied`, or `notDetermined` (API 33+ permission + channel state). **`requestNotificationsPermission`** triggers the system prompt on API 33+ and replies with `{ granted }`. Both paths are gated by remote **kill switches** (`userSettingsMessaging`, `notificationsPermissionMessaging`).
> 
> **`subscriptionSelected`** may include `scheduleNotification.daysBeforeCancel`; that value is held until purchase succeeds, then—if **`subscriptionExpirationReminderNotification`** is on and notifications are enabled—a **WorkManager** one-shot fires **`daysBeforeCancel`** before `expiresOrRenewsAt`, showing a new schedulable notification (subscription settings deep link, pixels). Scheduling is skipped when notifications are off, delay ≤ 0, or toggles block the flow.
> 
> **`SubscriptionsHandler`** registers the two new methods; **`SubscriptionWebViewViewModel`** / **`SubscriptionsWebViewActivity`** implement the command/permission wiring. Unit tests cover scheduler guards and ViewModel JS/toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8b74e11522562f63627a030b0af6b34d2d11b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->